### PR TITLE
chore(internal): add docs to generated JSON schemas

### DIFF
--- a/api-yml.schema.json
+++ b/api-yml.schema.json
@@ -88,7 +88,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Global Headers for the entire API"
     },
     "name": {
       "type": "string"
@@ -231,7 +232,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "The variable name as it appears in the URL template"
         },
         "default": {
           "oneOf": [
@@ -241,7 +243,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default value for this variable"
         },
         "values": {
           "oneOf": [
@@ -254,7 +257,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Allowed values for this variable (from enum)"
         }
       },
       "required": [
@@ -299,7 +303,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A separate default URL to use when no variables are provided (from x-fern-default-url extension)"
         },
         "url-template": {
           "oneOf": [
@@ -309,7 +314,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The original URL template with variable placeholders (e.g., \"https://api.{region}.example.com\")"
         },
         "variables": {
           "oneOf": [
@@ -322,7 +328,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Server variables for URL templating"
         }
       },
       "required": [
@@ -373,7 +380,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL templates with variable placeholders for each base URL (e.g., \"https://api.{region}.example.com\")"
         },
         "default-urls": {
           "oneOf": [
@@ -386,7 +394,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Default URLs to use when no variables are provided (from x-fern-default-url extension)"
         },
         "variables": {
           "oneOf": [
@@ -402,7 +411,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Server variables for URL templating, keyed by base URL ID"
         }
       },
       "required": [
@@ -498,7 +508,8 @@
           ]
         },
         "endpoint-security": {
-          "$ref": "#/definitions/auth.EndpointSecuritySchemaDetails"
+          "$ref": "#/definitions/auth.EndpointSecuritySchemaDetails",
+          "description": "Indicates that authentication requirements are defined per-endpoint via the `security` field."
         }
       },
       "required": [
@@ -536,7 +547,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the client ID."
         },
         "client-secret": {
           "oneOf": [
@@ -546,7 +558,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the client secret."
         },
         "scopes": {
           "oneOf": [
@@ -556,7 +569,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the scopes."
         }
       },
       "additionalProperties": false
@@ -572,7 +586,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the access token."
         },
         "expires-in": {
           "oneOf": [
@@ -582,7 +597,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the expires in property."
         },
         "refresh-token": {
           "oneOf": [
@@ -592,7 +608,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the refresh token"
         }
       },
       "additionalProperties": false
@@ -601,7 +618,8 @@
       "type": "object",
       "properties": {
         "endpoint": {
-          "type": "string"
+          "type": "string",
+          "description": "The endpoint to get the access token, such as 'auth.get_token"
         },
         "request-properties": {
           "oneOf": [
@@ -633,7 +651,8 @@
       "type": "object",
       "properties": {
         "refresh-token": {
-          "type": "string"
+          "type": "string",
+          "description": "The property name for the refresh token."
         }
       },
       "required": [
@@ -652,7 +671,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the access token."
         },
         "expires-in": {
           "oneOf": [
@@ -662,7 +682,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the expires in property."
         },
         "refresh-token": {
           "oneOf": [
@@ -672,7 +693,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the refresh token."
         }
       },
       "additionalProperties": false
@@ -681,7 +703,8 @@
       "type": "object",
       "properties": {
         "endpoint": {
-          "type": "string"
+          "type": "string",
+          "description": "The endpoint to refresh the access token, such as 'auth.refresh_token"
         },
         "request-properties": {
           "oneOf": [
@@ -769,7 +792,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the token header value prefix. Defaults to 'Bearer'"
         },
         "token-header": {
           "oneOf": [
@@ -779,7 +803,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the token header key name. Defaults to 'Authorization'"
         },
         "get-token": {
           "$ref": "#/definitions/auth.OAuthGetTokenEndpointSchema"
@@ -846,7 +871,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to string"
         },
         "prefix": {
           "oneOf": [
@@ -866,7 +892,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The placeholder value to use in code snippets (e.g., \"YOUR_API_KEY\")."
         }
       },
       "required": [
@@ -905,7 +932,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the auth variable will be omitted from the SDK."
         },
         "placeholder": {
           "oneOf": [
@@ -915,7 +943,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The placeholder value to use in code snippets (e.g., \"YOUR_API_KEY\")."
         }
       },
       "additionalProperties": false
@@ -998,10 +1027,12 @@
       "type": "object",
       "properties": {
         "response-property": {
-          "type": "string"
+          "type": "string",
+          "description": "The property to retrieve the header value from the get token or refresh endpoint response."
         },
         "header-name": {
-          "type": "string"
+          "type": "string",
+          "description": "The header name to put the token in for any authenticated HTTP request."
         },
         "value-prefix": {
           "oneOf": [
@@ -1011,20 +1042,23 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Commonly used for setting the `Authorization` scheme, but could be used for other things."
         }
       },
       "required": [
         "response-property",
         "header-name"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "A header that will be set on HTTP requests when the inferred auth scheme is applied to an endpoint. These are not headers for the authorization endpoint."
     },
     "auth.InferredGetTokenEndpointSchemaObject": {
       "type": "object",
       "properties": {
         "endpoint": {
-          "type": "string"
+          "type": "string",
+          "description": "The endpoint to get the access token, such as 'auth.get_token'"
         },
         "expiry-response-property": {
           "oneOf": [
@@ -1034,7 +1068,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the expiry time in the response."
         },
         "authenticated-request-headers": {
           "oneOf": [
@@ -1047,7 +1082,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The headers that will be set on HTTP requests when the inferred auth scheme is applied to an endpoint."
         }
       },
       "required": [
@@ -1121,7 +1157,8 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the Protobuf type (e.g. google.protobuf.Struct)."
         }
       },
       "required": [
@@ -1727,13 +1764,16 @@
       "type": "object",
       "properties": {
         "cursor": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the request property for the cursor."
         },
         "next_cursor": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next cursor."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -1747,10 +1787,12 @@
       "type": "object",
       "properties": {
         "offset": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the request property for the page offset."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         },
         "step": {
           "oneOf": [
@@ -1760,7 +1802,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the request property for the page step."
         },
         "has-next-page": {
           "oneOf": [
@@ -1770,7 +1813,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the response property indicating next page presence."
         }
       },
       "required": [
@@ -1783,26 +1827,31 @@
       "type": "object",
       "properties": {
         "type": {
-          "const": "custom"
+          "const": "custom",
+          "description": "The type of pagination."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The response property is used to determine the results response type\ngenerated in the endpoint."
         }
       },
       "required": [
         "type",
         "results"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Pagination where the SDK author is responsible for implementing the pagination\nlogic in the SDK."
     },
     "pagination.UriPaginationSchema": {
       "type": "object",
       "properties": {
         "next_uri": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next URI."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -1815,10 +1864,12 @@
       "type": "object",
       "properties": {
         "next_path": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next path."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -1899,7 +1950,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The name of the parameter used to represent the header"
         },
         "env": {
           "oneOf": [
@@ -1909,10 +1961,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The environment variable to read the header value from (if any)"
         },
         "value": {
-          "type": "string"
+          "type": "string",
+          "description": "The wire representation of the header (e.g. X-API-Version)"
         }
       },
       "required": [
@@ -2022,7 +2076,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The name of the parameter used to represent the header"
         },
         "env": {
           "oneOf": [
@@ -2032,10 +2087,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The environment variable to read the header value from (if any)"
         },
         "value": {
-          "type": "string"
+          "type": "string",
+          "description": "The wire representation of the header (e.g. X-API-Product)"
         }
       },
       "required": [

--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -15,7 +15,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "A string that is used as the tab bar title."
     },
     "libraries": {
       "oneOf": [
@@ -28,7 +29,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Configuration for library documentation generation. Each library entry defines\na source repository and output location for generated MDX documentation.\n\nExample:\n```yaml\nlibraries:\n  my-sdk:\n    input:\n      git: https://github.com/acme/sdk-python\n      subpath: src/sdk\n    output:\n      path: ./static/sdk-docs\n    lang: python\n```"
     },
     "analytics": {
       "oneOf": [
@@ -38,7 +40,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The `analytics` object allows you to configure analytics for your docs site.\nCurrently, only Segment is supported."
     },
     "announcement": {
       "oneOf": [
@@ -61,7 +64,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Global list of roles that can be used to filter the navigation and content based on the user's session."
     },
     "tabs": {
       "oneOf": [
@@ -110,7 +114,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Creates a landing page for your documentation website."
     },
     "navigation": {
       "oneOf": [
@@ -120,7 +125,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The navigation config is skipped when multiple versions are present."
     },
     "navbar-links": {
       "oneOf": [
@@ -163,7 +169,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Name of a global theme stored in Fern's cloud to apply to this documentation site.\nTheme values override local branding configuration (colors, typography, logo, fonts, JS, CSS, etc.).\nUpload a theme first with: fern beta docs theme upload --name <theme-name>"
     },
     "experimental": {
       "oneOf": [
@@ -183,7 +190,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Sets the default language displayed by code snippets in the API Reference.\nOptions include: typescript, python, java, go, ruby, csharp, php, swift, curl"
     },
     "languages": {
       "oneOf": [
@@ -209,7 +217,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Configuration for multi-language documentation. Each entry defines a locale\nthat the documentation supports. Use the `translations/` directory alongside\n`docs.yml` to provide per-language content.\n\nExample (object syntax):\n```yaml\ntranslations:\n  - lang: en\n    default: true\n  - lang: ja\n  - lang: fr\n```\n\nExample (simplified syntax):\n```yaml\ntranslations:\n  - en\n  - ja\n  - fr\n```\n\nYou can mix both syntaxes:\n```yaml\ntranslations:\n  - lang: en\n    default: true\n  - ja\n  - fr\n```"
     },
     "ai-chat": {
       "oneOf": [
@@ -239,7 +248,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Configure AI-powered example enhancement for API documentation. When enabled, API examples will be enhanced with AI-generated content to provide more comprehensive and realistic examples."
     },
     "agents": {
       "oneOf": [
@@ -249,7 +259,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Configuration for agent-serving endpoints."
     },
     "metadata": {
       "oneOf": [
@@ -302,7 +313,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Relative filepath to the favicon."
     },
     "background-image": {
       "oneOf": [
@@ -402,7 +414,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Relative filepath to a custom React component (TSX/JSX) that replaces the default header.\nThe component must have a default export."
     },
     "footer": {
       "oneOf": [
@@ -412,7 +425,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Relative filepath to a custom React component (TSX/JSX) that replaces the default footer.\nThe component must have a default export."
     }
   },
   "required": [
@@ -444,13 +458,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "@default: `github.com`"
         },
         "owner": {
-          "type": "string"
+          "type": "string",
+          "description": "The GitHub organization that owns the documentation repository."
         },
         "repo": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the GitHub repository containing your fern folder."
         },
         "branch": {
           "oneOf": [
@@ -460,7 +477,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The branch of the repository you would like the GitHub editor to open a PR to. Default is `main`."
         }
       },
       "required": [
@@ -497,13 +515,15 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The launch method for \"Edit this page\" button. Defaults to github."
         }
       },
       "additionalProperties": false
     },
     "docs.AudienceId": {
-      "type": "string"
+      "type": "string",
+      "description": "ID of audience which is used to filter the API spec."
     },
     "docs.Audience": {
       "anyOf": [
@@ -516,13 +536,15 @@
             "$ref": "#/definitions/docs.AudienceId"
           }
         }
-      ]
+      ],
+      "description": "Audience can either be a string or list of strings\ni.e. `audiences: internal` or `audiences: [internal, beta]`"
     },
     "docs.DocsInstance": {
       "type": "object",
       "properties": {
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "The URL where your Fern documentation is deployed. Must contain the suffix `docs.buildwithfern.com`."
         },
         "custom-domain": {
           "oneOf": [
@@ -532,7 +554,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The custom domain where your documentation is hosted. Learn more about setting up a custom domain."
         },
         "edit-this-page": {
           "oneOf": [
@@ -542,7 +565,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If specified, adds an \"Edit this page\" link to the bottom of each page that links to the given public GitHub repository."
         },
         "audiences": {
           "oneOf": [
@@ -552,7 +576,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Specify which audiences this instance serves (e.g., internal developers, beta testers, public customers).\nYou can use audiences to control which versions and products appear in each documentation instance, enabling you to create separate sites for different user groups. Content is included when its audience tag matches the instance audience. Content without an audience tag is included by default."
         },
         "multi-source": {
           "oneOf": [
@@ -562,7 +587,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When enabled, docs registration uses a basepath-aware S3 key format, allowing multiple independent doc sites to be hosted under the same custom domain with different basepaths. If true, the url and custom-domain must share the same basepath."
         }
       },
       "required": [
@@ -574,7 +600,8 @@
       "type": "object",
       "properties": {
         "git": {
-          "type": "string"
+          "type": "string",
+          "description": "GitHub URL to the repository containing the library source code.\nExample: https://github.com/django/django"
         },
         "subpath": {
           "oneOf": [
@@ -584,25 +611,29 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Optional path within the repository to the library source.\nExample: django/core"
         }
       },
       "required": [
         "git"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Configuration for fetching library source from a Git repository."
     },
     "docs.PathLibraryInputSchema": {
       "type": "object",
       "properties": {
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Local filesystem path to the library source.\nExample: ./src/my-library"
         }
       },
       "required": [
         "path"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Configuration for using a local filesystem path as library source. (Not yet implemented)"
     },
     "docs.LibraryInputConfiguration": {
       "anyOf": [
@@ -612,26 +643,30 @@
         {
           "$ref": "#/definitions/docs.PathLibraryInputSchema"
         }
-      ]
+      ],
+      "description": "Configuration for the library source location."
     },
     "docs.LibraryOutputConfiguration": {
       "type": "object",
       "properties": {
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "The output directory where MDX files will be generated.\nExample: ./static/sdk-docs"
         }
       },
       "required": [
         "path"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Configuration for the library documentation output."
     },
     "docs.LibraryLanguage": {
       "type": "string",
       "enum": [
         "python",
         "cpp"
-      ]
+      ],
+      "description": "The programming language of the library source code."
     },
     "docs.LibraryConfig": {
       "type": "object",
@@ -644,22 +679,27 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Path to a Doxyfile for C++ library documentation, relative to the fern/ directory.\nWhen provided, the backend uses this Doxyfile instead of auto-generating one.\nOnly valid when lang is cpp."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Language-specific configuration for library documentation.\nValid fields depend on the `lang` value of the parent LibraryConfiguration."
     },
     "docs.LibraryConfiguration": {
       "type": "object",
       "properties": {
         "input": {
-          "$ref": "#/definitions/docs.LibraryInputConfiguration"
+          "$ref": "#/definitions/docs.LibraryInputConfiguration",
+          "description": "Configuration for the library source location."
         },
         "output": {
-          "$ref": "#/definitions/docs.LibraryOutputConfiguration"
+          "$ref": "#/definitions/docs.LibraryOutputConfiguration",
+          "description": "Configuration for the library documentation output."
         },
         "lang": {
-          "$ref": "#/definitions/docs.LibraryLanguage"
+          "$ref": "#/definitions/docs.LibraryLanguage",
+          "description": "The programming language of the library source code."
         },
         "config": {
           "oneOf": [
@@ -669,7 +709,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Language-specific configuration options. Valid fields depend on the lang value."
         }
       },
       "required": [
@@ -677,7 +718,8 @@
         "output",
         "lang"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Configuration for a library documentation source.\nUsed by `fern docs md generate` to generate MDX files from library source code."
     },
     "docs.SegmentConfig": {
       "type": "object",
@@ -729,7 +771,8 @@
       "type": "object",
       "properties": {
         "api-key": {
-          "type": "string"
+          "type": "string",
+          "description": "Your PostHog project API key. Defaults to the api-host of \"https://us.i.posthog.com\"."
         },
         "endpoint": {
           "oneOf": [
@@ -751,7 +794,8 @@
       "type": "object",
       "properties": {
         "container-id": {
-          "type": "string"
+          "type": "string",
+          "description": "Your Google Tag Manager container ID. Must start with \"GTM-\"."
         }
       },
       "required": [
@@ -763,7 +807,8 @@
       "type": "object",
       "properties": {
         "measurement-id": {
-          "type": "string"
+          "type": "string",
+          "description": "Your Google Analytics 4 measurement ID. Must start with \"G-\"."
         }
       },
       "required": [
@@ -841,7 +886,8 @@
       "type": "object",
       "properties": {
         "message": {
-          "type": "string"
+          "type": "string",
+          "description": "The message to display in the announcement bar. Markdown is supported."
         }
       },
       "required": [
@@ -850,7 +896,8 @@
       "additionalProperties": false
     },
     "docs.RoleId": {
-      "type": "string"
+      "type": "string",
+      "description": "ID of role which is used to filter the content shown in Fern Docs."
     },
     "docs.Role": {
       "anyOf": [
@@ -863,13 +910,15 @@
             "$ref": "#/definitions/docs.RoleId"
           }
         }
-      ]
+      ],
+      "description": "Audience can either be a string or list of strings\ni.e. `audience: internal` or `audience: [internal, beta]`"
     },
     "docs.FeatureFlag": {
       "type": "object",
       "properties": {
         "flag": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the feature flag to check."
         },
         "fallback-value": {
           "oneOf": [
@@ -886,7 +935,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default value to use if the feature flag is not set. If not specified, defaults to false."
         },
         "match": {
           "oneOf": [
@@ -903,7 +953,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The value that the feature flag should match for the content to be shown. If not specified, content is shown when the flag is true."
         }
       },
       "required": [
@@ -940,7 +991,8 @@
       ]
     },
     "docs.ChangelogFolderRelativePath": {
-      "type": "string"
+      "type": "string",
+      "description": "The relative path to a folder containing markdown files broken down by date.\n\nExample:\n```\nchangelog: \"changelog\"\n```\n\nThis will look for markdown files in the `/fern/changelog` directory, which should contain files named like\n- `/fern/changelog/2024-04-29.mdx`.\n- `/fern/changelog/2023-01-02.mdx`."
     },
     "docs.TabConfig": {
       "type": "object",
@@ -963,7 +1015,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1026,7 +1079,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `href` is set, clicking on the tab will redirect to the given URL.\n\nTabs with `href` must not have children in the navigation config."
         },
         "target": {
           "oneOf": [
@@ -1087,7 +1141,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1103,7 +1158,8 @@
           "type": "string"
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "The relative path to the version's docs.yml file."
         },
         "slug": {
           "oneOf": [
@@ -1113,7 +1169,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The \"slug\" is this version's basePath. If not set, the slug will be generated from the display-name."
         },
         "availability": {
           "oneOf": [
@@ -1123,7 +1180,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `availability` is set to `deprecated`, Fern will display a warning banner on the docs site."
         },
         "audiences": {
           "oneOf": [
@@ -1143,7 +1201,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, this version will be hidden from navigation, search, and indexing, but still accessible via direct URL."
         },
         "announcement": {
           "oneOf": [
@@ -1196,7 +1255,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The image to display in the product card. This will override the icon field if both are set."
         },
         "versions": {
           "oneOf": [
@@ -1239,7 +1299,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1252,7 +1313,8 @@
           ]
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "The relative path to the version's docs.yml file."
         },
         "slug": {
           "oneOf": [
@@ -1262,7 +1324,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The \"slug\" is this version's basePath. If not set, the slug will be generated from the display-name."
         },
         "announcement": {
           "oneOf": [
@@ -1315,7 +1378,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The image to display in the product card. This will override the icon field if both are set."
         },
         "versions": {
           "oneOf": [
@@ -1358,7 +1422,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1371,7 +1436,8 @@
           ]
         },
         "href": {
-          "type": "string"
+          "type": "string",
+          "description": "The absolute URL to the product."
         },
         "target": {
           "oneOf": [
@@ -1381,7 +1447,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The target of the URL"
         }
       },
       "required": [
@@ -1435,7 +1502,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1547,7 +1615,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1570,7 +1639,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The relative path to the markdown file that will be displayed when the section is clicked."
         },
         "contents": {
           "type": "array",
@@ -1586,7 +1656,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -1596,7 +1667,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -1606,7 +1678,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open)."
         },
         "slug": {
           "oneOf": [
@@ -1689,7 +1762,8 @@
         {
           "$ref": "#/definitions/docs.VersionedSnippetLanguageConfiguration"
         }
-      ]
+      ],
+      "description": "This snippets config object is meant to allow users to specify a specific package for the snippets,\nand optionally a version for that package. If you pass in a string, that should be the name of the package."
     },
     "docs.SnippetsConfiguration": {
       "type": "object",
@@ -1827,7 +1901,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A list of environment IDs that are allowed to be used in the playground. If not provided, all environments are allowed. And if the provided list is empty, the playground should be disabled."
         },
         "button": {
           "oneOf": [
@@ -1857,7 +1932,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The maximum number of websocket messages per connection in the playground."
         }
       },
       "additionalProperties": false
@@ -1883,7 +1959,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1913,7 +1990,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file. This summary is displayed at the top of the API section."
         },
         "contents": {
           "oneOf": [
@@ -1986,7 +2064,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that is applied only to descendants of this api package."
         }
       },
       "additionalProperties": false
@@ -2025,7 +2104,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2038,7 +2118,8 @@
           ]
         },
         "section": {
-          "type": "string"
+          "type": "string",
+          "description": "The title of the api package that will be displayed in the sidebar."
         },
         "referenced-packages": {
           "oneOf": [
@@ -2051,7 +2132,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "This section will inherit the endpoints from the specified subpackage(s). If multiple packages are specified, they will be merged."
         },
         "summary": {
           "oneOf": [
@@ -2061,7 +2143,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file."
         },
         "contents": {
           "oneOf": [
@@ -2124,7 +2207,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -2134,7 +2218,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user in the sidebar."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -2144,7 +2229,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when collapsible is true."
         },
         "availability": {
           "oneOf": [
@@ -2164,7 +2250,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affects all endpoints."
         }
       },
       "required": [
@@ -2193,7 +2280,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2266,7 +2354,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affect this endpoint specifically."
         }
       },
       "required": [
@@ -2295,7 +2384,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2354,7 +2444,8 @@
       "required": [
         "operation"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Defines a GraphQL-native schema for selecting operations (REST -> Endpoint === GraphQL -> Operation)"
     },
     "docs.LinkConfiguration": {
       "type": "object",
@@ -2420,7 +2511,8 @@
         {
           "$ref": "#/definitions/docs.LinkConfiguration"
         }
-      ]
+      ],
+      "description": "Use the `layout` object to customize the order that your API endpoints\nare displayed in the docs site."
     },
     "docs.ApiReferenceConfiguration": {
       "type": "object",
@@ -2443,7 +2535,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2466,7 +2559,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Name of API that we are referencing"
         },
         "openrpc": {
           "oneOf": [
@@ -2476,7 +2570,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Path to an openrpc spec."
         },
         "audiences": {
           "oneOf": [
@@ -2496,7 +2591,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to false"
         },
         "tag-description-pages": {
           "oneOf": [
@@ -2506,7 +2602,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, a page will be created for each tag in the OpenAPI spec that contains a description."
         },
         "snippets": {
           "oneOf": [
@@ -2526,7 +2623,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to a Postman collection for this API reference"
         },
         "summary": {
           "oneOf": [
@@ -2536,7 +2634,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file"
         },
         "layout": {
           "oneOf": [
@@ -2549,7 +2648,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Advanced usage: when specified, this object will be used to customize the order that your API endpoints are displayed in the docs site, including subpackages, and additional markdown pages (to be rendered in between API endpoints). If not specified, the order will be inferred from the OpenAPI Spec or Fern Definition."
         },
         "collapsed": {
           "oneOf": [
@@ -2619,7 +2719,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `alphabetized` is set to true, packages and endpoints will be sorted alphabetically, unless explicitly ordered in the `layout` object."
         },
         "flattened": {
           "oneOf": [
@@ -2629,7 +2730,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `flattened` is set to true, the title specified in `api` will be hidden, and its endpoints and subpackages won't be grouped under it.\n\nThis setting is useful if the API reference is short and you want to display all endpoints at the top level."
         },
         "paginated": {
           "oneOf": [
@@ -2639,7 +2741,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the API reference will be paginated rather than displayed in a single page (long-scrolling)."
         },
         "playground": {
           "oneOf": [
@@ -2649,7 +2752,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affects all endpoints."
         }
       },
       "required": [
@@ -2658,7 +2762,8 @@
       "additionalProperties": false
     },
     "docs.LibraryName": {
-      "type": "string"
+      "type": "string",
+      "description": "The name identifier for a library. Used to reference the library in navigation."
     },
     "docs.LibraryReferenceConfiguration": {
       "type": "object",
@@ -2681,7 +2786,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2694,7 +2800,8 @@
           ]
         },
         "library": {
-          "$ref": "#/definitions/docs.LibraryName"
+          "$ref": "#/definitions/docs.LibraryName",
+          "description": "The name of the library to reference (must match a key in the `libraries` section)."
         },
         "title": {
           "oneOf": [
@@ -2704,7 +2811,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the display title for this library reference."
         },
         "slug": {
           "oneOf": [
@@ -2714,13 +2822,15 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the URL slug for this library reference."
         }
       },
       "required": [
         "library"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "References a library defined in the `libraries` section.\nThe library's generated navigation will be injected at this point."
     },
     "docs.ChangelogConfiguration": {
       "type": "object",
@@ -2743,7 +2853,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2832,7 +2943,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2845,7 +2957,8 @@
           ]
         },
         "folder": {
-          "type": "string"
+          "type": "string",
+          "description": "The relative path to a folder containing markdown files. Fern will automatically discover and add all markdown files from this folder to the navigation."
         },
         "title": {
           "oneOf": [
@@ -2855,7 +2968,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The title to display for this folder section. If not provided, the folder name will be used."
         },
         "title-source": {
           "oneOf": [
@@ -2865,7 +2979,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Determines how page titles are derived for files in this folder. Options are `frontmatter` (use the `title` field from the file's frontmatter) or `filename` (derive title from the file name). Defaults to `filename`."
         },
         "slug": {
           "oneOf": [
@@ -2915,7 +3030,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -2925,7 +3041,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -2935,7 +3052,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open)."
         },
         "availability": {
           "oneOf": [
@@ -3004,7 +3122,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `href` is set, `layout` must be null."
         }
       },
       "required": [
@@ -3033,7 +3152,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -3229,7 +3349,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The URL once you click on the button.\nExample: https://buildwithfern.com/contact"
         },
         "target": {
           "oneOf": [
@@ -3249,7 +3370,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Use `href` instead."
         },
         "text": {
           "oneOf": [
@@ -3259,7 +3381,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Text inside the button."
         },
         "icon": {
           "oneOf": [
@@ -3269,7 +3392,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The icon to be used in the button. This icon will appear to the **left** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`)."
         },
         "rightIcon": {
           "oneOf": [
@@ -3279,7 +3403,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The icon to be used in the button. This icon will appear to the **right** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`).\n\nBy default, the `rightIcon` for a `filled` button is set to `arrow-right`."
         },
         "rounded": {
           "oneOf": [
@@ -3289,7 +3414,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `true`, the border radius of the button will be fully rounded."
         }
       },
       "additionalProperties": false
@@ -3334,7 +3460,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The URL once you click on the button.\nExample: https://buildwithfern.com/contact"
             },
             "target": {
               "oneOf": [
@@ -3354,7 +3481,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Use `href` instead."
             },
             "text": {
               "oneOf": [
@@ -3364,7 +3492,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Text inside the button."
             },
             "icon": {
               "oneOf": [
@@ -3374,7 +3503,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **left** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`)."
             },
             "rightIcon": {
               "oneOf": [
@@ -3384,7 +3514,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **right** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`).\n\nBy default, the `rightIcon` for a `filled` button is set to `arrow-right`."
             },
             "rounded": {
               "oneOf": [
@@ -3394,7 +3525,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "When `true`, the border radius of the button will be fully rounded."
             }
           },
           "required": [
@@ -3424,7 +3556,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The URL once you click on the button.\nExample: https://buildwithfern.com/contact"
             },
             "target": {
               "oneOf": [
@@ -3444,7 +3577,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Use `href` instead."
             },
             "text": {
               "oneOf": [
@@ -3454,7 +3588,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Text inside the button."
             },
             "icon": {
               "oneOf": [
@@ -3464,7 +3599,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **left** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`)."
             },
             "rightIcon": {
               "oneOf": [
@@ -3474,7 +3610,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **right** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`).\n\nBy default, the `rightIcon` for a `filled` button is set to `arrow-right`."
             },
             "rounded": {
               "oneOf": [
@@ -3484,7 +3621,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "When `true`, the border radius of the button will be fully rounded."
             }
           },
           "required": [
@@ -3514,7 +3652,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The URL once you click on the button.\nExample: https://buildwithfern.com/contact"
             },
             "target": {
               "oneOf": [
@@ -3534,7 +3673,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Use `href` instead."
             },
             "text": {
               "oneOf": [
@@ -3544,7 +3684,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Text inside the button."
             },
             "icon": {
               "oneOf": [
@@ -3554,7 +3695,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **left** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`)."
             },
             "rightIcon": {
               "oneOf": [
@@ -3564,7 +3706,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **right** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`).\n\nBy default, the `rightIcon` for a `filled` button is set to `arrow-right`."
             },
             "rounded": {
               "oneOf": [
@@ -3574,7 +3717,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "When `true`, the border radius of the button will be fully rounded."
             }
           },
           "required": [
@@ -3684,7 +3828,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The URL once you click on the button.\nExample: https://buildwithfern.com/contact"
             },
             "target": {
               "oneOf": [
@@ -3704,7 +3849,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Use `href` instead."
             },
             "text": {
               "oneOf": [
@@ -3714,7 +3860,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Text inside the button."
             },
             "icon": {
               "oneOf": [
@@ -3724,7 +3871,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **left** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`)."
             },
             "rightIcon": {
               "oneOf": [
@@ -3734,7 +3882,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **right** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`).\n\nBy default, the `rightIcon` for a `filled` button is set to `arrow-right`."
             },
             "rounded": {
               "oneOf": [
@@ -3744,7 +3893,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "When `true`, the border radius of the button will be fully rounded."
             }
           },
           "required": [
@@ -3774,7 +3924,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The URL once you click on the button.\nExample: https://buildwithfern.com/contact"
             },
             "target": {
               "oneOf": [
@@ -3794,7 +3945,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Use `href` instead."
             },
             "text": {
               "oneOf": [
@@ -3804,7 +3956,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Text inside the button."
             },
             "icon": {
               "oneOf": [
@@ -3814,7 +3967,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **left** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`)."
             },
             "rightIcon": {
               "oneOf": [
@@ -3824,7 +3978,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **right** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`).\n\nBy default, the `rightIcon` for a `filled` button is set to `arrow-right`."
             },
             "rounded": {
               "oneOf": [
@@ -3834,7 +3989,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "When `true`, the border radius of the button will be fully rounded."
             }
           },
           "required": [
@@ -3854,7 +4010,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your GitHub repository or organization."
         },
         "twitter": {
           "oneOf": [
@@ -3864,7 +4021,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Twitter profile. Use `footer-links.x` for the new X branding."
         },
         "x": {
           "oneOf": [
@@ -3874,7 +4032,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your X (formerly Twitter) profile."
         },
         "linkedin": {
           "oneOf": [
@@ -3884,7 +4043,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your LinkedIn company page or profile."
         },
         "youtube": {
           "oneOf": [
@@ -3894,7 +4054,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your YouTube channel."
         },
         "instagram": {
           "oneOf": [
@@ -3904,7 +4065,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Instagram profile."
         },
         "facebook": {
           "oneOf": [
@@ -3914,7 +4076,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Facebook page."
         },
         "discord": {
           "oneOf": [
@@ -3924,7 +4087,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Discord server invite."
         },
         "slack": {
           "oneOf": [
@@ -3934,7 +4098,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Slack community or workspace."
         },
         "hackernews": {
           "oneOf": [
@@ -3944,7 +4109,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Hacker News profile."
         },
         "medium": {
           "oneOf": [
@@ -3954,7 +4120,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Medium publication or profile."
         },
         "website": {
           "oneOf": [
@@ -3964,7 +4131,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your main website or homepage."
         }
       },
       "additionalProperties": false
@@ -3986,7 +4154,8 @@
       "type": "object",
       "properties": {
         "title": {
-          "type": "string"
+          "type": "string",
+          "description": "The title of the custom action."
         },
         "subtitle": {
           "oneOf": [
@@ -3996,10 +4165,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The subtitle/helper text of the custom action."
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "The URL to navigate to. Use {slug} as a placeholder for the current page slug, {domain} as a placeholder for the current domain, and {url} as a placeholder for the current full URL."
         },
         "icon": {
           "oneOf": [
@@ -4009,7 +4180,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Icon to display for the custom action. Can be a relative filepath, an image URL (starting with http://, https://, or /), or a Font Awesome icon name (e.g., \"fa-solid fa-star\" or \"star\")."
         },
         "default": {
           "oneOf": [
@@ -4019,14 +4191,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether this custom action should be the default action."
         }
       },
       "required": [
         "title",
         "url"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "A custom page action that can be configured by the user."
     },
     "docs.PageActionOptions": {
       "type": "object",
@@ -4039,7 +4213,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When enabled, displays a button that allows users to copy the entire page content to their clipboard for easy sharing or reference.\n\n@default: true"
         },
         "view-as-markdown": {
           "oneOf": [
@@ -4049,7 +4224,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When enabled, displays a button that allows users to view the raw Markdown source of the current page.\n\n@default: true"
         },
         "ask-ai": {
           "oneOf": [
@@ -4059,7 +4235,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When enabled, displays an \"Ask AI\" button that allows users to ask questions about the page content using AI-powered assistance.\n\n@default: true"
         },
         "chatgpt": {
           "oneOf": [
@@ -4069,7 +4246,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the \"Open in ChatGPT\" button, which sends the page content to ChatGPT for further\nexploration and Q&A. Set to `false` to hide it.\n\n@default: true"
         },
         "claude": {
           "oneOf": [
@@ -4079,7 +4257,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the \"Open in Claude\" button, which sends the page content to Claude for further\nexploration and Q&A. Set to `false` to hide it.\n\n@default: true"
         },
         "claude-code": {
           "oneOf": [
@@ -4089,7 +4268,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the \"Connect to Claude Code\" button, which copies a `claude mcp add` command to the\nclipboard so users can register this docs site's MCP server with Claude Code. The button only\nrenders on docs sites that have Ask AI enabled; set to `false` to hide it on those sites.\n\n@default: true"
         },
         "cursor": {
           "oneOf": [
@@ -4099,7 +4279,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the \"Connect to Cursor\" button, which installs this docs site's MCP server in\nCursor via a deeplink. The button only renders on docs sites that have Ask AI enabled; set\nto `false` to hide it on those sites.\n\n@default: true"
         },
         "vscode": {
           "oneOf": [
@@ -4109,7 +4290,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When enabled, displays an \"Open in VS Code\" button that allows users to open the page content in Visual Studio Code for editing and development.\n\n@default: false"
         },
         "custom": {
           "oneOf": [
@@ -4122,7 +4304,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When enabled, displays a custom button that allows users to open the page content in a custom IDE for editing and development.\nThe value of this property should be the name of the custom IDE.\nExample: `cursor`"
         }
       },
       "additionalProperties": false
@@ -4138,7 +4321,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default page action to display. Options: copy-page, view-as-markdown, ask-ai, chatgpt, claude, cursor, vscode."
         },
         "options": {
           "oneOf": [
@@ -4167,7 +4351,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "List of relative paths to folders or files that end in .{ts,tsx,js,jsx},\nand makes them available for use in MDX files."
         },
         "disable-stream-toggle": {
           "oneOf": [
@@ -4177,7 +4362,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `disable-stream-toggle` is set to true, the stream toggle will be disabled.\n\nThis behavior is unstable and may change in the future."
         },
         "openapi-parser-v2": {
           "oneOf": [
@@ -4187,7 +4373,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "OpenAPI parser rewrite, now deprecated."
         },
         "openapi-parser-v3": {
           "oneOf": [
@@ -4197,7 +4384,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "OpenAPI parser in alpha."
         },
         "dynamic-snippets": {
           "oneOf": [
@@ -4207,7 +4395,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "By default, SDK snippets are static code examples that are displayed in your API Reference. Alternatively, you can use dynamic SDK snippets that allow users to modify parameters and see code examples update in real time.\n\nEnable dynamic snippets in `docs.yml`, then configure them by following the SDK snippets setup instructions."
         },
         "ai-examples": {
           "oneOf": [
@@ -4217,7 +4406,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enable AI-powered example enhancement for API documentation. When enabled, API examples will be enhanced with AI-generated content to provide more comprehensive and realistic examples.\n\nDEPRECATED: Use the top-level `ai-examples` property instead."
         },
         "ai-example-style-instructions": {
           "oneOf": [
@@ -4227,7 +4417,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Custom styling instructions for AI-generated examples. When provided, these instructions will guide the AI in generating examples that match your preferred style, naming conventions, or domain-specific terminology. Limited to 500 characters.\n\nDEPRECATED: Use the top-level `ai-example-style-instructions` property instead."
         },
         "exclude-apis": {
           "oneOf": [
@@ -4237,7 +4428,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Experimental flag to exclude API reference sections from documentation generation. When enabled, API reference content will be omitted from the generated documentation."
         },
         "basepath-aware": {
           "oneOf": [
@@ -4247,7 +4439,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated: Use `multi-source: true` on the instance instead. When enabled, docs registration uses a basepath-aware S3 key format, allowing multiple independent doc sites to be hosted under the same custom domain with different basepaths."
         }
       },
       "additionalProperties": false
@@ -4275,7 +4468,8 @@
       ]
     },
     "docs.Language": {
-      "type": "string"
+      "type": "string",
+      "description": "A BCP 47 language tag identifying a docs locale. Common shorthand codes\nlike \"en\", \"es\", \"ja\" are accepted, as well as regional variants such as\n\"ja-JP\", \"pt-BR\", \"zh-Hans\", and \"zh-Hans-CN\". See RFC 5646 for the full\ngrammar."
     },
     "docs.TranslationConfigObject": {
       "type": "object",
@@ -4291,7 +4485,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether this language is the default. At most one entry should be marked as default."
         }
       },
       "required": [
@@ -4307,7 +4502,8 @@
         {
           "$ref": "#/definitions/docs.TranslationConfigObject"
         }
-      ]
+      ],
+      "description": "Translation configuration can be either a language code string or an object with additional options.\nWhen using a string, it's equivalent to `{ lang: <string> }`."
     },
     "docs.AIChatModel": {
       "type": "string",
@@ -4329,7 +4525,8 @@
       "type": "object",
       "properties": {
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "The URL of the website to index. Ask Fern will crawl and index the content from this URL."
         },
         "title": {
           "oneOf": [
@@ -4339,7 +4536,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "An optional display name for this datasource. This helps users understand where the information is coming from when Ask Fern cites content from this source."
         }
       },
       "required": [
@@ -4375,7 +4573,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "By default, Ask Fern uses system prompts to finetune AI search results. Add a custom prompt here to override it.\nSee Anthropic's prompting guide for ideas and examples."
         },
         "location": {
           "oneOf": [
@@ -4388,7 +4587,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Specifies where Ask Fern will be available. Options:\n- `docs` enables Ask Fern on your documentation site\n- `slack` enables Ask Fern in Slack\n- `discord` enables Ask Fern in Discord\n\nMost users should enable Ask Fern for both `docs` and either `slack` or `discord`."
         },
         "datasources": {
           "oneOf": [
@@ -4401,7 +4601,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Additional content sources that Ask Fern should index and search."
         }
       },
       "additionalProperties": false
@@ -4417,7 +4618,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enable AI-powered example enhancement for API documentation. When enabled, API examples will be enhanced with AI-generated content to provide more comprehensive and realistic examples."
         },
         "style": {
           "oneOf": [
@@ -4427,7 +4629,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Custom styling instructions for AI-generated examples. When provided, these instructions will guide the AI in generating examples that match your preferred style, naming conventions, or domain-specific terminology. Limited to 500 characters."
         }
       },
       "additionalProperties": false
@@ -4450,7 +4653,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Text to prepend to each page when it is served through agent endpoints."
         },
         "page-description-source": {
           "oneOf": [
@@ -4460,7 +4664,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls which frontmatter field is preferred for one-line page descriptions\nin llms.txt. Defaults to \"description\". If the preferred field is not present\nin a page's frontmatter, falls back to other fields (description, subtitle,\nog:description, headline, excerpt)."
         },
         "llms-txt": {
           "oneOf": [
@@ -4470,7 +4675,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative filepath to a custom `llms.txt` file that Fern should host at `/llms.txt`,\noverriding the auto-generated version. The file should follow the llmstxt.org specification."
         },
         "llms-full-txt": {
           "oneOf": [
@@ -4480,7 +4686,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative filepath to a custom `llms-full.txt` file that Fern should host at `/llms-full.txt`,\noverriding the auto-generated version. The file should contain the full concatenated documentation content."
         },
         "robots-txt": {
           "oneOf": [
@@ -4490,7 +4697,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative filepath to a custom `robots.txt` file that Fern should host at `/robots.txt`,\noverriding the auto-generated version. Fern automatically appends a rule to disallow\nits internal `/api/fern-docs/` routes so they are excluded from crawler indexing."
         }
       },
       "additionalProperties": false
@@ -4522,7 +4730,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The name of your website for Open Graph tags."
         },
         "og:title": {
           "oneOf": [
@@ -4532,7 +4741,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The title shown in social media previews."
         },
         "og:description": {
           "oneOf": [
@@ -4542,7 +4752,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The description shown in social media previews."
         },
         "og:url": {
           "oneOf": [
@@ -4552,7 +4763,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The canonical URL of your documentation."
         },
         "og:image": {
           "oneOf": [
@@ -4562,7 +4774,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The image shown in social media previews. Recommended size is 1200x630 pixels."
         },
         "og:image:width": {
           "oneOf": [
@@ -4572,7 +4785,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The width of your Open Graph image in pixels."
         },
         "og:image:height": {
           "oneOf": [
@@ -4582,7 +4796,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The height of your Open Graph image in pixels."
         },
         "og:locale": {
           "oneOf": [
@@ -4592,7 +4807,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The locale of your content (e.g., \"en_US\")."
         },
         "og:logo": {
           "oneOf": [
@@ -4602,7 +4818,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your company logo."
         },
         "twitter:title": {
           "oneOf": [
@@ -4612,7 +4829,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The title shown in Twitter Card previews."
         },
         "twitter:description": {
           "oneOf": [
@@ -4622,7 +4840,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The description shown in Twitter Card previews."
         },
         "twitter:handle": {
           "oneOf": [
@@ -4632,7 +4851,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Your company's Twitter handle."
         },
         "twitter:image": {
           "oneOf": [
@@ -4642,7 +4862,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The image shown in Twitter Card previews."
         },
         "twitter:site": {
           "oneOf": [
@@ -4652,7 +4873,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The Twitter handle for your website."
         },
         "twitter:url": {
           "oneOf": [
@@ -4672,7 +4894,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The Twitter Card type. Options are `summary`, `summary_large_image`, `app`, or `player`."
         },
         "og:dynamic": {
           "oneOf": [
@@ -4682,7 +4905,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When true, enables dynamic OG image generation for pages that don't have a custom og:image set."
         },
         "og:dynamic:background-image": {
           "oneOf": [
@@ -4692,7 +4916,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A custom background image for dynamically generated OG images. Can be a URL or a file path."
         },
         "og:dynamic:text-color": {
           "oneOf": [
@@ -4702,7 +4927,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the text color for dynamically generated OG images. Accepts any valid CSS color value (e.g., \"#1a1a1a\")."
         },
         "og:dynamic:background-color": {
           "oneOf": [
@@ -4712,7 +4938,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the background color for dynamically generated OG images. Accepts any valid CSS color value (e.g., \"#ffffff\")."
         },
         "og:dynamic:logo-color": {
           "oneOf": [
@@ -4722,7 +4949,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Choose which logo variant from docs.yml to render in dynamically generated OG images. Defaults to `dark`."
         },
         "og:dynamic:show-logo": {
           "oneOf": [
@@ -4732,7 +4960,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Toggle visibility of the logo in dynamically generated OG images. Defaults to true when og:dynamic is enabled."
         },
         "og:dynamic:show-section": {
           "oneOf": [
@@ -4742,7 +4971,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Toggle visibility of the section title in dynamically generated OG images. Defaults to true when og:dynamic is enabled."
         },
         "og:dynamic:show-description": {
           "oneOf": [
@@ -4752,7 +4982,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Toggle visibility of the page description in dynamically generated OG images. Defaults to true when og:dynamic is enabled."
         },
         "og:dynamic:show-url": {
           "oneOf": [
@@ -4762,7 +4993,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Toggle visibility of the page URL in dynamically generated OG images. Defaults to true when og:dynamic is enabled."
         },
         "og:dynamic:show-gradient": {
           "oneOf": [
@@ -4772,7 +5004,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Toggle visibility of the accent gradient overlay in dynamically generated OG images. Defaults to true when og:dynamic is enabled."
         },
         "canonical-host": {
           "oneOf": [
@@ -4782,19 +5015,23 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The host of your documentation website. This will be used to set the canonical URL for metadata tags and documents like the sitemap.\nDefaults to the URL defined in the `instances` configuration."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "The `metadata` object allows you to customize the appearance of your docs site in search engines and social media.\nThese settings are applied globally, but can be overridden on a per-page basis using frontmatter."
     },
     "docs.RedirectConfig": {
       "type": "object",
       "properties": {
         "source": {
-          "type": "string"
+          "type": "string",
+          "description": "The path you want to redirect from."
         },
         "destination": {
-          "type": "string"
+          "type": "string",
+          "description": "The path you want to route to. Can be an internal path (`/new-path`) or an external URL (`https://example.com`).\nExternal URLs must include the full address, including `https`."
         },
         "permanent": {
           "oneOf": [
@@ -4804,14 +5041,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "By default, uses the 308 status code to instructs clients and search engines to cache the redirect forever. Set to `false` only if you need a temporary redirect using the 307 status code, which won't be cached.\n\n@default: true"
         }
       },
       "required": [
         "source",
         "destination"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "The `redirects` object allows you to redirect traffic from one path to another. You can redirect exact paths or use dynamic patterns with regex parameters like `:slug` to handle bulk redirects. You can redirect to internal paths within your site or external URLs.\n\n```yaml\nredirects:\n  - source: \"/old-path\"\n    destination: \"/new-path\"\n```\n\nBoth source and destination paths support regex. See https://github.com/pillarjs/path-to-regexp"
     },
     "docs.CheckRuleSeverity": {
       "type": "string",
@@ -4831,7 +5070,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for OpenAPI example validation. Default is warn."
         },
         "broken-links": {
           "oneOf": [
@@ -4841,7 +5081,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for broken link detection. Defaults to error for broken internal links and warn for malformed URLs."
         },
         "no-non-component-refs": {
           "oneOf": [
@@ -4851,7 +5092,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for non-component OpenAPI reference validation. Default is error."
         },
         "valid-local-references": {
           "oneOf": [
@@ -4861,7 +5103,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for local OpenAPI reference validation. Default is warn."
         },
         "no-circular-redirects": {
           "oneOf": [
@@ -4871,7 +5114,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for circular redirect validation. Default is error."
         },
         "valid-docs-endpoints": {
           "oneOf": [
@@ -4881,7 +5125,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for docs endpoint URL validation. Default is warn."
         },
         "missing-redirects": {
           "oneOf": [
@@ -4891,7 +5136,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for detecting previously published URLs that disappeared without an explicit redirect. Default is warn."
         },
         "valid-changelog-slug": {
           "oneOf": [
@@ -4901,7 +5147,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for validating that each changelog's effective URL slug is one of the allowlisted values served as an RSS/Atom/JSON feed. Default is error."
         }
       },
       "additionalProperties": false
@@ -4920,7 +5167,8 @@
           ]
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Configure the severity of validation rules run by `fern check`.\nEach rule can be set to `warn` (non-blocking) or `error` (blocking)."
     },
     "docs.LogoConfiguration": {
       "type": "object",
@@ -4933,7 +5181,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Path to your dark mode logo file, relative to the docs root. SVG format is recommended for optimal quality.\nExample: `assets/images/logo-dark.svg`"
         },
         "light": {
           "oneOf": [
@@ -4943,7 +5192,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Path to your light mode logo file, relative to the docs root. SVG format is recommended for optimal quality.\nExample: `assets/images/logo-light.svg`"
         },
         "height": {
           "oneOf": [
@@ -4963,7 +5213,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The URL that users will be directed to when clicking the logo. Typically your company's homepage or app."
         },
         "right-text": {
           "oneOf": [
@@ -4973,7 +5224,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Text to display to the right of the logo image. This is useful for adding a tagline or product name next to your logo.\nExample: `Docs`"
         }
       },
       "additionalProperties": false
@@ -4989,7 +5241,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative filepath to the dark-mode background image."
         },
         "light": {
           "oneOf": [
@@ -4999,7 +5252,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative filepath to the light-mode background image."
         }
       },
       "additionalProperties": false
@@ -5012,7 +5266,8 @@
         {
           "$ref": "#/definitions/docs.BackgroundImageThemedConfig"
         }
-      ]
+      ],
+      "description": "This background image is used to customize the appearance of your docs site."
     },
     "docs.ColorThemedConfig": {
       "type": "object",
@@ -5061,7 +5316,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The primary brand color used for interactive elements like links, buttons, and highlighted text.\nConfigure separate colors for light and dark modes to ensure proper contrast and visibility.\n\n@default: #818CF8"
         },
         "accentPrimary": {
           "oneOf": [
@@ -5071,7 +5327,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Use `accent-primary` instead."
         },
         "background": {
           "oneOf": [
@@ -5081,7 +5338,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The main background color for all documentation pages. Choose colors that provide good contrast with text\nand complement your brand colors. Dark mode colors should reduce eye strain.\n\n@default:\n  dark: #111111\n  light: #F9F9F9\n\nIf not set, there will be also be a vertical gradient from the top using the accent primary color with 5% opacity."
         },
         "border": {
           "oneOf": [
@@ -5091,7 +5349,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Used for dividing lines, borders around elements, and visual separators. Choose subtle colors that create\nclear boundaries without being too prominent.\n\n@default:\n  dark: black/12%\n  white: white/13%"
         },
         "sidebar-background": {
           "oneOf": [
@@ -5101,7 +5360,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Background color for the navigation sidebar. When specified, includes a 1px border on the right side.\nIf omitted, the sidebar uses a transparent background without a border."
         },
         "header-background": {
           "oneOf": [
@@ -5111,7 +5371,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Background color for the top navigation header. When specified, includes a 1px solid border on the bottom.\nIf omitted, the header uses a transparent background with a subtle gradient border."
         },
         "card-background": {
           "oneOf": [
@@ -5121,7 +5382,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Background color for cards, code blocks, and other contained elements. Should be slightly different from the\nmain background to create visual hierarchy while maintaining readability.\n\n@default:\n  dark: white/3.5%\n  light: white/70%"
         },
         "accent-1": {
           "oneOf": [
@@ -5131,7 +5393,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 1. This is the lightest accent color, typically used for subtle backgrounds.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-2": {
           "oneOf": [
@@ -5141,7 +5404,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 2. A very light accent color for backgrounds.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-3": {
           "oneOf": [
@@ -5151,7 +5415,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 3. A light accent color for UI element backgrounds.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-4": {
           "oneOf": [
@@ -5161,7 +5426,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 4. Used for hovered UI element backgrounds.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-5": {
           "oneOf": [
@@ -5171,7 +5437,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 5. Used for active/selected UI element backgrounds.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-6": {
           "oneOf": [
@@ -5181,7 +5448,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 6. Used for subtle borders and separators.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-7": {
           "oneOf": [
@@ -5191,7 +5459,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 7. Used for UI element borders and focus rings.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-8": {
           "oneOf": [
@@ -5201,7 +5470,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 8. Used for hovered UI element borders.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-9": {
           "oneOf": [
@@ -5211,7 +5481,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 9. The solid accent color, used for solid backgrounds like buttons.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-10": {
           "oneOf": [
@@ -5221,7 +5492,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 10. Used for hovered solid backgrounds.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-11": {
           "oneOf": [
@@ -5231,7 +5503,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 11. Used for low-contrast text.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-12": {
           "oneOf": [
@@ -5241,7 +5514,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 12. The darkest accent color, used for high-contrast text.\nBy default, this is automatically calculated from the accent-primary color."
         }
       },
       "additionalProperties": false
@@ -5277,7 +5551,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "@default: `100 900`."
         },
         "style": {
           "oneOf": [
@@ -5287,7 +5562,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "@default: `normal`."
         }
       },
       "required": [
@@ -5326,7 +5602,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The name of the font. Defaults to a generated name that will be used to reference your custom font in the eventually injected CSS."
         },
         "path": {
           "oneOf": [
@@ -5336,7 +5613,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to your font file, relative to your docs folder. Use this when you have a single font file.\nFor multiple font files (like separate files for bold, italic etc), use `paths` instead."
         },
         "weight": {
           "oneOf": [
@@ -5346,7 +5624,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The weight of the font. Can be a number (400, 700) or a range for variable fonts (400 700).\nCommon values: 400 (normal), 700 (bold).\n\n@default: `100 900`."
         },
         "style": {
           "oneOf": [
@@ -5356,7 +5635,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The font style, either \"normal\" or \"italic\". Defaults to \"normal\" if not specified.\n\n@default: `normal`."
         },
         "paths": {
           "oneOf": [
@@ -5369,7 +5649,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A list of font files for particular weights. Each element in the list includes a `path`, `weight`, and `style` property."
         },
         "display": {
           "oneOf": [
@@ -5379,7 +5660,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "@default: `swap`."
         },
         "fallback": {
           "oneOf": [
@@ -5392,7 +5674,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Define fallback fonts in case the custom font fails to load."
         },
         "font-variation-settings": {
           "oneOf": [
@@ -5418,7 +5701,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The font used for headings, titles, and other prominent text elements. Can be the same as your body font\nif you prefer a unified look. Supports multiple weights for different heading levels."
         },
         "bodyFont": {
           "oneOf": [
@@ -5428,7 +5712,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The font used for all body text including paragraphs, lists, and general content.\nFor optimal performance, use WOFF2 format."
         },
         "codeFont": {
           "oneOf": [
@@ -5438,17 +5723,25 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The font used for code blocks and inline code. Monospace fonts are recommended for better code readability.\nPopular choices include JetBrains Mono, Fira Code, and Source Code Pro."
         }
       },
       "additionalProperties": false
     },
     "docs.SearchbarPlacement": {
       "type": "string",
-      "enum": [
-        "header",
-        "header-tabs",
-        "sidebar"
+      "oneOf": [
+        {
+          "const": "header"
+        },
+        {
+          "const": "header-tabs",
+          "description": "The searchbar will be placed in the header, but on the tabs row. If the tabs row is hidden, the searchbar will be placed in the header instead.\nThis is a good option if you want to keep the searchbar visible, but save space in the header for more navbar links."
+        },
+        {
+          "const": "sidebar"
+        }
       ]
     },
     "docs.TabsPlacement": {
@@ -5490,7 +5783,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the maximum width of the docs layout, including the sidebar and content.\n\n@default: 88rem (1408px)\n\nValid options are:\n- `{number}rem`\n- `{number}px`\n- `full` (100% of the viewport width)"
         },
         "content-width": {
           "oneOf": [
@@ -5500,7 +5794,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the maximum width of the markdown article content.\n\n@default: 44rem (704px)\n\nValid options are:\n- `{number}rem`\n- `{number}px`"
         },
         "sidebar-width": {
           "oneOf": [
@@ -5510,7 +5805,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the width of the sidebar in desktop mode\n\n@default: 18rem (288px)\n\nValid options are:\n- `{number}rem`\n- `{number}px`"
         },
         "header-height": {
           "oneOf": [
@@ -5520,7 +5816,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the height of the header\n\n@default: 4rem (64px)\n\nValid options are:\n- `{number}rem`\n- `{number}px`"
         },
         "searchbar-placement": {
           "oneOf": [
@@ -5530,7 +5827,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the placement of the searchbar\n\n@default: `sidebar`\n\nNote: this setting is ignored when `disable-header` is set to true."
         },
         "tabs-placement": {
           "oneOf": [
@@ -5540,7 +5838,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Set the placement of the tabs\n\n@default: `sidebar`\n\nNote: this setting is ignored when `disable-header` is set to true."
         },
         "switcher-placement": {
           "oneOf": [
@@ -5550,7 +5849,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Set the placement of the version and language switcher\n\n@default: `header`\n\nNote: this setting is ignored when `disable-header` is set to true."
         },
         "content-alignment": {
           "oneOf": [
@@ -5560,7 +5860,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Set the alignment of the mardown content.\n\n@default: `center`\n\nSide effects:\n- When the alignment is set to `center`, the \"On this page\" (ToC) will be aligned to the right of the page.\n- When the alignment is set to `left`, the content will be aligned next to the right of the markdown content."
         },
         "header-position": {
           "oneOf": [
@@ -5570,7 +5871,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `header-position` is set to `fixed`, the header will be fixed to the top of the viewport.\nIf `header-position` is set to `absolute`, the header will be absolute and will scroll with the content.\n\n@default: `fixed`"
         },
         "disable-header": {
           "oneOf": [
@@ -5580,7 +5882,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `disable-header` is set to true, the header will not be rendered. Instead, the logo will be rendered as part of the sidebar,\nand a 1px border will separate the sidebar from the content."
         },
         "hide-nav-links": {
           "oneOf": [
@@ -5590,7 +5893,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `hide-nav-links` is set to true, the navbar links will not be rendered. This can be overridden for a specific page using the frontmatter."
         },
         "hide-feedback": {
           "oneOf": [
@@ -5600,7 +5904,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `hide-feedback` is set to true, the feedback button will not be rendered. This can be overridden for a specific page using the frontmatter."
         },
         "mobile-toc": {
           "oneOf": [
@@ -5610,7 +5915,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `mobile-toc` is set to true, a sticky collapsible table of contents bar will be shown on mobile viewports for guide and overview layout pages."
         }
       },
       "additionalProperties": false
@@ -5661,7 +5967,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The text to display in the searchbar.\n\n@default: Search"
         },
         "disable-search": {
           "oneOf": [
@@ -5671,7 +5978,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set to true, the searchbar will be disabled. Use this if you want to use a custom search solution.\n\n@default: false"
         },
         "dark-mode-code": {
           "oneOf": [
@@ -5681,7 +5989,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set to true, the code blocks will be displayed in dark mode, regardless of the selected theme.\n\n@default: false"
         },
         "default-search-filters": {
           "oneOf": [
@@ -5691,7 +6000,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "By default (`false`), search will display results for pages across all products and versions.\nIf set to true, search will display results for pages within the current product and version.\n\n@default: false"
         },
         "http-snippets": {
           "oneOf": [
@@ -5701,7 +6011,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the display of HTTP snippets in the API Reference. HTTP snippets are enabled by default for all languages.\n- Set to `false` to disable HTTP snippets completely\n- Provide a list of languages to enable snippets for specific languages only\n\n@default: true"
         },
         "hide-404-page": {
           "oneOf": [
@@ -5711,7 +6022,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set to true, when a user navigates to a page that does not exist, they will be redirected to the home page.\nBy default, a 404 page will be displayed.\n\n@default: false"
         },
         "use-javascript-as-typescript": {
           "oneOf": [
@@ -5721,7 +6033,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set to true, the TypeScript snippets will be displayed as JavaScript snippets in the API Reference.\n\n@default: false"
         },
         "disable-explorer-proxy": {
           "oneOf": [
@@ -5731,7 +6044,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set to true, the API Explorer will bypass the proxy when sending requests directly to your API.\n\nWhen this feature is enabled, your API must have Cross-Origin Resource Sharing (CORS) enabled to allow requests from the documentation domain.\n\n@default: false"
         },
         "disable-environment-editing": {
           "oneOf": [
@@ -5741,7 +6055,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set to true, the base URL (environment) shown in the endpoint header on API reference\ndocs pages will no longer be editable. Users will still be able to switch between configured\nenvironments via the dropdown, but will not be able to double-click and type in a custom\nURL. This does not affect the API Playground.\n\n@default: false"
         },
         "disable-analytics": {
           "oneOf": [
@@ -5771,7 +6086,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the default title source for all folder navigations. When set, this value is used as the\ndefault `title-source` for any folder that does not explicitly specify its own `title-source`.\nOptions are `frontmatter` (use the `title` field from the file's frontmatter) or `filename`\n(derive title from the file name)."
         },
         "substitute-env-vars": {
           "oneOf": [
@@ -5781,7 +6097,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When true, substitutes ${ENV_VAR} expressions using environment variables across all files in the docs bundle,\nincluding markdown/MDX content. This is useful for injecting dynamic values like API keys or URLs.\nUse \\$\\{VAR\\} to escape and output literal ${VAR} without substitution.\n\n@default: false"
         },
         "websocket-oneof-display": {
           "oneOf": [
@@ -5791,7 +6108,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls how WebSocket messages with oneOf bodies are displayed in the API Reference.\n- `flat` (default): Each variant in the oneOf is shown as a separate top-level entry.\n- `grouped`: Messages are shown as a single parent entry with nested variants.\n\n@default: flat"
         }
       },
       "additionalProperties": false
@@ -5996,7 +6314,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative filepath to a `context7.json` file that Fern should host at `/context7.json`.\nFern only checks that the file exists and is valid JSON, then passes it through as-is."
         }
       },
       "additionalProperties": false
@@ -6012,7 +6331,8 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "description": "The `css` object allows you to customize the appearance of your docs site by injecting custom CSS, i.e.\n\n```yaml\ncss: \"path/to/css/file.css\"\n```\n\nor, multiple files:\n\n```yaml\ncss:\n  - \"path/to/css/file.css\"\n  - \"path/to/another/css/file.css\"\n```"
     },
     "docs.JsScriptStrategy": {
       "type": "string",
@@ -6097,7 +6417,8 @@
             "$ref": "#/definitions/docs.JsConfigOptions"
           }
         }
-      ]
+      ],
+      "description": "The `js` object allows you to customize the behavior of your docs site by injecting custom JavaScript, i.e.\n\n```yaml\njs: \"path/to/js/file.js\"\n```\n\nor, multiple files:\n\n```yaml\njs:\n  - \"path/to/js/file.js\"\n  - \"path/to/another/js/file.js\"\n```\n\nor remote js:\n\n```yaml\njs:\n  url: \"https://example.com/path/to/js/file.js\"\n  strategy: \"afterInteractive\"\n```\n\nor, mixed:\n\n```yaml\njs:\n  - \"path/to/js/file.js\"\n  - path: \"path/to/another/js/file.js\"\n    strategy: \"beforeInteractive\"\n  - url: \"https://example.com/path/to/js/file.js\"\n```"
     }
   }
 }

--- a/fern.schema.json
+++ b/fern.schema.json
@@ -81,7 +81,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Default webhook signature verification configuration.\nApplied to all webhooks in this file that do not declare their own signature."
     },
     "channel": {
       "oneOf": [
@@ -142,7 +143,8 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the Protobuf type (e.g. google.protobuf.Struct)."
         }
       },
       "required": [
@@ -170,7 +172,8 @@
       "type": "object",
       "properties": {
         "openapi": {
-          "type": "string"
+          "type": "string",
+          "description": "Path to the OpenAPI spec"
         }
       },
       "required": [
@@ -182,7 +185,8 @@
       "type": "object",
       "properties": {
         "proto": {
-          "type": "string"
+          "type": "string",
+          "description": "Path to the Protobuf spec"
         }
       },
       "required": [
@@ -919,7 +923,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Context for where the discriminator exists. Defaults to \"data\" for backward compatibility.\n\"data\" means the discriminator is within the union data itself.\n\"protocol\" means the discriminator is at the SSE protocol level."
         }
       },
       "required": [
@@ -1592,7 +1597,8 @@
       "type": "object",
       "properties": {
         "service-name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the gRPC service."
         }
       },
       "required": [
@@ -1679,13 +1685,15 @@
         "items": {
           "$ref": "#/definitions/auth.AuthScope"
         }
-      }
+      },
+      "description": "A collection of auth schemes that all need to be satisfied for the endpoint."
     },
     "service.HttpEndpointSecurity": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/service.HttpEndpointSecurityItem"
-      }
+      },
+      "description": "A list of auth scheme collections. \nTo satisfy the security requirements, the caller must satisfy at least one collection of schemes."
     },
     "service.HttpEndpointAuth": {
       "anyOf": [
@@ -2109,7 +2117,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to json encoding"
         },
         "content-type": {
           "oneOf": [
@@ -2391,7 +2400,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "For SSE responses (`format: sse`), when true, the endpoint\nparticipates in client-side reconnection using `Last-Event-ID`\nand `retry:`. Defaults to false. No effect on non-SSE streams."
         }
       },
       "required": [
@@ -2775,13 +2785,16 @@
       "type": "object",
       "properties": {
         "cursor": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the request property for the cursor."
         },
         "next_cursor": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next cursor."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -2795,10 +2808,12 @@
       "type": "object",
       "properties": {
         "offset": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the request property for the page offset."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         },
         "step": {
           "oneOf": [
@@ -2808,7 +2823,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the request property for the page step."
         },
         "has-next-page": {
           "oneOf": [
@@ -2818,7 +2834,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the response property indicating next page presence."
         }
       },
       "required": [
@@ -2831,26 +2848,31 @@
       "type": "object",
       "properties": {
         "type": {
-          "const": "custom"
+          "const": "custom",
+          "description": "The type of pagination."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The response property is used to determine the results response type\ngenerated in the endpoint."
         }
       },
       "required": [
         "type",
         "results"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Pagination where the SDK author is responsible for implementing the pagination\nlogic in the SDK."
     },
     "pagination.UriPaginationSchema": {
       "type": "object",
       "properties": {
         "next_uri": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next URI."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -2863,10 +2885,12 @@
       "type": "object",
       "properties": {
         "next_path": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next path."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -3446,7 +3470,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to empty string."
         },
         "body-sort": {
           "oneOf": [
@@ -3456,7 +3481,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When set, POST body parameters are sorted before being concatenated\ninto the signing payload. Required by providers like Twilio."
         }
       },
       "required": [
@@ -3486,7 +3512,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to unix-seconds."
         },
         "tolerance": {
           "oneOf": [
@@ -3496,7 +3523,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Allowed clock skew in seconds. Defaults to 300."
         }
       },
       "required": [
@@ -3544,7 +3572,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to sha256."
             },
             "encoding": {
               "oneOf": [
@@ -3554,7 +3583,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to base64."
             },
             "signature-prefix": {
               "oneOf": [
@@ -3564,7 +3594,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Prefix in the header value before the signature (e.g. \"sha256=\")."
             },
             "payload-format": {
               "oneOf": [
@@ -3574,7 +3605,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to body-only (components: [body], delimiter: \"\")."
             },
             "timestamp": {
               "oneOf": [
@@ -3611,7 +3643,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to base64."
             },
             "signature-prefix": {
               "oneOf": [
@@ -3621,7 +3654,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Prefix in the header value before the signature."
             },
             "jwks-url": {
               "oneOf": [
@@ -3631,7 +3665,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "JWKS endpoint URL. When omitted, a static public key is expected at runtime."
             },
             "key-id-header": {
               "oneOf": [
@@ -3641,7 +3676,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "HTTP header containing the key ID for JWKS key selection."
             },
             "timestamp": {
               "oneOf": [

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -78,7 +78,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Aliases that map to multiple groups. When running `fern generate <alias>`,\nall groups in the alias will be run. For example:\n```yaml\naliases:\n  all: [\"php-sdk\", \"ts-sdk\", \"go-sdk\"]\n```\nThen `fern generate all` will run all three groups."
     },
     "groups": {
       "oneOf": [
@@ -111,7 +112,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Configuration for SDK customization replay.\nAutomatically preserves user customizations across SDK regenerations."
     },
     "ai": {
       "oneOf": [
@@ -131,7 +133,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "If true, automatically release SDKs when changes are detected.\nCan be overridden at the individual generator level."
     },
     "automation": {
       "oneOf": [
@@ -141,7 +144,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Controls which automation features (GitHub Actions workflows) are enabled.\nCan be overridden at the group or generator level.\nAll features default to true when not specified."
     },
     "openapi": {
       "oneOf": [
@@ -151,7 +155,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Deprecated, use the `api` key instead"
     },
     "openapi-overrides": {
       "oneOf": [
@@ -161,7 +166,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Deprecated, use the `api` key instead"
     },
     "spec-origin": {
       "oneOf": [
@@ -171,7 +177,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Deprecated, use the `api` key instead"
     },
     "async-api": {
       "oneOf": [
@@ -181,7 +188,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Deprecated, use the `api` key instead"
     },
     "api-settings": {
       "oneOf": [
@@ -191,7 +199,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Deprecated, use the `api` key instead"
     }
   },
   "additionalProperties": false,
@@ -210,7 +219,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the client ID."
         },
         "client-secret": {
           "oneOf": [
@@ -220,7 +230,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the client secret."
         },
         "scopes": {
           "oneOf": [
@@ -230,7 +241,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the scopes."
         }
       },
       "additionalProperties": false
@@ -246,7 +258,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the access token."
         },
         "expires-in": {
           "oneOf": [
@@ -256,7 +269,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the expires in property."
         },
         "refresh-token": {
           "oneOf": [
@@ -266,7 +280,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the refresh token"
         }
       },
       "additionalProperties": false
@@ -275,7 +290,8 @@
       "type": "object",
       "properties": {
         "endpoint": {
-          "type": "string"
+          "type": "string",
+          "description": "The endpoint to get the access token, such as 'auth.get_token"
         },
         "request-properties": {
           "oneOf": [
@@ -307,7 +323,8 @@
       "type": "object",
       "properties": {
         "refresh-token": {
-          "type": "string"
+          "type": "string",
+          "description": "The property name for the refresh token."
         }
       },
       "required": [
@@ -326,7 +343,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the access token."
         },
         "expires-in": {
           "oneOf": [
@@ -336,7 +354,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the expires in property."
         },
         "refresh-token": {
           "oneOf": [
@@ -346,7 +365,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the refresh token."
         }
       },
       "additionalProperties": false
@@ -355,7 +375,8 @@
       "type": "object",
       "properties": {
         "endpoint": {
-          "type": "string"
+          "type": "string",
+          "description": "The endpoint to refresh the access token, such as 'auth.refresh_token"
         },
         "request-properties": {
           "oneOf": [
@@ -443,7 +464,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the token header value prefix. Defaults to 'Bearer'"
         },
         "token-header": {
           "oneOf": [
@@ -453,7 +475,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the token header key name. Defaults to 'Authorization'"
         },
         "get-token": {
           "$ref": "#/definitions/fernDefinition.auth.OAuthGetTokenEndpointSchema"
@@ -520,7 +543,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to string"
         },
         "prefix": {
           "oneOf": [
@@ -540,7 +564,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The placeholder value to use in code snippets (e.g., \"YOUR_API_KEY\")."
         }
       },
       "required": [
@@ -579,7 +604,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the auth variable will be omitted from the SDK."
         },
         "placeholder": {
           "oneOf": [
@@ -589,7 +615,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The placeholder value to use in code snippets (e.g., \"YOUR_API_KEY\")."
         }
       },
       "additionalProperties": false
@@ -672,10 +699,12 @@
       "type": "object",
       "properties": {
         "response-property": {
-          "type": "string"
+          "type": "string",
+          "description": "The property to retrieve the header value from the get token or refresh endpoint response."
         },
         "header-name": {
-          "type": "string"
+          "type": "string",
+          "description": "The header name to put the token in for any authenticated HTTP request."
         },
         "value-prefix": {
           "oneOf": [
@@ -685,20 +714,23 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Commonly used for setting the `Authorization` scheme, but could be used for other things."
         }
       },
       "required": [
         "response-property",
         "header-name"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "A header that will be set on HTTP requests when the inferred auth scheme is applied to an endpoint. These are not headers for the authorization endpoint."
     },
     "fernDefinition.auth.InferredGetTokenEndpointSchemaObject": {
       "type": "object",
       "properties": {
         "endpoint": {
-          "type": "string"
+          "type": "string",
+          "description": "The endpoint to get the access token, such as 'auth.get_token'"
         },
         "expiry-response-property": {
           "oneOf": [
@@ -708,7 +740,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the expiry time in the response."
         },
         "authenticated-request-headers": {
           "oneOf": [
@@ -721,7 +754,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The headers that will be set on HTTP requests when the inferred auth scheme is applied to an endpoint."
         }
       },
       "required": [
@@ -792,7 +826,8 @@
       ]
     },
     "generators.APIDefinitionPathSchema": {
-      "type": "string"
+      "type": "string",
+      "description": "Path to the OpenAPI, AsyncAPI or Fern Definition"
     },
     "generators.OverridesSchema": {
       "anyOf": [
@@ -805,7 +840,8 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "description": "Paths to override files. Can be a single path or an array of paths.\nWhen multiple paths are provided, overrides are applied sequentially in order."
     },
     "generators.UnionSettingsSchema": {
       "type": "string",
@@ -825,21 +861,24 @@
       "enum": [
         "environment-per-server",
         "urls-per-environment"
-      ]
+      ],
+      "description": "Controls how multiple top-level OpenAPI servers map to environments in the generated Fern definition."
     },
     "generators.RemoveDiscriminantsFromSchemas": {
       "type": "string",
       "enum": [
         "always",
         "never"
-      ]
+      ],
+      "description": "Whether to remove discriminant properties from schemas when generating types, unless the schema is also used outside of a discriminated union."
     },
     "generators.PathParameterOrder": {
       "type": "string",
       "enum": [
         "url-order",
         "spec-order"
-      ]
+      ],
+      "description": "Controls the order of path parameters in generated method signatures."
     },
     "generators.APIDefinitionSettingsSchema": {
       "type": "object",
@@ -852,7 +891,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to use the titles of the schemas within an OpenAPI definition as the names of the types within Fern. Defaults to false.\nDeprecated, use the `api.specs.[].settings.title-as-schema-name` key instead."
         },
         "unions": {
           "oneOf": [
@@ -862,7 +902,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "What version of union generation to use, this will grow over time. Defaults to v0.\nDeprecated, use the `api.specs.[].settings.prefer-undiscriminated-unions-with-literals` key instead."
         },
         "message-naming": {
           "oneOf": [
@@ -872,7 +913,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "What version of message naming to use for AsyncAPI messages, this will grow over time. Defaults to v1."
         },
         "respect-nullable-schemas": {
           "oneOf": [
@@ -882,7 +924,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Preserves nullable schemas in API definition settings. Defaults to true, where nullable schemas are treated as optional."
         },
         "only-include-referenced-schemas": {
           "oneOf": [
@@ -892,7 +935,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to only include schemas referenced by endpoints in the generated SDK (i.e. a form of tree-shaking). Defaults to false."
         },
         "inline-path-parameters": {
           "oneOf": [
@@ -902,7 +946,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to include path parameters within the generated in-lined request. Defaults to true."
         },
         "idiomatic-request-names": {
           "oneOf": [
@@ -912,7 +957,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to use idiomatic request names for endpoints (e.g. ListUsersRequest instead of UsersListRequest). Defaults to true."
         },
         "wrap-references-to-nullable-in-optional": {
           "oneOf": [
@@ -922,7 +968,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the converter will wrap references to nullable schemas in optional.\nIf false, the converter will wrap references to nullable schemas in nullable.\nDefaults to true."
         },
         "coerce-optional-schemas-to-nullable": {
           "oneOf": [
@@ -932,7 +979,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the converter will coerce nullable schemas to optional.\nIf false, the converter will keep nullable schemas as nullable.\nDefaults to true."
         },
         "group-environments-by-host": {
           "oneOf": [
@@ -942,7 +990,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, group servers by host into unified environments regardless of protocol.\nThis allows APIs with multiple protocols (REST, WebSocket, etc.) to share environment configuration.\nWhen enabled, environment URL IDs are generated with collision resolution:\n- Use server name alone if no collision\n- Add path segment if collision (e.g., \"prod: https://api.com/foo\" -> \"foo\")\n- Add protocol if still collision (e.g., \"prod: wss://api.com/foo\" -> \"foo_wss\", only for non-HTTPS protocols)"
         },
         "multi-server-strategy": {
           "oneOf": [
@@ -952,7 +1001,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls how multiple top-level OpenAPI servers are mapped to environments in the generated\nFern definition, when those servers each declare an `x-fern-server-name` and endpoint-level\n`servers:` overrides reference those names.\n- `environment-per-server`: emit one environment per top-level server (each `x-fern-server-name`\n  becomes its own environment constant in generated SDKs, e.g. `Environment.PRODUCTION` and\n  `Environment.AGENT`). This is the default.\n- `urls-per-environment`: collapse all top-level servers into a single environment with each\n  server exposed as a named URL. Useful for APIs that expose multiple base hosts that together\n  form a single logical environment (e.g. `api.box.com`, `upload.box.com`, `dl.boxcloud.com`)."
         },
         "remove-discriminants-from-schemas": {
           "oneOf": [
@@ -962,7 +1012,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `always`, remove discriminant properties from schemas when generating types, unless the schema is also used outside of a discriminated union.\nIf `never`, keep discriminant properties in schemas when generating types.\nDefaults to `always`."
         },
         "path-parameter-order": {
           "oneOf": [
@@ -972,10 +1023,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the order of path parameters in generated method signatures.\n- `url-order`: Use the order path parameters appear in the URL path (e.g., /users/{userId}/posts/{postId})\n- `spec-order`: Use the order path parameters are defined in the spec\nDefaults to `url-order`."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Deprecated, use the `api.specs` key instead"
     },
     "generators.APIDefinitionWithOverridesSchema": {
       "type": "object",
@@ -991,7 +1044,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The URL of the API definition origin, from which the file should be polled."
         },
         "overrides": {
           "oneOf": [
@@ -1001,7 +1055,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Paths to the OpenAPI or AsyncAPI overrides. Can be a single path or an array of paths applied sequentially."
         },
         "audiences": {
           "oneOf": [
@@ -1014,7 +1069,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Audiences that you would like to filter to"
         },
         "settings": {
           "oneOf": [
@@ -1043,10 +1099,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the target `.proto` file that defines the API (e.g. `proto/user/v1/user.proto`)."
         },
         "root": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the `.proto` directory root (e.g. `proto`)."
         },
         "overrides": {
           "oneOf": [
@@ -1056,7 +1114,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Paths to the overrides configuration. Can be a single path or an array of paths applied sequentially."
         },
         "local-generation": {
           "oneOf": [
@@ -1066,7 +1125,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to compile the `.proto` files locally. By default, we generate remotely."
         },
         "from-openapi": {
           "oneOf": [
@@ -1076,7 +1136,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to convert to OpenAPI before generating"
         },
         "dependencies": {
           "oneOf": [
@@ -1089,7 +1150,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Dependencies to use for generation."
         }
       },
       "required": [
@@ -1163,7 +1225,8 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the Protobuf type (e.g. google.protobuf.Struct)."
         }
       },
       "required": [
@@ -1538,7 +1601,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "The variable name as it appears in the URL template"
         },
         "default": {
           "oneOf": [
@@ -1548,7 +1612,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default value for this variable"
         },
         "values": {
           "oneOf": [
@@ -1561,7 +1626,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Allowed values for this variable (from enum)"
         }
       },
       "required": [
@@ -1606,7 +1672,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A separate default URL to use when no variables are provided (from x-fern-default-url extension)"
         },
         "url-template": {
           "oneOf": [
@@ -1616,7 +1683,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The original URL template with variable placeholders (e.g., \"https://api.{region}.example.com\")"
         },
         "variables": {
           "oneOf": [
@@ -1629,7 +1697,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Server variables for URL templating"
         }
       },
       "required": [
@@ -1680,7 +1749,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL templates with variable placeholders for each base URL (e.g., \"https://api.{region}.example.com\")"
         },
         "default-urls": {
           "oneOf": [
@@ -1693,7 +1763,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Default URLs to use when no variables are provided (from x-fern-default-url extension)"
         },
         "variables": {
           "oneOf": [
@@ -1709,7 +1780,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Server variables for URL templating, keyed by base URL ID"
         }
       },
       "required": [
@@ -1805,7 +1877,8 @@
           ]
         },
         "endpoint-security": {
-          "$ref": "#/definitions/fernDefinition.auth.EndpointSecuritySchemaDetails"
+          "$ref": "#/definitions/fernDefinition.auth.EndpointSecuritySchemaDetails",
+          "description": "Indicates that authentication requirements are defined per-endpoint via the `security` field."
         }
       },
       "required": [
@@ -1835,7 +1908,8 @@
         "literals",
         "enums",
         "enums-coerceable-to-literals"
-      ]
+      ],
+      "description": "Controls how const values in OpenAPI specs are represented."
     },
     "generators.FormParameterEncoding": {
       "type": "string",
@@ -1858,7 +1932,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Endpoints to include in the generated SDK (e.g. \"POST /users\")."
         }
       },
       "additionalProperties": false
@@ -1874,7 +1949,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the maximum depth for which optional properties will have examples generated. A depth of 0 means no optional properties will have examples."
         }
       },
       "additionalProperties": false
@@ -1919,7 +1995,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Names of alias types to exclude from resolving."
         }
       },
       "additionalProperties": false
@@ -1954,7 +2031,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Preserves nullable schemas in API definition settings. Defaults to true, where nullable schemas are treated as optional."
         },
         "title-as-schema-name": {
           "oneOf": [
@@ -1964,7 +2042,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to use the titles of the schemas within an OpenAPI definition as the names of the types within Fern. Defaults to false."
         },
         "optional-additional-properties": {
           "oneOf": [
@@ -1984,7 +2063,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to coerce single value enums to literals. Defaults to true."
         },
         "idiomatic-request-names": {
           "oneOf": [
@@ -2004,7 +2084,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the converter will convert nullable schemas to optional nullable.\nIf false, the converter will convert nullable schemas to required nullable.\nDefaults to true."
         },
         "coerce-optional-schemas-to-nullable": {
           "oneOf": [
@@ -2014,7 +2095,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the converter will coerce nullable schemas to optional.\nIf false, the converter will keep nullable schemas as nullable.\nDefaults to true."
         },
         "group-environments-by-host": {
           "oneOf": [
@@ -2024,7 +2106,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, group servers by host into unified environments regardless of protocol.\nThis allows APIs with multiple protocols (REST, WebSocket, etc.) to share environment configuration.\nWhen enabled, environment URL IDs are generated with collision resolution:\n- Use server name alone if no collision\n- Add path segment if collision (e.g., \"prod: https://api.com/foo\" -> \"foo\")\n- Add protocol if still collision (e.g., \"prod: wss://api.com/foo\" -> \"foo_wss\", only for non-HTTPS protocols)"
         },
         "multi-server-strategy": {
           "oneOf": [
@@ -2034,7 +2117,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls how multiple top-level OpenAPI servers are mapped to environments in the generated\nFern definition, when those servers each declare an `x-fern-server-name` and endpoint-level\n`servers:` overrides reference those names.\n- `environment-per-server`: emit one environment per top-level server (each `x-fern-server-name`\n  becomes its own environment constant in generated SDKs, e.g. `Environment.PRODUCTION` and\n  `Environment.AGENT`). This is the default.\n- `urls-per-environment`: collapse all top-level servers into a single environment with each\n  server exposed as a named URL. Useful for APIs that expose multiple base hosts that together\n  form a single logical environment (e.g. `api.box.com`, `upload.box.com`, `dl.boxcloud.com`)."
         },
         "remove-discriminants-from-schemas": {
           "oneOf": [
@@ -2044,7 +2128,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `always`, remove discriminant properties from schemas when generating types, unless the schema is also used outside of a discriminated union.\nIf `never`, keep discriminant properties in schemas when generating types.\nDefaults to `always`."
         },
         "path-parameter-order": {
           "oneOf": [
@@ -2054,7 +2139,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the order of path parameters in generated method signatures.\n- `url-order`: Use the order path parameters appear in the URL path (e.g., /users/{userId}/posts/{postId})\n- `spec-order`: Use the order path parameters are defined in the spec\nDefaults to `url-order`."
         },
         "resolve-schema-collisions": {
           "oneOf": [
@@ -2064,7 +2150,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, resolve schema name collisions by appending numbers (e.g., Schema2, Schema3) and emit warnings.\nIf false, throw hard errors when schema collisions are detected.\nDefaults to false."
         },
         "infer-forward-compatible": {
           "oneOf": [
@@ -2074,7 +2161,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, infer forward-compatible enums from oneOf [enum, string] or anyOf [enum, string] patterns. Defaults to false."
         },
         "infer-default-environment": {
           "oneOf": [
@@ -2084,7 +2172,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to automatically infer the default environment from the first server. Defaults to true. When false, SDK users must explicitly provide a base URL."
         },
         "coerce-consts-to": {
           "oneOf": [
@@ -2094,7 +2183,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls how `const` values in OpenAPI specs are represented.\n- `literals`: Convert const values directly to literals with defaults.\n- `enums`: Convert const values to single-element enums; blocks transitive coercion via `coerce-enums-to-literals`.\n- `enums-coerceable-to-literals`: Convert const values to single-element enums, but allow `coerce-enums-to-literals` to coerce them transitively.\nDefaults to `enums-coerceable-to-literals`."
         },
         "only-include-referenced-schemas": {
           "oneOf": [
@@ -2104,7 +2194,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to only include schemas referenced by endpoints in the generated SDK (i.e. a form of tree-shaking). Defaults to false."
         },
         "inline-path-parameters": {
           "oneOf": [
@@ -2114,7 +2205,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to include path parameters within the generated in-lined request. Defaults to true."
         },
         "prefer-undiscriminated-unions-with-literals": {
           "oneOf": [
@@ -2124,7 +2216,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to prefer undiscriminated unions with literals. Defaults to false."
         },
         "object-query-parameters": {
           "oneOf": [
@@ -2134,7 +2227,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enables parsing deep object query parameters"
         },
         "respect-readonly-schemas": {
           "oneOf": [
@@ -2144,7 +2238,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enables exploring readonly schemas in OpenAPI specifications"
         },
         "respect-forward-compatible-enums": {
           "oneOf": [
@@ -2154,7 +2249,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enables respecting forward compatible enums in OpenAPI specifications. Defaults to false."
         },
         "use-bytes-for-binary-response": {
           "oneOf": [
@@ -2164,7 +2260,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enables using the `bytes` type for binary responsesin OpenAPI specifications. Defaults to a file stream."
         },
         "default-form-parameter-encoding": {
           "oneOf": [
@@ -2174,7 +2271,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default encoding of form parameters. Defaults to JSON."
         },
         "filter": {
           "oneOf": [
@@ -2184,7 +2282,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Filter to apply to the OpenAPI specification."
         },
         "example-generation": {
           "oneOf": [
@@ -2194,7 +2293,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Fine-tune your example generation"
         },
         "additional-properties-defaults-to": {
           "oneOf": [
@@ -2204,7 +2304,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Configure what `additionalProperties` should default to when not explicitly defined on a schema. Defaults to `false`."
         },
         "type-dates-as-strings": {
           "oneOf": [
@@ -2214,7 +2315,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, convert strings with format date to strings.\nIf false, convert strings with format date to dates.\nDefaults to true."
         },
         "preserve-single-schema-oneof": {
           "oneOf": [
@@ -2224,7 +2326,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, preserve oneOf structures with a single schema.\nIf false, unwrap oneOf structures with a single schema.\nDefaults to false."
         },
         "inline-all-of-schemas": {
           "oneOf": [
@@ -2234,7 +2337,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to inline allOf schemas. If false, allOf schemas will be\nextended in the code generation."
         },
         "resolve-aliases": {
           "oneOf": [
@@ -2244,7 +2348,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to resolve aliases and inline them if possible.\nIf provided, all aliases will be resolved except for the ones in the except array.\nDefaults to false, meaning that no aliases will be resolved."
         },
         "group-multi-api-environments": {
           "oneOf": [
@@ -2254,7 +2359,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, automatically group multiple APIs with matching environments into unified environments with multiple base URLs.\nThis is useful for organizations with multiple APIs deployed to the same set of environments."
         },
         "default-integer-format": {
           "oneOf": [
@@ -2264,7 +2370,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default format to use for integer types when no format is specified in the OpenAPI schema.\nDefaults to int32."
         },
         "infer-discriminated-union-base-properties": {
           "oneOf": [
@@ -2274,7 +2381,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, properties shared by every variant of a discriminated `oneOf`\n(including via `allOf`/`$ref`) are lifted into the union's base properties\nso SDKs can expose them directly on the union type without casting.\nDefaults to false."
         }
       },
       "additionalProperties": false
@@ -2352,7 +2460,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Preserves nullable schemas in API definition settings. Defaults to true, where nullable schemas are treated as optional."
         },
         "title-as-schema-name": {
           "oneOf": [
@@ -2362,7 +2471,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to use the titles of the schemas within an OpenAPI definition as the names of the types within Fern. Defaults to false."
         },
         "optional-additional-properties": {
           "oneOf": [
@@ -2382,7 +2492,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to coerce single value enums to literals. Defaults to true."
         },
         "idiomatic-request-names": {
           "oneOf": [
@@ -2402,7 +2513,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the converter will convert nullable schemas to optional nullable.\nIf false, the converter will convert nullable schemas to required nullable.\nDefaults to true."
         },
         "coerce-optional-schemas-to-nullable": {
           "oneOf": [
@@ -2412,7 +2524,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the converter will coerce nullable schemas to optional.\nIf false, the converter will keep nullable schemas as nullable.\nDefaults to true."
         },
         "group-environments-by-host": {
           "oneOf": [
@@ -2422,7 +2535,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, group servers by host into unified environments regardless of protocol.\nThis allows APIs with multiple protocols (REST, WebSocket, etc.) to share environment configuration.\nWhen enabled, environment URL IDs are generated with collision resolution:\n- Use server name alone if no collision\n- Add path segment if collision (e.g., \"prod: https://api.com/foo\" -> \"foo\")\n- Add protocol if still collision (e.g., \"prod: wss://api.com/foo\" -> \"foo_wss\", only for non-HTTPS protocols)"
         },
         "multi-server-strategy": {
           "oneOf": [
@@ -2432,7 +2546,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls how multiple top-level OpenAPI servers are mapped to environments in the generated\nFern definition, when those servers each declare an `x-fern-server-name` and endpoint-level\n`servers:` overrides reference those names.\n- `environment-per-server`: emit one environment per top-level server (each `x-fern-server-name`\n  becomes its own environment constant in generated SDKs, e.g. `Environment.PRODUCTION` and\n  `Environment.AGENT`). This is the default.\n- `urls-per-environment`: collapse all top-level servers into a single environment with each\n  server exposed as a named URL. Useful for APIs that expose multiple base hosts that together\n  form a single logical environment (e.g. `api.box.com`, `upload.box.com`, `dl.boxcloud.com`)."
         },
         "remove-discriminants-from-schemas": {
           "oneOf": [
@@ -2442,7 +2557,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `always`, remove discriminant properties from schemas when generating types, unless the schema is also used outside of a discriminated union.\nIf `never`, keep discriminant properties in schemas when generating types.\nDefaults to `always`."
         },
         "path-parameter-order": {
           "oneOf": [
@@ -2452,7 +2568,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the order of path parameters in generated method signatures.\n- `url-order`: Use the order path parameters appear in the URL path (e.g., /users/{userId}/posts/{postId})\n- `spec-order`: Use the order path parameters are defined in the spec\nDefaults to `url-order`."
         },
         "resolve-schema-collisions": {
           "oneOf": [
@@ -2462,7 +2579,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, resolve schema name collisions by appending numbers (e.g., Schema2, Schema3) and emit warnings.\nIf false, throw hard errors when schema collisions are detected.\nDefaults to false."
         },
         "infer-forward-compatible": {
           "oneOf": [
@@ -2472,7 +2590,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, infer forward-compatible enums from oneOf [enum, string] or anyOf [enum, string] patterns. Defaults to false."
         },
         "infer-default-environment": {
           "oneOf": [
@@ -2482,7 +2601,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to automatically infer the default environment from the first server. Defaults to true. When false, SDK users must explicitly provide a base URL."
         },
         "coerce-consts-to": {
           "oneOf": [
@@ -2492,7 +2612,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls how `const` values in OpenAPI specs are represented.\n- `literals`: Convert const values directly to literals with defaults.\n- `enums`: Convert const values to single-element enums; blocks transitive coercion via `coerce-enums-to-literals`.\n- `enums-coerceable-to-literals`: Convert const values to single-element enums, but allow `coerce-enums-to-literals` to coerce them transitively.\nDefaults to `enums-coerceable-to-literals`."
         },
         "message-naming": {
           "oneOf": [
@@ -2502,7 +2623,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "What version of message naming to use for AsyncAPI messages, this will grow over time. Defaults to v1."
         }
       },
       "additionalProperties": false
@@ -2700,7 +2822,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to only include schemas referenced by endpoints in the generated SDK (i.e. a form of tree-shaking). Defaults to false."
         },
         "inline-path-parameters": {
           "oneOf": [
@@ -2710,7 +2833,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to include path parameters within the generated in-lined request. Defaults to true."
         },
         "prefer-undiscriminated-unions-with-literals": {
           "oneOf": [
@@ -2720,7 +2844,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to prefer undiscriminated unions with literals. Defaults to false."
         },
         "object-query-parameters": {
           "oneOf": [
@@ -2730,7 +2855,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enables parsing deep object query parameters"
         },
         "respect-readonly-schemas": {
           "oneOf": [
@@ -2740,7 +2866,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enables exploring readonly schemas in OpenAPI specifications"
         },
         "respect-forward-compatible-enums": {
           "oneOf": [
@@ -2750,7 +2877,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enables respecting forward compatible enums in OpenAPI specifications. Defaults to false."
         },
         "use-bytes-for-binary-response": {
           "oneOf": [
@@ -2760,7 +2888,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enables using the `bytes` type for binary responsesin OpenAPI specifications. Defaults to a file stream."
         },
         "default-form-parameter-encoding": {
           "oneOf": [
@@ -2770,7 +2899,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default encoding of form parameters. Defaults to JSON."
         },
         "filter": {
           "oneOf": [
@@ -2780,7 +2910,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Filter to apply to the OpenAPI specification."
         },
         "example-generation": {
           "oneOf": [
@@ -2790,7 +2921,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Fine-tune your example generation"
         },
         "additional-properties-defaults-to": {
           "oneOf": [
@@ -2800,7 +2932,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Configure what `additionalProperties` should default to when not explicitly defined on a schema. Defaults to `false`."
         },
         "type-dates-as-strings": {
           "oneOf": [
@@ -2810,7 +2943,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, convert strings with format date to strings.\nIf false, convert strings with format date to dates.\nDefaults to true."
         },
         "preserve-single-schema-oneof": {
           "oneOf": [
@@ -2820,7 +2954,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, preserve oneOf structures with a single schema.\nIf false, unwrap oneOf structures with a single schema.\nDefaults to false."
         },
         "inline-all-of-schemas": {
           "oneOf": [
@@ -2830,7 +2965,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to inline allOf schemas. If false, allOf schemas will be\nextended in the code generation."
         },
         "resolve-aliases": {
           "oneOf": [
@@ -2840,7 +2976,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to resolve aliases and inline them if possible.\nIf provided, all aliases will be resolved except for the ones in the except array.\nDefaults to false, meaning that no aliases will be resolved."
         },
         "group-multi-api-environments": {
           "oneOf": [
@@ -2850,7 +2987,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, automatically group multiple APIs with matching environments into unified environments with multiple base URLs.\nThis is useful for organizations with multiple APIs deployed to the same set of environments."
         },
         "default-integer-format": {
           "oneOf": [
@@ -2860,7 +2998,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default format to use for integer types when no format is specified in the OpenAPI schema.\nDefaults to int32."
         },
         "infer-discriminated-union-base-properties": {
           "oneOf": [
@@ -2870,7 +3009,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, properties shared by every variant of a discriminated `oneOf`\n(including via `allOf`/`$ref`) are lifted into the union's base properties\nso SDKs can expose them directly on the union type without casting.\nDefaults to false."
         },
         "respect-nullable-schemas": {
           "oneOf": [
@@ -2880,7 +3020,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Preserves nullable schemas in API definition settings. Defaults to true, where nullable schemas are treated as optional."
         },
         "title-as-schema-name": {
           "oneOf": [
@@ -2890,7 +3031,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to use the titles of the schemas within an OpenAPI definition as the names of the types within Fern. Defaults to false."
         },
         "optional-additional-properties": {
           "oneOf": [
@@ -2910,7 +3052,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to coerce single value enums to literals. Defaults to true."
         },
         "idiomatic-request-names": {
           "oneOf": [
@@ -2930,7 +3073,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the converter will convert nullable schemas to optional nullable.\nIf false, the converter will convert nullable schemas to required nullable.\nDefaults to true."
         },
         "coerce-optional-schemas-to-nullable": {
           "oneOf": [
@@ -2940,7 +3084,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the converter will coerce nullable schemas to optional.\nIf false, the converter will keep nullable schemas as nullable.\nDefaults to true."
         },
         "group-environments-by-host": {
           "oneOf": [
@@ -2950,7 +3095,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, group servers by host into unified environments regardless of protocol.\nThis allows APIs with multiple protocols (REST, WebSocket, etc.) to share environment configuration.\nWhen enabled, environment URL IDs are generated with collision resolution:\n- Use server name alone if no collision\n- Add path segment if collision (e.g., \"prod: https://api.com/foo\" -> \"foo\")\n- Add protocol if still collision (e.g., \"prod: wss://api.com/foo\" -> \"foo_wss\", only for non-HTTPS protocols)"
         },
         "multi-server-strategy": {
           "oneOf": [
@@ -2960,7 +3106,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls how multiple top-level OpenAPI servers are mapped to environments in the generated\nFern definition, when those servers each declare an `x-fern-server-name` and endpoint-level\n`servers:` overrides reference those names.\n- `environment-per-server`: emit one environment per top-level server (each `x-fern-server-name`\n  becomes its own environment constant in generated SDKs, e.g. `Environment.PRODUCTION` and\n  `Environment.AGENT`). This is the default.\n- `urls-per-environment`: collapse all top-level servers into a single environment with each\n  server exposed as a named URL. Useful for APIs that expose multiple base hosts that together\n  form a single logical environment (e.g. `api.box.com`, `upload.box.com`, `dl.boxcloud.com`)."
         },
         "remove-discriminants-from-schemas": {
           "oneOf": [
@@ -2970,7 +3117,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `always`, remove discriminant properties from schemas when generating types, unless the schema is also used outside of a discriminated union.\nIf `never`, keep discriminant properties in schemas when generating types.\nDefaults to `always`."
         },
         "path-parameter-order": {
           "oneOf": [
@@ -2980,7 +3128,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the order of path parameters in generated method signatures.\n- `url-order`: Use the order path parameters appear in the URL path (e.g., /users/{userId}/posts/{postId})\n- `spec-order`: Use the order path parameters are defined in the spec\nDefaults to `url-order`."
         },
         "resolve-schema-collisions": {
           "oneOf": [
@@ -2990,7 +3139,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, resolve schema name collisions by appending numbers (e.g., Schema2, Schema3) and emit warnings.\nIf false, throw hard errors when schema collisions are detected.\nDefaults to false."
         },
         "infer-forward-compatible": {
           "oneOf": [
@@ -3000,7 +3150,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, infer forward-compatible enums from oneOf [enum, string] or anyOf [enum, string] patterns. Defaults to false."
         },
         "infer-default-environment": {
           "oneOf": [
@@ -3010,7 +3161,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to automatically infer the default environment from the first server. Defaults to true. When false, SDK users must explicitly provide a base URL."
         },
         "coerce-consts-to": {
           "oneOf": [
@@ -3020,7 +3172,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls how `const` values in OpenAPI specs are represented.\n- `literals`: Convert const values directly to literals with defaults.\n- `enums`: Convert const values to single-element enums; blocks transitive coercion via `coerce-enums-to-literals`.\n- `enums-coerceable-to-literals`: Convert const values to single-element enums, but allow `coerce-enums-to-literals` to coerce them transitively.\nDefaults to `enums-coerceable-to-literals`."
         },
         "message-naming": {
           "oneOf": [
@@ -3030,10 +3183,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "What version of message naming to use for AsyncAPI messages, this will grow over time. Defaults to v1."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Global default API import settings that apply to all specs in this API configuration.\nIndividual spec settings in specs[].settings will override these defaults.\nGenerator settings in groups.generators[].api.settings will override both.\nSettings hierarchy (highest to lowest priority): generator > spec > api."
     },
     "generators.APIConfigurationV2Schema": {
       "type": "object",
@@ -3049,7 +3204,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Global Headers for the entire API"
         },
         "default-url": {
           "oneOf": [
@@ -3362,7 +3518,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set, use this endpoint's snippet as the default whenever possible"
         },
         "features": {
           "oneOf": [
@@ -3378,7 +3535,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Specifies a list of endpoints associated with the feature"
         },
         "customSections": {
           "oneOf": [
@@ -3391,7 +3549,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Supply custom sections as markdown to be included in the readme"
         },
         "exampleStyle": {
           "oneOf": [
@@ -3401,7 +3560,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls whether usage examples show only required parameters (minimal) or all parameters (comprehensive). Defaults to comprehensive."
         }
       },
       "additionalProperties": false
@@ -3907,7 +4067,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If specified, commits and tags the release on this branch instead of the default branch. The branch must exist."
         },
         "license": {
           "oneOf": [
@@ -4137,7 +4298,8 @@
       "type": "object",
       "properties": {
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the generated snippets file."
         }
       },
       "required": [
@@ -4182,7 +4344,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override or extend the global headers for this generator.\nWhen provided, these headers are merged with the top-level api.headers configuration,\nwith per-generator headers taking precedence for same-key headers."
         },
         "settings": {
           "oneOf": [
@@ -4202,10 +4365,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the specs configuration for this generator.\nWhen provided, this completely replaces the top-level api.specs configuration."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Override API configuration settings for a specific generator.\nWhen specs is provided, it completely replaces the top-level api.specs configuration for this generator."
     },
     "automation.AutomationSchema": {
       "type": "object",
@@ -4218,7 +4383,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enable or disable SDK generation automation (fern-generate workflow).\nDefaults to true."
         },
         "upgrade": {
           "oneOf": [
@@ -4228,7 +4394,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enable or disable CLI and generator upgrade automation (fern-upgrade workflow).\nDefaults to true."
         },
         "preview": {
           "oneOf": [
@@ -4238,7 +4405,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enable or disable SDK preview validation on PRs (fern-preview workflow).\nDefaults to true."
         },
         "verify": {
           "oneOf": [
@@ -4248,10 +4416,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enable or disable self-verification (install, build, test) of generated SDK output.\nRuns on PRs and on merge to main.\nDefaults to true."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Controls which automation features (GitHub Actions workflows) are enabled.\nCan be set at root, group, or generator level. Resolution order:\ngenerator → group → root → default (all enabled)."
     },
     "group.DefaultGeneratorInvocationSchema": {
       "type": "object",
@@ -4317,7 +4487,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Overrides the keywords that require safe name variants."
         },
         "snippets": {
           "oneOf": [
@@ -4327,7 +4498,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Configures snippets for a particular generator."
         },
         "ir-version": {
           "oneOf": [
@@ -4337,7 +4509,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Overrides the version of the IR used by the generator."
         },
         "smart-casing": {
           "oneOf": [
@@ -4347,7 +4520,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Feature flag used to enable better IR naming."
         },
         "api": {
           "oneOf": [
@@ -4357,7 +4531,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override API import settings (this is applied across all specs)"
         },
         "disable-examples": {
           "oneOf": [
@@ -4367,7 +4542,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Temporary way to unblock example serialization."
         },
         "publish-metadata": {
           "oneOf": [
@@ -4377,7 +4553,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated, use `metadata` on the output block instead."
         },
         "autorelease": {
           "oneOf": [
@@ -4387,7 +4564,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, automatically release this SDK when changes are detected.\nOverrides the top-level autorelease setting if specified."
         },
         "automation": {
           "oneOf": [
@@ -4397,33 +4575,39 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls which automation features are enabled for this generator.\nOverrides group-level and root-level automation settings."
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The generator name (e.g., `fernapi/fern-typescript-sdk`)."
         }
       },
       "required": [
         "version",
         "name"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "A generator invocation that uses a well-known generator name\n(e.g., `fernapi/fern-typescript-sdk`) and pulls from Docker Hub."
     },
     "generators.GeneratorImageObjectSchema": {
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The Docker image name (e.g., `fernapi/fern-typescript-sdk`)."
         },
         "registry": {
-          "type": "string"
+          "type": "string",
+          "description": "The container registry URL to pull the image from during local generation.\nExample: `ghcr.io/myorg` or `123456789.dkr.ecr.us-east-1.amazonaws.com`"
         }
       },
       "required": [
         "name",
         "registry"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Explicit Docker image configuration with a custom container registry."
     },
     "group.CustomGeneratorInvocationSchema": {
       "type": "object",
@@ -4489,7 +4673,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Overrides the keywords that require safe name variants."
         },
         "snippets": {
           "oneOf": [
@@ -4499,7 +4684,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Configures snippets for a particular generator."
         },
         "ir-version": {
           "oneOf": [
@@ -4509,7 +4695,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Overrides the version of the IR used by the generator."
         },
         "smart-casing": {
           "oneOf": [
@@ -4519,7 +4706,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Feature flag used to enable better IR naming."
         },
         "api": {
           "oneOf": [
@@ -4529,7 +4717,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override API import settings (this is applied across all specs)"
         },
         "disable-examples": {
           "oneOf": [
@@ -4539,7 +4728,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Temporary way to unblock example serialization."
         },
         "publish-metadata": {
           "oneOf": [
@@ -4549,7 +4739,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated, use `metadata` on the output block instead."
         },
         "autorelease": {
           "oneOf": [
@@ -4559,7 +4750,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, automatically release this SDK when changes are detected.\nOverrides the top-level autorelease setting if specified."
         },
         "automation": {
           "oneOf": [
@@ -4569,17 +4761,20 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls which automation features are enabled for this generator.\nOverrides group-level and root-level automation settings."
         },
         "image": {
-          "$ref": "#/definitions/generators.GeneratorImageObjectSchema"
+          "$ref": "#/definitions/generators.GeneratorImageObjectSchema",
+          "description": "The Docker image to use for this generator, with an optional custom container registry."
         }
       },
       "required": [
         "version",
         "image"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "A generator invocation that specifies a custom Docker image,\noptionally from a custom container registry."
     },
     "group.GeneratorInvocationSchema": {
       "anyOf": [
@@ -4589,7 +4784,8 @@
         {
           "$ref": "#/definitions/group.CustomGeneratorInvocationSchema"
         }
-      ]
+      ],
+      "description": "A generator invocation. Either uses a well-known generator `name` (default)\nor specifies a custom `image` with an optional container registry."
     },
     "group.GeneratorGroupSchema": {
       "type": "object",
@@ -4641,7 +4837,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls which automation features are enabled for this group.\nOverrides root-level automation settings.\nCan be further overridden at the generator level."
         }
       },
       "required": [
@@ -4653,7 +4850,8 @@
       "type": "object",
       "properties": {
         "enabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether to enable replay for this SDK"
         }
       },
       "required": [

--- a/package-yml.schema.json
+++ b/package-yml.schema.json
@@ -71,7 +71,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Default webhook signature verification configuration.\nApplied to all webhooks in this file that do not declare their own signature."
     },
     "channel": {
       "oneOf": [
@@ -162,7 +163,8 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the Protobuf type (e.g. google.protobuf.Struct)."
         }
       },
       "required": [
@@ -190,7 +192,8 @@
       "type": "object",
       "properties": {
         "openapi": {
-          "type": "string"
+          "type": "string",
+          "description": "Path to the OpenAPI spec"
         }
       },
       "required": [
@@ -202,7 +205,8 @@
       "type": "object",
       "properties": {
         "proto": {
-          "type": "string"
+          "type": "string",
+          "description": "Path to the Protobuf spec"
         }
       },
       "required": [
@@ -939,7 +943,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Context for where the discriminator exists. Defaults to \"data\" for backward compatibility.\n\"data\" means the discriminator is within the union data itself.\n\"protocol\" means the discriminator is at the SSE protocol level."
         }
       },
       "required": [
@@ -1612,7 +1617,8 @@
       "type": "object",
       "properties": {
         "service-name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the gRPC service."
         }
       },
       "required": [
@@ -1699,13 +1705,15 @@
         "items": {
           "$ref": "#/definitions/auth.AuthScope"
         }
-      }
+      },
+      "description": "A collection of auth schemes that all need to be satisfied for the endpoint."
     },
     "service.HttpEndpointSecurity": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/service.HttpEndpointSecurityItem"
-      }
+      },
+      "description": "A list of auth scheme collections. \nTo satisfy the security requirements, the caller must satisfy at least one collection of schemes."
     },
     "service.HttpEndpointAuth": {
       "anyOf": [
@@ -2129,7 +2137,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to json encoding"
         },
         "content-type": {
           "oneOf": [
@@ -2411,7 +2420,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "For SSE responses (`format: sse`), when true, the endpoint\nparticipates in client-side reconnection using `Last-Event-ID`\nand `retry:`. Defaults to false. No effect on non-SSE streams."
         }
       },
       "required": [
@@ -2795,13 +2805,16 @@
       "type": "object",
       "properties": {
         "cursor": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the request property for the cursor."
         },
         "next_cursor": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next cursor."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -2815,10 +2828,12 @@
       "type": "object",
       "properties": {
         "offset": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the request property for the page offset."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         },
         "step": {
           "oneOf": [
@@ -2828,7 +2843,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the request property for the page step."
         },
         "has-next-page": {
           "oneOf": [
@@ -2838,7 +2854,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the response property indicating next page presence."
         }
       },
       "required": [
@@ -2851,26 +2868,31 @@
       "type": "object",
       "properties": {
         "type": {
-          "const": "custom"
+          "const": "custom",
+          "description": "The type of pagination."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The response property is used to determine the results response type\ngenerated in the endpoint."
         }
       },
       "required": [
         "type",
         "results"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Pagination where the SDK author is responsible for implementing the pagination\nlogic in the SDK."
     },
     "pagination.UriPaginationSchema": {
       "type": "object",
       "properties": {
         "next_uri": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next URI."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -2883,10 +2905,12 @@
       "type": "object",
       "properties": {
         "next_path": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next path."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -3466,7 +3490,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to empty string."
         },
         "body-sort": {
           "oneOf": [
@@ -3476,7 +3501,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When set, POST body parameters are sorted before being concatenated\ninto the signing payload. Required by providers like Twilio."
         }
       },
       "required": [
@@ -3506,7 +3532,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to unix-seconds."
         },
         "tolerance": {
           "oneOf": [
@@ -3516,7 +3543,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Allowed clock skew in seconds. Defaults to 300."
         }
       },
       "required": [
@@ -3564,7 +3592,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to sha256."
             },
             "encoding": {
               "oneOf": [
@@ -3574,7 +3603,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to base64."
             },
             "signature-prefix": {
               "oneOf": [
@@ -3584,7 +3614,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Prefix in the header value before the signature (e.g. \"sha256=\")."
             },
             "payload-format": {
               "oneOf": [
@@ -3594,7 +3625,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to body-only (components: [body], delimiter: \"\")."
             },
             "timestamp": {
               "oneOf": [
@@ -3631,7 +3663,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to base64."
             },
             "signature-prefix": {
               "oneOf": [
@@ -3641,7 +3674,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Prefix in the header value before the signature."
             },
             "jwks-url": {
               "oneOf": [
@@ -3651,7 +3685,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "JWKS endpoint URL. When omitted, a static public key is expected at runtime."
             },
             "key-id-header": {
               "oneOf": [
@@ -3661,7 +3696,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "HTTP header containing the key ID for JWKS key selection."
             },
             "timestamp": {
               "oneOf": [

--- a/packages/cli/cli/changes/unreleased/feat-jsonschema-docs.yml
+++ b/packages/cli/cli/changes/unreleased/feat-jsonschema-docs.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Propagate Fern `docs:` strings into generated JSON Schemas so editor hovers
+    work for schemas served from `schema.buildwithfern.dev`.
+  type: chore

--- a/packages/cli/ete-tests/src/tests/jsonschema/__snapshots__/jsonschema.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/jsonschema/__snapshots__/jsonschema.test.ts.snap
@@ -5,6 +5,7 @@ exports[`jsonschema > works with latest version 1`] = `
   "additionalProperties": false,
   "definitions": {
     "imdb.MovieId": {
+      "description": "The unique identifier for a Movie in the database",
       "type": "string",
     },
   },
@@ -13,6 +14,7 @@ exports[`jsonschema > works with latest version 1`] = `
       "$ref": "#/definitions/imdb.MovieId",
     },
     "rating": {
+      "description": "The rating scale out of ten stars",
       "type": "number",
     },
     "title": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/alias/type__Object.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/alias/type__Object.json
@@ -1,8 +1,10 @@
 {
   "$ref": "#/definitions/Type",
+  "description": "Object is an alias for a type.",
   "definitions": {
     "TypeId": {
-      "type": "string"
+      "type": "string",
+      "description": "An alias for type IDs."
     },
     "Type": {
       "type": "object",
@@ -18,7 +20,8 @@
         "id",
         "name"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "A simple type with just a name."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/alias/type__Type.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/alias/type__Type.json
@@ -13,9 +13,11 @@
     "name"
   ],
   "additionalProperties": false,
+  "description": "A simple type with just a name.",
   "definitions": {
     "TypeId": {
-      "type": "string"
+      "type": "string",
+      "description": "An alias for type IDs."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/alias/type__TypeId.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/alias/type__TypeId.json
@@ -1,4 +1,5 @@
 {
   "type": "string",
+  "description": "An alias for type IDs.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__AuditInfo.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__AuditInfo.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The user who created this resource."
     },
     "createdDateTime": {
       "oneOf": [
@@ -20,7 +21,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "When this resource was created."
     },
     "modifiedBy": {
       "oneOf": [
@@ -30,7 +32,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The user who last modified this resource."
     },
     "modifiedDateTime": {
       "oneOf": [
@@ -41,9 +44,11 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "When this resource was last modified."
     }
   },
   "additionalProperties": false,
+  "description": "Common audit metadata.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__BaseOrg.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__BaseOrg.json
@@ -24,7 +24,8 @@
       "type": "object",
       "properties": {
         "region": {
-          "type": "string"
+          "type": "string",
+          "description": "Deployment region from BaseOrg."
         },
         "tier": {
           "oneOf": [
@@ -34,7 +35,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Subscription tier."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__BaseOrgMetadata.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__BaseOrgMetadata.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "region": {
-      "type": "string"
+      "type": "string",
+      "description": "Deployment region from BaseOrg."
     },
     "tier": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Subscription tier."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__CombinedEntity.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__CombinedEntity.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string"
+      "type": "string",
+      "description": "Unique identifier."
     },
     "name": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Display name from Describable."
     },
     "summary": {
       "oneOf": [
@@ -22,7 +24,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "A short summary."
     },
     "status": {
       "$ref": "#/definitions/CombinedEntityStatus"

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__Describable.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__Describable.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Display name from Describable."
     },
     "summary": {
       "oneOf": [
@@ -19,7 +20,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "A short summary."
     }
   },
   "additionalProperties": false,

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__DetailedOrg.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__DetailedOrg.json
@@ -18,7 +18,8 @@
       "type": "object",
       "properties": {
         "region": {
-          "type": "string"
+          "type": "string",
+          "description": "Deployment region from DetailedOrg."
         },
         "domain": {
           "oneOf": [
@@ -28,7 +29,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Custom domain name."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__DetailedOrgMetadata.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__DetailedOrgMetadata.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "region": {
-      "type": "string"
+      "type": "string",
+      "description": "Deployment region from DetailedOrg."
     },
     "domain": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Custom domain name."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__Identifiable.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__Identifiable.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string"
+      "type": "string",
+      "description": "Unique identifier."
     },
     "name": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Display name from Identifiable."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__Organization.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__Organization.json
@@ -28,7 +28,8 @@
       "type": "object",
       "properties": {
         "region": {
-          "type": "string"
+          "type": "string",
+          "description": "Deployment region from DetailedOrg."
         },
         "domain": {
           "oneOf": [
@@ -38,7 +39,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Custom domain name."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__OrganizationMetadata.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__OrganizationMetadata.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "region": {
-      "type": "string"
+      "type": "string",
+      "description": "Deployment region from DetailedOrg."
     },
     "domain": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Custom domain name."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__PaginatedResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__PaginatedResult.json
@@ -15,7 +15,8 @@
           "array",
           "null"
         ]
-      }
+      },
+      "description": "Current page of results from the requested resource."
     }
   },
   "required": [
@@ -28,7 +29,8 @@
       "type": "object",
       "properties": {
         "next": {
-          "type": "string"
+          "type": "string",
+          "description": "Cursor for the next page of results."
         },
         "previous": {
           "oneOf": [
@@ -38,7 +40,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Cursor for the previous page of results."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__PagingCursors.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__PagingCursors.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "next": {
-      "type": "string"
+      "type": "string",
+      "description": "Cursor for the next page of results."
     },
     "previous": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Cursor for the previous page of results."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__RuleCreateRequestExecutionContext.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__RuleCreateRequestExecutionContext.json
@@ -5,5 +5,6 @@
     "staging",
     "dev"
   ],
+  "description": "Execution context for the rule, excluding the prod environment.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__RuleExecutionContext.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__RuleExecutionContext.json
@@ -5,5 +5,6 @@
     "staging",
     "dev"
   ],
+  "description": "Execution environment for a rule.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__RuleResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__RuleResponse.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The user who created this resource."
     },
     "createdDateTime": {
       "oneOf": [
@@ -20,7 +21,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "When this resource was created."
     },
     "modifiedBy": {
       "oneOf": [
@@ -30,7 +32,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The user who last modified this resource."
     },
     "modifiedDateTime": {
       "oneOf": [
@@ -41,7 +44,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "When this resource was last modified."
     },
     "id": {
       "type": "string"
@@ -84,7 +88,8 @@
         "prod",
         "staging",
         "dev"
-      ]
+      ],
+      "description": "Execution environment for a rule."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__RuleTypeSearchResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__RuleTypeSearchResponse.json
@@ -15,7 +15,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Current page of results from the requested resource."
     }
   },
   "required": [
@@ -27,7 +28,8 @@
       "type": "object",
       "properties": {
         "next": {
-          "type": "string"
+          "type": "string",
+          "description": "Cursor for the next page of results."
         },
         "previous": {
           "oneOf": [
@@ -37,7 +39,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Cursor for the previous page of results."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__UserSearchResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof-inline/type__UserSearchResponse.json
@@ -15,7 +15,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Current page of results from the requested resource."
     }
   },
   "required": [
@@ -27,7 +28,8 @@
       "type": "object",
       "properties": {
         "next": {
-          "type": "string"
+          "type": "string",
+          "description": "Cursor for the next page of results."
         },
         "previous": {
           "oneOf": [
@@ -37,7 +39,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Cursor for the previous page of results."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__AuditInfo.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__AuditInfo.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The user who created this resource."
     },
     "createdDateTime": {
       "oneOf": [
@@ -20,7 +21,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "When this resource was created."
     },
     "modifiedBy": {
       "oneOf": [
@@ -30,7 +32,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The user who last modified this resource."
     },
     "modifiedDateTime": {
       "oneOf": [
@@ -41,9 +44,11 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "When this resource was last modified."
     }
   },
   "additionalProperties": false,
+  "description": "Common audit metadata.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__BaseOrg.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__BaseOrg.json
@@ -24,7 +24,8 @@
       "type": "object",
       "properties": {
         "region": {
-          "type": "string"
+          "type": "string",
+          "description": "Deployment region from BaseOrg."
         },
         "tier": {
           "oneOf": [
@@ -34,7 +35,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Subscription tier."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__BaseOrgMetadata.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__BaseOrgMetadata.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "region": {
-      "type": "string"
+      "type": "string",
+      "description": "Deployment region from BaseOrg."
     },
     "tier": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Subscription tier."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__CombinedEntity.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__CombinedEntity.json
@@ -5,7 +5,8 @@
       "$ref": "#/definitions/CombinedEntityStatus"
     },
     "id": {
-      "type": "string"
+      "type": "string",
+      "description": "Unique identifier."
     },
     "name": {
       "oneOf": [
@@ -15,7 +16,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Display name from Identifiable."
     },
     "summary": {
       "oneOf": [
@@ -25,7 +27,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "A short summary."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__Describable.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__Describable.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Display name from Describable."
     },
     "summary": {
       "oneOf": [
@@ -19,7 +20,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "A short summary."
     }
   },
   "additionalProperties": false,

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__DetailedOrg.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__DetailedOrg.json
@@ -18,7 +18,8 @@
       "type": "object",
       "properties": {
         "region": {
-          "type": "string"
+          "type": "string",
+          "description": "Deployment region from DetailedOrg."
         },
         "domain": {
           "oneOf": [
@@ -28,7 +29,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Custom domain name."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__DetailedOrgMetadata.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__DetailedOrgMetadata.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "region": {
-      "type": "string"
+      "type": "string",
+      "description": "Deployment region from DetailedOrg."
     },
     "domain": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Custom domain name."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__Identifiable.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__Identifiable.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string"
+      "type": "string",
+      "description": "Unique identifier."
     },
     "name": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Display name from Identifiable."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__Organization.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__Organization.json
@@ -28,7 +28,8 @@
       "type": "object",
       "properties": {
         "region": {
-          "type": "string"
+          "type": "string",
+          "description": "Deployment region from BaseOrg."
         },
         "tier": {
           "oneOf": [
@@ -38,7 +39,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Subscription tier."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__PaginatedResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__PaginatedResult.json
@@ -15,7 +15,8 @@
           "array",
           "null"
         ]
-      }
+      },
+      "description": "Current page of results from the requested resource."
     }
   },
   "required": [
@@ -28,7 +29,8 @@
       "type": "object",
       "properties": {
         "next": {
-          "type": "string"
+          "type": "string",
+          "description": "Cursor for the next page of results."
         },
         "previous": {
           "oneOf": [
@@ -38,7 +40,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Cursor for the previous page of results."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__PagingCursors.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__PagingCursors.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "next": {
-      "type": "string"
+      "type": "string",
+      "description": "Cursor for the next page of results."
     },
     "previous": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Cursor for the previous page of results."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__RuleCreateRequestExecutionContext.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__RuleCreateRequestExecutionContext.json
@@ -5,5 +5,6 @@
     "staging",
     "dev"
   ],
+  "description": "Execution context for the rule, excluding the prod environment.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__RuleExecutionContext.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__RuleExecutionContext.json
@@ -5,5 +5,6 @@
     "staging",
     "dev"
   ],
+  "description": "Execution environment for a rule.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__RuleResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__RuleResponse.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The user who created this resource."
     },
     "createdDateTime": {
       "oneOf": [
@@ -20,7 +21,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "When this resource was created."
     },
     "modifiedBy": {
       "oneOf": [
@@ -30,7 +32,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The user who last modified this resource."
     },
     "modifiedDateTime": {
       "oneOf": [
@@ -41,7 +44,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "When this resource was last modified."
     },
     "id": {
       "type": "string"
@@ -84,7 +88,8 @@
         "prod",
         "staging",
         "dev"
-      ]
+      ],
+      "description": "Execution environment for a rule."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__RuleTypeSearchResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__RuleTypeSearchResponse.json
@@ -12,7 +12,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Current page of results from the requested resource."
     },
     "paging": {
       "$ref": "#/definitions/PagingCursors"
@@ -53,7 +54,8 @@
       "type": "object",
       "properties": {
         "next": {
-          "type": "string"
+          "type": "string",
+          "description": "Cursor for the next page of results."
         },
         "previous": {
           "oneOf": [
@@ -63,7 +65,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Cursor for the previous page of results."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__UserSearchResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/allof/type__UserSearchResponse.json
@@ -12,7 +12,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Current page of results from the requested resource."
     },
     "paging": {
       "$ref": "#/definitions/PagingCursors"
@@ -43,7 +44,8 @@
       "type": "object",
       "properties": {
         "next": {
-          "type": "string"
+          "type": "string",
+          "description": "Cursor for the next page of results."
         },
         "previous": {
           "oneOf": [
@@ -53,7 +55,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Cursor for the previous page of results."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/any-auth/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/any-auth/type_auth_TokenResponse.json
@@ -23,5 +23,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/circular-references-advanced/type_ast_ObjectFieldValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/circular-references-advanced/type_ast_ObjectFieldValue.json
@@ -13,6 +13,7 @@
     "value"
   ],
   "additionalProperties": false,
+  "description": "This type allows us to test a circular reference with a union type (see FieldValue).",
   "definitions": {
     "ast.FieldName": {
       "type": "string"

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/client-side-params/type_types_Client.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/client-side-params/type_types_Client.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "client_id": {
-      "type": "string"
+      "type": "string",
+      "description": "The unique client identifier"
     },
     "tenant": {
       "oneOf": [
@@ -12,10 +13,12 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The tenant name"
     },
     "name": {
-      "type": "string"
+      "type": "string",
+      "description": "Name of the client"
     },
     "description": {
       "oneOf": [
@@ -25,7 +28,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Free text description of the client"
     },
     "global": {
       "oneOf": [
@@ -35,7 +39,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether this is a global client"
     },
     "client_secret": {
       "oneOf": [
@@ -45,7 +50,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The client secret (only for non-public clients)"
     },
     "app_type": {
       "oneOf": [
@@ -55,7 +61,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The type of application (spa, native, regular_web, non_interactive)"
     },
     "logo_uri": {
       "oneOf": [
@@ -65,7 +72,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "URL of the client logo"
     },
     "is_first_party": {
       "oneOf": [
@@ -75,7 +83,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether this client is a first party client"
     },
     "oidc_conformant": {
       "oneOf": [
@@ -85,7 +94,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether this client conforms to OIDC specifications"
     },
     "callbacks": {
       "oneOf": [
@@ -98,7 +108,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Allowed callback URLs"
     },
     "allowed_origins": {
       "oneOf": [
@@ -111,7 +122,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Allowed origins for CORS"
     },
     "web_origins": {
       "oneOf": [
@@ -124,7 +136,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Allowed web origins for CORS"
     },
     "grant_types": {
       "oneOf": [
@@ -137,7 +150,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Allowed grant types"
     },
     "jwt_configuration": {
       "oneOf": [
@@ -157,7 +171,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "JWT configuration for the client"
     },
     "signing_keys": {
       "oneOf": [
@@ -180,7 +195,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Client signing keys"
     },
     "encryption_key": {
       "oneOf": [
@@ -200,7 +216,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Encryption key"
     },
     "sso": {
       "oneOf": [
@@ -210,7 +227,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether SSO is enabled"
     },
     "sso_disabled": {
       "oneOf": [
@@ -220,7 +238,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether SSO is disabled"
     },
     "cross_origin_auth": {
       "oneOf": [
@@ -230,7 +249,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether to use cross-origin authentication"
     },
     "cross_origin_loc": {
       "oneOf": [
@@ -240,7 +260,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "URL for cross-origin authentication"
     },
     "custom_login_page_on": {
       "oneOf": [
@@ -250,7 +271,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether a custom login page is enabled"
     },
     "custom_login_page": {
       "oneOf": [
@@ -260,7 +282,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Custom login page URL"
     },
     "custom_login_page_preview": {
       "oneOf": [
@@ -270,7 +293,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Custom login page preview URL"
     },
     "form_template": {
       "oneOf": [
@@ -280,7 +304,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Form template for WS-Federation"
     },
     "is_heroku_app": {
       "oneOf": [
@@ -290,7 +315,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether this is a Heroku application"
     },
     "addons": {
       "oneOf": [
@@ -310,7 +336,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Addons enabled for this client"
     },
     "token_endpoint_auth_method": {
       "oneOf": [
@@ -320,7 +347,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Requested authentication method for the token endpoint"
     },
     "client_metadata": {
       "oneOf": [
@@ -340,7 +368,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Metadata associated with the client"
     },
     "mobile": {
       "oneOf": [
@@ -360,7 +389,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Mobile app settings"
     }
   },
   "required": [
@@ -368,5 +398,6 @@
     "name"
   ],
   "additionalProperties": false,
+  "description": "Represents a client application",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/client-side-params/type_types_Connection.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/client-side-params/type_types_Connection.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string"
+      "type": "string",
+      "description": "Connection identifier"
     },
     "name": {
-      "type": "string"
+      "type": "string",
+      "description": "Connection name"
     },
     "display_name": {
       "oneOf": [
@@ -15,10 +17,12 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Display name for the connection"
     },
     "strategy": {
-      "type": "string"
+      "type": "string",
+      "description": "The identity provider identifier (auth0, google-oauth2, facebook, etc.)"
     },
     "options": {
       "oneOf": [
@@ -38,7 +42,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Connection-specific configuration options"
     },
     "enabled_clients": {
       "oneOf": [
@@ -51,7 +56,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "List of client IDs that can use this connection"
     },
     "realms": {
       "oneOf": [
@@ -64,7 +70,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Applicable realms for enterprise connections"
     },
     "is_domain_connection": {
       "oneOf": [
@@ -74,7 +81,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether this is a domain connection"
     },
     "metadata": {
       "oneOf": [
@@ -94,7 +102,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Additional metadata"
     }
   },
   "required": [
@@ -103,5 +112,6 @@
     "strategy"
   ],
   "additionalProperties": false,
+  "description": "Represents an identity provider connection",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/client-side-params/type_types_PaginatedClientResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/client-side-params/type_types_PaginatedClientResponse.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "start": {
-      "type": "integer"
+      "type": "integer",
+      "description": "Starting index (zero-based)"
     },
     "limit": {
-      "type": "integer"
+      "type": "integer",
+      "description": "Number of items requested"
     },
     "length": {
-      "type": "integer"
+      "type": "integer",
+      "description": "Number of items returned"
     },
     "total": {
       "oneOf": [
@@ -18,13 +21,15 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Total number of items (when include_totals=true)"
     },
     "clients": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/types.Client"
-      }
+      },
+      "description": "List of clients"
     }
   },
   "required": [
@@ -34,12 +39,14 @@
     "clients"
   ],
   "additionalProperties": false,
+  "description": "Paginated response for clients listing",
   "definitions": {
     "types.Client": {
       "type": "object",
       "properties": {
         "client_id": {
-          "type": "string"
+          "type": "string",
+          "description": "The unique client identifier"
         },
         "tenant": {
           "oneOf": [
@@ -49,10 +56,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The tenant name"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the client"
         },
         "description": {
           "oneOf": [
@@ -62,7 +71,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Free text description of the client"
         },
         "global": {
           "oneOf": [
@@ -72,7 +82,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether this is a global client"
         },
         "client_secret": {
           "oneOf": [
@@ -82,7 +93,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The client secret (only for non-public clients)"
         },
         "app_type": {
           "oneOf": [
@@ -92,7 +104,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The type of application (spa, native, regular_web, non_interactive)"
         },
         "logo_uri": {
           "oneOf": [
@@ -102,7 +115,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL of the client logo"
         },
         "is_first_party": {
           "oneOf": [
@@ -112,7 +126,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether this client is a first party client"
         },
         "oidc_conformant": {
           "oneOf": [
@@ -122,7 +137,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether this client conforms to OIDC specifications"
         },
         "callbacks": {
           "oneOf": [
@@ -135,7 +151,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Allowed callback URLs"
         },
         "allowed_origins": {
           "oneOf": [
@@ -148,7 +165,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Allowed origins for CORS"
         },
         "web_origins": {
           "oneOf": [
@@ -161,7 +179,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Allowed web origins for CORS"
         },
         "grant_types": {
           "oneOf": [
@@ -174,7 +193,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Allowed grant types"
         },
         "jwt_configuration": {
           "oneOf": [
@@ -194,7 +214,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "JWT configuration for the client"
         },
         "signing_keys": {
           "oneOf": [
@@ -217,7 +238,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Client signing keys"
         },
         "encryption_key": {
           "oneOf": [
@@ -237,7 +259,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Encryption key"
         },
         "sso": {
           "oneOf": [
@@ -247,7 +270,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether SSO is enabled"
         },
         "sso_disabled": {
           "oneOf": [
@@ -257,7 +281,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether SSO is disabled"
         },
         "cross_origin_auth": {
           "oneOf": [
@@ -267,7 +292,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to use cross-origin authentication"
         },
         "cross_origin_loc": {
           "oneOf": [
@@ -277,7 +303,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL for cross-origin authentication"
         },
         "custom_login_page_on": {
           "oneOf": [
@@ -287,7 +314,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether a custom login page is enabled"
         },
         "custom_login_page": {
           "oneOf": [
@@ -297,7 +325,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Custom login page URL"
         },
         "custom_login_page_preview": {
           "oneOf": [
@@ -307,7 +336,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Custom login page preview URL"
         },
         "form_template": {
           "oneOf": [
@@ -317,7 +347,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Form template for WS-Federation"
         },
         "is_heroku_app": {
           "oneOf": [
@@ -327,7 +358,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether this is a Heroku application"
         },
         "addons": {
           "oneOf": [
@@ -347,7 +379,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Addons enabled for this client"
         },
         "token_endpoint_auth_method": {
           "oneOf": [
@@ -357,7 +390,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Requested authentication method for the token endpoint"
         },
         "client_metadata": {
           "oneOf": [
@@ -377,7 +411,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Metadata associated with the client"
         },
         "mobile": {
           "oneOf": [
@@ -397,14 +432,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Mobile app settings"
         }
       },
       "required": [
         "client_id",
         "name"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Represents a client application"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/client-side-params/type_types_PaginatedUserResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/client-side-params/type_types_PaginatedUserResponse.json
@@ -34,6 +34,7 @@
     "length"
   ],
   "additionalProperties": false,
+  "description": "Response with pagination info like Auth0",
   "definitions": {
     "types.Identity": {
       "type": "object",
@@ -294,7 +295,8 @@
         "created_at",
         "updated_at"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "User object similar to Auth0 users"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/client-side-params/type_types_User.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/client-side-params/type_types_User.json
@@ -214,6 +214,7 @@
     "updated_at"
   ],
   "additionalProperties": false,
+  "description": "User object similar to Auth0 users",
   "definitions": {
     "types.Identity": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-grpc-proto-exhaustive/type__CreateResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-grpc-proto-exhaustive/type__CreateResponse.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The created resource."
     },
     "success": {
       "oneOf": [
@@ -19,7 +20,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Indicates successful creation."
     },
     "error_message": {
       "oneOf": [
@@ -29,7 +31,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Error message if creation failed."
     }
   },
   "additionalProperties": false,

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-grpc-proto-exhaustive/type__GoogleProtobufAny.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-grpc-proto-exhaustive/type__GoogleProtobufAny.json
@@ -9,9 +9,11 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The type of the serialized message."
     }
   },
   "additionalProperties": true,
+  "description": "Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-grpc-proto-exhaustive/type__GoogleRpcStatus.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-grpc-proto-exhaustive/type__GoogleRpcStatus.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code]."
     },
     "message": {
       "oneOf": [
@@ -19,7 +20,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client."
     },
     "details": {
       "oneOf": [
@@ -32,10 +34,12 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "A list of messages that carry the error details.  There is a common set of message types for APIs to use."
     }
   },
   "additionalProperties": false,
+  "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).",
   "definitions": {
     "GoogleProtobufAny": {
       "type": "object",
@@ -48,10 +52,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The type of the serialized message."
         }
       },
-      "additionalProperties": true
+      "additionalProperties": true,
+      "description": "Contains an arbitrary serialized message along with a @type that describes the type of the serialized message."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-grpc-proto-exhaustive/type__ToolChoice.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-grpc-proto-exhaustive/type__ToolChoice.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Force the model to perform in a given mode."
     },
     "function_name": {
       "oneOf": [
@@ -19,7 +20,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Force the model to call a particular function."
     }
   },
   "additionalProperties": false,

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-grpc-proto-exhaustive/type__UpdateResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-grpc-proto-exhaustive/type__UpdateResponse.json
@@ -77,10 +77,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The type of the serialized message."
         }
       },
-      "additionalProperties": true
+      "additionalProperties": true,
+      "description": "Contains an arbitrary serialized message along with a @type that describes the type of the serialized message."
     },
     "UpdateResponse_Status": {
       "type": "string",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__DiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__DiscriminatedUnion1.json
@@ -17,13 +17,16 @@
           "const": "type1"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "$ref": "#/definitions/DiscriminatedUnion1InlineType1InlineType1"
+          "$ref": "#/definitions/DiscriminatedUnion1InlineType1InlineType1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -31,7 +34,8 @@
         "foo",
         "bar",
         "ref"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     {
       "properties": {
@@ -39,17 +43,20 @@
           "const": "type2"
         },
         "baz": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "baz",
         "ref"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     {
       "properties": {
@@ -57,43 +64,51 @@
           "const": "ref"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "foo"
-      ]
+      ],
+      "description": "lorem ipsum"
     }
   ],
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__DiscriminatedUnion1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__DiscriminatedUnion1InlineType1.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/DiscriminatedUnion1InlineType1InlineType1"
+      "$ref": "#/definitions/DiscriminatedUnion1InlineType1InlineType1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -17,34 +20,40 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__DiscriminatedUnion1InlineType1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__DiscriminatedUnion1InlineType1InlineType1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__DiscriminatedUnion1InlineType2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__DiscriminatedUnion1InlineType2.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "baz": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__InlineEnum1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__InlineEnum1.json
@@ -6,5 +6,6 @@
     "RAINING",
     "SNOWING"
   ],
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__ReferenceType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__ReferenceType.json
@@ -2,12 +2,14 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     }
   },
   "required": [
     "foo"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RequestTypeInlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RequestTypeInlineType1.json
@@ -2,12 +2,14 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     }
   },
   "required": [
     "foo"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RootType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RootType1.json
@@ -2,32 +2,38 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/RootType1InlineType1"
+      "$ref": "#/definitions/RootType1InlineType1",
+      "description": "lorem ipsum"
     },
     "fooMap": {
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/RootType1FooMapValue"
-      }
+      },
+      "description": "lorem ipsum"
     },
     "fooList": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/RootType1FooListItem"
-      }
+      },
+      "description": "lorem ipsum"
     },
     "fooSet": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/RootType1FooSetItem"
       },
-      "uniqueItems": true
+      "uniqueItems": true,
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -39,6 +45,7 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "InlineEnum1": {
       "type": "string",
@@ -47,34 +54,41 @@
         "CLOUDY",
         "RAINING",
         "SNOWING"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1InlineType1NestedInlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "myEnum": {
-          "$ref": "#/definitions/InlineEnum1"
+          "$ref": "#/definitions/InlineEnum1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -83,19 +97,23 @@
         "myEnum",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "$ref": "#/definitions/RootType1InlineType1NestedInlineType1"
+          "$ref": "#/definitions/RootType1InlineType1NestedInlineType1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -103,55 +121,65 @@
         "bar",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1FooMapValue": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1FooListItem": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1FooSetItem": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RootType1FooListItem.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RootType1FooListItem.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RootType1FooMapValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RootType1FooMapValue.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RootType1FooSetItem.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RootType1FooSetItem.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RootType1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RootType1InlineType1.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/RootType1InlineType1NestedInlineType1"
+      "$ref": "#/definitions/RootType1InlineType1NestedInlineType1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -17,6 +20,7 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "InlineEnum1": {
       "type": "string",
@@ -25,34 +29,41 @@
         "CLOUDY",
         "RAINING",
         "SNOWING"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1InlineType1NestedInlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "myEnum": {
-          "$ref": "#/definitions/InlineEnum1"
+          "$ref": "#/definitions/InlineEnum1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -61,7 +72,8 @@
         "myEnum",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RootType1InlineType1NestedInlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__RootType1InlineType1NestedInlineType1.json
@@ -2,16 +2,20 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "myEnum": {
-      "$ref": "#/definitions/InlineEnum1"
+      "$ref": "#/definitions/InlineEnum1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -21,6 +25,7 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "InlineEnum1": {
       "type": "string",
@@ -29,19 +34,22 @@
         "CLOUDY",
         "RAINING",
         "SNOWING"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__TypesPropertyCollisionBaseParent.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__TypesPropertyCollisionBaseParent.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "types": {
-      "type": "string"
+      "type": "string",
+      "description": "This inherited property collides with the default nested class name \"Types\""
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__TypesPropertyCollisionExtendsParent.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__TypesPropertyCollisionExtendsParent.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "types": {
-      "type": "string"
+      "type": "string",
+      "description": "This inherited property collides with the default nested class name \"Types\""
     },
     "child": {
-      "$ref": "#/definitions/TypesPropertyCollisionExtendsChild"
+      "$ref": "#/definitions/TypesPropertyCollisionExtendsChild",
+      "description": "This inline child should be nested inside InnerTypes since \"Types\" is inherited"
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__TypesPropertyCollisionParent.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__TypesPropertyCollisionParent.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "types": {
-      "type": "string"
+      "type": "string",
+      "description": "This property collides with the default nested class name \"Types\""
     },
     "child": {
-      "$ref": "#/definitions/TypesPropertyCollisionChild"
+      "$ref": "#/definitions/TypesPropertyCollisionChild",
+      "description": "This inline child should be nested inside InnerTypes instead of Types"
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1.json
@@ -47,46 +47,55 @@
       "description": "lorem ipsum"
     }
   ],
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "$ref": "#/definitions/UndiscriminatedUnion1InlineType1InlineType1"
+          "$ref": "#/definitions/UndiscriminatedUnion1InlineType1InlineType1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -94,39 +103,46 @@
         "bar",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineType2": {
       "type": "object",
       "properties": {
         "baz": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "baz",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1DiscriminatedUnion1": {
       "type": "object",
@@ -147,13 +163,16 @@
               "const": "type1"
             },
             "foo": {
-              "type": "string"
+              "type": "string",
+              "description": "lorem ipsum"
             },
             "bar": {
-              "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1"
+              "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1",
+              "description": "lorem ipsum"
             },
             "ref": {
-              "$ref": "#/definitions/ReferenceType"
+              "$ref": "#/definitions/ReferenceType",
+              "description": "lorem ipsum"
             }
           },
           "required": [
@@ -161,7 +180,8 @@
             "foo",
             "bar",
             "ref"
-          ]
+          ],
+          "description": "lorem ipsum"
         },
         {
           "properties": {
@@ -169,17 +189,20 @@
               "const": "type2"
             },
             "baz": {
-              "type": "string"
+              "type": "string",
+              "description": "lorem ipsum"
             },
             "ref": {
-              "$ref": "#/definitions/ReferenceType"
+              "$ref": "#/definitions/ReferenceType",
+              "description": "lorem ipsum"
             }
           },
           "required": [
             "type",
             "baz",
             "ref"
-          ]
+          ],
+          "description": "lorem ipsum"
         },
         {
           "properties": {
@@ -187,15 +210,18 @@
               "const": "ref"
             },
             "foo": {
-              "type": "string"
+              "type": "string",
+              "description": "lorem ipsum"
             }
           },
           "required": [
             "type",
             "foo"
-          ]
+          ],
+          "description": "lorem ipsum"
         }
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineEnum1": {
       "type": "string",
@@ -204,58 +230,69 @@
         "CLOUDY",
         "RAINING",
         "SNOWING"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "UserId": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineListItem1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineSetItem1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineMapItem1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1.json
@@ -17,13 +17,16 @@
           "const": "type1"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1"
+          "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -31,7 +34,8 @@
         "foo",
         "bar",
         "ref"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     {
       "properties": {
@@ -39,17 +43,20 @@
           "const": "type2"
         },
         "baz": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "baz",
         "ref"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     {
       "properties": {
@@ -57,43 +64,51 @@
           "const": "ref"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "foo"
-      ]
+      ],
+      "description": "lorem ipsum"
     }
   ],
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType1.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1"
+      "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -17,34 +20,40 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType2.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "baz": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineEnum1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineEnum1.json
@@ -6,5 +6,6 @@
     "RAINING",
     "SNOWING"
   ],
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineListItem1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineListItem1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineMapItem1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineMapItem1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineSetItem1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineSetItem1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineType1.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/UndiscriminatedUnion1InlineType1InlineType1"
+      "$ref": "#/definitions/UndiscriminatedUnion1InlineType1InlineType1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -17,34 +20,40 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineType1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineType1InlineType1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineType2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UndiscriminatedUnion1InlineType2.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "baz": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UnionWithTypesVariant.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UnionWithTypesVariant.json
@@ -16,17 +16,20 @@
           "const": "types"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "foo",
         "ref"
-      ]
+      ],
+      "description": "This variant name collides with the default nested class name \"Types\""
     },
     {
       "properties": {
@@ -34,31 +37,37 @@
           "const": "otherVariant"
         },
         "bar": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "bar",
         "ref"
-      ]
+      ],
+      "description": "This is a non-colliding variant"
     }
   ],
+  "description": "A union with a variant named \"types\" that could collide with the inline Types class",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UnionWithTypesVariantInlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UnionWithTypesVariantInlineType1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UnionWithTypesVariantOtherInlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UnionWithTypesVariantOtherInlineType1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "bar": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UserId.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-inline-types/type__UserId.json
@@ -1,4 +1,5 @@
 {
   "type": "string",
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-readonly-request/type__CreateVendorRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-readonly-request/type__CreateVendorRequest.json
@@ -5,28 +5,34 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/Vendor"
-      }
+      },
+      "description": "Map of vendor ID to vendor data"
     }
   },
   "required": [
     "vendors"
   ],
   "additionalProperties": false,
+  "description": "Request to create vendors",
   "definitions": {
     "Vendor": {
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "The unique identifier for the vendor."
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the vendor."
         },
         "created_at": {
-          "type": "string"
+          "type": "string",
+          "description": "The timestamp when the vendor was created."
         },
         "updated_at": {
-          "type": "string"
+          "type": "string",
+          "description": "The timestamp when the vendor was last updated."
         }
       },
       "required": [
@@ -35,7 +41,8 @@
         "created_at",
         "updated_at"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "A vendor object with read-only timestamps"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-readonly-request/type__CreateVendorResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-readonly-request/type__CreateVendorResponse.json
@@ -5,28 +5,34 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/Vendor"
-      }
+      },
+      "description": "Map of vendor ID to created vendor"
     }
   },
   "required": [
     "vendors"
   ],
   "additionalProperties": false,
+  "description": "Response from creating vendors",
   "definitions": {
     "Vendor": {
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "The unique identifier for the vendor."
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the vendor."
         },
         "created_at": {
-          "type": "string"
+          "type": "string",
+          "description": "The timestamp when the vendor was created."
         },
         "updated_at": {
-          "type": "string"
+          "type": "string",
+          "description": "The timestamp when the vendor was last updated."
         }
       },
       "required": [
@@ -35,7 +41,8 @@
         "created_at",
         "updated_at"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "A vendor object with read-only timestamps"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-readonly-request/type__Vendor.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-readonly-request/type__Vendor.json
@@ -2,16 +2,20 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string"
+      "type": "string",
+      "description": "The unique identifier for the vendor."
     },
     "name": {
-      "type": "string"
+      "type": "string",
+      "description": "The name of the vendor."
     },
     "created_at": {
-      "type": "string"
+      "type": "string",
+      "description": "The timestamp when the vendor was created."
     },
     "updated_at": {
-      "type": "string"
+      "type": "string",
+      "description": "The timestamp when the vendor was last updated."
     }
   },
   "required": [
@@ -21,5 +25,6 @@
     "updated_at"
   ],
   "additionalProperties": false,
+  "description": "A vendor object with read-only timestamps",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-xml-entities/type__TimeZoneModel.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/csharp-xml-entities/type__TimeZoneModel.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "timeZoneOffset": {
-      "type": "string"
+      "type": "string",
+      "description": "Format is UTC &plus; offset notation (e.g., &plus;05:30)"
     },
     "mathExpression": {
-      "type": "string"
+      "type": "string",
+      "description": "Expression: A &plus; B &minus; C &times; D &divide; E"
     },
     "validEntity": {
-      "type": "string"
+      "type": "string",
+      "description": "This uses valid XML entity: A &lt; B &amp; C &gt; D"
     },
     "specialChars": {
       "oneOf": [
@@ -18,7 +21,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Special characters: &nbsp; &hellip; &middot; &copy;"
     }
   },
   "required": [
@@ -27,5 +31,6 @@
     "validEntity"
   ],
   "additionalProperties": false,
+  "description": "Model demonstrating HTML entity bug in C# XML documentation.\nThis description contains HTML entities that are not valid in XML.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/endpoint-security-auth/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/endpoint-security-auth/type_auth_TokenResponse.json
@@ -23,5 +23,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/enum/type__ColorOrOperand.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/enum/type__ColorOrOperand.json
@@ -17,11 +17,19 @@
     },
     "Operand": {
       "type": "string",
-      "enum": [
-        ">",
-        "=",
-        "less_than"
-      ]
+      "oneOf": [
+        {
+          "const": ">"
+        },
+        {
+          "const": "="
+        },
+        {
+          "const": "less_than",
+          "description": "The name and value should be similar\nare similar for less than."
+        }
+      ],
+      "description": "Tests enum name and value can be\ndifferent."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/enum/type__ForwardCompatibleEnum.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/enum/type__ForwardCompatibleEnum.json
@@ -4,5 +4,6 @@
     "active",
     "inactive"
   ],
+  "description": "Tests forward-compatible enums that accept\nboth known values and arbitrary strings.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/enum/type__Operand.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/enum/type__Operand.json
@@ -1,9 +1,17 @@
 {
   "type": "string",
-  "enum": [
-    ">",
-    "=",
-    "less_than"
+  "oneOf": [
+    {
+      "const": ">"
+    },
+    {
+      "const": "="
+    },
+    {
+      "const": "less_than",
+      "description": "The name and value should be similar\nare similar for less than."
+    }
   ],
+  "description": "Tests enum name and value can be\ndifferent.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_BigEntity.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_BigEntity.json
@@ -224,7 +224,8 @@
           "type": "string"
         },
         "rating": {
-          "type": "number"
+          "type": "number",
+          "description": "The rating scale is one to five stars"
         },
         "type": {
           "const": "movie"
@@ -501,10 +502,18 @@
     },
     "types.MigrationStatus": {
       "type": "string",
-      "enum": [
-        "RUNNING",
-        "FAILED",
-        "FINISHED"
+      "oneOf": [
+        {
+          "const": "RUNNING",
+          "description": "The migration is running."
+        },
+        {
+          "const": "FAILED",
+          "description": "The migration failed."
+        },
+        {
+          "const": "FINISHED"
+        }
       ]
     },
     "types.Migration": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_ExtendedMovie.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_ExtendedMovie.json
@@ -21,7 +21,8 @@
       "type": "string"
     },
     "rating": {
-      "type": "number"
+      "type": "number",
+      "description": "The rating scale is one to five stars"
     },
     "type": {
       "const": "movie"

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_Migration.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_Migration.json
@@ -16,10 +16,18 @@
   "definitions": {
     "types.MigrationStatus": {
       "type": "string",
-      "enum": [
-        "RUNNING",
-        "FAILED",
-        "FINISHED"
+      "oneOf": [
+        {
+          "const": "RUNNING",
+          "description": "The migration is running."
+        },
+        {
+          "const": "FAILED",
+          "description": "The migration failed."
+        },
+        {
+          "const": "FINISHED"
+        }
       ]
     }
   }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_MigrationStatus.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_MigrationStatus.json
@@ -1,9 +1,17 @@
 {
   "type": "string",
-  "enum": [
-    "RUNNING",
-    "FAILED",
-    "FINISHED"
+  "oneOf": [
+    {
+      "const": "RUNNING",
+      "description": "The migration is running."
+    },
+    {
+      "const": "FAILED",
+      "description": "The migration failed."
+    },
+    {
+      "const": "FINISHED"
+    }
   ],
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_Movie.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/examples/type_types_Movie.json
@@ -21,7 +21,8 @@
       "type": "string"
     },
     "rating": {
-      "type": "number"
+      "type": "number",
+      "description": "The rating scale is one to five stars"
     },
     "type": {
       "const": "movie"

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/docs_ObjectWithDocs.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/docs_ObjectWithDocs.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "string": {
-      "type": "string"
+      "type": "string",
+      "description": "Characters that could lead to broken generated SDKs:\n\nMarkdown Escapes:\n- \\_: Escaped underscore (e.g., FOO\\_BAR)\n- \\*: Escaped asterisk\n\nJSDoc (JavaScript/TypeScript):\n- @: Used for JSDoc tags\n- {: }: Used for type definitions\n- <: >: HTML tags\n- *: Can interfere with comment blocks\n- /**: JSDoc comment start\n- ** /: JSDoc comment end\n- &: HTML entities\n\nXMLDoc (C#):\n- <: >: XML tags\n- &: ': \": <: >: XML special characters\n- {: }: Used for interpolated strings\n- ///: Comment marker\n- /**: Block comment start\n- ** /: Block comment end\n\nXMLDoc (C#) (Example of actual XML tags):\nSee <a href=\"https://example.com/docs\">the docs</a> for more info.\nUse <code>getValue()</code> to retrieve the value.\nNote: when count < 10 or count > 100, special handling applies.\n\nJavadoc (Java):\n- @: Used for Javadoc tags\n- <: >: HTML tags\n- &: HTML entities\n- *: Can interfere with comment blocks\n- /**: Javadoc comment start\n- ** /: Javadoc comment end\n\nDoxygen (C++):\n- \\: Used for Doxygen commands\n- @: Alternative command prefix\n- <: >: XML/HTML tags\n- &: HTML entities\n- /**: C-style comment start\n- ** /: C-style comment end\n\nRDoc (Ruby):\n- :: Used in symbol notation\n- =: Section markers\n- #: Comment marker\n- =begin: Block comment start\n- =end: Block comment end\n- @: Instance variable prefix\n- $: Global variable prefix\n- %: String literal delimiter\n- #{: String interpolation start\n- }: String interpolation end\n\nPHPDoc (PHP):\n- @: Used for PHPDoc tags\n- {: }: Used for type definitions\n- $: Variable prefix\n- /**: PHPDoc comment start\n- ** /: PHPDoc comment end\n- *: Can interfere with comment blocks\n- &: HTML entities"
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_DocumentedUnknownType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_DocumentedUnknownType.json
@@ -7,5 +7,6 @@
     "array",
     "null"
   ],
+  "description": "Tests that unknown types are able to preserve their docstrings.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_MapOfDocumentedUnknownType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_MapOfDocumentedUnknownType.json
@@ -3,6 +3,7 @@
   "additionalProperties": {
     "$ref": "#/definitions/types.object.DocumentedUnknownType"
   },
+  "description": "Tests that map value types with unknown types don't get spurious | undefined.",
   "definitions": {
     "types.object.DocumentedUnknownType": {
       "type": [
@@ -12,7 +13,8 @@
         "object",
         "array",
         "null"
-      ]
+      ],
+      "description": "Tests that unknown types are able to preserve their docstrings."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_NestedObjectWithOptionalField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_NestedObjectWithOptionalField.json
@@ -35,7 +35,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "This is a rather long descriptor of this single field in a more complex type. If you ask me I think this is a pretty good description for this field all things considered."
         },
         "integer": {
           "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_NestedObjectWithRequiredField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_NestedObjectWithRequiredField.json
@@ -25,7 +25,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "This is a rather long descriptor of this single field in a more complex type. If you ask me I think this is a pretty good description for this field all things considered."
         },
         "integer": {
           "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithDatetimeLikeString.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithDatetimeLikeString.json
@@ -2,11 +2,13 @@
   "type": "object",
   "properties": {
     "datetimeLikeString": {
-      "type": "string"
+      "type": "string",
+      "description": "A string field that happens to contain a datetime-like value"
     },
     "actualDatetime": {
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "description": "An actual datetime field for comparison"
     }
   },
   "required": [
@@ -14,5 +16,6 @@
     "actualDatetime"
   ],
   "additionalProperties": false,
+  "description": "This type tests that string fields containing datetime-like values\nare NOT reformatted by the wire test generator. The string field\nshould preserve its exact value even if it looks like a datetime.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithDocumentedUnknownType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithDocumentedUnknownType.json
@@ -9,6 +9,7 @@
     "documentedUnknownType"
   ],
   "additionalProperties": false,
+  "description": "Tests that unknown types are able to preserve their type names.",
   "definitions": {
     "types.object.DocumentedUnknownType": {
       "type": [
@@ -18,7 +19,8 @@
         "object",
         "array",
         "null"
-      ]
+      ],
+      "description": "Tests that unknown types are able to preserve their docstrings."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithMixedRequiredAndOptionalFields.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithMixedRequiredAndOptionalFields.json
@@ -27,5 +27,6 @@
     "requiredLong"
   ],
   "additionalProperties": false,
+  "description": "Tests that dynamic snippets include all required properties even when\nthe example data only provides a subset. In C#, properties marked as\n`required` must be set in the object initializer.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithOptionalField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithOptionalField.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "This is a rather long descriptor of this single field in a more complex type. If you ask me I think this is a pretty good description for this field all things considered."
     },
     "integer": {
       "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithRequiredNestedObject.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithRequiredNestedObject.json
@@ -13,6 +13,7 @@
     "requiredObject"
   ],
   "additionalProperties": false,
+  "description": "Tests that dynamic snippets recursively construct default objects for\nrequired properties whose type is a named object. The nested object's\nown required properties should also be filled with defaults.",
   "definitions": {
     "types.object.ObjectWithOptionalField": {
       "type": "object",
@@ -25,7 +26,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "This is a rather long descriptor of this single field in a more complex type. If you ask me I think this is a pretty good description for this field all things considered."
         },
         "integer": {
           "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithUnknownField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/exhaustive/type_types/object_ObjectWithUnknownField.json
@@ -16,5 +16,6 @@
     "unknown"
   ],
   "additionalProperties": false,
+  "description": "Tests that unknown/any values containing backslashes in map keys\nare properly escaped in Go string literals.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/file-upload-openapi/type__FileId.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/file-upload-openapi/type__FileId.json
@@ -1,4 +1,5 @@
 {
   "type": "string",
+  "description": "The unique identifier for a File in the database",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-deterministic-ordering/type_types/docs_ObjectWithDocs.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-deterministic-ordering/type_types/docs_ObjectWithDocs.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "string": {
-      "type": "string"
+      "type": "string",
+      "description": "Characters that could lead to broken generated SDKs:\n\nMarkdown Escapes:\n- \\_: Escaped underscore (e.g., FOO\\_BAR)\n- \\*: Escaped asterisk\n\nJSDoc (JavaScript/TypeScript):\n- @: Used for JSDoc tags\n- {: }: Used for type definitions\n- <: >: HTML tags\n- *: Can interfere with comment blocks\n- /**: JSDoc comment start\n- ** /: JSDoc comment end\n- &: HTML entities\n\nXMLDoc (C#):\n- <: >: XML tags\n- &: ': \": <: >: XML special characters\n- {: }: Used for interpolated strings\n- ///: Comment marker\n- /**: Block comment start\n- ** /: Block comment end\n\nXMLDoc (C#) (Example of actual XML tags):\nSee <a href=\"https://example.com/docs\">the docs</a> for more info.\nUse <code>getValue()</code> to retrieve the value.\nNote: when count < 10 or count > 100, special handling applies.\n\nJavadoc (Java):\n- @: Used for Javadoc tags\n- <: >: HTML tags\n- &: HTML entities\n- *: Can interfere with comment blocks\n- /**: Javadoc comment start\n- ** /: Javadoc comment end\n\nDoxygen (C++):\n- \\: Used for Doxygen commands\n- @: Alternative command prefix\n- <: >: XML/HTML tags\n- &: HTML entities\n- /**: C-style comment start\n- ** /: C-style comment end\n\nRDoc (Ruby):\n- :: Used in symbol notation\n- =: Section markers\n- #: Comment marker\n- =begin: Block comment start\n- =end: Block comment end\n- @: Instance variable prefix\n- $: Global variable prefix\n- %: String literal delimiter\n- #{: String interpolation start\n- }: String interpolation end\n\nPHPDoc (PHP):\n- @: Used for PHPDoc tags\n- {: }: Used for type definitions\n- $: Variable prefix\n- /**: PHPDoc comment start\n- ** /: PHPDoc comment end\n- *: Can interfere with comment blocks\n- &: HTML entities"
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-deterministic-ordering/type_types/object_NestedObjectWithOptionalField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-deterministic-ordering/type_types/object_NestedObjectWithOptionalField.json
@@ -35,7 +35,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "This is a rather long descriptor of this single field in a more complex type. If you ask me I think this is a pretty good description for this field all things considered."
         },
         "integer": {
           "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-deterministic-ordering/type_types/object_NestedObjectWithRequiredField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-deterministic-ordering/type_types/object_NestedObjectWithRequiredField.json
@@ -25,7 +25,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "This is a rather long descriptor of this single field in a more complex type. If you ask me I think this is a pretty good description for this field all things considered."
         },
         "integer": {
           "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-deterministic-ordering/type_types/object_ObjectWithDatetimeLikeString.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-deterministic-ordering/type_types/object_ObjectWithDatetimeLikeString.json
@@ -2,11 +2,13 @@
   "type": "object",
   "properties": {
     "datetimeLikeString": {
-      "type": "string"
+      "type": "string",
+      "description": "A string field that happens to contain a datetime-like value"
     },
     "actualDatetime": {
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "description": "An actual datetime field for comparison"
     }
   },
   "required": [
@@ -14,5 +16,6 @@
     "actualDatetime"
   ],
   "additionalProperties": false,
+  "description": "This type tests that string fields containing datetime-like values\nare NOT reformatted by the wire test generator. The string field\nshould preserve its exact value even if it looks like a datetime.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-deterministic-ordering/type_types/object_ObjectWithOptionalField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-deterministic-ordering/type_types/object_ObjectWithOptionalField.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "This is a rather long descriptor of this single field in a more complex type. If you ask me I think this is a pretty good description for this field all things considered."
     },
     "integer": {
       "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-deterministic-ordering/type_types/object_ObjectWithUnknownField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-deterministic-ordering/type_types/object_ObjectWithUnknownField.json
@@ -16,5 +16,6 @@
     "unknown"
   ],
   "additionalProperties": false,
+  "description": "Tests that unknown/any values containing backslashes in map keys\nare properly escaped in Go string literals.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-optional-literal-alias/type__SearchRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-optional-literal-alias/type__SearchRequest.json
@@ -9,10 +9,12 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The sort field to use"
     },
     "query": {
-      "type": "string"
+      "type": "string",
+      "description": "The search query"
     }
   },
   "required": [
@@ -21,7 +23,8 @@
   "additionalProperties": false,
   "definitions": {
     "SortField": {
-      "const": "DEFAULT"
+      "const": "DEFAULT",
+      "description": "A sort field that only allows the value \"DEFAULT\""
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-optional-literal-alias/type__SortField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/go-optional-literal-alias/type__SortField.json
@@ -1,4 +1,5 @@
 {
   "const": "DEFAULT",
+  "description": "A sort field that only allows the value \"DEFAULT\"",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/imdb/type_imdb_Movie.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/imdb/type_imdb_Movie.json
@@ -8,7 +8,8 @@
       "type": "string"
     },
     "rating": {
-      "type": "number"
+      "type": "number",
+      "description": "The rating scale is one to five stars"
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-explicit/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-explicit/type_auth_TokenResponse.json
@@ -23,5 +23,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-implicit-api-key/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-implicit-api-key/type_auth_TokenResponse.json
@@ -27,5 +27,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An auth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-implicit-no-expiry/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-implicit-no-expiry/type_auth_TokenResponse.json
@@ -19,5 +19,6 @@
     "access_token"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-implicit-reference/type_auth_GetTokenRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-implicit-reference/type_auth_GetTokenRequest.json
@@ -31,5 +31,6 @@
     "grant_type"
   ],
   "additionalProperties": false,
+  "description": "A request to obtain an OAuth token.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-implicit-reference/type_auth_RefreshTokenRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-implicit-reference/type_auth_RefreshTokenRequest.json
@@ -35,5 +35,6 @@
     "grant_type"
   ],
   "additionalProperties": false,
+  "description": "A request to refresh an OAuth token.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-implicit-reference/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-implicit-reference/type_auth_TokenResponse.json
@@ -23,5 +23,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-implicit/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/inferred-auth-implicit/type_auth_TokenResponse.json
@@ -23,5 +23,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-custom-package-prefix/type_imdb_Movie.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-custom-package-prefix/type_imdb_Movie.json
@@ -8,7 +8,8 @@
       "type": "string"
     },
     "rating": {
-      "type": "number"
+      "type": "number",
+      "description": "The rating scale is one to five stars"
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__DiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__DiscriminatedUnion1.json
@@ -17,13 +17,16 @@
           "const": "type1"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "$ref": "#/definitions/DiscriminatedUnion1InlineType1InlineType1"
+          "$ref": "#/definitions/DiscriminatedUnion1InlineType1InlineType1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -31,7 +34,8 @@
         "foo",
         "bar",
         "ref"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     {
       "properties": {
@@ -39,17 +43,20 @@
           "const": "type2"
         },
         "baz": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "baz",
         "ref"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     {
       "properties": {
@@ -57,43 +64,51 @@
           "const": "ref"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "foo"
-      ]
+      ],
+      "description": "lorem ipsum"
     }
   ],
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__DiscriminatedUnion1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__DiscriminatedUnion1InlineType1.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/DiscriminatedUnion1InlineType1InlineType1"
+      "$ref": "#/definitions/DiscriminatedUnion1InlineType1InlineType1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -17,34 +20,40 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__DiscriminatedUnion1InlineType1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__DiscriminatedUnion1InlineType1InlineType1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__DiscriminatedUnion1InlineType2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__DiscriminatedUnion1InlineType2.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "baz": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__InlineEnum1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__InlineEnum1.json
@@ -6,5 +6,6 @@
     "RAINING",
     "SNOWING"
   ],
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__ReferenceType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__ReferenceType.json
@@ -2,12 +2,14 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     }
   },
   "required": [
     "foo"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RequestTypeInlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RequestTypeInlineType1.json
@@ -2,12 +2,14 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     }
   },
   "required": [
     "foo"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RootType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RootType1.json
@@ -2,32 +2,38 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/RootType1InlineType1"
+      "$ref": "#/definitions/RootType1InlineType1",
+      "description": "lorem ipsum"
     },
     "fooMap": {
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/RootType1FooMapValue"
-      }
+      },
+      "description": "lorem ipsum"
     },
     "fooList": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/RootType1FooListItem"
-      }
+      },
+      "description": "lorem ipsum"
     },
     "fooSet": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/RootType1FooSetItem"
       },
-      "uniqueItems": true
+      "uniqueItems": true,
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -39,6 +45,7 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "InlineEnum1": {
       "type": "string",
@@ -47,34 +54,41 @@
         "CLOUDY",
         "RAINING",
         "SNOWING"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1InlineType1NestedInlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "myEnum": {
-          "$ref": "#/definitions/InlineEnum1"
+          "$ref": "#/definitions/InlineEnum1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -83,19 +97,23 @@
         "myEnum",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "$ref": "#/definitions/RootType1InlineType1NestedInlineType1"
+          "$ref": "#/definitions/RootType1InlineType1NestedInlineType1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -103,55 +121,65 @@
         "bar",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1FooMapValue": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1FooListItem": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1FooSetItem": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RootType1FooListItem.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RootType1FooListItem.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RootType1FooMapValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RootType1FooMapValue.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RootType1FooSetItem.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RootType1FooSetItem.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RootType1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RootType1InlineType1.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/RootType1InlineType1NestedInlineType1"
+      "$ref": "#/definitions/RootType1InlineType1NestedInlineType1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -17,6 +20,7 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "InlineEnum1": {
       "type": "string",
@@ -25,34 +29,41 @@
         "CLOUDY",
         "RAINING",
         "SNOWING"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1InlineType1NestedInlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "myEnum": {
-          "$ref": "#/definitions/InlineEnum1"
+          "$ref": "#/definitions/InlineEnum1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -61,7 +72,8 @@
         "myEnum",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RootType1InlineType1NestedInlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__RootType1InlineType1NestedInlineType1.json
@@ -2,16 +2,20 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "myEnum": {
-      "$ref": "#/definitions/InlineEnum1"
+      "$ref": "#/definitions/InlineEnum1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -21,6 +25,7 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "InlineEnum1": {
       "type": "string",
@@ -29,19 +34,22 @@
         "CLOUDY",
         "RAINING",
         "SNOWING"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1.json
@@ -47,46 +47,55 @@
       "description": "lorem ipsum"
     }
   ],
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "$ref": "#/definitions/UndiscriminatedUnion1InlineType1InlineType1"
+          "$ref": "#/definitions/UndiscriminatedUnion1InlineType1InlineType1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -94,39 +103,46 @@
         "bar",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineType2": {
       "type": "object",
       "properties": {
         "baz": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "baz",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1DiscriminatedUnion1": {
       "type": "object",
@@ -147,13 +163,16 @@
               "const": "type1"
             },
             "foo": {
-              "type": "string"
+              "type": "string",
+              "description": "lorem ipsum"
             },
             "bar": {
-              "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1"
+              "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1",
+              "description": "lorem ipsum"
             },
             "ref": {
-              "$ref": "#/definitions/ReferenceType"
+              "$ref": "#/definitions/ReferenceType",
+              "description": "lorem ipsum"
             }
           },
           "required": [
@@ -161,7 +180,8 @@
             "foo",
             "bar",
             "ref"
-          ]
+          ],
+          "description": "lorem ipsum"
         },
         {
           "properties": {
@@ -169,17 +189,20 @@
               "const": "type2"
             },
             "baz": {
-              "type": "string"
+              "type": "string",
+              "description": "lorem ipsum"
             },
             "ref": {
-              "$ref": "#/definitions/ReferenceType"
+              "$ref": "#/definitions/ReferenceType",
+              "description": "lorem ipsum"
             }
           },
           "required": [
             "type",
             "baz",
             "ref"
-          ]
+          ],
+          "description": "lorem ipsum"
         },
         {
           "properties": {
@@ -187,15 +210,18 @@
               "const": "ref"
             },
             "foo": {
-              "type": "string"
+              "type": "string",
+              "description": "lorem ipsum"
             }
           },
           "required": [
             "type",
             "foo"
-          ]
+          ],
+          "description": "lorem ipsum"
         }
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineEnum1": {
       "type": "string",
@@ -204,58 +230,69 @@
         "CLOUDY",
         "RAINING",
         "SNOWING"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "UserId": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineListItem1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineSetItem1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineMapItem1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1.json
@@ -17,13 +17,16 @@
           "const": "type1"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1"
+          "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -31,7 +34,8 @@
         "foo",
         "bar",
         "ref"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     {
       "properties": {
@@ -39,17 +43,20 @@
           "const": "type2"
         },
         "baz": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "baz",
         "ref"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     {
       "properties": {
@@ -57,43 +64,51 @@
           "const": "ref"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "foo"
-      ]
+      ],
+      "description": "lorem ipsum"
     }
   ],
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType1.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1"
+      "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -17,34 +20,40 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType2.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "baz": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineEnum1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineEnum1.json
@@ -6,5 +6,6 @@
     "RAINING",
     "SNOWING"
   ],
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineListItem1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineListItem1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineMapItem1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineMapItem1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineSetItem1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineSetItem1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineType1.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/UndiscriminatedUnion1InlineType1InlineType1"
+      "$ref": "#/definitions/UndiscriminatedUnion1InlineType1InlineType1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -17,34 +20,40 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineType1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineType1InlineType1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineType2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UndiscriminatedUnion1InlineType2.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "baz": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UserId.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-inline-types/type__UserId.json
@@ -1,4 +1,5 @@
 {
   "type": "string",
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-many-properties/type_types_LargeObjectWithLongsAndDoubles.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-many-properties/type_types_LargeObjectWithLongsAndDoubles.json
@@ -2003,5 +2003,6 @@
     }
   },
   "additionalProperties": false,
+  "description": "Object with long and double fields to test precise JVM slot counting.\nEach long/double field consumes 2 JVM parameter slots instead of 1.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-optional-nullable-query-params/type__SearchResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-optional-nullable-query-params/type__SearchResponse.json
@@ -56,13 +56,15 @@
     "totalCount"
   ],
   "additionalProperties": false,
+  "description": "Search response",
   "definitions": {
     "SortOrder": {
       "type": "string",
       "enum": [
         "ASC",
         "DESC"
-      ]
+      ],
+      "description": "Sort order enum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-optional-nullable-query-params/type__SortOrder.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-optional-nullable-query-params/type__SortOrder.json
@@ -4,5 +4,6 @@
     "ASC",
     "DESC"
   ],
+  "description": "Sort order enum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-optional-query-params-overloads/type__InsurancePolicy.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-optional-query-params-overloads/type__InsurancePolicy.json
@@ -25,6 +25,7 @@
     "coverageAmount"
   ],
   "additionalProperties": false,
+  "description": "Insurance policy details",
   "definitions": {
     "PolicyType": {
       "type": "string",
@@ -33,7 +34,8 @@
         "AUTO",
         "HOME",
         "LIFE"
-      ]
+      ],
+      "description": "Type of insurance policy"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-optional-query-params-overloads/type__PolicyType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-optional-query-params-overloads/type__PolicyType.json
@@ -6,5 +6,6 @@
     "HOME",
     "LIFE"
   ],
+  "description": "Type of insurance policy",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-required-body-optional-headers/type__User.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-required-body-optional-headers/type__User.json
@@ -31,5 +31,6 @@
     "createdAt"
   ],
   "additionalProperties": false,
+  "description": "User entity",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-required-body-optional-headers/type__UserData.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-required-body-optional-headers/type__UserData.json
@@ -15,7 +15,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "User's age"
     }
   },
   "required": [
@@ -23,5 +24,6 @@
     "email"
   ],
   "additionalProperties": false,
+  "description": "User data for creation/update",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-with-property-conflict/type__ConfigurableProp.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/java-with-property-conflict/type__ConfigurableProp.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "name": {
-      "type": "string"
+      "type": "string",
+      "description": "The name of the prop"
     },
     "label": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The display label"
     },
     "withLabel": {
       "oneOf": [
@@ -22,7 +24,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "If true, requires label-value format"
     },
     "description": {
       "oneOf": [
@@ -32,12 +35,14 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "A description of the prop"
     }
   },
   "required": [
     "name"
   ],
   "additionalProperties": false,
+  "description": "A type with both 'label' and 'withLabel' properties that triggers Jackson conflict",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/license/type__Type.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/license/type__Type.json
@@ -9,5 +9,6 @@
     "name"
   ],
   "additionalProperties": false,
+  "description": "A simple type with just a name.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/literals-unions/type_literals_LiteralString.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/literals-unions/type_literals_LiteralString.json
@@ -1,4 +1,5 @@
 {
   "const": "literally",
+  "description": "A string literal.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/literals-unions/type_literals_UnionOverLiteral.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/literals-unions/type_literals_UnionOverLiteral.json
@@ -7,9 +7,11 @@
       "$ref": "#/definitions/literals.LiteralString"
     }
   ],
+  "description": "An undiscriminated union over a literal.",
   "definitions": {
     "literals.LiteralString": {
-      "const": "literally"
+      "const": "literally",
+      "description": "A string literal."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/multi-line-docs/type__Operand.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/multi-line-docs/type__Operand.json
@@ -1,9 +1,17 @@
 {
   "type": "string",
-  "enum": [
-    ">",
-    "=",
-    "less_than"
+  "oneOf": [
+    {
+      "const": ">"
+    },
+    {
+      "const": "="
+    },
+    {
+      "const": "less_than",
+      "description": "The name and value should be similar\nare similar for less than."
+    }
   ],
+  "description": "Tests enum name and value can be \ndifferent.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/multi-line-docs/type_user_User.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/multi-line-docs/type_user_User.json
@@ -5,7 +5,8 @@
       "type": "string"
     },
     "name": {
-      "type": "string"
+      "type": "string",
+      "description": "The user's name. This name is unique to each user. A few examples are included below:\n - Alice\n - Bob\n - Charlie"
     },
     "age": {
       "oneOf": [
@@ -15,7 +16,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The user's age."
     }
   },
   "required": [
@@ -23,5 +25,6 @@
     "name"
   ],
   "additionalProperties": false,
+  "description": "A user object. This type is used throughout the following APIs:\n  - createUser\n  - getUser",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/null-type/type__User.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/null-type/type__User.json
@@ -22,7 +22,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Always null for active users."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/null-type/type_conversations_OutboundCallConversationsResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/null-type/type_conversations_OutboundCallConversationsResponse.json
@@ -16,10 +16,12 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Always null when dry_run is true."
     },
     "dry_run": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Always true for this response."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-allof-extends/type__NormalObject.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-allof-extends/type__NormalObject.json
@@ -13,5 +13,6 @@
     }
   },
   "additionalProperties": false,
+  "description": "A standard object with no nullable issues.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-allof-extends/type__NullableObject.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-allof-extends/type__NullableObject.json
@@ -13,5 +13,6 @@
     }
   },
   "additionalProperties": false,
+  "description": "This schema has nullable:true at the top level.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-allof-extends/type__RootObject.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-allof-extends/type__RootObject.json
@@ -23,5 +23,6 @@
     }
   },
   "additionalProperties": false,
+  "description": "Object inheriting from a nullable schema via allOf.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_Address.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_Address.json
@@ -51,6 +51,7 @@
     "buildingId"
   ],
   "additionalProperties": false,
+  "description": "Nested object for testing",
   "definitions": {
     "nullable-optional.NullableUserId": {
       "oneOf": [
@@ -60,7 +61,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for a nullable user ID"
     },
     "nullable-optional.OptionalUserId": {
       "oneOf": [
@@ -70,7 +72,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for an optional user ID"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_ComplexProfile.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_ComplexProfile.json
@@ -232,6 +232,7 @@
     "nullableListOfUnions"
   ],
   "additionalProperties": false,
+  "description": "Test object with nullable enums, unions, and arrays",
   "definitions": {
     "nullable-optional.UserRole": {
       "type": "string",
@@ -240,7 +241,8 @@
         "USER",
         "GUEST",
         "MODERATOR"
-      ]
+      ],
+      "description": "Test enum for nullable enum fields"
     },
     "nullable-optional.UserStatus": {
       "type": "string",
@@ -249,7 +251,8 @@
         "inactive",
         "suspended",
         "deleted"
-      ]
+      ],
+      "description": "Test enum with values for optional enum fields"
     },
     "nullable-optional.NotificationMethod": {
       "type": "object",
@@ -352,7 +355,8 @@
             "body"
           ]
         }
-      ]
+      ],
+      "description": "Discriminated union for testing nullable unions"
     },
     "nullable-optional.NullableUserId": {
       "oneOf": [
@@ -362,7 +366,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for a nullable user ID"
     },
     "nullable-optional.OptionalUserId": {
       "oneOf": [
@@ -372,7 +377,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for an optional user ID"
     },
     "nullable-optional.Address": {
       "type": "object",
@@ -426,7 +432,8 @@
         "zipCode",
         "buildingId"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Nested object for testing"
     },
     "nullable-optional.SearchResult": {
       "type": "object",
@@ -592,7 +599,8 @@
             "author"
           ]
         }
-      ]
+      ],
+      "description": "Undiscriminated union for testing"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_CreateUserRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_CreateUserRequest.json
@@ -49,7 +49,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for a nullable user ID"
     },
     "nullable-optional.OptionalUserId": {
       "oneOf": [
@@ -59,7 +60,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for an optional user ID"
     },
     "nullable-optional.Address": {
       "type": "object",
@@ -113,7 +115,8 @@
         "zipCode",
         "buildingId"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Nested object for testing"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_DeserializationTestRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_DeserializationTestRequest.json
@@ -131,6 +131,7 @@
     "nullableObject"
   ],
   "additionalProperties": false,
+  "description": "Request body for testing deserialization of null values",
   "definitions": {
     "nullable-optional.UserRole": {
       "type": "string",
@@ -139,7 +140,8 @@
         "USER",
         "GUEST",
         "MODERATOR"
-      ]
+      ],
+      "description": "Test enum for nullable enum fields"
     },
     "nullable-optional.UserStatus": {
       "type": "string",
@@ -148,7 +150,8 @@
         "inactive",
         "suspended",
         "deleted"
-      ]
+      ],
+      "description": "Test enum with values for optional enum fields"
     },
     "nullable-optional.NotificationMethod": {
       "type": "object",
@@ -251,7 +254,8 @@
             "body"
           ]
         }
-      ]
+      ],
+      "description": "Discriminated union for testing nullable unions"
     },
     "nullable-optional.NullableUserId": {
       "oneOf": [
@@ -261,7 +265,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for a nullable user ID"
     },
     "nullable-optional.OptionalUserId": {
       "oneOf": [
@@ -271,7 +276,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for an optional user ID"
     },
     "nullable-optional.Address": {
       "type": "object",
@@ -325,7 +331,8 @@
         "zipCode",
         "buildingId"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Nested object for testing"
     },
     "nullable-optional.SearchResult": {
       "type": "object",
@@ -491,7 +498,8 @@
             "author"
           ]
         }
-      ]
+      ],
+      "description": "Undiscriminated union for testing"
     },
     "nullable-optional.Organization": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_DeserializationTestResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_DeserializationTestResponse.json
@@ -22,6 +22,7 @@
     "presentFieldsCount"
   ],
   "additionalProperties": false,
+  "description": "Response for deserialization test",
   "definitions": {
     "nullable-optional.UserRole": {
       "type": "string",
@@ -30,7 +31,8 @@
         "USER",
         "GUEST",
         "MODERATOR"
-      ]
+      ],
+      "description": "Test enum for nullable enum fields"
     },
     "nullable-optional.UserStatus": {
       "type": "string",
@@ -39,7 +41,8 @@
         "inactive",
         "suspended",
         "deleted"
-      ]
+      ],
+      "description": "Test enum with values for optional enum fields"
     },
     "nullable-optional.NotificationMethod": {
       "type": "object",
@@ -142,7 +145,8 @@
             "body"
           ]
         }
-      ]
+      ],
+      "description": "Discriminated union for testing nullable unions"
     },
     "nullable-optional.NullableUserId": {
       "oneOf": [
@@ -152,7 +156,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for a nullable user ID"
     },
     "nullable-optional.OptionalUserId": {
       "oneOf": [
@@ -162,7 +167,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for an optional user ID"
     },
     "nullable-optional.Address": {
       "type": "object",
@@ -216,7 +222,8 @@
         "zipCode",
         "buildingId"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Nested object for testing"
     },
     "nullable-optional.SearchResult": {
       "type": "object",
@@ -382,7 +389,8 @@
             "author"
           ]
         }
-      ]
+      ],
+      "description": "Undiscriminated union for testing"
     },
     "nullable-optional.Organization": {
       "type": "object",
@@ -553,7 +561,8 @@
         "nullableMap",
         "nullableObject"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Request body for testing deserialization of null values"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_NotificationMethod.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_NotificationMethod.json
@@ -100,5 +100,6 @@
       ]
     }
   ],
+  "description": "Discriminated union for testing nullable unions",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_NullableUserId.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_NullableUserId.json
@@ -7,5 +7,6 @@
       "type": "null"
     }
   ],
+  "description": "An alias for a nullable user ID",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_OptionalUserId.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_OptionalUserId.json
@@ -7,5 +7,6 @@
       "type": "null"
     }
   ],
+  "description": "An alias for an optional user ID",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_SearchResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_SearchResult.json
@@ -163,6 +163,7 @@
       ]
     }
   ],
+  "description": "Undiscriminated union for testing",
   "definitions": {
     "nullable-optional.NullableUserId": {
       "oneOf": [
@@ -172,7 +173,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for a nullable user ID"
     },
     "nullable-optional.OptionalUserId": {
       "oneOf": [
@@ -182,7 +184,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for an optional user ID"
     },
     "nullable-optional.Address": {
       "type": "object",
@@ -236,7 +239,8 @@
         "zipCode",
         "buildingId"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Nested object for testing"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_UpdateUserRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_UpdateUserRequest.json
@@ -43,6 +43,7 @@
     }
   },
   "additionalProperties": false,
+  "description": "For testing PATCH operations",
   "definitions": {
     "nullable-optional.NullableUserId": {
       "oneOf": [
@@ -52,7 +53,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for a nullable user ID"
     },
     "nullable-optional.OptionalUserId": {
       "oneOf": [
@@ -62,7 +64,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for an optional user ID"
     },
     "nullable-optional.Address": {
       "type": "object",
@@ -116,7 +119,8 @@
         "zipCode",
         "buildingId"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Nested object for testing"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_UserProfile.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_UserProfile.json
@@ -194,6 +194,7 @@
     "nullableMap"
   ],
   "additionalProperties": false,
+  "description": "Test object with nullable and optional fields",
   "definitions": {
     "nullable-optional.NullableUserId": {
       "oneOf": [
@@ -203,7 +204,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for a nullable user ID"
     },
     "nullable-optional.OptionalUserId": {
       "oneOf": [
@@ -213,7 +215,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for an optional user ID"
     },
     "nullable-optional.Address": {
       "type": "object",
@@ -267,7 +270,8 @@
         "zipCode",
         "buildingId"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Nested object for testing"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_UserResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_UserResponse.json
@@ -70,7 +70,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for a nullable user ID"
     },
     "nullable-optional.OptionalUserId": {
       "oneOf": [
@@ -80,7 +81,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "An alias for an optional user ID"
     },
     "nullable-optional.Address": {
       "type": "object",
@@ -134,7 +136,8 @@
         "zipCode",
         "buildingId"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Nested object for testing"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_UserRole.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_UserRole.json
@@ -6,5 +6,6 @@
     "GUEST",
     "MODERATOR"
   ],
+  "description": "Test enum for nullable enum fields",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_UserStatus.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/nullable-optional/type_nullable-optional_UserStatus.json
@@ -6,5 +6,6 @@
     "suspended",
     "deleted"
   ],
+  "description": "Test enum with values for optional enum fields",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-custom/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-custom/type_auth_TokenResponse.json
@@ -23,5 +23,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-default/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-default/type_auth_TokenResponse.json
@@ -13,5 +13,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-environment-variables/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-environment-variables/type_auth_TokenResponse.json
@@ -23,5 +23,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-mandatory-auth/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-mandatory-auth/type_auth_TokenResponse.json
@@ -23,5 +23,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-nested-root/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-nested-root/type_auth_TokenResponse.json
@@ -23,5 +23,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-reference/type_auth_GetTokenRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-reference/type_auth_GetTokenRequest.json
@@ -13,5 +13,6 @@
     "client_secret"
   ],
   "additionalProperties": false,
+  "description": "The request body for getting an OAuth token.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-reference/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-reference/type_auth_TokenResponse.json
@@ -13,5 +13,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-with-variables/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials-with-variables/type_auth_TokenResponse.json
@@ -23,5 +23,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/oauth-client-credentials/type_auth_TokenResponse.json
@@ -23,5 +23,6 @@
     "expires_in"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/object/type__Type.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/object/type__Type.json
@@ -172,6 +172,7 @@
     "twentythree"
   ],
   "additionalProperties": false,
+  "description": "Exercises all of the built-in types.",
   "definitions": {
     "Name": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/objects-with-imports/type_file/directory_Directory.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/objects-with-imports/type_file/directory_Directory.json
@@ -38,9 +38,15 @@
   "definitions": {
     "file.FileInfo": {
       "type": "string",
-      "enum": [
-        "REGULAR",
-        "DIRECTORY"
+      "oneOf": [
+        {
+          "const": "REGULAR",
+          "description": "A regular file (e.g. foo.txt)."
+        },
+        {
+          "const": "DIRECTORY",
+          "description": "A directory (e.g. foo/)."
+        }
       ]
     },
     "file.File": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/objects-with-imports/type_file_File.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/objects-with-imports/type_file_File.json
@@ -20,9 +20,15 @@
   "definitions": {
     "file.FileInfo": {
       "type": "string",
-      "enum": [
-        "REGULAR",
-        "DIRECTORY"
+      "oneOf": [
+        {
+          "const": "REGULAR",
+          "description": "A regular file (e.g. foo.txt)."
+        },
+        {
+          "const": "DIRECTORY",
+          "description": "A directory (e.g. foo/)."
+        }
       ]
     }
   }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/objects-with-imports/type_file_FileInfo.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/objects-with-imports/type_file_FileInfo.json
@@ -1,8 +1,14 @@
 {
   "type": "string",
-  "enum": [
-    "REGULAR",
-    "DIRECTORY"
+  "oneOf": [
+    {
+      "const": "REGULAR",
+      "description": "A regular file (e.g. foo.txt)."
+    },
+    {
+      "const": "DIRECTORY",
+      "description": "A directory (e.g. foo/)."
+    }
   ],
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_inline-users/inline-users_ListUsersExtendedOptionalListResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_inline-users/inline-users_ListUsersExtendedOptionalListResponse.json
@@ -16,7 +16,8 @@
       ]
     },
     "total_count": {
-      "type": "integer"
+      "type": "integer",
+      "description": "The totall number of /users"
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_inline-users/inline-users_ListUsersExtendedResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_inline-users/inline-users_ListUsersExtendedResponse.json
@@ -16,7 +16,8 @@
       ]
     },
     "total_count": {
-      "type": "integer"
+      "type": "integer",
+      "description": "The totall number of /users"
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_inline-users/inline-users_ListUsersPaginationResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_inline-users/inline-users_ListUsersPaginationResponse.json
@@ -22,7 +22,8 @@
       ]
     },
     "total_count": {
-      "type": "integer"
+      "type": "integer",
+      "description": "The totall number of /users"
     },
     "data": {
       "$ref": "#/definitions/inline-users.inline-users.Users"
@@ -54,7 +55,8 @@
       "type": "object",
       "properties": {
         "page": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The current page"
         },
         "next": {
           "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_inline-users/inline-users_Page.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_inline-users/inline-users_Page.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "page": {
-      "type": "integer"
+      "type": "integer",
+      "description": "The current page"
     },
     "next": {
       "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_ListUsersAliasedDataPaginationResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_ListUsersAliasedDataPaginationResponse.json
@@ -22,7 +22,8 @@
       ]
     },
     "total_count": {
-      "type": "integer"
+      "type": "integer",
+      "description": "The totall number of /users"
     },
     "data": {
       "$ref": "#/definitions/users.UserList"
@@ -54,7 +55,8 @@
       "type": "object",
       "properties": {
         "page": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The current page"
         },
         "next": {
           "oneOf": [
@@ -100,7 +102,8 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/users.User"
-      }
+      },
+      "description": "A type alias for a list of users"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_ListUsersExtendedOptionalListResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_ListUsersExtendedOptionalListResponse.json
@@ -16,7 +16,8 @@
       ]
     },
     "total_count": {
-      "type": "integer"
+      "type": "integer",
+      "description": "The totall number of /users"
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_ListUsersExtendedResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_ListUsersExtendedResponse.json
@@ -16,7 +16,8 @@
       ]
     },
     "total_count": {
-      "type": "integer"
+      "type": "integer",
+      "description": "The totall number of /users"
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_ListUsersOptionalDataPaginationResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_ListUsersOptionalDataPaginationResponse.json
@@ -22,7 +22,8 @@
       ]
     },
     "total_count": {
-      "type": "integer"
+      "type": "integer",
+      "description": "The totall number of /users"
     },
     "data": {
       "oneOf": [
@@ -63,7 +64,8 @@
       "type": "object",
       "properties": {
         "page": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The current page"
         },
         "next": {
           "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_ListUsersPaginationResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_ListUsersPaginationResponse.json
@@ -22,7 +22,8 @@
       ]
     },
     "total_count": {
-      "type": "integer"
+      "type": "integer",
+      "description": "The totall number of /users"
     },
     "data": {
       "type": "array",
@@ -57,7 +58,8 @@
       "type": "object",
       "properties": {
         "page": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The current page"
         },
         "next": {
           "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_Page.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_Page.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "page": {
-      "type": "integer"
+      "type": "integer",
+      "description": "The current page"
     },
     "next": {
       "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_UserList.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/pagination/type_users_UserList.json
@@ -3,6 +3,7 @@
   "items": {
     "$ref": "#/definitions/users.User"
   },
+  "description": "A type alias for a list of users",
   "definitions": {
     "users.User": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/property-access/type__Admin.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/property-access/type__Admin.json
@@ -2,19 +2,24 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string"
+      "type": "string",
+      "description": "The unique identifier for the user."
     },
     "email": {
-      "type": "string"
+      "type": "string",
+      "description": "The email address of the user."
     },
     "password": {
-      "type": "string"
+      "type": "string",
+      "description": "The password for the user."
     },
     "profile": {
-      "$ref": "#/definitions/UserProfile"
+      "$ref": "#/definitions/UserProfile",
+      "description": "User profile object"
     },
     "adminLevel": {
-      "type": "string"
+      "type": "string",
+      "description": "The level of admin privileges."
     }
   },
   "required": [
@@ -25,30 +30,36 @@
     "adminLevel"
   ],
   "additionalProperties": false,
+  "description": "Admin user object",
   "definitions": {
     "UserProfileVerification": {
       "type": "object",
       "properties": {
         "verified": {
-          "type": "string"
+          "type": "string",
+          "description": "User profile verification status"
         }
       },
       "required": [
         "verified"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "User profile verification object"
     },
     "UserProfile": {
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the user."
         },
         "verification": {
-          "$ref": "#/definitions/UserProfileVerification"
+          "$ref": "#/definitions/UserProfileVerification",
+          "description": "User profile verification object"
         },
         "ssn": {
-          "type": "string"
+          "type": "string",
+          "description": "The social security number of the user."
         }
       },
       "required": [
@@ -56,7 +67,8 @@
         "verification",
         "ssn"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "User profile object"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/property-access/type__User.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/property-access/type__User.json
@@ -2,16 +2,20 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string"
+      "type": "string",
+      "description": "The unique identifier for the user."
     },
     "email": {
-      "type": "string"
+      "type": "string",
+      "description": "The email address of the user."
     },
     "password": {
-      "type": "string"
+      "type": "string",
+      "description": "The password for the user."
     },
     "profile": {
-      "$ref": "#/definitions/UserProfile"
+      "$ref": "#/definitions/UserProfile",
+      "description": "User profile object"
     }
   },
   "required": [
@@ -21,30 +25,36 @@
     "profile"
   ],
   "additionalProperties": false,
+  "description": "User object",
   "definitions": {
     "UserProfileVerification": {
       "type": "object",
       "properties": {
         "verified": {
-          "type": "string"
+          "type": "string",
+          "description": "User profile verification status"
         }
       },
       "required": [
         "verified"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "User profile verification object"
     },
     "UserProfile": {
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the user."
         },
         "verification": {
-          "$ref": "#/definitions/UserProfileVerification"
+          "$ref": "#/definitions/UserProfileVerification",
+          "description": "User profile verification object"
         },
         "ssn": {
-          "type": "string"
+          "type": "string",
+          "description": "The social security number of the user."
         }
       },
       "required": [
@@ -52,7 +62,8 @@
         "verification",
         "ssn"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "User profile object"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/property-access/type__UserOrAdmin.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/property-access/type__UserOrAdmin.json
@@ -7,30 +7,36 @@
       "$ref": "#/definitions/Admin"
     }
   ],
+  "description": "Example of an undiscriminated union",
   "definitions": {
     "UserProfileVerification": {
       "type": "object",
       "properties": {
         "verified": {
-          "type": "string"
+          "type": "string",
+          "description": "User profile verification status"
         }
       },
       "required": [
         "verified"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "User profile verification object"
     },
     "UserProfile": {
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the user."
         },
         "verification": {
-          "$ref": "#/definitions/UserProfileVerification"
+          "$ref": "#/definitions/UserProfileVerification",
+          "description": "User profile verification object"
         },
         "ssn": {
-          "type": "string"
+          "type": "string",
+          "description": "The social security number of the user."
         }
       },
       "required": [
@@ -38,22 +44,27 @@
         "verification",
         "ssn"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "User profile object"
     },
     "User": {
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "The unique identifier for the user."
         },
         "email": {
-          "type": "string"
+          "type": "string",
+          "description": "The email address of the user."
         },
         "password": {
-          "type": "string"
+          "type": "string",
+          "description": "The password for the user."
         },
         "profile": {
-          "$ref": "#/definitions/UserProfile"
+          "$ref": "#/definitions/UserProfile",
+          "description": "User profile object"
         }
       },
       "required": [
@@ -62,25 +73,31 @@
         "password",
         "profile"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "User object"
     },
     "Admin": {
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "The unique identifier for the user."
         },
         "email": {
-          "type": "string"
+          "type": "string",
+          "description": "The email address of the user."
         },
         "password": {
-          "type": "string"
+          "type": "string",
+          "description": "The password for the user."
         },
         "profile": {
-          "$ref": "#/definitions/UserProfile"
+          "$ref": "#/definitions/UserProfile",
+          "description": "User profile object"
         },
         "adminLevel": {
-          "type": "string"
+          "type": "string",
+          "description": "The level of admin privileges."
         }
       },
       "required": [
@@ -90,7 +107,8 @@
         "profile",
         "adminLevel"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Admin user object"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/property-access/type__UserOrAdminDiscriminated.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/property-access/type__UserOrAdminDiscriminated.json
@@ -17,16 +17,20 @@
           "const": "user"
         },
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "The unique identifier for the user."
         },
         "email": {
-          "type": "string"
+          "type": "string",
+          "description": "The email address of the user."
         },
         "password": {
-          "type": "string"
+          "type": "string",
+          "description": "The password for the user."
         },
         "profile": {
-          "$ref": "#/definitions/UserProfile"
+          "$ref": "#/definitions/UserProfile",
+          "description": "User profile object"
         }
       },
       "required": [
@@ -61,30 +65,36 @@
       ]
     }
   ],
+  "description": "Example of an discriminated union",
   "definitions": {
     "UserProfileVerification": {
       "type": "object",
       "properties": {
         "verified": {
-          "type": "string"
+          "type": "string",
+          "description": "User profile verification status"
         }
       },
       "required": [
         "verified"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "User profile verification object"
     },
     "UserProfile": {
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the user."
         },
         "verification": {
-          "$ref": "#/definitions/UserProfileVerification"
+          "$ref": "#/definitions/UserProfileVerification",
+          "description": "User profile verification object"
         },
         "ssn": {
-          "type": "string"
+          "type": "string",
+          "description": "The social security number of the user."
         }
       },
       "required": [
@@ -92,25 +102,31 @@
         "verification",
         "ssn"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "User profile object"
     },
     "Admin": {
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "The unique identifier for the user."
         },
         "email": {
-          "type": "string"
+          "type": "string",
+          "description": "The email address of the user."
         },
         "password": {
-          "type": "string"
+          "type": "string",
+          "description": "The password for the user."
         },
         "profile": {
-          "$ref": "#/definitions/UserProfile"
+          "$ref": "#/definitions/UserProfile",
+          "description": "User profile object"
         },
         "adminLevel": {
-          "type": "string"
+          "type": "string",
+          "description": "The level of admin privileges."
         }
       },
       "required": [
@@ -120,7 +136,8 @@
         "profile",
         "adminLevel"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Admin user object"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/property-access/type__UserProfile.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/property-access/type__UserProfile.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "name": {
-      "type": "string"
+      "type": "string",
+      "description": "The name of the user."
     },
     "verification": {
-      "$ref": "#/definitions/UserProfileVerification"
+      "$ref": "#/definitions/UserProfileVerification",
+      "description": "User profile verification object"
     },
     "ssn": {
-      "type": "string"
+      "type": "string",
+      "description": "The social security number of the user."
     }
   },
   "required": [
@@ -17,18 +20,21 @@
     "ssn"
   ],
   "additionalProperties": false,
+  "description": "User profile object",
   "definitions": {
     "UserProfileVerification": {
       "type": "object",
       "properties": {
         "verified": {
-          "type": "string"
+          "type": "string",
+          "description": "User profile verification status"
         }
       },
       "required": [
         "verified"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "User profile verification object"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/property-access/type__UserProfileVerification.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/property-access/type__UserProfileVerification.json
@@ -2,12 +2,14 @@
   "type": "object",
   "properties": {
     "verified": {
-      "type": "string"
+      "type": "string",
+      "description": "User profile verification status"
     }
   },
   "required": [
     "verified"
   ],
   "additionalProperties": false,
+  "description": "User profile verification object",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/python-backslash-escape/type_user_User.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/python-backslash-escape/type_user_User.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string"
+      "type": "string",
+      "description": "The unique identifier"
     },
     "name": {
-      "type": "string"
+      "type": "string",
+      "description": "The user's name.\nFor Windows: DOMAIN\\username"
     },
     "email": {
-      "type": "string"
+      "type": "string",
+      "description": "The user's email address"
     }
   },
   "required": [
@@ -17,5 +20,6 @@
     "email"
   ],
   "additionalProperties": false,
+  "description": "Represents a user in the system.\nWindows users should use DOMAIN\\username format.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/python-streaming-parameter-openapi/type__ChatRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/python-streaming-parameter-openapi/type__ChatRequest.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "prompt": {
-      "type": "string"
+      "type": "string",
+      "description": "The user's message"
     },
     "stream": {
       "oneOf": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__CompletionFullResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__CompletionFullResponse.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The complete generated answer."
     },
     "finishReason": {
       "oneOf": [
@@ -19,10 +20,12 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Why generation stopped."
     }
   },
   "additionalProperties": false,
+  "description": "Full response returned when streaming is disabled.",
   "definitions": {
     "CompletionFullResponseFinishReason": {
       "type": "string",
@@ -30,7 +33,8 @@
         "complete",
         "length",
         "error"
-      ]
+      ],
+      "description": "Why generation stopped."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__CompletionFullResponseFinishReason.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__CompletionFullResponseFinishReason.json
@@ -5,5 +5,6 @@
     "length",
     "error"
   ],
+  "description": "Why generation stopped.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__CompletionRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__CompletionRequest.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "query": {
-      "type": "string"
+      "type": "string",
+      "description": "The prompt or query to complete."
     },
     "stream": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether to stream the response."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__CompletionStreamChunk.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__CompletionStreamChunk.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The incremental text chunk."
     },
     "tokens": {
       "oneOf": [
@@ -19,9 +20,11 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Number of tokens in this chunk."
     }
   },
   "additionalProperties": false,
+  "description": "A single chunk in a streamed completion response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__NullableStreamRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__NullableStreamRequest.json
@@ -2,7 +2,8 @@
   "type": "object",
   "properties": {
     "query": {
-      "type": "string"
+      "type": "string",
+      "description": "The prompt or query to complete."
     },
     "stream": {
       "oneOf": [
@@ -12,7 +13,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether to stream the response. This field is nullable (OAS 3.1 type array), which previously caused the const literal to be overwritten by the nullable type during spread in the importer."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__ObjectPayloadWithEventField.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__ObjectPayloadWithEventField.json
@@ -8,7 +8,8 @@
       "type": "string"
     },
     "event": {
-      "type": "string"
+      "type": "string",
+      "description": "An event type field inside the data payload that collides with the SSE envelope's event field used for discrimination."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__ProtocolCollisionObjectEvent.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__ProtocolCollisionObjectEvent.json
@@ -20,7 +20,8 @@
           "type": "string"
         },
         "event": {
-          "type": "string"
+          "type": "string",
+          "description": "An event type field inside the data payload that collides with the SSE envelope's event field used for discrimination."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__StreamProtocolCollisionResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__StreamProtocolCollisionResponse.json
@@ -76,7 +76,8 @@
           "type": "string"
         },
         "event": {
-          "type": "string"
+          "type": "string",
+          "description": "An event type field inside the data payload that collides with the SSE envelope's event field used for discrimination."
         }
       },
       "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__StreamXFernStreamingUnionRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__StreamXFernStreamingUnionRequest.json
@@ -24,13 +24,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to stream the response."
         },
         "prompt": {
-          "type": "string"
+          "type": "string",
+          "description": "The input prompt."
         },
         "message": {
-          "type": "string"
+          "type": "string",
+          "description": "The message content."
         }
       },
       "required": [
@@ -52,10 +55,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to stream the response."
         },
         "prompt": {
-          "type": "string"
+          "type": "string",
+          "description": "The input prompt."
         }
       },
       "required": [
@@ -76,13 +81,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to stream the response."
         },
         "prompt": {
-          "type": "string"
+          "type": "string",
+          "description": "The input prompt."
         },
         "data": {
-          "type": "string"
+          "type": "string",
+          "description": "Compact data payload."
         }
       },
       "required": [
@@ -92,5 +100,6 @@
       ]
     }
   ],
+  "description": "A discriminated union request matching the Vectara pattern (FER-9556). Each variant inherits stream_response from UnionStreamRequestBase via allOf. The importer pins stream_response to Literal[True/False] at this union level, but the allOf inheritance re-introduces it as boolean in each variant, causing the type conflict.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__StreamXFernStreamingUnionStreamRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__StreamXFernStreamingUnionStreamRequest.json
@@ -24,13 +24,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to stream the response."
         },
         "prompt": {
-          "type": "string"
+          "type": "string",
+          "description": "The input prompt."
         },
         "message": {
-          "type": "string"
+          "type": "string",
+          "description": "The message content."
         }
       },
       "required": [
@@ -52,10 +55,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to stream the response."
         },
         "prompt": {
-          "type": "string"
+          "type": "string",
+          "description": "The input prompt."
         }
       },
       "required": [
@@ -76,13 +81,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to stream the response."
         },
         "prompt": {
-          "type": "string"
+          "type": "string",
+          "description": "The input prompt."
         },
         "data": {
-          "type": "string"
+          "type": "string",
+          "description": "Compact data payload."
         }
       },
       "required": [
@@ -92,5 +100,6 @@
       ]
     }
   ],
+  "description": "A discriminated union request matching the Vectara pattern (FER-9556). Each variant inherits stream_response from UnionStreamRequestBase via allOf. The importer pins stream_response to Literal[True/False] at this union level, but the allOf inheritance re-introduces it as boolean in each variant, causing the type conflict.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__UnionStreamCompactVariant.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__UnionStreamCompactVariant.json
@@ -9,13 +9,16 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether to stream the response."
     },
     "prompt": {
-      "type": "string"
+      "type": "string",
+      "description": "The input prompt."
     },
     "data": {
-      "type": "string"
+      "type": "string",
+      "description": "Compact data payload."
     }
   },
   "required": [
@@ -23,5 +26,6 @@
     "data"
   ],
   "additionalProperties": false,
+  "description": "Requests compaction of history. Inherits stream_response from base and adds compact-specific fields.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__UnionStreamInterruptVariant.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__UnionStreamInterruptVariant.json
@@ -9,15 +9,18 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether to stream the response."
     },
     "prompt": {
-      "type": "string"
+      "type": "string",
+      "description": "The input prompt."
     }
   },
   "required": [
     "prompt"
   ],
   "additionalProperties": false,
+  "description": "Cancels the current operation. Inherits stream_response from base.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__UnionStreamMessageVariant.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__UnionStreamMessageVariant.json
@@ -9,13 +9,16 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether to stream the response."
     },
     "prompt": {
-      "type": "string"
+      "type": "string",
+      "description": "The input prompt."
     },
     "message": {
-      "type": "string"
+      "type": "string",
+      "description": "The message content."
     }
   },
   "required": [
@@ -23,5 +26,6 @@
     "message"
   ],
   "additionalProperties": false,
+  "description": "A user input message. Inherits stream_response from base via allOf.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__UnionStreamRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__UnionStreamRequest.json
@@ -24,13 +24,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to stream the response."
         },
         "prompt": {
-          "type": "string"
+          "type": "string",
+          "description": "The input prompt."
         },
         "message": {
-          "type": "string"
+          "type": "string",
+          "description": "The message content."
         }
       },
       "required": [
@@ -52,10 +55,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to stream the response."
         },
         "prompt": {
-          "type": "string"
+          "type": "string",
+          "description": "The input prompt."
         }
       },
       "required": [
@@ -76,13 +81,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether to stream the response."
         },
         "prompt": {
-          "type": "string"
+          "type": "string",
+          "description": "The input prompt."
         },
         "data": {
-          "type": "string"
+          "type": "string",
+          "description": "Compact data payload."
         }
       },
       "required": [
@@ -92,5 +100,6 @@
       ]
     }
   ],
+  "description": "A discriminated union request matching the Vectara pattern (FER-9556). Each variant inherits stream_response from UnionStreamRequestBase via allOf. The importer pins stream_response to Literal[True/False] at this union level, but the allOf inheritance re-introduces it as boolean in each variant, causing the type conflict.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__UnionStreamRequestBase.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/server-sent-events-openapi/type__UnionStreamRequestBase.json
@@ -9,15 +9,18 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether to stream the response."
     },
     "prompt": {
-      "type": "string"
+      "type": "string",
+      "description": "The input prompt."
     }
   },
   "required": [
     "prompt"
   ],
   "additionalProperties": false,
+  "description": "Base schema for union stream requests. Contains the stream_response field that is inherited by all oneOf variants via allOf. This schema is also referenced directly by a non-streaming endpoint to ensure it is not excluded from the context.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_ListType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_ListType.json
@@ -12,7 +12,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
     }
   },
   "required": [
@@ -106,7 +107,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_MapType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_MapType.json
@@ -100,7 +100,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_VariableType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_commons_VariableType.json
@@ -84,7 +84,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
         }
       },
       "required": [
@@ -228,7 +229,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_migration_Migration.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_migration_Migration.json
@@ -16,10 +16,18 @@
   "definitions": {
     "migration.MigrationStatus": {
       "type": "string",
-      "enum": [
-        "RUNNING",
-        "FAILED",
-        "FINISHED"
+      "oneOf": [
+        {
+          "const": "RUNNING",
+          "description": "The migration is running"
+        },
+        {
+          "const": "FAILED",
+          "description": "The migration is failed"
+        },
+        {
+          "const": "FINISHED"
+        }
       ]
     }
   }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_migration_MigrationStatus.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_migration_MigrationStatus.json
@@ -1,9 +1,17 @@
 {
   "type": "string",
-  "enum": [
-    "RUNNING",
-    "FAILED",
-    "FINISHED"
+  "oneOf": [
+    {
+      "const": "RUNNING",
+      "description": "The migration is running"
+    },
+    {
+      "const": "FAILED",
+      "description": "The migration is failed"
+    },
+    {
+      "const": "FINISHED"
+    }
   ],
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_playlist_UpdatePlaylistRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_playlist_UpdatePlaylistRequest.json
@@ -8,7 +8,8 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/commons.ProblemId"
-      }
+      },
+      "description": "The problems that make up the playlist."
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_CreateProblemRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_CreateProblemRequest.json
@@ -562,7 +562,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_ProblemInfo.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_ProblemInfo.json
@@ -577,7 +577,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_VariableTypeAndName.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_problem_VariableTypeAndName.json
@@ -100,7 +100,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_CodeExecutionUpdate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_CodeExecutionUpdate.json
@@ -35,7 +35,8 @@
         "type",
         "submissionId",
         "status"
-      ]
+      ],
+      "description": "Statuses if an executor for the session isn't ready (Before RunningResponse)."
     },
     {
       "properties": {
@@ -53,7 +54,8 @@
         "type",
         "submissionId",
         "state"
-      ]
+      ],
+      "description": "Sent once a test submission is executing."
     },
     {
       "properties": {
@@ -71,7 +73,8 @@
         "type",
         "submissionId",
         "errorInfo"
-      ]
+      ],
+      "description": "Sent if a submission cannot be run (i.e. Compile Error)."
     },
     {
       "properties": {
@@ -85,7 +88,8 @@
       "required": [
         "type",
         "submissionId"
-      ]
+      ],
+      "description": "Sent if a submission is stopped."
     },
     {
       "properties": {
@@ -106,7 +110,8 @@
         "type",
         "submissionId",
         "testCases"
-      ]
+      ],
+      "description": "Graded testcases without trace information."
     },
     {
       "properties": {
@@ -127,7 +132,8 @@
         "type",
         "submissionId",
         "testCases"
-      ]
+      ],
+      "description": "Graded submission for v2 problems."
     },
     {
       "properties": {
@@ -145,7 +151,8 @@
         "type",
         "submissionId",
         "runDetails"
-      ]
+      ],
+      "description": "Workspace run without trace information."
     },
     {
       "properties": {
@@ -187,7 +194,8 @@
         "submissionId",
         "lineNumber",
         "lightweightStackInfo"
-      ]
+      ],
+      "description": "Gives progress about what is being recorded."
     },
     {
       "properties": {
@@ -215,7 +223,8 @@
         "type",
         "submissionId",
         "traceResponsesSize"
-      ]
+      ],
+      "description": "Graded testcases with trace information."
     },
     {
       "properties": {
@@ -233,7 +242,8 @@
         "type",
         "request",
         "cause"
-      ]
+      ],
+      "description": "Sent if an invalid request is sent for a submission."
     },
     {
       "properties": {
@@ -247,7 +257,8 @@
       "required": [
         "type",
         "submissionId"
-      ]
+      ],
+      "description": "Sent once a submission is graded and fully recorded."
     }
   ],
   "definitions": {
@@ -335,7 +346,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -349,7 +361,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },
@@ -1162,7 +1175,8 @@
           "required": [
             "type",
             "missingSubmissionId"
-          ]
+          ],
+          "description": "The submission request references a submission id that doesn't exist."
         },
         {
           "properties": {
@@ -1198,7 +1212,8 @@
             "type",
             "expectedLanguage",
             "actualLanguage"
-          ]
+          ],
+          "description": "The submission request was routed to an incorrect language executor."
         }
       ]
     }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ErrorInfo.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ErrorInfo.json
@@ -37,7 +37,8 @@
       "required": [
         "type",
         "message"
-      ]
+      ],
+      "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
     },
     {
       "properties": {
@@ -51,7 +52,8 @@
       "required": [
         "type",
         "exceptionInfo"
-      ]
+      ],
+      "description": "If the trace backend encounters an unexpected error."
     }
   ],
   "definitions": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ErroredResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ErroredResponse.json
@@ -77,7 +77,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -91,7 +92,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ExecutionSessionState.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_ExecutionSessionState.json
@@ -12,7 +12,8 @@
       ]
     },
     "sessionId": {
-      "type": "string"
+      "type": "string",
+      "description": "The auto-generated session id. Formatted as a uuid."
     },
     "isWarmInstance": {
       "type": "boolean"

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_GetExecutionSessionStateResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_GetExecutionSessionStateResponse.json
@@ -63,7 +63,8 @@
           ]
         },
         "sessionId": {
-          "type": "string"
+          "type": "string",
+          "description": "The auto-generated session id. Formatted as a uuid."
         },
         "isWarmInstance": {
           "type": "boolean"

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_GetSubmissionStateResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_GetSubmissionStateResponse.json
@@ -447,7 +447,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -461,7 +462,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_InvalidRequestCause.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_InvalidRequestCause.json
@@ -23,7 +23,8 @@
       "required": [
         "type",
         "missingSubmissionId"
-      ]
+      ],
+      "description": "The submission request references a submission id that doesn't exist."
     },
     {
       "properties": {
@@ -59,7 +60,8 @@
         "type",
         "expectedLanguage",
         "actualLanguage"
-      ]
+      ],
+      "description": "The submission request was routed to an incorrect language executor."
     }
   ],
   "definitions": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_InvalidRequestResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_InvalidRequestResponse.json
@@ -223,7 +223,8 @@
           "required": [
             "type",
             "missingSubmissionId"
-          ]
+          ],
+          "description": "The submission request references a submission id that doesn't exist."
         },
         {
           "properties": {
@@ -259,7 +260,8 @@
             "type",
             "expectedLanguage",
             "actualLanguage"
-          ]
+          ],
+          "description": "The submission request was routed to an incorrect language executor."
         }
       ]
     }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionResponse.json
@@ -181,7 +181,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -195,7 +196,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },
@@ -1005,7 +1007,8 @@
           "required": [
             "type",
             "missingSubmissionId"
-          ]
+          ],
+          "description": "The submission request references a submission id that doesn't exist."
         },
         {
           "properties": {
@@ -1041,7 +1044,8 @@
             "type",
             "expectedLanguage",
             "actualLanguage"
-          ]
+          ],
+          "description": "The submission request was routed to an incorrect language executor."
         }
       ]
     },
@@ -1082,7 +1086,8 @@
             "type",
             "submissionId",
             "status"
-          ]
+          ],
+          "description": "Statuses if an executor for the session isn't ready (Before RunningResponse)."
         },
         {
           "properties": {
@@ -1100,7 +1105,8 @@
             "type",
             "submissionId",
             "state"
-          ]
+          ],
+          "description": "Sent once a test submission is executing."
         },
         {
           "properties": {
@@ -1118,7 +1124,8 @@
             "type",
             "submissionId",
             "errorInfo"
-          ]
+          ],
+          "description": "Sent if a submission cannot be run (i.e. Compile Error)."
         },
         {
           "properties": {
@@ -1132,7 +1139,8 @@
           "required": [
             "type",
             "submissionId"
-          ]
+          ],
+          "description": "Sent if a submission is stopped."
         },
         {
           "properties": {
@@ -1153,7 +1161,8 @@
             "type",
             "submissionId",
             "testCases"
-          ]
+          ],
+          "description": "Graded testcases without trace information."
         },
         {
           "properties": {
@@ -1174,7 +1183,8 @@
             "type",
             "submissionId",
             "testCases"
-          ]
+          ],
+          "description": "Graded submission for v2 problems."
         },
         {
           "properties": {
@@ -1192,7 +1202,8 @@
             "type",
             "submissionId",
             "runDetails"
-          ]
+          ],
+          "description": "Workspace run without trace information."
         },
         {
           "properties": {
@@ -1234,7 +1245,8 @@
             "submissionId",
             "lineNumber",
             "lightweightStackInfo"
-          ]
+          ],
+          "description": "Gives progress about what is being recorded."
         },
         {
           "properties": {
@@ -1262,7 +1274,8 @@
             "type",
             "submissionId",
             "traceResponsesSize"
-          ]
+          ],
+          "description": "Graded testcases with trace information."
         },
         {
           "properties": {
@@ -1280,7 +1293,8 @@
             "type",
             "request",
             "cause"
-          ]
+          ],
+          "description": "Sent if an invalid request is sent for a submission."
         },
         {
           "properties": {
@@ -1294,7 +1308,8 @@
           "required": [
             "type",
             "submissionId"
-          ]
+          ],
+          "description": "Sent once a submission is graded and fully recorded."
         }
       ]
     }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionStatusV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionStatusV2.json
@@ -127,7 +127,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -141,7 +142,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },
@@ -875,7 +877,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionTypeEnum.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionTypeEnum.json
@@ -3,5 +3,6 @@
   "enum": [
     "TEST"
   ],
+  "description": "Keep in sync with SubmissionType.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionTypeState.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_SubmissionTypeState.json
@@ -468,7 +468,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -482,7 +483,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionState.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionState.json
@@ -438,7 +438,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -452,7 +453,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionStatus.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionStatus.json
@@ -125,7 +125,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -139,7 +140,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionStatusV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionStatusV2.json
@@ -94,7 +94,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -108,7 +109,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },
@@ -842,7 +844,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionUpdate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionUpdate.json
@@ -84,7 +84,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -98,7 +99,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionUpdateInfo.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TestSubmissionUpdateInfo.json
@@ -167,7 +167,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -181,7 +182,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TraceResponsesPage.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TraceResponsesPage.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "If present, use this to load subsequent pages.\nThe offset is the id of the next trace response to load."
     },
     "traceResponses": {
       "type": "array",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TraceResponsesPageV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_TraceResponsesPageV2.json
@@ -9,7 +9,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "If present, use this to load subsequent pages.\nThe offset is the id of the next trace response to load."
     },
     "traceResponses": {
       "type": "array",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionState.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionState.json
@@ -69,7 +69,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -83,7 +84,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionStatus.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionStatus.json
@@ -178,7 +178,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -192,7 +193,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionStatusV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionStatusV2.json
@@ -128,7 +128,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -142,7 +143,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionUpdate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionUpdate.json
@@ -130,7 +130,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -144,7 +145,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     },

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionUpdateInfo.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_submission_WorkspaceSubmissionUpdateInfo.json
@@ -236,7 +236,8 @@
           "required": [
             "type",
             "message"
-          ]
+          ],
+          "description": "If the submission cannot be executed and throws a runtime error before getting to any of the testcases."
         },
         {
           "properties": {
@@ -250,7 +251,8 @@
           "required": [
             "type",
             "exceptionInfo"
-          ]
+          ],
+          "description": "If the trace backend encounters an unexpected error."
         }
       ]
     }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_AssertCorrectnessCheck.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_AssertCorrectnessCheck.json
@@ -136,7 +136,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_BasicCustomFiles.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_BasicCustomFiles.json
@@ -114,7 +114,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_CreateProblemRequestV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_CreateProblemRequestV2.json
@@ -531,7 +531,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_CustomFiles.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_CustomFiles.json
@@ -146,7 +146,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_DefaultProvidedFile.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_DefaultProvidedFile.json
@@ -127,7 +127,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_FunctionSignature.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_FunctionSignature.json
@@ -68,7 +68,8 @@
         "type",
         "parameters",
         "actualResultType"
-      ]
+      ],
+      "description": "Useful when specifying custom grading for a testcase where actualResult is defined."
     }
   ],
   "definitions": {
@@ -161,7 +162,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetBasicSolutionFileRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetBasicSolutionFileRequest.json
@@ -103,7 +103,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetFunctionSignatureRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetFunctionSignatureRequest.json
@@ -99,7 +99,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [
@@ -247,7 +248,8 @@
             "type",
             "parameters",
             "actualResultType"
-          ]
+          ],
+          "description": "Useful when specifying custom grading for a testcase where actualResult is defined."
         }
       ]
     }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetGeneratedTestCaseFileRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetGeneratedTestCaseFileRequest.json
@@ -167,7 +167,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetGeneratedTestCaseTemplateFileRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_GetGeneratedTestCaseTemplateFileRequest.json
@@ -157,7 +157,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_LightweightProblemInfoV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_LightweightProblemInfoV2.json
@@ -115,7 +115,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_NonVoidFunctionDefinition.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_NonVoidFunctionDefinition.json
@@ -103,7 +103,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_NonVoidFunctionSignature.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_NonVoidFunctionSignature.json
@@ -106,7 +106,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_Parameter.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_Parameter.json
@@ -107,7 +107,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_ProblemInfoV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_ProblemInfoV2.json
@@ -554,7 +554,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseFunction.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseFunction.json
@@ -140,7 +140,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseImplementation.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseImplementation.json
@@ -158,7 +158,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseImplementationReference.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseImplementationReference.json
@@ -190,7 +190,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseTemplate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseTemplate.json
@@ -165,7 +165,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseV2.json
@@ -201,7 +201,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseWithActualResultImplementation.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_TestCaseWithActualResultImplementation.json
@@ -103,7 +103,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionDefinition.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionDefinition.json
@@ -106,7 +106,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionDefinitionThatTakesActualResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionDefinitionThatTakesActualResult.json
@@ -16,6 +16,7 @@
     "code"
   ],
   "additionalProperties": false,
+  "description": "The generated signature will include an additional param, actualResult",
   "definitions": {
     "v2.problem.ParameterId": {
       "type": "string"
@@ -106,7 +107,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionSignature.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionSignature.json
@@ -102,7 +102,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionSignatureThatTakesActualResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/problem_VoidFunctionSignatureThatTakesActualResult.json
@@ -106,7 +106,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_AssertCorrectnessCheck.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_AssertCorrectnessCheck.json
@@ -136,7 +136,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_BasicCustomFiles.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_BasicCustomFiles.json
@@ -114,7 +114,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_CreateProblemRequestV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_CreateProblemRequestV2.json
@@ -531,7 +531,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_CustomFiles.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_CustomFiles.json
@@ -146,7 +146,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_DefaultProvidedFile.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_DefaultProvidedFile.json
@@ -127,7 +127,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_FunctionSignature.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_FunctionSignature.json
@@ -68,7 +68,8 @@
         "type",
         "parameters",
         "actualResultType"
-      ]
+      ],
+      "description": "Useful when specifying custom grading for a testcase where actualResult is defined."
     }
   ],
   "definitions": {
@@ -161,7 +162,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetBasicSolutionFileRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetBasicSolutionFileRequest.json
@@ -103,7 +103,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetFunctionSignatureRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetFunctionSignatureRequest.json
@@ -99,7 +99,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [
@@ -247,7 +248,8 @@
             "type",
             "parameters",
             "actualResultType"
-          ]
+          ],
+          "description": "Useful when specifying custom grading for a testcase where actualResult is defined."
         }
       ]
     }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetGeneratedTestCaseFileRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetGeneratedTestCaseFileRequest.json
@@ -167,7 +167,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetGeneratedTestCaseTemplateFileRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_GetGeneratedTestCaseTemplateFileRequest.json
@@ -157,7 +157,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_LightweightProblemInfoV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_LightweightProblemInfoV2.json
@@ -115,7 +115,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_NonVoidFunctionDefinition.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_NonVoidFunctionDefinition.json
@@ -103,7 +103,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_NonVoidFunctionSignature.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_NonVoidFunctionSignature.json
@@ -106,7 +106,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_Parameter.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_Parameter.json
@@ -107,7 +107,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_ProblemInfoV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_ProblemInfoV2.json
@@ -554,7 +554,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseFunction.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseFunction.json
@@ -140,7 +140,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseImplementation.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseImplementation.json
@@ -158,7 +158,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseImplementationReference.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseImplementationReference.json
@@ -190,7 +190,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseTemplate.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseTemplate.json
@@ -165,7 +165,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseV2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseV2.json
@@ -201,7 +201,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseWithActualResultImplementation.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_TestCaseWithActualResultImplementation.json
@@ -103,7 +103,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionDefinition.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionDefinition.json
@@ -106,7 +106,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionDefinitionThatTakesActualResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionDefinitionThatTakesActualResult.json
@@ -16,6 +16,7 @@
     "code"
   ],
   "additionalProperties": false,
+  "description": "The generated signature will include an additional param, actualResult",
   "definitions": {
     "v2.v3.problem.ParameterId": {
       "type": "string"
@@ -106,7 +107,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionSignature.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionSignature.json
@@ -102,7 +102,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionSignatureThatTakesActualResult.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/trace/type_v2/v3/problem_VoidFunctionSignatureThatTakesActualResult.json
@@ -106,7 +106,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Whether this list is fixed-size (for languages that supports fixed-size lists). Defaults to false."
             }
           },
           "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-express-casing/type_imdb_Movie.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-express-casing/type_imdb_Movie.json
@@ -8,7 +8,8 @@
       "type": "string"
     },
     "rating": {
-      "type": "number"
+      "type": "number",
+      "description": "The rating scale is one to five stars"
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__DiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__DiscriminatedUnion1.json
@@ -17,13 +17,16 @@
           "const": "type1"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "$ref": "#/definitions/DiscriminatedUnion1InlineType1InlineType1"
+          "$ref": "#/definitions/DiscriminatedUnion1InlineType1InlineType1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -31,7 +34,8 @@
         "foo",
         "bar",
         "ref"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     {
       "properties": {
@@ -39,17 +43,20 @@
           "const": "type2"
         },
         "baz": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "baz",
         "ref"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     {
       "properties": {
@@ -57,43 +64,51 @@
           "const": "ref"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "foo"
-      ]
+      ],
+      "description": "lorem ipsum"
     }
   ],
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__DiscriminatedUnion1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__DiscriminatedUnion1InlineType1.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/DiscriminatedUnion1InlineType1InlineType1"
+      "$ref": "#/definitions/DiscriminatedUnion1InlineType1InlineType1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -17,34 +20,40 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__DiscriminatedUnion1InlineType1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__DiscriminatedUnion1InlineType1InlineType1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__DiscriminatedUnion1InlineType2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__DiscriminatedUnion1InlineType2.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "baz": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__InlineEnum1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__InlineEnum1.json
@@ -6,5 +6,6 @@
     "RAINING",
     "SNOWING"
   ],
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__ReferenceType.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__ReferenceType.json
@@ -2,12 +2,14 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     }
   },
   "required": [
     "foo"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RequestTypeInlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RequestTypeInlineType1.json
@@ -2,12 +2,14 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     }
   },
   "required": [
     "foo"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RootType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RootType1.json
@@ -2,32 +2,38 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/RootType1InlineType1"
+      "$ref": "#/definitions/RootType1InlineType1",
+      "description": "lorem ipsum"
     },
     "fooMap": {
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/RootType1FooMapValue"
-      }
+      },
+      "description": "lorem ipsum"
     },
     "fooList": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/RootType1FooListItem"
-      }
+      },
+      "description": "lorem ipsum"
     },
     "fooSet": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/RootType1FooSetItem"
       },
-      "uniqueItems": true
+      "uniqueItems": true,
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -39,6 +45,7 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "InlineEnum1": {
       "type": "string",
@@ -47,34 +54,41 @@
         "CLOUDY",
         "RAINING",
         "SNOWING"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1InlineType1NestedInlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "myEnum": {
-          "$ref": "#/definitions/InlineEnum1"
+          "$ref": "#/definitions/InlineEnum1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -83,19 +97,23 @@
         "myEnum",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "$ref": "#/definitions/RootType1InlineType1NestedInlineType1"
+          "$ref": "#/definitions/RootType1InlineType1NestedInlineType1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -103,55 +121,65 @@
         "bar",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1FooMapValue": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1FooListItem": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1FooSetItem": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RootType1FooListItem.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RootType1FooListItem.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RootType1FooMapValue.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RootType1FooMapValue.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RootType1FooSetItem.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RootType1FooSetItem.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RootType1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RootType1InlineType1.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/RootType1InlineType1NestedInlineType1"
+      "$ref": "#/definitions/RootType1InlineType1NestedInlineType1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -17,6 +20,7 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "InlineEnum1": {
       "type": "string",
@@ -25,34 +29,41 @@
         "CLOUDY",
         "RAINING",
         "SNOWING"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "RootType1InlineType1NestedInlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "myEnum": {
-          "$ref": "#/definitions/InlineEnum1"
+          "$ref": "#/definitions/InlineEnum1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -61,7 +72,8 @@
         "myEnum",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RootType1InlineType1NestedInlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__RootType1InlineType1NestedInlineType1.json
@@ -2,16 +2,20 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "myEnum": {
-      "$ref": "#/definitions/InlineEnum1"
+      "$ref": "#/definitions/InlineEnum1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -21,6 +25,7 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "InlineEnum1": {
       "type": "string",
@@ -29,19 +34,22 @@
         "CLOUDY",
         "RAINING",
         "SNOWING"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1.json
@@ -47,46 +47,55 @@
       "description": "lorem ipsum"
     }
   ],
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "$ref": "#/definitions/UndiscriminatedUnion1InlineType1InlineType1"
+          "$ref": "#/definitions/UndiscriminatedUnion1InlineType1InlineType1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -94,39 +103,46 @@
         "bar",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineType2": {
       "type": "object",
       "properties": {
         "baz": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "baz",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1DiscriminatedUnion1": {
       "type": "object",
@@ -147,13 +163,16 @@
               "const": "type1"
             },
             "foo": {
-              "type": "string"
+              "type": "string",
+              "description": "lorem ipsum"
             },
             "bar": {
-              "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1"
+              "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1",
+              "description": "lorem ipsum"
             },
             "ref": {
-              "$ref": "#/definitions/ReferenceType"
+              "$ref": "#/definitions/ReferenceType",
+              "description": "lorem ipsum"
             }
           },
           "required": [
@@ -161,7 +180,8 @@
             "foo",
             "bar",
             "ref"
-          ]
+          ],
+          "description": "lorem ipsum"
         },
         {
           "properties": {
@@ -169,17 +189,20 @@
               "const": "type2"
             },
             "baz": {
-              "type": "string"
+              "type": "string",
+              "description": "lorem ipsum"
             },
             "ref": {
-              "$ref": "#/definitions/ReferenceType"
+              "$ref": "#/definitions/ReferenceType",
+              "description": "lorem ipsum"
             }
           },
           "required": [
             "type",
             "baz",
             "ref"
-          ]
+          ],
+          "description": "lorem ipsum"
         },
         {
           "properties": {
@@ -187,15 +210,18 @@
               "const": "ref"
             },
             "foo": {
-              "type": "string"
+              "type": "string",
+              "description": "lorem ipsum"
             }
           },
           "required": [
             "type",
             "foo"
-          ]
+          ],
+          "description": "lorem ipsum"
         }
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineEnum1": {
       "type": "string",
@@ -204,58 +230,69 @@
         "CLOUDY",
         "RAINING",
         "SNOWING"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     "UserId": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineListItem1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineSetItem1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineMapItem1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1.json
@@ -17,13 +17,16 @@
           "const": "type1"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "bar": {
-          "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1"
+          "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
@@ -31,7 +34,8 @@
         "foo",
         "bar",
         "ref"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     {
       "properties": {
@@ -39,17 +43,20 @@
           "const": "type2"
         },
         "baz": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "baz",
         "ref"
-      ]
+      ],
+      "description": "lorem ipsum"
     },
     {
       "properties": {
@@ -57,43 +64,51 @@
           "const": "ref"
         },
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "type",
         "foo"
-      ]
+      ],
+      "description": "lorem ipsum"
     }
   ],
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType1.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1"
+      "$ref": "#/definitions/UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -17,34 +20,40 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType1InlineType1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1DiscriminatedUnion1InlineType2.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "baz": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineEnum1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineEnum1.json
@@ -6,5 +6,6 @@
     "RAINING",
     "SNOWING"
   ],
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineListItem1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineListItem1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineMapItem1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineMapItem1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineSetItem1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineSetItem1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineType1.json
@@ -2,13 +2,16 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "bar": {
-      "$ref": "#/definitions/UndiscriminatedUnion1InlineType1InlineType1"
+      "$ref": "#/definitions/UndiscriminatedUnion1InlineType1InlineType1",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -17,34 +20,40 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     },
     "UndiscriminatedUnion1InlineType1InlineType1": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         },
         "ref": {
-          "$ref": "#/definitions/ReferenceType"
+          "$ref": "#/definitions/ReferenceType",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo",
         "ref"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineType1InlineType1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineType1InlineType1.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "foo": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineType2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UndiscriminatedUnion1InlineType2.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "baz": {
-      "type": "string"
+      "type": "string",
+      "description": "lorem ipsum"
     },
     "ref": {
-      "$ref": "#/definitions/ReferenceType"
+      "$ref": "#/definitions/ReferenceType",
+      "description": "lorem ipsum"
     }
   },
   "required": [
@@ -13,18 +15,21 @@
     "ref"
   ],
   "additionalProperties": false,
+  "description": "lorem ipsum",
   "definitions": {
     "ReferenceType": {
       "type": "object",
       "properties": {
         "foo": {
-          "type": "string"
+          "type": "string",
+          "description": "lorem ipsum"
         }
       },
       "required": [
         "foo"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "lorem ipsum"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UserId.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/ts-inline-types/type__UserId.json
@@ -1,4 +1,5 @@
 {
   "type": "string",
+  "description": "lorem ipsum",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-union-with-response-property/type__MyUnion.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-union-with-response-property/type__MyUnion.json
@@ -10,6 +10,7 @@
       "$ref": "#/definitions/VariantC"
     }
   ],
+  "description": "Undiscriminated union with multiple object variants.\nThis reproduces the Pipedream issue where Emitter is a union of\nDeployedComponent, HttpInterface, and TimerInterface.",
   "definitions": {
     "VariantA": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-union-with-response-property/type__UnionListResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-union-with-response-property/type__UnionListResponse.json
@@ -72,7 +72,8 @@
         {
           "$ref": "#/definitions/VariantC"
         }
-      ]
+      ],
+      "description": "Undiscriminated union with multiple object variants.\nThis reproduces the Pipedream issue where Emitter is a union of\nDeployedComponent, HttpInterface, and TimerInterface."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-union-with-response-property/type__UnionResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-union-with-response-property/type__UnionResponse.json
@@ -69,7 +69,8 @@
         {
           "$ref": "#/definitions/VariantC"
         }
-      ]
+      ],
+      "description": "Undiscriminated union with multiple object variants.\nThis reproduces the Pipedream issue where Emitter is a union of\nDeployedComponent, HttpInterface, and TimerInterface."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_AliasedLeafA.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_AliasedLeafA.json
@@ -1,5 +1,6 @@
 {
   "$ref": "#/definitions/union.LeafObjectA",
+  "description": "An alias around LeafObjectA.",
   "definitions": {
     "union.LeafObjectA": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_AliasedLeafB.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_AliasedLeafB.json
@@ -1,5 +1,6 @@
 {
   "$ref": "#/definitions/union.AliasToLeafB",
+  "description": "An alias around an alias around LeafObjectB, to exercise the alias-walk loop.",
   "definitions": {
     "union.LeafObjectB": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_AliasedObjectUnion.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_AliasedObjectUnion.json
@@ -7,6 +7,7 @@
       "$ref": "#/definitions/union.AliasedLeafB"
     }
   ],
+  "description": "Undiscriminated union whose members are named aliases of object types\n(including an alias-of-alias). Required keys are disjoint, so a correct\ndeserializer must emit containsKey() guards for each alias variant.",
   "definitions": {
     "union.LeafObjectA": {
       "type": "object",
@@ -25,7 +26,8 @@
       "additionalProperties": false
     },
     "union.AliasedLeafA": {
-      "$ref": "#/definitions/union.LeafObjectA"
+      "$ref": "#/definitions/union.LeafObjectA",
+      "description": "An alias around LeafObjectA."
     },
     "union.LeafObjectB": {
       "type": "object",
@@ -43,7 +45,8 @@
       "$ref": "#/definitions/union.LeafObjectB"
     },
     "union.AliasedLeafB": {
-      "$ref": "#/definitions/union.AliasToLeafB"
+      "$ref": "#/definitions/union.AliasToLeafB",
+      "description": "An alias around an alias around LeafObjectB, to exercise the alias-walk loop."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_Metadata.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_Metadata.json
@@ -3,5 +3,6 @@
   "additionalProperties": {
     "type": "string"
   },
+  "description": "Undiscriminated unions can act as a map key\nas long as all of their values are valid keys\n(i.e. do they have a valid string representation).",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_MyUnion.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_MyUnion.json
@@ -35,5 +35,6 @@
       "uniqueItems": true
     }
   ],
+  "description": "Several different types are accepted.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_Name.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_Name.json
@@ -1,4 +1,5 @@
 {
   "type": "string",
+  "description": "A name (alias for string)",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_NestedObjectUnion.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_NestedObjectUnion.json
@@ -7,6 +7,7 @@
       "$ref": "#/definitions/union.LeafTypeB"
     }
   ],
+  "description": "Inner union with two object variants that have disjoint required keys.\nTests that required-key guards work correctly inside nested union contexts.",
   "definitions": {
     "union.LeafTypeA": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_NestedUnionL1.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_NestedUnionL1.json
@@ -20,6 +20,7 @@
       "$ref": "#/definitions/union.NestedUnionL2"
     }
   ],
+  "description": "Nested layer 1.",
   "definitions": {
     "union.NestedUnionL2": {
       "anyOf": [
@@ -39,7 +40,8 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "description": "Nested layer 2."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_NestedUnionL2.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_NestedUnionL2.json
@@ -17,5 +17,6 @@
       }
     }
   ],
+  "description": "Nested layer 2.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_NestedUnionRoot.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_NestedUnionRoot.json
@@ -13,6 +13,7 @@
       "$ref": "#/definitions/union.NestedUnionL1"
     }
   ],
+  "description": "Nested union root.",
   "definitions": {
     "union.NestedUnionL2": {
       "anyOf": [
@@ -32,7 +33,8 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "description": "Nested layer 2."
     },
     "union.NestedUnionL1": {
       "anyOf": [
@@ -55,7 +57,8 @@
         {
           "$ref": "#/definitions/union.NestedUnionL2"
         }
-      ]
+      ],
+      "description": "Nested layer 1."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_OuterNestedUnion.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_OuterNestedUnion.json
@@ -7,6 +7,7 @@
       "$ref": "#/definitions/union.WrapperObject"
     }
   ],
+  "description": "Outer union where one variant is an object containing a nested union field.\nTests that the deserializer correctly handles transitive union deserialization.",
   "definitions": {
     "union.LeafTypeA": {
       "type": "object",
@@ -44,7 +45,8 @@
         {
           "$ref": "#/definitions/union.LeafTypeB"
         }
-      ]
+      ],
+      "description": "Inner union with two object variants that have disjoint required keys.\nTests that required-key guards work correctly inside nested union contexts."
     },
     "union.WrapperObject": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_PaymentMethodUnion.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_PaymentMethodUnion.json
@@ -7,6 +7,7 @@
       "$ref": "#/definitions/union.ConvertToken"
     }
   ],
+  "description": "Tests that nested properties with camelCase wire names are properly\nconverted from snake_case Ruby keys when passed as Hash values.",
   "definitions": {
     "union.TokenizeCard": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_TypeWithOptionalUnion.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_TypeWithOptionalUnion.json
@@ -50,7 +50,8 @@
           },
           "uniqueItems": true
         }
-      ]
+      ],
+      "description": "Several different types are accepted."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UnionWithBaseProperties.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UnionWithBaseProperties.json
@@ -7,6 +7,7 @@
       "$ref": "#/definitions/union.OptionalMetadata"
     }
   ],
+  "description": "Tests that base-properties on an undiscriminated union are correctly\nrepresented in the IR and generated code.",
   "definitions": {
     "union.NamedMetadata": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UnionWithDuplicateTypes.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UnionWithDuplicateTypes.json
@@ -20,5 +20,6 @@
       "uniqueItems": true
     }
   ],
+  "description": "Duplicate types.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UnionWithIdenticalPrimitives.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UnionWithIdenticalPrimitives.json
@@ -10,5 +10,6 @@
       "type": "string"
     }
   ],
+  "description": "Mix of primitives where some resolve to the same Java type.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UnionWithIdenticalStrings.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UnionWithIdenticalStrings.json
@@ -4,5 +4,6 @@
       "type": "string"
     }
   ],
+  "description": "Multiple string types that all resolve to String in Java.\nThis tests the fix for duplicate method signatures.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UnionWithReservedNames.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UnionWithReservedNames.json
@@ -10,5 +10,6 @@
       "type": "string"
     }
   ],
+  "description": "Tests that union members named 'Type' or 'Value' don't collide with internal properties",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UnionWithTypeAliases.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UnionWithTypeAliases.json
@@ -10,12 +10,15 @@
       "$ref": "#/definitions/union.Name"
     }
   ],
+  "description": "Union with multiple named type aliases that all resolve to the same C# type (string).\nWithout the fix, this would generate duplicate implicit operators:\n  public static implicit operator UnionWithTypeAliases(string value) => ...\n  public static implicit operator UnionWithTypeAliases(string value) => ...\n  public static implicit operator UnionWithTypeAliases(string value) => ...\ncausing CS0557 compiler error.",
   "definitions": {
     "union.UserId": {
-      "type": "string"
+      "type": "string",
+      "description": "A user identifier (alias for string)"
     },
     "union.Name": {
-      "type": "string"
+      "type": "string",
+      "description": "A name (alias for string)"
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UserId.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_UserId.json
@@ -1,4 +1,5 @@
 {
   "type": "string",
+  "description": "A user identifier (alias for string)",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_WrapperObject.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/undiscriminated-unions/type_union_WrapperObject.json
@@ -50,7 +50,8 @@
         {
           "$ref": "#/definitions/union.LeafTypeB"
         }
-      ]
+      ],
+      "description": "Inner union with two object variants that have disjoint required keys.\nTests that required-key guards work correctly inside nested union contexts."
     }
   }
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/union-query-parameters/type_events_EventTypeParam.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/union-query-parameters/type_events_EventTypeParam.json
@@ -10,6 +10,7 @@
       }
     }
   ],
+  "description": "Either a single event type or a list of event types.",
   "definitions": {
     "events.EventTypeEnum": {
       "type": "string",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/union-query-parameters/type_events_StringOrListParam.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/union-query-parameters/type_events_StringOrListParam.json
@@ -10,5 +10,6 @@
       }
     }
   ],
+  "description": "Either a single string or a list of strings.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions-with-local-date/type_types_Union.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions-with-local-date/type_types_Union.json
@@ -37,6 +37,7 @@
       ]
     }
   ],
+  "description": "This is a simple union.",
   "definitions": {
     "types.Foo": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions-with-local-date/type_types_UnionWithDiscriminant.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions-with-local-date/type_types_UnionWithDiscriminant.json
@@ -21,7 +21,8 @@
       },
       "required": [
         "_type"
-      ]
+      ],
+      "description": "This is a Foo field."
     },
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions-with-local-date/type_types_UnionWithoutKey.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions-with-local-date/type_types_UnionWithoutKey.json
@@ -36,7 +36,8 @@
       "required": [
         "type",
         "name"
-      ]
+      ],
+      "description": "This is a bar field."
     }
   ],
   "definitions": {}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_Union.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_Union.json
@@ -37,6 +37,7 @@
       ]
     }
   ],
+  "description": "This is a simple union.",
   "definitions": {
     "types.Foo": {
       "type": "object",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithDiscriminant.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithDiscriminant.json
@@ -21,7 +21,8 @@
       },
       "required": [
         "_type"
-      ]
+      ],
+      "description": "This is a Foo field."
     },
     {
       "properties": {

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithoutKey.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/unions/type_types_UnionWithoutKey.json
@@ -36,7 +36,8 @@
       "required": [
         "type",
         "name"
-      ]
+      ],
+      "description": "This is a bar field."
     }
   ],
   "definitions": {}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/url-form-encoded/type__TokenRequest.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/url-form-encoded/type__TokenRequest.json
@@ -2,10 +2,12 @@
   "type": "object",
   "properties": {
     "client_id": {
-      "type": "string"
+      "type": "string",
+      "description": "Client identifier"
     },
     "client_secret": {
-      "type": "string"
+      "type": "string",
+      "description": "Client secret"
     }
   },
   "required": [

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/validation/type__Type.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/validation/type__Type.json
@@ -21,6 +21,7 @@
     "shape"
   ],
   "additionalProperties": false,
+  "description": "Defines properties with default values and validation rules.",
   "definitions": {
     "Shape": {
       "type": "string",

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/websocket-inferred-auth/type_auth_TokenResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/websocket-inferred-auth/type_auth_TokenResponse.json
@@ -19,5 +19,6 @@
     "access_token"
   ],
   "additionalProperties": false,
+  "description": "An OAuth token response.",
   "definitions": {}
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/converters/convertTypeDeclarationToJsonSchema.ts
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/converters/convertTypeDeclarationToJsonSchema.ts
@@ -20,6 +20,14 @@ export function convertTypeDeclarationToJsonSchema({
     typeDeclaration,
     context
 }: convertTypeDeclarationToJsonSchema.Args): JSONSchema4 {
+    const schema = convertShape({ typeDeclaration, context });
+    if (typeDeclaration.docs != null && schema.description == null) {
+        schema.description = typeDeclaration.docs;
+    }
+    return schema;
+}
+
+function convertShape({ typeDeclaration, context }: convertTypeDeclarationToJsonSchema.Args): JSONSchema4 {
     switch (typeDeclaration.shape.type) {
         case "object":
             return convertObjectToJsonSchema({ object: typeDeclaration.shape, context });

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/converters/enumToJsonSchema.ts
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/converters/enumToJsonSchema.ts
@@ -12,8 +12,27 @@ export declare namespace convertEnumToJsonSchema {
 }
 
 export function convertEnumToJsonSchema({ enum: enumDeclaration, context }: convertEnumToJsonSchema.Args): JSONSchema4 {
+    const hasAnyValueDocs = enumDeclaration.values.some((value) => value.docs != null && value.docs.length > 0);
+
+    if (!hasAnyValueDocs) {
+        return {
+            type: "string",
+            enum: enumDeclaration.values.map((value) => getWireValue(value.name))
+        };
+    }
+
+    // Emit each value as a `const` entry under `oneOf` so we can attach per-value
+    // hover docs via `description`. This is standard JSON Schema (unlike the
+    // `enumDescriptions` extension) and is recognized by the YAML language
+    // server, JSON Schema validators, and IDE autocomplete.
     return {
         type: "string",
-        enum: enumDeclaration.values.map((value) => getWireValue(value.name))
+        oneOf: enumDeclaration.values.map((value) => {
+            const entry: JSONSchema4 = { const: getWireValue(value.name) };
+            if (value.docs != null && value.docs.length > 0) {
+                entry.description = value.docs;
+            }
+            return entry;
+        })
     };
 }

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/converters/objectToJsonSchema.ts
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/converters/objectToJsonSchema.ts
@@ -25,6 +25,9 @@ export function convertObjectToJsonSchema({ object, context }: convertObjectToJs
             typeReference: property.valueType,
             context
         });
+        if (property.docs != null && propertySchema.description == null) {
+            propertySchema.description = property.docs;
+        }
         return [propertyName, propertySchema];
     });
 

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/converters/unionToJsonSchema.ts
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/converters/unionToJsonSchema.ts
@@ -50,13 +50,17 @@ export function convertUnionToJsonSchema({ union, context }: convertUnionToJsonS
                 default:
                     assertNever(member.shape);
             }
-            return {
+            const memberSchema: JSONSchema4 = {
                 properties: {
                     [discriminant]: { const: getWireValue(member.discriminantValue) },
                     ...properties
                 },
                 required: [discriminant, ...required]
             };
+            if (member.docs != null) {
+                memberSchema.description = member.docs;
+            }
+            return memberSchema;
         })
     };
 }

--- a/packages/cli/workspace/lazy-fern-workspace/src/api-yml.schema.json
+++ b/packages/cli/workspace/lazy-fern-workspace/src/api-yml.schema.json
@@ -88,7 +88,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Global Headers for the entire API"
     },
     "name": {
       "type": "string"
@@ -231,7 +232,8 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "The variable name as it appears in the URL template"
         },
         "default": {
           "oneOf": [
@@ -241,7 +243,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default value for this variable"
         },
         "values": {
           "oneOf": [
@@ -254,7 +257,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Allowed values for this variable (from enum)"
         }
       },
       "required": [
@@ -299,7 +303,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A separate default URL to use when no variables are provided (from x-fern-default-url extension)"
         },
         "url-template": {
           "oneOf": [
@@ -309,7 +314,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The original URL template with variable placeholders (e.g., \"https://api.{region}.example.com\")"
         },
         "variables": {
           "oneOf": [
@@ -322,7 +328,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Server variables for URL templating"
         }
       },
       "required": [
@@ -373,7 +380,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL templates with variable placeholders for each base URL (e.g., \"https://api.{region}.example.com\")"
         },
         "default-urls": {
           "oneOf": [
@@ -386,7 +394,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Default URLs to use when no variables are provided (from x-fern-default-url extension)"
         },
         "variables": {
           "oneOf": [
@@ -402,7 +411,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Server variables for URL templating, keyed by base URL ID"
         }
       },
       "required": [
@@ -498,7 +508,8 @@
           ]
         },
         "endpoint-security": {
-          "$ref": "#/definitions/auth.EndpointSecuritySchemaDetails"
+          "$ref": "#/definitions/auth.EndpointSecuritySchemaDetails",
+          "description": "Indicates that authentication requirements are defined per-endpoint via the `security` field."
         }
       },
       "required": [
@@ -536,7 +547,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the client ID."
         },
         "client-secret": {
           "oneOf": [
@@ -546,7 +558,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the client secret."
         },
         "scopes": {
           "oneOf": [
@@ -556,7 +569,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the scopes."
         }
       },
       "additionalProperties": false
@@ -572,7 +586,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the access token."
         },
         "expires-in": {
           "oneOf": [
@@ -582,7 +597,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the expires in property."
         },
         "refresh-token": {
           "oneOf": [
@@ -592,7 +608,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the refresh token"
         }
       },
       "additionalProperties": false
@@ -601,7 +618,8 @@
       "type": "object",
       "properties": {
         "endpoint": {
-          "type": "string"
+          "type": "string",
+          "description": "The endpoint to get the access token, such as 'auth.get_token"
         },
         "request-properties": {
           "oneOf": [
@@ -633,7 +651,8 @@
       "type": "object",
       "properties": {
         "refresh-token": {
-          "type": "string"
+          "type": "string",
+          "description": "The property name for the refresh token."
         }
       },
       "required": [
@@ -652,7 +671,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the access token."
         },
         "expires-in": {
           "oneOf": [
@@ -662,7 +682,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the expires in property."
         },
         "refresh-token": {
           "oneOf": [
@@ -672,7 +693,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the refresh token."
         }
       },
       "additionalProperties": false
@@ -681,7 +703,8 @@
       "type": "object",
       "properties": {
         "endpoint": {
-          "type": "string"
+          "type": "string",
+          "description": "The endpoint to refresh the access token, such as 'auth.refresh_token"
         },
         "request-properties": {
           "oneOf": [
@@ -769,7 +792,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the token header value prefix. Defaults to 'Bearer'"
         },
         "token-header": {
           "oneOf": [
@@ -779,7 +803,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the token header key name. Defaults to 'Authorization'"
         },
         "get-token": {
           "$ref": "#/definitions/auth.OAuthGetTokenEndpointSchema"
@@ -846,7 +871,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to string"
         },
         "prefix": {
           "oneOf": [
@@ -866,7 +892,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The placeholder value to use in code snippets (e.g., \"YOUR_API_KEY\")."
         }
       },
       "required": [
@@ -905,7 +932,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the auth variable will be omitted from the SDK."
         },
         "placeholder": {
           "oneOf": [
@@ -915,7 +943,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The placeholder value to use in code snippets (e.g., \"YOUR_API_KEY\")."
         }
       },
       "additionalProperties": false
@@ -998,10 +1027,12 @@
       "type": "object",
       "properties": {
         "response-property": {
-          "type": "string"
+          "type": "string",
+          "description": "The property to retrieve the header value from the get token or refresh endpoint response."
         },
         "header-name": {
-          "type": "string"
+          "type": "string",
+          "description": "The header name to put the token in for any authenticated HTTP request."
         },
         "value-prefix": {
           "oneOf": [
@@ -1011,20 +1042,23 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Commonly used for setting the `Authorization` scheme, but could be used for other things."
         }
       },
       "required": [
         "response-property",
         "header-name"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "A header that will be set on HTTP requests when the inferred auth scheme is applied to an endpoint. These are not headers for the authorization endpoint."
     },
     "auth.InferredGetTokenEndpointSchemaObject": {
       "type": "object",
       "properties": {
         "endpoint": {
-          "type": "string"
+          "type": "string",
+          "description": "The endpoint to get the access token, such as 'auth.get_token'"
         },
         "expiry-response-property": {
           "oneOf": [
@@ -1034,7 +1068,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The property name for the expiry time in the response."
         },
         "authenticated-request-headers": {
           "oneOf": [
@@ -1047,7 +1082,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The headers that will be set on HTTP requests when the inferred auth scheme is applied to an endpoint."
         }
       },
       "required": [
@@ -1121,7 +1157,8 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the Protobuf type (e.g. google.protobuf.Struct)."
         }
       },
       "required": [
@@ -1727,13 +1764,16 @@
       "type": "object",
       "properties": {
         "cursor": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the request property for the cursor."
         },
         "next_cursor": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next cursor."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -1747,10 +1787,12 @@
       "type": "object",
       "properties": {
         "offset": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the request property for the page offset."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         },
         "step": {
           "oneOf": [
@@ -1760,7 +1802,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the request property for the page step."
         },
         "has-next-page": {
           "oneOf": [
@@ -1770,7 +1813,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the response property indicating next page presence."
         }
       },
       "required": [
@@ -1783,26 +1827,31 @@
       "type": "object",
       "properties": {
         "type": {
-          "const": "custom"
+          "const": "custom",
+          "description": "The type of pagination."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The response property is used to determine the results response type\ngenerated in the endpoint."
         }
       },
       "required": [
         "type",
         "results"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Pagination where the SDK author is responsible for implementing the pagination\nlogic in the SDK."
     },
     "pagination.UriPaginationSchema": {
       "type": "object",
       "properties": {
         "next_uri": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next URI."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -1815,10 +1864,12 @@
       "type": "object",
       "properties": {
         "next_path": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next path."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -1899,7 +1950,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The name of the parameter used to represent the header"
         },
         "env": {
           "oneOf": [
@@ -1909,10 +1961,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The environment variable to read the header value from (if any)"
         },
         "value": {
-          "type": "string"
+          "type": "string",
+          "description": "The wire representation of the header (e.g. X-API-Version)"
         }
       },
       "required": [
@@ -2022,7 +2076,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The name of the parameter used to represent the header"
         },
         "env": {
           "oneOf": [
@@ -2032,10 +2087,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The environment variable to read the header value from (if any)"
         },
         "value": {
-          "type": "string"
+          "type": "string",
+          "description": "The wire representation of the header (e.g. X-API-Product)"
         }
       },
       "required": [

--- a/packages/cli/workspace/lazy-fern-workspace/src/fern.schema.json
+++ b/packages/cli/workspace/lazy-fern-workspace/src/fern.schema.json
@@ -81,7 +81,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Default webhook signature verification configuration.\nApplied to all webhooks in this file that do not declare their own signature."
     },
     "channel": {
       "oneOf": [
@@ -142,7 +143,8 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the Protobuf type (e.g. google.protobuf.Struct)."
         }
       },
       "required": [
@@ -170,7 +172,8 @@
       "type": "object",
       "properties": {
         "openapi": {
-          "type": "string"
+          "type": "string",
+          "description": "Path to the OpenAPI spec"
         }
       },
       "required": [
@@ -182,7 +185,8 @@
       "type": "object",
       "properties": {
         "proto": {
-          "type": "string"
+          "type": "string",
+          "description": "Path to the Protobuf spec"
         }
       },
       "required": [
@@ -919,7 +923,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Context for where the discriminator exists. Defaults to \"data\" for backward compatibility.\n\"data\" means the discriminator is within the union data itself.\n\"protocol\" means the discriminator is at the SSE protocol level."
         }
       },
       "required": [
@@ -1592,7 +1597,8 @@
       "type": "object",
       "properties": {
         "service-name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the gRPC service."
         }
       },
       "required": [
@@ -1679,13 +1685,15 @@
         "items": {
           "$ref": "#/definitions/auth.AuthScope"
         }
-      }
+      },
+      "description": "A collection of auth schemes that all need to be satisfied for the endpoint."
     },
     "service.HttpEndpointSecurity": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/service.HttpEndpointSecurityItem"
-      }
+      },
+      "description": "A list of auth scheme collections. \nTo satisfy the security requirements, the caller must satisfy at least one collection of schemes."
     },
     "service.HttpEndpointAuth": {
       "anyOf": [
@@ -2109,7 +2117,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to json encoding"
         },
         "content-type": {
           "oneOf": [
@@ -2391,7 +2400,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "For SSE responses (`format: sse`), when true, the endpoint\nparticipates in client-side reconnection using `Last-Event-ID`\nand `retry:`. Defaults to false. No effect on non-SSE streams."
         }
       },
       "required": [
@@ -2775,13 +2785,16 @@
       "type": "object",
       "properties": {
         "cursor": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the request property for the cursor."
         },
         "next_cursor": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next cursor."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -2795,10 +2808,12 @@
       "type": "object",
       "properties": {
         "offset": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the request property for the page offset."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         },
         "step": {
           "oneOf": [
@@ -2808,7 +2823,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the request property for the page step."
         },
         "has-next-page": {
           "oneOf": [
@@ -2818,7 +2834,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the response property indicating next page presence."
         }
       },
       "required": [
@@ -2831,26 +2848,31 @@
       "type": "object",
       "properties": {
         "type": {
-          "const": "custom"
+          "const": "custom",
+          "description": "The type of pagination."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The response property is used to determine the results response type\ngenerated in the endpoint."
         }
       },
       "required": [
         "type",
         "results"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Pagination where the SDK author is responsible for implementing the pagination\nlogic in the SDK."
     },
     "pagination.UriPaginationSchema": {
       "type": "object",
       "properties": {
         "next_uri": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next URI."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -2863,10 +2885,12 @@
       "type": "object",
       "properties": {
         "next_path": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next path."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -3446,7 +3470,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to empty string."
         },
         "body-sort": {
           "oneOf": [
@@ -3456,7 +3481,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When set, POST body parameters are sorted before being concatenated\ninto the signing payload. Required by providers like Twilio."
         }
       },
       "required": [
@@ -3486,7 +3512,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to unix-seconds."
         },
         "tolerance": {
           "oneOf": [
@@ -3496,7 +3523,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Allowed clock skew in seconds. Defaults to 300."
         }
       },
       "required": [
@@ -3544,7 +3572,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to sha256."
             },
             "encoding": {
               "oneOf": [
@@ -3554,7 +3583,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to base64."
             },
             "signature-prefix": {
               "oneOf": [
@@ -3564,7 +3594,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Prefix in the header value before the signature (e.g. \"sha256=\")."
             },
             "payload-format": {
               "oneOf": [
@@ -3574,7 +3605,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to body-only (components: [body], delimiter: \"\")."
             },
             "timestamp": {
               "oneOf": [
@@ -3611,7 +3643,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to base64."
             },
             "signature-prefix": {
               "oneOf": [
@@ -3621,7 +3654,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Prefix in the header value before the signature."
             },
             "jwks-url": {
               "oneOf": [
@@ -3631,7 +3665,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "JWKS endpoint URL. When omitted, a static public key is expected at runtime."
             },
             "key-id-header": {
               "oneOf": [
@@ -3641,7 +3676,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "HTTP header containing the key ID for JWKS key selection."
             },
             "timestamp": {
               "oneOf": [

--- a/packages/cli/workspace/lazy-fern-workspace/src/package-yml.schema.json
+++ b/packages/cli/workspace/lazy-fern-workspace/src/package-yml.schema.json
@@ -71,7 +71,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Default webhook signature verification configuration.\nApplied to all webhooks in this file that do not declare their own signature."
     },
     "channel": {
       "oneOf": [
@@ -162,7 +163,8 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the Protobuf type (e.g. google.protobuf.Struct)."
         }
       },
       "required": [
@@ -190,7 +192,8 @@
       "type": "object",
       "properties": {
         "openapi": {
-          "type": "string"
+          "type": "string",
+          "description": "Path to the OpenAPI spec"
         }
       },
       "required": [
@@ -202,7 +205,8 @@
       "type": "object",
       "properties": {
         "proto": {
-          "type": "string"
+          "type": "string",
+          "description": "Path to the Protobuf spec"
         }
       },
       "required": [
@@ -939,7 +943,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Context for where the discriminator exists. Defaults to \"data\" for backward compatibility.\n\"data\" means the discriminator is within the union data itself.\n\"protocol\" means the discriminator is at the SSE protocol level."
         }
       },
       "required": [
@@ -1612,7 +1617,8 @@
       "type": "object",
       "properties": {
         "service-name": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the gRPC service."
         }
       },
       "required": [
@@ -1699,13 +1705,15 @@
         "items": {
           "$ref": "#/definitions/auth.AuthScope"
         }
-      }
+      },
+      "description": "A collection of auth schemes that all need to be satisfied for the endpoint."
     },
     "service.HttpEndpointSecurity": {
       "type": "array",
       "items": {
         "$ref": "#/definitions/service.HttpEndpointSecurityItem"
-      }
+      },
+      "description": "A list of auth scheme collections. \nTo satisfy the security requirements, the caller must satisfy at least one collection of schemes."
     },
     "service.HttpEndpointAuth": {
       "anyOf": [
@@ -2129,7 +2137,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to json encoding"
         },
         "content-type": {
           "oneOf": [
@@ -2411,7 +2420,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "For SSE responses (`format: sse`), when true, the endpoint\nparticipates in client-side reconnection using `Last-Event-ID`\nand `retry:`. Defaults to false. No effect on non-SSE streams."
         }
       },
       "required": [
@@ -2795,13 +2805,16 @@
       "type": "object",
       "properties": {
         "cursor": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the request property for the cursor."
         },
         "next_cursor": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next cursor."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -2815,10 +2828,12 @@
       "type": "object",
       "properties": {
         "offset": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the request property for the page offset."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         },
         "step": {
           "oneOf": [
@@ -2828,7 +2843,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the request property for the page step."
         },
         "has-next-page": {
           "oneOf": [
@@ -2838,7 +2854,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to the response property indicating next page presence."
         }
       },
       "required": [
@@ -2851,26 +2868,31 @@
       "type": "object",
       "properties": {
         "type": {
-          "const": "custom"
+          "const": "custom",
+          "description": "The type of pagination."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The response property is used to determine the results response type\ngenerated in the endpoint."
         }
       },
       "required": [
         "type",
         "results"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Pagination where the SDK author is responsible for implementing the pagination\nlogic in the SDK."
     },
     "pagination.UriPaginationSchema": {
       "type": "object",
       "properties": {
         "next_uri": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next URI."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -2883,10 +2905,12 @@
       "type": "object",
       "properties": {
         "next_path": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the next path."
         },
         "results": {
-          "type": "string"
+          "type": "string",
+          "description": "The path to the response property for the page elements."
         }
       },
       "required": [
@@ -3466,7 +3490,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to empty string."
         },
         "body-sort": {
           "oneOf": [
@@ -3476,7 +3501,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When set, POST body parameters are sorted before being concatenated\ninto the signing payload. Required by providers like Twilio."
         }
       },
       "required": [
@@ -3506,7 +3532,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to unix-seconds."
         },
         "tolerance": {
           "oneOf": [
@@ -3516,7 +3543,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Allowed clock skew in seconds. Defaults to 300."
         }
       },
       "required": [
@@ -3564,7 +3592,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to sha256."
             },
             "encoding": {
               "oneOf": [
@@ -3574,7 +3603,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to base64."
             },
             "signature-prefix": {
               "oneOf": [
@@ -3584,7 +3614,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Prefix in the header value before the signature (e.g. \"sha256=\")."
             },
             "payload-format": {
               "oneOf": [
@@ -3594,7 +3625,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to body-only (components: [body], delimiter: \"\")."
             },
             "timestamp": {
               "oneOf": [
@@ -3631,7 +3663,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Defaults to base64."
             },
             "signature-prefix": {
               "oneOf": [
@@ -3641,7 +3674,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Prefix in the header value before the signature."
             },
             "jwks-url": {
               "oneOf": [
@@ -3651,7 +3685,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "JWKS endpoint URL. When omitted, a static public key is expected at runtime."
             },
             "key-id-header": {
               "oneOf": [
@@ -3661,7 +3696,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "HTTP header containing the key ID for JWKS key selection."
             },
             "timestamp": {
               "oneOf": [

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -15,7 +15,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "A string that is used as the tab bar title."
     },
     "libraries": {
       "oneOf": [
@@ -28,7 +29,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Configuration for library documentation generation. Each library entry defines\na source repository and output location for generated MDX documentation.\n\nExample:\n```yaml\nlibraries:\n  my-sdk:\n    input:\n      git: https://github.com/acme/sdk-python\n      subpath: src/sdk\n    output:\n      path: ./static/sdk-docs\n    lang: python\n```"
     },
     "analytics": {
       "oneOf": [
@@ -38,7 +40,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The `analytics` object allows you to configure analytics for your docs site.\nCurrently, only Segment is supported."
     },
     "announcement": {
       "oneOf": [
@@ -61,7 +64,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Global list of roles that can be used to filter the navigation and content based on the user's session."
     },
     "tabs": {
       "oneOf": [
@@ -110,7 +114,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Creates a landing page for your documentation website."
     },
     "navigation": {
       "oneOf": [
@@ -120,7 +125,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "The navigation config is skipped when multiple versions are present."
     },
     "navbar-links": {
       "oneOf": [
@@ -163,7 +169,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Name of a global theme stored in Fern's cloud to apply to this documentation site.\nTheme values override local branding configuration (colors, typography, logo, fonts, JS, CSS, etc.).\nUpload a theme first with: fern beta docs theme upload --name <theme-name>"
     },
     "experimental": {
       "oneOf": [
@@ -183,7 +190,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Sets the default language displayed by code snippets in the API Reference.\nOptions include: typescript, python, java, go, ruby, csharp, php, swift, curl"
     },
     "languages": {
       "oneOf": [
@@ -209,7 +217,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Configuration for multi-language documentation. Each entry defines a locale\nthat the documentation supports. Use the `translations/` directory alongside\n`docs.yml` to provide per-language content.\n\nExample (object syntax):\n```yaml\ntranslations:\n  - lang: en\n    default: true\n  - lang: ja\n  - lang: fr\n```\n\nExample (simplified syntax):\n```yaml\ntranslations:\n  - en\n  - ja\n  - fr\n```\n\nYou can mix both syntaxes:\n```yaml\ntranslations:\n  - lang: en\n    default: true\n  - ja\n  - fr\n```"
     },
     "ai-chat": {
       "oneOf": [
@@ -239,7 +248,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Configure AI-powered example enhancement for API documentation. When enabled, API examples will be enhanced with AI-generated content to provide more comprehensive and realistic examples."
     },
     "agents": {
       "oneOf": [
@@ -249,7 +259,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Configuration for agent-serving endpoints."
     },
     "metadata": {
       "oneOf": [
@@ -302,7 +313,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Relative filepath to the favicon."
     },
     "background-image": {
       "oneOf": [
@@ -402,7 +414,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Relative filepath to a custom React component (TSX/JSX) that replaces the default header.\nThe component must have a default export."
     },
     "footer": {
       "oneOf": [
@@ -412,7 +425,8 @@
         {
           "type": "null"
         }
-      ]
+      ],
+      "description": "Relative filepath to a custom React component (TSX/JSX) that replaces the default footer.\nThe component must have a default export."
     }
   },
   "required": [
@@ -444,13 +458,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "@default: `github.com`"
         },
         "owner": {
-          "type": "string"
+          "type": "string",
+          "description": "The GitHub organization that owns the documentation repository."
         },
         "repo": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the GitHub repository containing your fern folder."
         },
         "branch": {
           "oneOf": [
@@ -460,7 +477,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The branch of the repository you would like the GitHub editor to open a PR to. Default is `main`."
         }
       },
       "required": [
@@ -497,13 +515,15 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The launch method for \"Edit this page\" button. Defaults to github."
         }
       },
       "additionalProperties": false
     },
     "docs.AudienceId": {
-      "type": "string"
+      "type": "string",
+      "description": "ID of audience which is used to filter the API spec."
     },
     "docs.Audience": {
       "anyOf": [
@@ -516,13 +536,15 @@
             "$ref": "#/definitions/docs.AudienceId"
           }
         }
-      ]
+      ],
+      "description": "Audience can either be a string or list of strings\ni.e. `audiences: internal` or `audiences: [internal, beta]`"
     },
     "docs.DocsInstance": {
       "type": "object",
       "properties": {
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "The URL where your Fern documentation is deployed. Must contain the suffix `docs.buildwithfern.com`."
         },
         "custom-domain": {
           "oneOf": [
@@ -532,7 +554,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The custom domain where your documentation is hosted. Learn more about setting up a custom domain."
         },
         "edit-this-page": {
           "oneOf": [
@@ -542,7 +565,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If specified, adds an \"Edit this page\" link to the bottom of each page that links to the given public GitHub repository."
         },
         "audiences": {
           "oneOf": [
@@ -552,7 +576,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Specify which audiences this instance serves (e.g., internal developers, beta testers, public customers).\nYou can use audiences to control which versions and products appear in each documentation instance, enabling you to create separate sites for different user groups. Content is included when its audience tag matches the instance audience. Content without an audience tag is included by default."
         },
         "multi-source": {
           "oneOf": [
@@ -562,7 +587,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When enabled, docs registration uses a basepath-aware S3 key format, allowing multiple independent doc sites to be hosted under the same custom domain with different basepaths. If true, the url and custom-domain must share the same basepath."
         }
       },
       "required": [
@@ -574,7 +600,8 @@
       "type": "object",
       "properties": {
         "git": {
-          "type": "string"
+          "type": "string",
+          "description": "GitHub URL to the repository containing the library source code.\nExample: https://github.com/django/django"
         },
         "subpath": {
           "oneOf": [
@@ -584,25 +611,29 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Optional path within the repository to the library source.\nExample: django/core"
         }
       },
       "required": [
         "git"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Configuration for fetching library source from a Git repository."
     },
     "docs.PathLibraryInputSchema": {
       "type": "object",
       "properties": {
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "Local filesystem path to the library source.\nExample: ./src/my-library"
         }
       },
       "required": [
         "path"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Configuration for using a local filesystem path as library source. (Not yet implemented)"
     },
     "docs.LibraryInputConfiguration": {
       "anyOf": [
@@ -612,26 +643,30 @@
         {
           "$ref": "#/definitions/docs.PathLibraryInputSchema"
         }
-      ]
+      ],
+      "description": "Configuration for the library source location."
     },
     "docs.LibraryOutputConfiguration": {
       "type": "object",
       "properties": {
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "The output directory where MDX files will be generated.\nExample: ./static/sdk-docs"
         }
       },
       "required": [
         "path"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Configuration for the library documentation output."
     },
     "docs.LibraryLanguage": {
       "type": "string",
       "enum": [
         "python",
         "cpp"
-      ]
+      ],
+      "description": "The programming language of the library source code."
     },
     "docs.LibraryConfig": {
       "type": "object",
@@ -644,22 +679,27 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Path to a Doxyfile for C++ library documentation, relative to the fern/ directory.\nWhen provided, the backend uses this Doxyfile instead of auto-generating one.\nOnly valid when lang is cpp."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Language-specific configuration for library documentation.\nValid fields depend on the `lang` value of the parent LibraryConfiguration."
     },
     "docs.LibraryConfiguration": {
       "type": "object",
       "properties": {
         "input": {
-          "$ref": "#/definitions/docs.LibraryInputConfiguration"
+          "$ref": "#/definitions/docs.LibraryInputConfiguration",
+          "description": "Configuration for the library source location."
         },
         "output": {
-          "$ref": "#/definitions/docs.LibraryOutputConfiguration"
+          "$ref": "#/definitions/docs.LibraryOutputConfiguration",
+          "description": "Configuration for the library documentation output."
         },
         "lang": {
-          "$ref": "#/definitions/docs.LibraryLanguage"
+          "$ref": "#/definitions/docs.LibraryLanguage",
+          "description": "The programming language of the library source code."
         },
         "config": {
           "oneOf": [
@@ -669,7 +709,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Language-specific configuration options. Valid fields depend on the lang value."
         }
       },
       "required": [
@@ -677,7 +718,8 @@
         "output",
         "lang"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Configuration for a library documentation source.\nUsed by `fern docs md generate` to generate MDX files from library source code."
     },
     "docs.SegmentConfig": {
       "type": "object",
@@ -729,7 +771,8 @@
       "type": "object",
       "properties": {
         "api-key": {
-          "type": "string"
+          "type": "string",
+          "description": "Your PostHog project API key. Defaults to the api-host of \"https://us.i.posthog.com\"."
         },
         "endpoint": {
           "oneOf": [
@@ -751,7 +794,8 @@
       "type": "object",
       "properties": {
         "container-id": {
-          "type": "string"
+          "type": "string",
+          "description": "Your Google Tag Manager container ID. Must start with \"GTM-\"."
         }
       },
       "required": [
@@ -763,7 +807,8 @@
       "type": "object",
       "properties": {
         "measurement-id": {
-          "type": "string"
+          "type": "string",
+          "description": "Your Google Analytics 4 measurement ID. Must start with \"G-\"."
         }
       },
       "required": [
@@ -841,7 +886,8 @@
       "type": "object",
       "properties": {
         "message": {
-          "type": "string"
+          "type": "string",
+          "description": "The message to display in the announcement bar. Markdown is supported."
         }
       },
       "required": [
@@ -850,7 +896,8 @@
       "additionalProperties": false
     },
     "docs.RoleId": {
-      "type": "string"
+      "type": "string",
+      "description": "ID of role which is used to filter the content shown in Fern Docs."
     },
     "docs.Role": {
       "anyOf": [
@@ -863,13 +910,15 @@
             "$ref": "#/definitions/docs.RoleId"
           }
         }
-      ]
+      ],
+      "description": "Audience can either be a string or list of strings\ni.e. `audience: internal` or `audience: [internal, beta]`"
     },
     "docs.FeatureFlag": {
       "type": "object",
       "properties": {
         "flag": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the feature flag to check."
         },
         "fallback-value": {
           "oneOf": [
@@ -886,7 +935,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default value to use if the feature flag is not set. If not specified, defaults to false."
         },
         "match": {
           "oneOf": [
@@ -903,7 +953,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The value that the feature flag should match for the content to be shown. If not specified, content is shown when the flag is true."
         }
       },
       "required": [
@@ -940,7 +991,8 @@
       ]
     },
     "docs.ChangelogFolderRelativePath": {
-      "type": "string"
+      "type": "string",
+      "description": "The relative path to a folder containing markdown files broken down by date.\n\nExample:\n```\nchangelog: \"changelog\"\n```\n\nThis will look for markdown files in the `/fern/changelog` directory, which should contain files named like\n- `/fern/changelog/2024-04-29.mdx`.\n- `/fern/changelog/2023-01-02.mdx`."
     },
     "docs.TabConfig": {
       "type": "object",
@@ -963,7 +1015,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1026,7 +1079,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `href` is set, clicking on the tab will redirect to the given URL.\n\nTabs with `href` must not have children in the navigation config."
         },
         "target": {
           "oneOf": [
@@ -1087,7 +1141,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1103,7 +1158,8 @@
           "type": "string"
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "The relative path to the version's docs.yml file."
         },
         "slug": {
           "oneOf": [
@@ -1113,7 +1169,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The \"slug\" is this version's basePath. If not set, the slug will be generated from the display-name."
         },
         "availability": {
           "oneOf": [
@@ -1123,7 +1180,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `availability` is set to `deprecated`, Fern will display a warning banner on the docs site."
         },
         "audiences": {
           "oneOf": [
@@ -1143,7 +1201,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, this version will be hidden from navigation, search, and indexing, but still accessible via direct URL."
         },
         "announcement": {
           "oneOf": [
@@ -1196,7 +1255,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The image to display in the product card. This will override the icon field if both are set."
         },
         "versions": {
           "oneOf": [
@@ -1239,7 +1299,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1252,7 +1313,8 @@
           ]
         },
         "path": {
-          "type": "string"
+          "type": "string",
+          "description": "The relative path to the version's docs.yml file."
         },
         "slug": {
           "oneOf": [
@@ -1262,7 +1324,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The \"slug\" is this version's basePath. If not set, the slug will be generated from the display-name."
         },
         "announcement": {
           "oneOf": [
@@ -1315,7 +1378,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The image to display in the product card. This will override the icon field if both are set."
         },
         "versions": {
           "oneOf": [
@@ -1358,7 +1422,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1371,7 +1436,8 @@
           ]
         },
         "href": {
-          "type": "string"
+          "type": "string",
+          "description": "The absolute URL to the product."
         },
         "target": {
           "oneOf": [
@@ -1381,7 +1447,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The target of the URL"
         }
       },
       "required": [
@@ -1435,7 +1502,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1547,7 +1615,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1570,7 +1639,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The relative path to the markdown file that will be displayed when the section is clicked."
         },
         "contents": {
           "type": "array",
@@ -1586,7 +1656,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -1596,7 +1667,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -1606,7 +1678,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open)."
         },
         "slug": {
           "oneOf": [
@@ -1689,7 +1762,8 @@
         {
           "$ref": "#/definitions/docs.VersionedSnippetLanguageConfiguration"
         }
-      ]
+      ],
+      "description": "This snippets config object is meant to allow users to specify a specific package for the snippets,\nand optionally a version for that package. If you pass in a string, that should be the name of the package."
     },
     "docs.SnippetsConfiguration": {
       "type": "object",
@@ -1827,7 +1901,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A list of environment IDs that are allowed to be used in the playground. If not provided, all environments are allowed. And if the provided list is empty, the playground should be disabled."
         },
         "button": {
           "oneOf": [
@@ -1857,7 +1932,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The maximum number of websocket messages per connection in the playground."
         }
       },
       "additionalProperties": false
@@ -1883,7 +1959,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1913,7 +1990,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file. This summary is displayed at the top of the API section."
         },
         "contents": {
           "oneOf": [
@@ -1986,7 +2064,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that is applied only to descendants of this api package."
         }
       },
       "additionalProperties": false
@@ -2025,7 +2104,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2038,7 +2118,8 @@
           ]
         },
         "section": {
-          "type": "string"
+          "type": "string",
+          "description": "The title of the api package that will be displayed in the sidebar."
         },
         "referenced-packages": {
           "oneOf": [
@@ -2051,7 +2132,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "This section will inherit the endpoints from the specified subpackage(s). If multiple packages are specified, they will be merged."
         },
         "summary": {
           "oneOf": [
@@ -2061,7 +2143,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file."
         },
         "contents": {
           "oneOf": [
@@ -2124,7 +2207,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -2134,7 +2218,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user in the sidebar."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -2144,7 +2229,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when collapsible is true."
         },
         "availability": {
           "oneOf": [
@@ -2164,7 +2250,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affects all endpoints."
         }
       },
       "required": [
@@ -2193,7 +2280,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2266,7 +2354,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affect this endpoint specifically."
         }
       },
       "required": [
@@ -2295,7 +2384,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2354,7 +2444,8 @@
       "required": [
         "operation"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Defines a GraphQL-native schema for selecting operations (REST -> Endpoint === GraphQL -> Operation)"
     },
     "docs.LinkConfiguration": {
       "type": "object",
@@ -2420,7 +2511,8 @@
         {
           "$ref": "#/definitions/docs.LinkConfiguration"
         }
-      ]
+      ],
+      "description": "Use the `layout` object to customize the order that your API endpoints\nare displayed in the docs site."
     },
     "docs.ApiReferenceConfiguration": {
       "type": "object",
@@ -2443,7 +2535,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2466,7 +2559,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Name of API that we are referencing"
         },
         "openrpc": {
           "oneOf": [
@@ -2476,7 +2570,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Path to an openrpc spec."
         },
         "audiences": {
           "oneOf": [
@@ -2496,7 +2591,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to false"
         },
         "tag-description-pages": {
           "oneOf": [
@@ -2506,7 +2602,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, a page will be created for each tag in the OpenAPI spec that contains a description."
         },
         "snippets": {
           "oneOf": [
@@ -2526,7 +2623,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to a Postman collection for this API reference"
         },
         "summary": {
           "oneOf": [
@@ -2536,7 +2634,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file"
         },
         "layout": {
           "oneOf": [
@@ -2549,7 +2648,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Advanced usage: when specified, this object will be used to customize the order that your API endpoints are displayed in the docs site, including subpackages, and additional markdown pages (to be rendered in between API endpoints). If not specified, the order will be inferred from the OpenAPI Spec or Fern Definition."
         },
         "collapsed": {
           "oneOf": [
@@ -2619,7 +2719,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `alphabetized` is set to true, packages and endpoints will be sorted alphabetically, unless explicitly ordered in the `layout` object."
         },
         "flattened": {
           "oneOf": [
@@ -2629,7 +2730,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `flattened` is set to true, the title specified in `api` will be hidden, and its endpoints and subpackages won't be grouped under it.\n\nThis setting is useful if the API reference is short and you want to display all endpoints at the top level."
         },
         "paginated": {
           "oneOf": [
@@ -2639,7 +2741,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the API reference will be paginated rather than displayed in a single page (long-scrolling)."
         },
         "playground": {
           "oneOf": [
@@ -2649,7 +2752,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affects all endpoints."
         }
       },
       "required": [
@@ -2658,7 +2762,8 @@
       "additionalProperties": false
     },
     "docs.LibraryName": {
-      "type": "string"
+      "type": "string",
+      "description": "The name identifier for a library. Used to reference the library in navigation."
     },
     "docs.LibraryReferenceConfiguration": {
       "type": "object",
@@ -2681,7 +2786,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2694,7 +2800,8 @@
           ]
         },
         "library": {
-          "$ref": "#/definitions/docs.LibraryName"
+          "$ref": "#/definitions/docs.LibraryName",
+          "description": "The name of the library to reference (must match a key in the `libraries` section)."
         },
         "title": {
           "oneOf": [
@@ -2704,7 +2811,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the display title for this library reference."
         },
         "slug": {
           "oneOf": [
@@ -2714,13 +2822,15 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the URL slug for this library reference."
         }
       },
       "required": [
         "library"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "References a library defined in the `libraries` section.\nThe library's generated navigation will be injected at this point."
     },
     "docs.ChangelogConfiguration": {
       "type": "object",
@@ -2743,7 +2853,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2832,7 +2943,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -2845,7 +2957,8 @@
           ]
         },
         "folder": {
-          "type": "string"
+          "type": "string",
+          "description": "The relative path to a folder containing markdown files. Fern will automatically discover and add all markdown files from this folder to the navigation."
         },
         "title": {
           "oneOf": [
@@ -2855,7 +2968,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The title to display for this folder section. If not provided, the folder name will be used."
         },
         "title-source": {
           "oneOf": [
@@ -2865,7 +2979,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Determines how page titles are derived for files in this folder. Options are `frontmatter` (use the `title` field from the file's frontmatter) or `filename` (derive title from the file name). Defaults to `filename`."
         },
         "slug": {
           "oneOf": [
@@ -2915,7 +3030,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -2925,7 +3041,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -2935,7 +3052,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open)."
         },
         "availability": {
           "oneOf": [
@@ -3004,7 +3122,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `href` is set, `layout` must be null."
         }
       },
       "required": [
@@ -3033,7 +3152,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -3229,7 +3349,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The URL once you click on the button.\nExample: https://buildwithfern.com/contact"
         },
         "target": {
           "oneOf": [
@@ -3249,7 +3370,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Use `href` instead."
         },
         "text": {
           "oneOf": [
@@ -3259,7 +3381,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Text inside the button."
         },
         "icon": {
           "oneOf": [
@@ -3269,7 +3392,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The icon to be used in the button. This icon will appear to the **left** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`)."
         },
         "rightIcon": {
           "oneOf": [
@@ -3279,7 +3403,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The icon to be used in the button. This icon will appear to the **right** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`).\n\nBy default, the `rightIcon` for a `filled` button is set to `arrow-right`."
         },
         "rounded": {
           "oneOf": [
@@ -3289,7 +3414,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `true`, the border radius of the button will be fully rounded."
         }
       },
       "additionalProperties": false
@@ -3334,7 +3460,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The URL once you click on the button.\nExample: https://buildwithfern.com/contact"
             },
             "target": {
               "oneOf": [
@@ -3354,7 +3481,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Use `href` instead."
             },
             "text": {
               "oneOf": [
@@ -3364,7 +3492,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Text inside the button."
             },
             "icon": {
               "oneOf": [
@@ -3374,7 +3503,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **left** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`)."
             },
             "rightIcon": {
               "oneOf": [
@@ -3384,7 +3514,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **right** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`).\n\nBy default, the `rightIcon` for a `filled` button is set to `arrow-right`."
             },
             "rounded": {
               "oneOf": [
@@ -3394,7 +3525,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "When `true`, the border radius of the button will be fully rounded."
             }
           },
           "required": [
@@ -3424,7 +3556,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The URL once you click on the button.\nExample: https://buildwithfern.com/contact"
             },
             "target": {
               "oneOf": [
@@ -3444,7 +3577,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Use `href` instead."
             },
             "text": {
               "oneOf": [
@@ -3454,7 +3588,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Text inside the button."
             },
             "icon": {
               "oneOf": [
@@ -3464,7 +3599,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **left** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`)."
             },
             "rightIcon": {
               "oneOf": [
@@ -3474,7 +3610,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **right** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`).\n\nBy default, the `rightIcon` for a `filled` button is set to `arrow-right`."
             },
             "rounded": {
               "oneOf": [
@@ -3484,7 +3621,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "When `true`, the border radius of the button will be fully rounded."
             }
           },
           "required": [
@@ -3514,7 +3652,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The URL once you click on the button.\nExample: https://buildwithfern.com/contact"
             },
             "target": {
               "oneOf": [
@@ -3534,7 +3673,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Use `href` instead."
             },
             "text": {
               "oneOf": [
@@ -3544,7 +3684,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Text inside the button."
             },
             "icon": {
               "oneOf": [
@@ -3554,7 +3695,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **left** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`)."
             },
             "rightIcon": {
               "oneOf": [
@@ -3564,7 +3706,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **right** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`).\n\nBy default, the `rightIcon` for a `filled` button is set to `arrow-right`."
             },
             "rounded": {
               "oneOf": [
@@ -3574,7 +3717,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "When `true`, the border radius of the button will be fully rounded."
             }
           },
           "required": [
@@ -3684,7 +3828,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The URL once you click on the button.\nExample: https://buildwithfern.com/contact"
             },
             "target": {
               "oneOf": [
@@ -3704,7 +3849,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Use `href` instead."
             },
             "text": {
               "oneOf": [
@@ -3714,7 +3860,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Text inside the button."
             },
             "icon": {
               "oneOf": [
@@ -3724,7 +3871,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **left** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`)."
             },
             "rightIcon": {
               "oneOf": [
@@ -3734,7 +3882,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **right** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`).\n\nBy default, the `rightIcon` for a `filled` button is set to `arrow-right`."
             },
             "rounded": {
               "oneOf": [
@@ -3744,7 +3893,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "When `true`, the border radius of the button will be fully rounded."
             }
           },
           "required": [
@@ -3774,7 +3924,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The URL once you click on the button.\nExample: https://buildwithfern.com/contact"
             },
             "target": {
               "oneOf": [
@@ -3794,7 +3945,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Use `href` instead."
             },
             "text": {
               "oneOf": [
@@ -3804,7 +3956,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Text inside the button."
             },
             "icon": {
               "oneOf": [
@@ -3814,7 +3967,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **left** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`)."
             },
             "rightIcon": {
               "oneOf": [
@@ -3824,7 +3978,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "The icon to be used in the button. This icon will appear to the **right** of the text content.\nIcons can be in three formats:\n- **Font Awesome icons**: Use icon names like `fa-solid fa-rocket`. Pro and Brand Icons from Font Awesome are supported.\n- **Custom image files**: Use relative paths to image files (e.g., `./assets/icons/my-icon.svg` or `../assets/icons/my-icon.png`). Paths are relative to the `docs.yml` file.\n- **Inline SVG**: Provide an SVG string wrapped in quotes (e.g., `\"<svg>...</svg>\"`).\n\nBy default, the `rightIcon` for a `filled` button is set to `arrow-right`."
             },
             "rounded": {
               "oneOf": [
@@ -3834,7 +3989,8 @@
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "When `true`, the border radius of the button will be fully rounded."
             }
           },
           "required": [
@@ -3854,7 +4010,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your GitHub repository or organization."
         },
         "twitter": {
           "oneOf": [
@@ -3864,7 +4021,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Twitter profile. Use `footer-links.x` for the new X branding."
         },
         "x": {
           "oneOf": [
@@ -3874,7 +4032,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your X (formerly Twitter) profile."
         },
         "linkedin": {
           "oneOf": [
@@ -3884,7 +4043,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your LinkedIn company page or profile."
         },
         "youtube": {
           "oneOf": [
@@ -3894,7 +4054,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your YouTube channel."
         },
         "instagram": {
           "oneOf": [
@@ -3904,7 +4065,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Instagram profile."
         },
         "facebook": {
           "oneOf": [
@@ -3914,7 +4076,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Facebook page."
         },
         "discord": {
           "oneOf": [
@@ -3924,7 +4087,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Discord server invite."
         },
         "slack": {
           "oneOf": [
@@ -3934,7 +4098,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Slack community or workspace."
         },
         "hackernews": {
           "oneOf": [
@@ -3944,7 +4109,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Hacker News profile."
         },
         "medium": {
           "oneOf": [
@@ -3954,7 +4120,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your Medium publication or profile."
         },
         "website": {
           "oneOf": [
@@ -3964,7 +4131,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your main website or homepage."
         }
       },
       "additionalProperties": false
@@ -3986,7 +4154,8 @@
       "type": "object",
       "properties": {
         "title": {
-          "type": "string"
+          "type": "string",
+          "description": "The title of the custom action."
         },
         "subtitle": {
           "oneOf": [
@@ -3996,10 +4165,12 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The subtitle/helper text of the custom action."
         },
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "The URL to navigate to. Use {slug} as a placeholder for the current page slug, {domain} as a placeholder for the current domain, and {url} as a placeholder for the current full URL."
         },
         "icon": {
           "oneOf": [
@@ -4009,7 +4180,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Icon to display for the custom action. Can be a relative filepath, an image URL (starting with http://, https://, or /), or a Font Awesome icon name (e.g., \"fa-solid fa-star\" or \"star\")."
         },
         "default": {
           "oneOf": [
@@ -4019,14 +4191,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether this custom action should be the default action."
         }
       },
       "required": [
         "title",
         "url"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "A custom page action that can be configured by the user."
     },
     "docs.PageActionOptions": {
       "type": "object",
@@ -4039,7 +4213,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When enabled, displays a button that allows users to copy the entire page content to their clipboard for easy sharing or reference.\n\n@default: true"
         },
         "view-as-markdown": {
           "oneOf": [
@@ -4049,7 +4224,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When enabled, displays a button that allows users to view the raw Markdown source of the current page.\n\n@default: true"
         },
         "ask-ai": {
           "oneOf": [
@@ -4059,7 +4235,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When enabled, displays an \"Ask AI\" button that allows users to ask questions about the page content using AI-powered assistance.\n\n@default: true"
         },
         "chatgpt": {
           "oneOf": [
@@ -4069,7 +4246,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the \"Open in ChatGPT\" button, which sends the page content to ChatGPT for further\nexploration and Q&A. Set to `false` to hide it.\n\n@default: true"
         },
         "claude": {
           "oneOf": [
@@ -4079,7 +4257,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the \"Open in Claude\" button, which sends the page content to Claude for further\nexploration and Q&A. Set to `false` to hide it.\n\n@default: true"
         },
         "claude-code": {
           "oneOf": [
@@ -4089,7 +4268,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the \"Connect to Claude Code\" button, which copies a `claude mcp add` command to the\nclipboard so users can register this docs site's MCP server with Claude Code. The button only\nrenders on docs sites that have Ask AI enabled; set to `false` to hide it on those sites.\n\n@default: true"
         },
         "cursor": {
           "oneOf": [
@@ -4099,7 +4279,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the \"Connect to Cursor\" button, which installs this docs site's MCP server in\nCursor via a deeplink. The button only renders on docs sites that have Ask AI enabled; set\nto `false` to hide it on those sites.\n\n@default: true"
         },
         "vscode": {
           "oneOf": [
@@ -4109,7 +4290,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When enabled, displays an \"Open in VS Code\" button that allows users to open the page content in Visual Studio Code for editing and development.\n\n@default: false"
         },
         "custom": {
           "oneOf": [
@@ -4122,7 +4304,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When enabled, displays a custom button that allows users to open the page content in a custom IDE for editing and development.\nThe value of this property should be the name of the custom IDE.\nExample: `cursor`"
         }
       },
       "additionalProperties": false
@@ -4138,7 +4321,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default page action to display. Options: copy-page, view-as-markdown, ask-ai, chatgpt, claude, cursor, vscode."
         },
         "options": {
           "oneOf": [
@@ -4167,7 +4351,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "List of relative paths to folders or files that end in .{ts,tsx,js,jsx},\nand makes them available for use in MDX files."
         },
         "disable-stream-toggle": {
           "oneOf": [
@@ -4177,7 +4362,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `disable-stream-toggle` is set to true, the stream toggle will be disabled.\n\nThis behavior is unstable and may change in the future."
         },
         "openapi-parser-v2": {
           "oneOf": [
@@ -4187,7 +4373,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "OpenAPI parser rewrite, now deprecated."
         },
         "openapi-parser-v3": {
           "oneOf": [
@@ -4197,7 +4384,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "OpenAPI parser in alpha."
         },
         "dynamic-snippets": {
           "oneOf": [
@@ -4207,7 +4395,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "By default, SDK snippets are static code examples that are displayed in your API Reference. Alternatively, you can use dynamic SDK snippets that allow users to modify parameters and see code examples update in real time.\n\nEnable dynamic snippets in `docs.yml`, then configure them by following the SDK snippets setup instructions."
         },
         "ai-examples": {
           "oneOf": [
@@ -4217,7 +4406,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enable AI-powered example enhancement for API documentation. When enabled, API examples will be enhanced with AI-generated content to provide more comprehensive and realistic examples.\n\nDEPRECATED: Use the top-level `ai-examples` property instead."
         },
         "ai-example-style-instructions": {
           "oneOf": [
@@ -4227,7 +4417,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Custom styling instructions for AI-generated examples. When provided, these instructions will guide the AI in generating examples that match your preferred style, naming conventions, or domain-specific terminology. Limited to 500 characters.\n\nDEPRECATED: Use the top-level `ai-example-style-instructions` property instead."
         },
         "exclude-apis": {
           "oneOf": [
@@ -4237,7 +4428,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Experimental flag to exclude API reference sections from documentation generation. When enabled, API reference content will be omitted from the generated documentation."
         },
         "basepath-aware": {
           "oneOf": [
@@ -4247,7 +4439,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated: Use `multi-source: true` on the instance instead. When enabled, docs registration uses a basepath-aware S3 key format, allowing multiple independent doc sites to be hosted under the same custom domain with different basepaths."
         }
       },
       "additionalProperties": false
@@ -4275,7 +4468,8 @@
       ]
     },
     "docs.Language": {
-      "type": "string"
+      "type": "string",
+      "description": "A BCP 47 language tag identifying a docs locale. Common shorthand codes\nlike \"en\", \"es\", \"ja\" are accepted, as well as regional variants such as\n\"ja-JP\", \"pt-BR\", \"zh-Hans\", and \"zh-Hans-CN\". See RFC 5646 for the full\ngrammar."
     },
     "docs.TranslationConfigObject": {
       "type": "object",
@@ -4291,7 +4485,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether this language is the default. At most one entry should be marked as default."
         }
       },
       "required": [
@@ -4307,7 +4502,8 @@
         {
           "$ref": "#/definitions/docs.TranslationConfigObject"
         }
-      ]
+      ],
+      "description": "Translation configuration can be either a language code string or an object with additional options.\nWhen using a string, it's equivalent to `{ lang: <string> }`."
     },
     "docs.AIChatModel": {
       "type": "string",
@@ -4329,7 +4525,8 @@
       "type": "object",
       "properties": {
         "url": {
-          "type": "string"
+          "type": "string",
+          "description": "The URL of the website to index. Ask Fern will crawl and index the content from this URL."
         },
         "title": {
           "oneOf": [
@@ -4339,7 +4536,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "An optional display name for this datasource. This helps users understand where the information is coming from when Ask Fern cites content from this source."
         }
       },
       "required": [
@@ -4375,7 +4573,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "By default, Ask Fern uses system prompts to finetune AI search results. Add a custom prompt here to override it.\nSee Anthropic's prompting guide for ideas and examples."
         },
         "location": {
           "oneOf": [
@@ -4388,7 +4587,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Specifies where Ask Fern will be available. Options:\n- `docs` enables Ask Fern on your documentation site\n- `slack` enables Ask Fern in Slack\n- `discord` enables Ask Fern in Discord\n\nMost users should enable Ask Fern for both `docs` and either `slack` or `discord`."
         },
         "datasources": {
           "oneOf": [
@@ -4401,7 +4601,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Additional content sources that Ask Fern should index and search."
         }
       },
       "additionalProperties": false
@@ -4417,7 +4618,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Enable AI-powered example enhancement for API documentation. When enabled, API examples will be enhanced with AI-generated content to provide more comprehensive and realistic examples."
         },
         "style": {
           "oneOf": [
@@ -4427,7 +4629,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Custom styling instructions for AI-generated examples. When provided, these instructions will guide the AI in generating examples that match your preferred style, naming conventions, or domain-specific terminology. Limited to 500 characters."
         }
       },
       "additionalProperties": false
@@ -4450,7 +4653,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Text to prepend to each page when it is served through agent endpoints."
         },
         "page-description-source": {
           "oneOf": [
@@ -4460,7 +4664,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls which frontmatter field is preferred for one-line page descriptions\nin llms.txt. Defaults to \"description\". If the preferred field is not present\nin a page's frontmatter, falls back to other fields (description, subtitle,\nog:description, headline, excerpt)."
         },
         "llms-txt": {
           "oneOf": [
@@ -4470,7 +4675,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative filepath to a custom `llms.txt` file that Fern should host at `/llms.txt`,\noverriding the auto-generated version. The file should follow the llmstxt.org specification."
         },
         "llms-full-txt": {
           "oneOf": [
@@ -4480,7 +4686,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative filepath to a custom `llms-full.txt` file that Fern should host at `/llms-full.txt`,\noverriding the auto-generated version. The file should contain the full concatenated documentation content."
         },
         "robots-txt": {
           "oneOf": [
@@ -4490,7 +4697,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative filepath to a custom `robots.txt` file that Fern should host at `/robots.txt`,\noverriding the auto-generated version. Fern automatically appends a rule to disallow\nits internal `/api/fern-docs/` routes so they are excluded from crawler indexing."
         }
       },
       "additionalProperties": false
@@ -4522,7 +4730,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The name of your website for Open Graph tags."
         },
         "og:title": {
           "oneOf": [
@@ -4532,7 +4741,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The title shown in social media previews."
         },
         "og:description": {
           "oneOf": [
@@ -4542,7 +4752,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The description shown in social media previews."
         },
         "og:url": {
           "oneOf": [
@@ -4552,7 +4763,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The canonical URL of your documentation."
         },
         "og:image": {
           "oneOf": [
@@ -4562,7 +4774,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The image shown in social media previews. Recommended size is 1200x630 pixels."
         },
         "og:image:width": {
           "oneOf": [
@@ -4572,7 +4785,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The width of your Open Graph image in pixels."
         },
         "og:image:height": {
           "oneOf": [
@@ -4582,7 +4796,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The height of your Open Graph image in pixels."
         },
         "og:locale": {
           "oneOf": [
@@ -4592,7 +4807,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The locale of your content (e.g., \"en_US\")."
         },
         "og:logo": {
           "oneOf": [
@@ -4602,7 +4818,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to your company logo."
         },
         "twitter:title": {
           "oneOf": [
@@ -4612,7 +4829,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The title shown in Twitter Card previews."
         },
         "twitter:description": {
           "oneOf": [
@@ -4622,7 +4840,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The description shown in Twitter Card previews."
         },
         "twitter:handle": {
           "oneOf": [
@@ -4632,7 +4851,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Your company's Twitter handle."
         },
         "twitter:image": {
           "oneOf": [
@@ -4642,7 +4862,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The image shown in Twitter Card previews."
         },
         "twitter:site": {
           "oneOf": [
@@ -4652,7 +4873,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The Twitter handle for your website."
         },
         "twitter:url": {
           "oneOf": [
@@ -4672,7 +4894,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The Twitter Card type. Options are `summary`, `summary_large_image`, `app`, or `player`."
         },
         "og:dynamic": {
           "oneOf": [
@@ -4682,7 +4905,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When true, enables dynamic OG image generation for pages that don't have a custom og:image set."
         },
         "og:dynamic:background-image": {
           "oneOf": [
@@ -4692,7 +4916,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A custom background image for dynamically generated OG images. Can be a URL or a file path."
         },
         "og:dynamic:text-color": {
           "oneOf": [
@@ -4702,7 +4927,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the text color for dynamically generated OG images. Accepts any valid CSS color value (e.g., \"#1a1a1a\")."
         },
         "og:dynamic:background-color": {
           "oneOf": [
@@ -4712,7 +4938,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the background color for dynamically generated OG images. Accepts any valid CSS color value (e.g., \"#ffffff\")."
         },
         "og:dynamic:logo-color": {
           "oneOf": [
@@ -4722,7 +4949,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Choose which logo variant from docs.yml to render in dynamically generated OG images. Defaults to `dark`."
         },
         "og:dynamic:show-logo": {
           "oneOf": [
@@ -4732,7 +4960,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Toggle visibility of the logo in dynamically generated OG images. Defaults to true when og:dynamic is enabled."
         },
         "og:dynamic:show-section": {
           "oneOf": [
@@ -4742,7 +4971,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Toggle visibility of the section title in dynamically generated OG images. Defaults to true when og:dynamic is enabled."
         },
         "og:dynamic:show-description": {
           "oneOf": [
@@ -4752,7 +4982,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Toggle visibility of the page description in dynamically generated OG images. Defaults to true when og:dynamic is enabled."
         },
         "og:dynamic:show-url": {
           "oneOf": [
@@ -4762,7 +4993,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Toggle visibility of the page URL in dynamically generated OG images. Defaults to true when og:dynamic is enabled."
         },
         "og:dynamic:show-gradient": {
           "oneOf": [
@@ -4772,7 +5004,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Toggle visibility of the accent gradient overlay in dynamically generated OG images. Defaults to true when og:dynamic is enabled."
         },
         "canonical-host": {
           "oneOf": [
@@ -4782,19 +5015,23 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The host of your documentation website. This will be used to set the canonical URL for metadata tags and documents like the sitemap.\nDefaults to the URL defined in the `instances` configuration."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "The `metadata` object allows you to customize the appearance of your docs site in search engines and social media.\nThese settings are applied globally, but can be overridden on a per-page basis using frontmatter."
     },
     "docs.RedirectConfig": {
       "type": "object",
       "properties": {
         "source": {
-          "type": "string"
+          "type": "string",
+          "description": "The path you want to redirect from."
         },
         "destination": {
-          "type": "string"
+          "type": "string",
+          "description": "The path you want to route to. Can be an internal path (`/new-path`) or an external URL (`https://example.com`).\nExternal URLs must include the full address, including `https`."
         },
         "permanent": {
           "oneOf": [
@@ -4804,14 +5041,16 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "By default, uses the 308 status code to instructs clients and search engines to cache the redirect forever. Set to `false` only if you need a temporary redirect using the 307 status code, which won't be cached.\n\n@default: true"
         }
       },
       "required": [
         "source",
         "destination"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "The `redirects` object allows you to redirect traffic from one path to another. You can redirect exact paths or use dynamic patterns with regex parameters like `:slug` to handle bulk redirects. You can redirect to internal paths within your site or external URLs.\n\n```yaml\nredirects:\n  - source: \"/old-path\"\n    destination: \"/new-path\"\n```\n\nBoth source and destination paths support regex. See https://github.com/pillarjs/path-to-regexp"
     },
     "docs.CheckRuleSeverity": {
       "type": "string",
@@ -4831,7 +5070,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for OpenAPI example validation. Default is warn."
         },
         "broken-links": {
           "oneOf": [
@@ -4841,7 +5081,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for broken link detection. Defaults to error for broken internal links and warn for malformed URLs."
         },
         "no-non-component-refs": {
           "oneOf": [
@@ -4851,7 +5092,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for non-component OpenAPI reference validation. Default is error."
         },
         "valid-local-references": {
           "oneOf": [
@@ -4861,7 +5103,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for local OpenAPI reference validation. Default is warn."
         },
         "no-circular-redirects": {
           "oneOf": [
@@ -4871,7 +5114,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for circular redirect validation. Default is error."
         },
         "valid-docs-endpoints": {
           "oneOf": [
@@ -4881,7 +5125,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for docs endpoint URL validation. Default is warn."
         },
         "missing-redirects": {
           "oneOf": [
@@ -4891,7 +5136,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for detecting previously published URLs that disappeared without an explicit redirect. Default is warn."
         },
         "valid-changelog-slug": {
           "oneOf": [
@@ -4901,7 +5147,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Severity for validating that each changelog's effective URL slug is one of the allowlisted values served as an RSS/Atom/JSON feed. Default is error."
         }
       },
       "additionalProperties": false
@@ -4920,7 +5167,8 @@
           ]
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Configure the severity of validation rules run by `fern check`.\nEach rule can be set to `warn` (non-blocking) or `error` (blocking)."
     },
     "docs.LogoConfiguration": {
       "type": "object",
@@ -4933,7 +5181,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Path to your dark mode logo file, relative to the docs root. SVG format is recommended for optimal quality.\nExample: `assets/images/logo-dark.svg`"
         },
         "light": {
           "oneOf": [
@@ -4943,7 +5192,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Path to your light mode logo file, relative to the docs root. SVG format is recommended for optimal quality.\nExample: `assets/images/logo-light.svg`"
         },
         "height": {
           "oneOf": [
@@ -4963,7 +5213,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The URL that users will be directed to when clicking the logo. Typically your company's homepage or app."
         },
         "right-text": {
           "oneOf": [
@@ -4973,7 +5224,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Text to display to the right of the logo image. This is useful for adding a tagline or product name next to your logo.\nExample: `Docs`"
         }
       },
       "additionalProperties": false
@@ -4989,7 +5241,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative filepath to the dark-mode background image."
         },
         "light": {
           "oneOf": [
@@ -4999,7 +5252,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative filepath to the light-mode background image."
         }
       },
       "additionalProperties": false
@@ -5012,7 +5266,8 @@
         {
           "$ref": "#/definitions/docs.BackgroundImageThemedConfig"
         }
-      ]
+      ],
+      "description": "This background image is used to customize the appearance of your docs site."
     },
     "docs.ColorThemedConfig": {
       "type": "object",
@@ -5061,7 +5316,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The primary brand color used for interactive elements like links, buttons, and highlighted text.\nConfigure separate colors for light and dark modes to ensure proper contrast and visibility.\n\n@default: #818CF8"
         },
         "accentPrimary": {
           "oneOf": [
@@ -5071,7 +5327,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Use `accent-primary` instead."
         },
         "background": {
           "oneOf": [
@@ -5081,7 +5338,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The main background color for all documentation pages. Choose colors that provide good contrast with text\nand complement your brand colors. Dark mode colors should reduce eye strain.\n\n@default:\n  dark: #111111\n  light: #F9F9F9\n\nIf not set, there will be also be a vertical gradient from the top using the accent primary color with 5% opacity."
         },
         "border": {
           "oneOf": [
@@ -5091,7 +5349,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Used for dividing lines, borders around elements, and visual separators. Choose subtle colors that create\nclear boundaries without being too prominent.\n\n@default:\n  dark: black/12%\n  white: white/13%"
         },
         "sidebar-background": {
           "oneOf": [
@@ -5101,7 +5360,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Background color for the navigation sidebar. When specified, includes a 1px border on the right side.\nIf omitted, the sidebar uses a transparent background without a border."
         },
         "header-background": {
           "oneOf": [
@@ -5111,7 +5371,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Background color for the top navigation header. When specified, includes a 1px solid border on the bottom.\nIf omitted, the header uses a transparent background with a subtle gradient border."
         },
         "card-background": {
           "oneOf": [
@@ -5121,7 +5382,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Background color for cards, code blocks, and other contained elements. Should be slightly different from the\nmain background to create visual hierarchy while maintaining readability.\n\n@default:\n  dark: white/3.5%\n  light: white/70%"
         },
         "accent-1": {
           "oneOf": [
@@ -5131,7 +5393,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 1. This is the lightest accent color, typically used for subtle backgrounds.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-2": {
           "oneOf": [
@@ -5141,7 +5404,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 2. A very light accent color for backgrounds.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-3": {
           "oneOf": [
@@ -5151,7 +5415,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 3. A light accent color for UI element backgrounds.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-4": {
           "oneOf": [
@@ -5161,7 +5426,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 4. Used for hovered UI element backgrounds.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-5": {
           "oneOf": [
@@ -5171,7 +5437,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 5. Used for active/selected UI element backgrounds.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-6": {
           "oneOf": [
@@ -5181,7 +5448,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 6. Used for subtle borders and separators.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-7": {
           "oneOf": [
@@ -5191,7 +5459,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 7. Used for UI element borders and focus rings.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-8": {
           "oneOf": [
@@ -5201,7 +5470,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 8. Used for hovered UI element borders.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-9": {
           "oneOf": [
@@ -5211,7 +5481,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 9. The solid accent color, used for solid backgrounds like buttons.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-10": {
           "oneOf": [
@@ -5221,7 +5492,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 10. Used for hovered solid backgrounds.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-11": {
           "oneOf": [
@@ -5231,7 +5503,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 11. Used for low-contrast text.\nBy default, this is automatically calculated from the accent-primary color."
         },
         "accent-12": {
           "oneOf": [
@@ -5241,7 +5514,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override for accent scale step 12. The darkest accent color, used for high-contrast text.\nBy default, this is automatically calculated from the accent-primary color."
         }
       },
       "additionalProperties": false
@@ -5277,7 +5551,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "@default: `100 900`."
         },
         "style": {
           "oneOf": [
@@ -5287,7 +5562,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "@default: `normal`."
         }
       },
       "required": [
@@ -5326,7 +5602,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The name of the font. Defaults to a generated name that will be used to reference your custom font in the eventually injected CSS."
         },
         "path": {
           "oneOf": [
@@ -5336,7 +5613,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The path to your font file, relative to your docs folder. Use this when you have a single font file.\nFor multiple font files (like separate files for bold, italic etc), use `paths` instead."
         },
         "weight": {
           "oneOf": [
@@ -5346,7 +5624,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The weight of the font. Can be a number (400, 700) or a range for variable fonts (400 700).\nCommon values: 400 (normal), 700 (bold).\n\n@default: `100 900`."
         },
         "style": {
           "oneOf": [
@@ -5356,7 +5635,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The font style, either \"normal\" or \"italic\". Defaults to \"normal\" if not specified.\n\n@default: `normal`."
         },
         "paths": {
           "oneOf": [
@@ -5369,7 +5649,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A list of font files for particular weights. Each element in the list includes a `path`, `weight`, and `style` property."
         },
         "display": {
           "oneOf": [
@@ -5379,7 +5660,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "@default: `swap`."
         },
         "fallback": {
           "oneOf": [
@@ -5392,7 +5674,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Define fallback fonts in case the custom font fails to load."
         },
         "font-variation-settings": {
           "oneOf": [
@@ -5418,7 +5701,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The font used for headings, titles, and other prominent text elements. Can be the same as your body font\nif you prefer a unified look. Supports multiple weights for different heading levels."
         },
         "bodyFont": {
           "oneOf": [
@@ -5428,7 +5712,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The font used for all body text including paragraphs, lists, and general content.\nFor optimal performance, use WOFF2 format."
         },
         "codeFont": {
           "oneOf": [
@@ -5438,17 +5723,25 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The font used for code blocks and inline code. Monospace fonts are recommended for better code readability.\nPopular choices include JetBrains Mono, Fira Code, and Source Code Pro."
         }
       },
       "additionalProperties": false
     },
     "docs.SearchbarPlacement": {
       "type": "string",
-      "enum": [
-        "header",
-        "header-tabs",
-        "sidebar"
+      "oneOf": [
+        {
+          "const": "header"
+        },
+        {
+          "const": "header-tabs",
+          "description": "The searchbar will be placed in the header, but on the tabs row. If the tabs row is hidden, the searchbar will be placed in the header instead.\nThis is a good option if you want to keep the searchbar visible, but save space in the header for more navbar links."
+        },
+        {
+          "const": "sidebar"
+        }
       ]
     },
     "docs.TabsPlacement": {
@@ -5490,7 +5783,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the maximum width of the docs layout, including the sidebar and content.\n\n@default: 88rem (1408px)\n\nValid options are:\n- `{number}rem`\n- `{number}px`\n- `full` (100% of the viewport width)"
         },
         "content-width": {
           "oneOf": [
@@ -5500,7 +5794,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the maximum width of the markdown article content.\n\n@default: 44rem (704px)\n\nValid options are:\n- `{number}rem`\n- `{number}px`"
         },
         "sidebar-width": {
           "oneOf": [
@@ -5510,7 +5805,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the width of the sidebar in desktop mode\n\n@default: 18rem (288px)\n\nValid options are:\n- `{number}rem`\n- `{number}px`"
         },
         "header-height": {
           "oneOf": [
@@ -5520,7 +5816,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the height of the header\n\n@default: 4rem (64px)\n\nValid options are:\n- `{number}rem`\n- `{number}px`"
         },
         "searchbar-placement": {
           "oneOf": [
@@ -5530,7 +5827,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the placement of the searchbar\n\n@default: `sidebar`\n\nNote: this setting is ignored when `disable-header` is set to true."
         },
         "tabs-placement": {
           "oneOf": [
@@ -5540,7 +5838,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Set the placement of the tabs\n\n@default: `sidebar`\n\nNote: this setting is ignored when `disable-header` is set to true."
         },
         "switcher-placement": {
           "oneOf": [
@@ -5550,7 +5849,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Set the placement of the version and language switcher\n\n@default: `header`\n\nNote: this setting is ignored when `disable-header` is set to true."
         },
         "content-alignment": {
           "oneOf": [
@@ -5560,7 +5860,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Set the alignment of the mardown content.\n\n@default: `center`\n\nSide effects:\n- When the alignment is set to `center`, the \"On this page\" (ToC) will be aligned to the right of the page.\n- When the alignment is set to `left`, the content will be aligned next to the right of the markdown content."
         },
         "header-position": {
           "oneOf": [
@@ -5570,7 +5871,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `header-position` is set to `fixed`, the header will be fixed to the top of the viewport.\nIf `header-position` is set to `absolute`, the header will be absolute and will scroll with the content.\n\n@default: `fixed`"
         },
         "disable-header": {
           "oneOf": [
@@ -5580,7 +5882,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `disable-header` is set to true, the header will not be rendered. Instead, the logo will be rendered as part of the sidebar,\nand a 1px border will separate the sidebar from the content."
         },
         "hide-nav-links": {
           "oneOf": [
@@ -5590,7 +5893,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `hide-nav-links` is set to true, the navbar links will not be rendered. This can be overridden for a specific page using the frontmatter."
         },
         "hide-feedback": {
           "oneOf": [
@@ -5600,7 +5904,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `hide-feedback` is set to true, the feedback button will not be rendered. This can be overridden for a specific page using the frontmatter."
         },
         "mobile-toc": {
           "oneOf": [
@@ -5610,7 +5915,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `mobile-toc` is set to true, a sticky collapsible table of contents bar will be shown on mobile viewports for guide and overview layout pages."
         }
       },
       "additionalProperties": false
@@ -5661,7 +5967,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The text to display in the searchbar.\n\n@default: Search"
         },
         "disable-search": {
           "oneOf": [
@@ -5671,7 +5978,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set to true, the searchbar will be disabled. Use this if you want to use a custom search solution.\n\n@default: false"
         },
         "dark-mode-code": {
           "oneOf": [
@@ -5681,7 +5989,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set to true, the code blocks will be displayed in dark mode, regardless of the selected theme.\n\n@default: false"
         },
         "default-search-filters": {
           "oneOf": [
@@ -5691,7 +6000,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "By default (`false`), search will display results for pages across all products and versions.\nIf set to true, search will display results for pages within the current product and version.\n\n@default: false"
         },
         "http-snippets": {
           "oneOf": [
@@ -5701,7 +6011,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls the display of HTTP snippets in the API Reference. HTTP snippets are enabled by default for all languages.\n- Set to `false` to disable HTTP snippets completely\n- Provide a list of languages to enable snippets for specific languages only\n\n@default: true"
         },
         "hide-404-page": {
           "oneOf": [
@@ -5711,7 +6022,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set to true, when a user navigates to a page that does not exist, they will be redirected to the home page.\nBy default, a 404 page will be displayed.\n\n@default: false"
         },
         "use-javascript-as-typescript": {
           "oneOf": [
@@ -5721,7 +6033,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set to true, the TypeScript snippets will be displayed as JavaScript snippets in the API Reference.\n\n@default: false"
         },
         "disable-explorer-proxy": {
           "oneOf": [
@@ -5731,7 +6044,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set to true, the API Explorer will bypass the proxy when sending requests directly to your API.\n\nWhen this feature is enabled, your API must have Cross-Origin Resource Sharing (CORS) enabled to allow requests from the documentation domain.\n\n@default: false"
         },
         "disable-environment-editing": {
           "oneOf": [
@@ -5741,7 +6055,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If set to true, the base URL (environment) shown in the endpoint header on API reference\ndocs pages will no longer be editable. Users will still be able to switch between configured\nenvironments via the dropdown, but will not be able to double-click and type in a custom\nURL. This does not affect the API Playground.\n\n@default: false"
         },
         "disable-analytics": {
           "oneOf": [
@@ -5771,7 +6086,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sets the default title source for all folder navigations. When set, this value is used as the\ndefault `title-source` for any folder that does not explicitly specify its own `title-source`.\nOptions are `frontmatter` (use the `title` field from the file's frontmatter) or `filename`\n(derive title from the file name)."
         },
         "substitute-env-vars": {
           "oneOf": [
@@ -5781,7 +6097,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When true, substitutes ${ENV_VAR} expressions using environment variables across all files in the docs bundle,\nincluding markdown/MDX content. This is useful for injecting dynamic values like API keys or URLs.\nUse \\$\\{VAR\\} to escape and output literal ${VAR} without substitution.\n\n@default: false"
         },
         "websocket-oneof-display": {
           "oneOf": [
@@ -5791,7 +6108,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Controls how WebSocket messages with oneOf bodies are displayed in the API Reference.\n- `flat` (default): Each variant in the oneOf is shown as a separate top-level entry.\n- `grouped`: Messages are shown as a single parent entry with nested variants.\n\n@default: flat"
         }
       },
       "additionalProperties": false
@@ -5996,7 +6314,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative filepath to a `context7.json` file that Fern should host at `/context7.json`.\nFern only checks that the file exists and is valid JSON, then passes it through as-is."
         }
       },
       "additionalProperties": false
@@ -6012,7 +6331,8 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "description": "The `css` object allows you to customize the appearance of your docs site by injecting custom CSS, i.e.\n\n```yaml\ncss: \"path/to/css/file.css\"\n```\n\nor, multiple files:\n\n```yaml\ncss:\n  - \"path/to/css/file.css\"\n  - \"path/to/another/css/file.css\"\n```"
     },
     "docs.JsScriptStrategy": {
       "type": "string",
@@ -6097,7 +6417,8 @@
             "$ref": "#/definitions/docs.JsConfigOptions"
           }
         }
-      ]
+      ],
+      "description": "The `js` object allows you to customize the behavior of your docs site by injecting custom JavaScript, i.e.\n\n```yaml\njs: \"path/to/js/file.js\"\n```\n\nor, multiple files:\n\n```yaml\njs:\n  - \"path/to/js/file.js\"\n  - \"path/to/another/js/file.js\"\n```\n\nor remote js:\n\n```yaml\njs:\n  url: \"https://example.com/path/to/js/file.js\"\n  strategy: \"afterInteractive\"\n```\n\nor, mixed:\n\n```yaml\njs:\n  - \"path/to/js/file.js\"\n  - path: \"path/to/another/js/file.js\"\n    strategy: \"beforeInteractive\"\n  - url: \"https://example.com/path/to/js/file.js\"\n```"
     }
   }
 }

--- a/packages/cli/yaml/docs-validator/src/docsAst/products-yml.schema.json
+++ b/packages/cli/yaml/docs-validator/src/docsAst/products-yml.schema.json
@@ -34,7 +34,8 @@
   "additionalProperties": false,
   "definitions": {
     "docs.RoleId": {
-      "type": "string"
+      "type": "string",
+      "description": "ID of role which is used to filter the content shown in Fern Docs."
     },
     "docs.Role": {
       "anyOf": [
@@ -47,13 +48,15 @@
             "$ref": "#/definitions/docs.RoleId"
           }
         }
-      ]
+      ],
+      "description": "Audience can either be a string or list of strings\ni.e. `audience: internal` or `audience: [internal, beta]`"
     },
     "docs.FeatureFlag": {
       "type": "object",
       "properties": {
         "flag": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the feature flag to check."
         },
         "fallback-value": {
           "oneOf": [
@@ -70,7 +73,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default value to use if the feature flag is not set. If not specified, defaults to false."
         },
         "match": {
           "oneOf": [
@@ -87,7 +91,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The value that the feature flag should match for the content to be shown. If not specified, content is shown when the flag is true."
         }
       },
       "required": [
@@ -124,7 +129,8 @@
       ]
     },
     "docs.ChangelogFolderRelativePath": {
-      "type": "string"
+      "type": "string",
+      "description": "The relative path to a folder containing markdown files broken down by date.\n\nExample:\n```\nchangelog: \"changelog\"\n```\n\nThis will look for markdown files in the `/fern/changelog` directory, which should contain files named like\n- `/fern/changelog/2024-04-29.mdx`.\n- `/fern/changelog/2023-01-02.mdx`."
     },
     "docs.TabConfig": {
       "type": "object",
@@ -147,7 +153,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -210,7 +217,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `href` is set, clicking on the tab will redirect to the given URL.\n\nTabs with `href` must not have children in the navigation config."
         },
         "target": {
           "oneOf": [
@@ -273,7 +281,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -385,7 +394,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -408,7 +418,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The relative path to the markdown file that will be displayed when the section is clicked."
         },
         "contents": {
           "type": "array",
@@ -424,7 +435,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -434,7 +446,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -444,7 +457,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open)."
         },
         "slug": {
           "oneOf": [
@@ -504,7 +518,8 @@
       "additionalProperties": false
     },
     "docs.AudienceId": {
-      "type": "string"
+      "type": "string",
+      "description": "ID of audience which is used to filter the API spec."
     },
     "docs.Audience": {
       "anyOf": [
@@ -517,7 +532,8 @@
             "$ref": "#/definitions/docs.AudienceId"
           }
         }
-      ]
+      ],
+      "description": "Audience can either be a string or list of strings\ni.e. `audiences: internal` or `audiences: [internal, beta]`"
     },
     "docs.VersionedSnippetLanguageConfiguration": {
       "type": "object",
@@ -543,7 +559,8 @@
         {
           "$ref": "#/definitions/docs.VersionedSnippetLanguageConfiguration"
         }
-      ]
+      ],
+      "description": "This snippets config object is meant to allow users to specify a specific package for the snippets,\nand optionally a version for that package. If you pass in a string, that should be the name of the package."
     },
     "docs.SnippetsConfiguration": {
       "type": "object",
@@ -681,7 +698,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A list of environment IDs that are allowed to be used in the playground. If not provided, all environments are allowed. And if the provided list is empty, the playground should be disabled."
         },
         "button": {
           "oneOf": [
@@ -711,7 +729,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The maximum number of websocket messages per connection in the playground."
         }
       },
       "additionalProperties": false
@@ -737,7 +756,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -767,7 +787,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file. This summary is displayed at the top of the API section."
         },
         "contents": {
           "oneOf": [
@@ -840,7 +861,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that is applied only to descendants of this api package."
         }
       },
       "additionalProperties": false
@@ -879,7 +901,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -892,7 +915,8 @@
           ]
         },
         "section": {
-          "type": "string"
+          "type": "string",
+          "description": "The title of the api package that will be displayed in the sidebar."
         },
         "referenced-packages": {
           "oneOf": [
@@ -905,7 +929,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "This section will inherit the endpoints from the specified subpackage(s). If multiple packages are specified, they will be merged."
         },
         "summary": {
           "oneOf": [
@@ -915,7 +940,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file."
         },
         "contents": {
           "oneOf": [
@@ -978,7 +1004,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -988,7 +1015,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user in the sidebar."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -998,7 +1026,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when collapsible is true."
         },
         "availability": {
           "oneOf": [
@@ -1018,7 +1047,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affects all endpoints."
         }
       },
       "required": [
@@ -1047,7 +1077,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1120,7 +1151,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affect this endpoint specifically."
         }
       },
       "required": [
@@ -1149,7 +1181,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1208,7 +1241,8 @@
       "required": [
         "operation"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Defines a GraphQL-native schema for selecting operations (REST -> Endpoint === GraphQL -> Operation)"
     },
     "docs.LinkConfiguration": {
       "type": "object",
@@ -1274,7 +1308,8 @@
         {
           "$ref": "#/definitions/docs.LinkConfiguration"
         }
-      ]
+      ],
+      "description": "Use the `layout` object to customize the order that your API endpoints\nare displayed in the docs site."
     },
     "docs.ApiReferenceConfiguration": {
       "type": "object",
@@ -1297,7 +1332,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1320,7 +1356,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Name of API that we are referencing"
         },
         "openrpc": {
           "oneOf": [
@@ -1330,7 +1367,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Path to an openrpc spec."
         },
         "audiences": {
           "oneOf": [
@@ -1350,7 +1388,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to false"
         },
         "tag-description-pages": {
           "oneOf": [
@@ -1360,7 +1399,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, a page will be created for each tag in the OpenAPI spec that contains a description."
         },
         "snippets": {
           "oneOf": [
@@ -1380,7 +1420,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to a Postman collection for this API reference"
         },
         "summary": {
           "oneOf": [
@@ -1390,7 +1431,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file"
         },
         "layout": {
           "oneOf": [
@@ -1403,7 +1445,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Advanced usage: when specified, this object will be used to customize the order that your API endpoints are displayed in the docs site, including subpackages, and additional markdown pages (to be rendered in between API endpoints). If not specified, the order will be inferred from the OpenAPI Spec or Fern Definition."
         },
         "collapsed": {
           "oneOf": [
@@ -1473,7 +1516,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `alphabetized` is set to true, packages and endpoints will be sorted alphabetically, unless explicitly ordered in the `layout` object."
         },
         "flattened": {
           "oneOf": [
@@ -1483,7 +1527,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `flattened` is set to true, the title specified in `api` will be hidden, and its endpoints and subpackages won't be grouped under it.\n\nThis setting is useful if the API reference is short and you want to display all endpoints at the top level."
         },
         "paginated": {
           "oneOf": [
@@ -1493,7 +1538,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the API reference will be paginated rather than displayed in a single page (long-scrolling)."
         },
         "playground": {
           "oneOf": [
@@ -1503,7 +1549,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affects all endpoints."
         }
       },
       "required": [
@@ -1512,7 +1559,8 @@
       "additionalProperties": false
     },
     "docs.LibraryName": {
-      "type": "string"
+      "type": "string",
+      "description": "The name identifier for a library. Used to reference the library in navigation."
     },
     "docs.LibraryReferenceConfiguration": {
       "type": "object",
@@ -1535,7 +1583,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1548,7 +1597,8 @@
           ]
         },
         "library": {
-          "$ref": "#/definitions/docs.LibraryName"
+          "$ref": "#/definitions/docs.LibraryName",
+          "description": "The name of the library to reference (must match a key in the `libraries` section)."
         },
         "title": {
           "oneOf": [
@@ -1558,7 +1608,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the display title for this library reference."
         },
         "slug": {
           "oneOf": [
@@ -1568,13 +1619,15 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the URL slug for this library reference."
         }
       },
       "required": [
         "library"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "References a library defined in the `libraries` section.\nThe library's generated navigation will be injected at this point."
     },
     "docs.ChangelogConfiguration": {
       "type": "object",
@@ -1597,7 +1650,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1686,7 +1740,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1699,7 +1754,8 @@
           ]
         },
         "folder": {
-          "type": "string"
+          "type": "string",
+          "description": "The relative path to a folder containing markdown files. Fern will automatically discover and add all markdown files from this folder to the navigation."
         },
         "title": {
           "oneOf": [
@@ -1709,7 +1765,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The title to display for this folder section. If not provided, the folder name will be used."
         },
         "title-source": {
           "oneOf": [
@@ -1719,7 +1776,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Determines how page titles are derived for files in this folder. Options are `frontmatter` (use the `title` field from the file's frontmatter) or `filename` (derive title from the file name). Defaults to `filename`."
         },
         "slug": {
           "oneOf": [
@@ -1769,7 +1827,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -1779,7 +1838,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -1789,7 +1849,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open)."
         },
         "availability": {
           "oneOf": [
@@ -1858,7 +1919,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `href` is set, `layout` must be null."
         }
       },
       "required": [
@@ -1887,7 +1949,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [

--- a/packages/cli/yaml/docs-validator/src/docsAst/versions-yml.schema.json
+++ b/packages/cli/yaml/docs-validator/src/docsAst/versions-yml.schema.json
@@ -34,7 +34,8 @@
   "additionalProperties": false,
   "definitions": {
     "docs.RoleId": {
-      "type": "string"
+      "type": "string",
+      "description": "ID of role which is used to filter the content shown in Fern Docs."
     },
     "docs.Role": {
       "anyOf": [
@@ -47,13 +48,15 @@
             "$ref": "#/definitions/docs.RoleId"
           }
         }
-      ]
+      ],
+      "description": "Audience can either be a string or list of strings\ni.e. `audience: internal` or `audience: [internal, beta]`"
     },
     "docs.FeatureFlag": {
       "type": "object",
       "properties": {
         "flag": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the feature flag to check."
         },
         "fallback-value": {
           "oneOf": [
@@ -70,7 +73,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default value to use if the feature flag is not set. If not specified, defaults to false."
         },
         "match": {
           "oneOf": [
@@ -87,7 +91,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The value that the feature flag should match for the content to be shown. If not specified, content is shown when the flag is true."
         }
       },
       "required": [
@@ -124,7 +129,8 @@
       ]
     },
     "docs.ChangelogFolderRelativePath": {
-      "type": "string"
+      "type": "string",
+      "description": "The relative path to a folder containing markdown files broken down by date.\n\nExample:\n```\nchangelog: \"changelog\"\n```\n\nThis will look for markdown files in the `/fern/changelog` directory, which should contain files named like\n- `/fern/changelog/2024-04-29.mdx`.\n- `/fern/changelog/2023-01-02.mdx`."
     },
     "docs.TabConfig": {
       "type": "object",
@@ -147,7 +153,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -210,7 +217,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `href` is set, clicking on the tab will redirect to the given URL.\n\nTabs with `href` must not have children in the navigation config."
         },
         "target": {
           "oneOf": [
@@ -273,7 +281,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -385,7 +394,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -408,7 +418,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The relative path to the markdown file that will be displayed when the section is clicked."
         },
         "contents": {
           "type": "array",
@@ -424,7 +435,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -434,7 +446,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -444,7 +457,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open)."
         },
         "slug": {
           "oneOf": [
@@ -504,7 +518,8 @@
       "additionalProperties": false
     },
     "docs.AudienceId": {
-      "type": "string"
+      "type": "string",
+      "description": "ID of audience which is used to filter the API spec."
     },
     "docs.Audience": {
       "anyOf": [
@@ -517,7 +532,8 @@
             "$ref": "#/definitions/docs.AudienceId"
           }
         }
-      ]
+      ],
+      "description": "Audience can either be a string or list of strings\ni.e. `audiences: internal` or `audiences: [internal, beta]`"
     },
     "docs.VersionedSnippetLanguageConfiguration": {
       "type": "object",
@@ -543,7 +559,8 @@
         {
           "$ref": "#/definitions/docs.VersionedSnippetLanguageConfiguration"
         }
-      ]
+      ],
+      "description": "This snippets config object is meant to allow users to specify a specific package for the snippets,\nand optionally a version for that package. If you pass in a string, that should be the name of the package."
     },
     "docs.SnippetsConfiguration": {
       "type": "object",
@@ -681,7 +698,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A list of environment IDs that are allowed to be used in the playground. If not provided, all environments are allowed. And if the provided list is empty, the playground should be disabled."
         },
         "button": {
           "oneOf": [
@@ -711,7 +729,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The maximum number of websocket messages per connection in the playground."
         }
       },
       "additionalProperties": false
@@ -737,7 +756,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -767,7 +787,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file. This summary is displayed at the top of the API section."
         },
         "contents": {
           "oneOf": [
@@ -840,7 +861,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that is applied only to descendants of this api package."
         }
       },
       "additionalProperties": false
@@ -879,7 +901,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -892,7 +915,8 @@
           ]
         },
         "section": {
-          "type": "string"
+          "type": "string",
+          "description": "The title of the api package that will be displayed in the sidebar."
         },
         "referenced-packages": {
           "oneOf": [
@@ -905,7 +929,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "This section will inherit the endpoints from the specified subpackage(s). If multiple packages are specified, they will be merged."
         },
         "summary": {
           "oneOf": [
@@ -915,7 +940,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file."
         },
         "contents": {
           "oneOf": [
@@ -978,7 +1004,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -988,7 +1015,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user in the sidebar."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -998,7 +1026,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when collapsible is true."
         },
         "availability": {
           "oneOf": [
@@ -1018,7 +1047,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affects all endpoints."
         }
       },
       "required": [
@@ -1047,7 +1077,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1120,7 +1151,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affect this endpoint specifically."
         }
       },
       "required": [
@@ -1149,7 +1181,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1208,7 +1241,8 @@
       "required": [
         "operation"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Defines a GraphQL-native schema for selecting operations (REST -> Endpoint === GraphQL -> Operation)"
     },
     "docs.LinkConfiguration": {
       "type": "object",
@@ -1274,7 +1308,8 @@
         {
           "$ref": "#/definitions/docs.LinkConfiguration"
         }
-      ]
+      ],
+      "description": "Use the `layout` object to customize the order that your API endpoints\nare displayed in the docs site."
     },
     "docs.ApiReferenceConfiguration": {
       "type": "object",
@@ -1297,7 +1332,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1320,7 +1356,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Name of API that we are referencing"
         },
         "openrpc": {
           "oneOf": [
@@ -1330,7 +1367,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Path to an openrpc spec."
         },
         "audiences": {
           "oneOf": [
@@ -1350,7 +1388,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to false"
         },
         "tag-description-pages": {
           "oneOf": [
@@ -1360,7 +1399,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, a page will be created for each tag in the OpenAPI spec that contains a description."
         },
         "snippets": {
           "oneOf": [
@@ -1380,7 +1420,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to a Postman collection for this API reference"
         },
         "summary": {
           "oneOf": [
@@ -1390,7 +1431,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file"
         },
         "layout": {
           "oneOf": [
@@ -1403,7 +1445,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Advanced usage: when specified, this object will be used to customize the order that your API endpoints are displayed in the docs site, including subpackages, and additional markdown pages (to be rendered in between API endpoints). If not specified, the order will be inferred from the OpenAPI Spec or Fern Definition."
         },
         "collapsed": {
           "oneOf": [
@@ -1473,7 +1516,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `alphabetized` is set to true, packages and endpoints will be sorted alphabetically, unless explicitly ordered in the `layout` object."
         },
         "flattened": {
           "oneOf": [
@@ -1483,7 +1527,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `flattened` is set to true, the title specified in `api` will be hidden, and its endpoints and subpackages won't be grouped under it.\n\nThis setting is useful if the API reference is short and you want to display all endpoints at the top level."
         },
         "paginated": {
           "oneOf": [
@@ -1493,7 +1538,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the API reference will be paginated rather than displayed in a single page (long-scrolling)."
         },
         "playground": {
           "oneOf": [
@@ -1503,7 +1549,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affects all endpoints."
         }
       },
       "required": [
@@ -1512,7 +1559,8 @@
       "additionalProperties": false
     },
     "docs.LibraryName": {
-      "type": "string"
+      "type": "string",
+      "description": "The name identifier for a library. Used to reference the library in navigation."
     },
     "docs.LibraryReferenceConfiguration": {
       "type": "object",
@@ -1535,7 +1583,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1548,7 +1597,8 @@
           ]
         },
         "library": {
-          "$ref": "#/definitions/docs.LibraryName"
+          "$ref": "#/definitions/docs.LibraryName",
+          "description": "The name of the library to reference (must match a key in the `libraries` section)."
         },
         "title": {
           "oneOf": [
@@ -1558,7 +1608,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the display title for this library reference."
         },
         "slug": {
           "oneOf": [
@@ -1568,13 +1619,15 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the URL slug for this library reference."
         }
       },
       "required": [
         "library"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "References a library defined in the `libraries` section.\nThe library's generated navigation will be injected at this point."
     },
     "docs.ChangelogConfiguration": {
       "type": "object",
@@ -1597,7 +1650,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1686,7 +1740,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1699,7 +1754,8 @@
           ]
         },
         "folder": {
-          "type": "string"
+          "type": "string",
+          "description": "The relative path to a folder containing markdown files. Fern will automatically discover and add all markdown files from this folder to the navigation."
         },
         "title": {
           "oneOf": [
@@ -1709,7 +1765,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The title to display for this folder section. If not provided, the folder name will be used."
         },
         "title-source": {
           "oneOf": [
@@ -1719,7 +1776,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Determines how page titles are derived for files in this folder. Options are `frontmatter` (use the `title` field from the file's frontmatter) or `filename` (derive title from the file name). Defaults to `filename`."
         },
         "slug": {
           "oneOf": [
@@ -1769,7 +1827,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -1779,7 +1838,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -1789,7 +1849,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open)."
         },
         "availability": {
           "oneOf": [
@@ -1858,7 +1919,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `href` is set, `layout` must be null."
         }
       },
       "required": [
@@ -1887,7 +1949,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [

--- a/product-yml.schema.json
+++ b/product-yml.schema.json
@@ -34,7 +34,8 @@
   "additionalProperties": false,
   "definitions": {
     "docs.RoleId": {
-      "type": "string"
+      "type": "string",
+      "description": "ID of role which is used to filter the content shown in Fern Docs."
     },
     "docs.Role": {
       "anyOf": [
@@ -47,13 +48,15 @@
             "$ref": "#/definitions/docs.RoleId"
           }
         }
-      ]
+      ],
+      "description": "Audience can either be a string or list of strings\ni.e. `audience: internal` or `audience: [internal, beta]`"
     },
     "docs.FeatureFlag": {
       "type": "object",
       "properties": {
         "flag": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the feature flag to check."
         },
         "fallback-value": {
           "oneOf": [
@@ -70,7 +73,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default value to use if the feature flag is not set. If not specified, defaults to false."
         },
         "match": {
           "oneOf": [
@@ -87,7 +91,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The value that the feature flag should match for the content to be shown. If not specified, content is shown when the flag is true."
         }
       },
       "required": [
@@ -124,7 +129,8 @@
       ]
     },
     "docs.ChangelogFolderRelativePath": {
-      "type": "string"
+      "type": "string",
+      "description": "The relative path to a folder containing markdown files broken down by date.\n\nExample:\n```\nchangelog: \"changelog\"\n```\n\nThis will look for markdown files in the `/fern/changelog` directory, which should contain files named like\n- `/fern/changelog/2024-04-29.mdx`.\n- `/fern/changelog/2023-01-02.mdx`."
     },
     "docs.TabConfig": {
       "type": "object",
@@ -147,7 +153,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -210,7 +217,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `href` is set, clicking on the tab will redirect to the given URL.\n\nTabs with `href` must not have children in the navigation config."
         },
         "target": {
           "oneOf": [
@@ -273,7 +281,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -385,7 +394,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -408,7 +418,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The relative path to the markdown file that will be displayed when the section is clicked."
         },
         "contents": {
           "type": "array",
@@ -424,7 +435,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -434,7 +446,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -444,7 +457,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open)."
         },
         "slug": {
           "oneOf": [
@@ -504,7 +518,8 @@
       "additionalProperties": false
     },
     "docs.AudienceId": {
-      "type": "string"
+      "type": "string",
+      "description": "ID of audience which is used to filter the API spec."
     },
     "docs.Audience": {
       "anyOf": [
@@ -517,7 +532,8 @@
             "$ref": "#/definitions/docs.AudienceId"
           }
         }
-      ]
+      ],
+      "description": "Audience can either be a string or list of strings\ni.e. `audiences: internal` or `audiences: [internal, beta]`"
     },
     "docs.VersionedSnippetLanguageConfiguration": {
       "type": "object",
@@ -543,7 +559,8 @@
         {
           "$ref": "#/definitions/docs.VersionedSnippetLanguageConfiguration"
         }
-      ]
+      ],
+      "description": "This snippets config object is meant to allow users to specify a specific package for the snippets,\nand optionally a version for that package. If you pass in a string, that should be the name of the package."
     },
     "docs.SnippetsConfiguration": {
       "type": "object",
@@ -681,7 +698,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A list of environment IDs that are allowed to be used in the playground. If not provided, all environments are allowed. And if the provided list is empty, the playground should be disabled."
         },
         "button": {
           "oneOf": [
@@ -711,7 +729,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The maximum number of websocket messages per connection in the playground."
         }
       },
       "additionalProperties": false
@@ -737,7 +756,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -767,7 +787,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file. This summary is displayed at the top of the API section."
         },
         "contents": {
           "oneOf": [
@@ -840,7 +861,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that is applied only to descendants of this api package."
         }
       },
       "additionalProperties": false
@@ -879,7 +901,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -892,7 +915,8 @@
           ]
         },
         "section": {
-          "type": "string"
+          "type": "string",
+          "description": "The title of the api package that will be displayed in the sidebar."
         },
         "referenced-packages": {
           "oneOf": [
@@ -905,7 +929,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "This section will inherit the endpoints from the specified subpackage(s). If multiple packages are specified, they will be merged."
         },
         "summary": {
           "oneOf": [
@@ -915,7 +940,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file."
         },
         "contents": {
           "oneOf": [
@@ -978,7 +1004,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -988,7 +1015,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user in the sidebar."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -998,7 +1026,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when collapsible is true."
         },
         "availability": {
           "oneOf": [
@@ -1018,7 +1047,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affects all endpoints."
         }
       },
       "required": [
@@ -1047,7 +1077,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1120,7 +1151,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affect this endpoint specifically."
         }
       },
       "required": [
@@ -1149,7 +1181,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1208,7 +1241,8 @@
       "required": [
         "operation"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Defines a GraphQL-native schema for selecting operations (REST -> Endpoint === GraphQL -> Operation)"
     },
     "docs.LinkConfiguration": {
       "type": "object",
@@ -1274,7 +1308,8 @@
         {
           "$ref": "#/definitions/docs.LinkConfiguration"
         }
-      ]
+      ],
+      "description": "Use the `layout` object to customize the order that your API endpoints\nare displayed in the docs site."
     },
     "docs.ApiReferenceConfiguration": {
       "type": "object",
@@ -1297,7 +1332,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1320,7 +1356,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Name of API that we are referencing"
         },
         "openrpc": {
           "oneOf": [
@@ -1330,7 +1367,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Path to an openrpc spec."
         },
         "audiences": {
           "oneOf": [
@@ -1350,7 +1388,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to false"
         },
         "tag-description-pages": {
           "oneOf": [
@@ -1360,7 +1399,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, a page will be created for each tag in the OpenAPI spec that contains a description."
         },
         "snippets": {
           "oneOf": [
@@ -1380,7 +1420,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to a Postman collection for this API reference"
         },
         "summary": {
           "oneOf": [
@@ -1390,7 +1431,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file"
         },
         "layout": {
           "oneOf": [
@@ -1403,7 +1445,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Advanced usage: when specified, this object will be used to customize the order that your API endpoints are displayed in the docs site, including subpackages, and additional markdown pages (to be rendered in between API endpoints). If not specified, the order will be inferred from the OpenAPI Spec or Fern Definition."
         },
         "collapsed": {
           "oneOf": [
@@ -1473,7 +1516,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `alphabetized` is set to true, packages and endpoints will be sorted alphabetically, unless explicitly ordered in the `layout` object."
         },
         "flattened": {
           "oneOf": [
@@ -1483,7 +1527,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `flattened` is set to true, the title specified in `api` will be hidden, and its endpoints and subpackages won't be grouped under it.\n\nThis setting is useful if the API reference is short and you want to display all endpoints at the top level."
         },
         "paginated": {
           "oneOf": [
@@ -1493,7 +1538,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the API reference will be paginated rather than displayed in a single page (long-scrolling)."
         },
         "playground": {
           "oneOf": [
@@ -1503,7 +1549,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affects all endpoints."
         }
       },
       "required": [
@@ -1512,7 +1559,8 @@
       "additionalProperties": false
     },
     "docs.LibraryName": {
-      "type": "string"
+      "type": "string",
+      "description": "The name identifier for a library. Used to reference the library in navigation."
     },
     "docs.LibraryReferenceConfiguration": {
       "type": "object",
@@ -1535,7 +1583,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1548,7 +1597,8 @@
           ]
         },
         "library": {
-          "$ref": "#/definitions/docs.LibraryName"
+          "$ref": "#/definitions/docs.LibraryName",
+          "description": "The name of the library to reference (must match a key in the `libraries` section)."
         },
         "title": {
           "oneOf": [
@@ -1558,7 +1608,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the display title for this library reference."
         },
         "slug": {
           "oneOf": [
@@ -1568,13 +1619,15 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the URL slug for this library reference."
         }
       },
       "required": [
         "library"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "References a library defined in the `libraries` section.\nThe library's generated navigation will be injected at this point."
     },
     "docs.ChangelogConfiguration": {
       "type": "object",
@@ -1597,7 +1650,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1686,7 +1740,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1699,7 +1754,8 @@
           ]
         },
         "folder": {
-          "type": "string"
+          "type": "string",
+          "description": "The relative path to a folder containing markdown files. Fern will automatically discover and add all markdown files from this folder to the navigation."
         },
         "title": {
           "oneOf": [
@@ -1709,7 +1765,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The title to display for this folder section. If not provided, the folder name will be used."
         },
         "title-source": {
           "oneOf": [
@@ -1719,7 +1776,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Determines how page titles are derived for files in this folder. Options are `frontmatter` (use the `title` field from the file's frontmatter) or `filename` (derive title from the file name). Defaults to `filename`."
         },
         "slug": {
           "oneOf": [
@@ -1769,7 +1827,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -1779,7 +1838,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -1789,7 +1849,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open)."
         },
         "availability": {
           "oneOf": [
@@ -1858,7 +1919,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `href` is set, `layout` must be null."
         }
       },
       "required": [
@@ -1887,7 +1949,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [

--- a/version-yml.schema.json
+++ b/version-yml.schema.json
@@ -34,7 +34,8 @@
   "additionalProperties": false,
   "definitions": {
     "docs.RoleId": {
-      "type": "string"
+      "type": "string",
+      "description": "ID of role which is used to filter the content shown in Fern Docs."
     },
     "docs.Role": {
       "anyOf": [
@@ -47,13 +48,15 @@
             "$ref": "#/definitions/docs.RoleId"
           }
         }
-      ]
+      ],
+      "description": "Audience can either be a string or list of strings\ni.e. `audience: internal` or `audience: [internal, beta]`"
     },
     "docs.FeatureFlag": {
       "type": "object",
       "properties": {
         "flag": {
-          "type": "string"
+          "type": "string",
+          "description": "The name of the feature flag to check."
         },
         "fallback-value": {
           "oneOf": [
@@ -70,7 +73,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The default value to use if the feature flag is not set. If not specified, defaults to false."
         },
         "match": {
           "oneOf": [
@@ -87,7 +91,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The value that the feature flag should match for the content to be shown. If not specified, content is shown when the flag is true."
         }
       },
       "required": [
@@ -124,7 +129,8 @@
       ]
     },
     "docs.ChangelogFolderRelativePath": {
-      "type": "string"
+      "type": "string",
+      "description": "The relative path to a folder containing markdown files broken down by date.\n\nExample:\n```\nchangelog: \"changelog\"\n```\n\nThis will look for markdown files in the `/fern/changelog` directory, which should contain files named like\n- `/fern/changelog/2024-04-29.mdx`.\n- `/fern/changelog/2023-01-02.mdx`."
     },
     "docs.TabConfig": {
       "type": "object",
@@ -147,7 +153,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -210,7 +217,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `href` is set, clicking on the tab will redirect to the given URL.\n\nTabs with `href` must not have children in the navigation config."
         },
         "target": {
           "oneOf": [
@@ -273,7 +281,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -385,7 +394,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -408,7 +418,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The relative path to the markdown file that will be displayed when the section is clicked."
         },
         "contents": {
           "type": "array",
@@ -424,7 +435,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -434,7 +446,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -444,7 +457,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open)."
         },
         "slug": {
           "oneOf": [
@@ -504,7 +518,8 @@
       "additionalProperties": false
     },
     "docs.AudienceId": {
-      "type": "string"
+      "type": "string",
+      "description": "ID of audience which is used to filter the API spec."
     },
     "docs.Audience": {
       "anyOf": [
@@ -517,7 +532,8 @@
             "$ref": "#/definitions/docs.AudienceId"
           }
         }
-      ]
+      ],
+      "description": "Audience can either be a string or list of strings\ni.e. `audiences: internal` or `audiences: [internal, beta]`"
     },
     "docs.VersionedSnippetLanguageConfiguration": {
       "type": "object",
@@ -543,7 +559,8 @@
         {
           "$ref": "#/definitions/docs.VersionedSnippetLanguageConfiguration"
         }
-      ]
+      ],
+      "description": "This snippets config object is meant to allow users to specify a specific package for the snippets,\nand optionally a version for that package. If you pass in a string, that should be the name of the package."
     },
     "docs.SnippetsConfiguration": {
       "type": "object",
@@ -681,7 +698,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "A list of environment IDs that are allowed to be used in the playground. If not provided, all environments are allowed. And if the provided list is empty, the playground should be disabled."
         },
         "button": {
           "oneOf": [
@@ -711,7 +729,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The maximum number of websocket messages per connection in the playground."
         }
       },
       "additionalProperties": false
@@ -737,7 +756,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -767,7 +787,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file. This summary is displayed at the top of the API section."
         },
         "contents": {
           "oneOf": [
@@ -840,7 +861,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that is applied only to descendants of this api package."
         }
       },
       "additionalProperties": false
@@ -879,7 +901,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -892,7 +915,8 @@
           ]
         },
         "section": {
-          "type": "string"
+          "type": "string",
+          "description": "The title of the api package that will be displayed in the sidebar."
         },
         "referenced-packages": {
           "oneOf": [
@@ -905,7 +929,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "This section will inherit the endpoints from the specified subpackage(s). If multiple packages are specified, they will be merged."
         },
         "summary": {
           "oneOf": [
@@ -915,7 +940,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file."
         },
         "contents": {
           "oneOf": [
@@ -978,7 +1004,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -988,7 +1015,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user in the sidebar."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -998,7 +1026,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when collapsible is true."
         },
         "availability": {
           "oneOf": [
@@ -1018,7 +1047,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affects all endpoints."
         }
       },
       "required": [
@@ -1047,7 +1077,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1120,7 +1151,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affect this endpoint specifically."
         }
       },
       "required": [
@@ -1149,7 +1181,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1208,7 +1241,8 @@
       "required": [
         "operation"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "Defines a GraphQL-native schema for selecting operations (REST -> Endpoint === GraphQL -> Operation)"
     },
     "docs.LinkConfiguration": {
       "type": "object",
@@ -1274,7 +1308,8 @@
         {
           "$ref": "#/definitions/docs.LinkConfiguration"
         }
-      ]
+      ],
+      "description": "Use the `layout` object to customize the order that your API endpoints\nare displayed in the docs site."
     },
     "docs.ApiReferenceConfiguration": {
       "type": "object",
@@ -1297,7 +1332,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1320,7 +1356,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Name of API that we are referencing"
         },
         "openrpc": {
           "oneOf": [
@@ -1330,7 +1367,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Path to an openrpc spec."
         },
         "audiences": {
           "oneOf": [
@@ -1350,7 +1388,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Defaults to false"
         },
         "tag-description-pages": {
           "oneOf": [
@@ -1360,7 +1399,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, a page will be created for each tag in the OpenAPI spec that contains a description."
         },
         "snippets": {
           "oneOf": [
@@ -1380,7 +1420,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "URL to a Postman collection for this API reference"
         },
         "summary": {
           "oneOf": [
@@ -1390,7 +1431,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Relative path to the markdown file"
         },
         "layout": {
           "oneOf": [
@@ -1403,7 +1445,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Advanced usage: when specified, this object will be used to customize the order that your API endpoints are displayed in the docs site, including subpackages, and additional markdown pages (to be rendered in between API endpoints). If not specified, the order will be inferred from the OpenAPI Spec or Fern Definition."
         },
         "collapsed": {
           "oneOf": [
@@ -1473,7 +1516,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `alphabetized` is set to true, packages and endpoints will be sorted alphabetically, unless explicitly ordered in the `layout` object."
         },
         "flattened": {
           "oneOf": [
@@ -1483,7 +1527,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `flattened` is set to true, the title specified in `api` will be hidden, and its endpoints and subpackages won't be grouped under it.\n\nThis setting is useful if the API reference is short and you want to display all endpoints at the top level."
         },
         "paginated": {
           "oneOf": [
@@ -1493,7 +1538,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If true, the API reference will be paginated rather than displayed in a single page (long-scrolling)."
         },
         "playground": {
           "oneOf": [
@@ -1503,7 +1549,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Settings for the api playground that affects all endpoints."
         }
       },
       "required": [
@@ -1512,7 +1559,8 @@
       "additionalProperties": false
     },
     "docs.LibraryName": {
-      "type": "string"
+      "type": "string",
+      "description": "The name identifier for a library. Used to reference the library in navigation."
     },
     "docs.LibraryReferenceConfiguration": {
       "type": "object",
@@ -1535,7 +1583,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1548,7 +1597,8 @@
           ]
         },
         "library": {
-          "$ref": "#/definitions/docs.LibraryName"
+          "$ref": "#/definitions/docs.LibraryName",
+          "description": "The name of the library to reference (must match a key in the `libraries` section)."
         },
         "title": {
           "oneOf": [
@@ -1558,7 +1608,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the display title for this library reference."
         },
         "slug": {
           "oneOf": [
@@ -1568,13 +1619,15 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Override the URL slug for this library reference."
         }
       },
       "required": [
         "library"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "description": "References a library defined in the `libraries` section.\nThe library's generated navigation will be injected at this point."
     },
     "docs.ChangelogConfiguration": {
       "type": "object",
@@ -1597,7 +1650,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1686,7 +1740,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [
@@ -1699,7 +1754,8 @@
           ]
         },
         "folder": {
-          "type": "string"
+          "type": "string",
+          "description": "The relative path to a folder containing markdown files. Fern will automatically discover and add all markdown files from this folder to the navigation."
         },
         "title": {
           "oneOf": [
@@ -1709,7 +1765,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "The title to display for this folder section. If not provided, the folder name will be used."
         },
         "title-source": {
           "oneOf": [
@@ -1719,7 +1776,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Determines how page titles are derived for files in this folder. Options are `frontmatter` (use the `title` field from the file's frontmatter) or `filename` (derive title from the file name). Defaults to `filename`."
         },
         "slug": {
           "oneOf": [
@@ -1769,7 +1827,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Deprecated. Use `collapsible` and `collapsed-by-default` instead."
         },
         "collapsible": {
           "oneOf": [
@@ -1779,7 +1838,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section can be expanded/collapsed by the user."
         },
         "collapsed-by-default": {
           "oneOf": [
@@ -1789,7 +1849,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Whether the section starts collapsed. Only meaningful when `collapsible` is true. Defaults to false (starts open)."
         },
         "availability": {
           "oneOf": [
@@ -1858,7 +1919,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "If `href` is set, `layout` must be null."
         }
       },
       "required": [
@@ -1887,7 +1949,8 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "When `orphaned` is set to `true`, the roles will not inherit from parents."
         },
         "feature-flag": {
           "oneOf": [


### PR DESCRIPTION
## Description
Linear ticket: Refs 

Propagates Fern `docs:` strings into generated JSON Schemas so schemas served from `schema.buildwithfern.dev`, including `docs-yml.json`, provide editor hover documentation in addition to validation.

## Changes Made
- Added JSON Schema `description` output for type-level, property-level, and union member docs.
- Emits documented enum values as standard `oneOf`/`const` entries with descriptions, while preserving simple `enum` output when enum values have no docs.
- Updated generated JSON Schema snapshots and regenerated public config schemas.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

Ran:
- `pnpm --filter @fern-api/ir-to-jsonschema test -u`
- `pnpm fern:build`
- `pnpm jsonschema`
- `pnpm turbo run test --filter @fern-api/configuration-loader`
- `pnpm lint:biome packages/cli/fern-definition/ir-to-jsonschema/src`