### PR TITLE
fix(cli): report escaped CLI errors through telemetry

### DIFF
--- a/packages/cli/cli/changes/unreleased/fatal-error-telemetry.yml
+++ b/packages/cli/cli/changes/unreleased/fatal-error-telemetry.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Report escaped fatal CLI errors through telemetry in packaged production runs.
+  type: fix

--- a/packages/cli/cli/src/cli-context/CliContext.ts
+++ b/packages/cli/cli/src/cli-context/CliContext.ts
@@ -90,7 +90,14 @@ export class CliContext {
             packageVersion,
             cliName
         };
-        this.sentryClient = new SentryClient({ release: `cli@${this.environment.packageVersion}` });
+        this.sentryClient = new SentryClient({
+            release: `cli@${this.environment.packageVersion}`,
+            telemetry: {
+                cliName: this.environment.cliName,
+                packageVersion: this.environment.packageVersion,
+                isLocal: this.isLocal
+            }
+        });
         this.automationTelemetryManager = new AutomationTelemetryManager(this);
     }
 

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -102,6 +102,7 @@ import { FERN_CWD_ENV_VAR } from "./cwd.js";
 import { rerunFernCliAtVersion } from "./rerunFernCliAtVersion.js";
 import { resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
 import { RUNTIME } from "./runtime.js";
+import { installProcessHandlers } from "./telemetry/processHandlers.js";
 
 // Node 26+ on Linux enables io_uring in libuv, which has a busy-loop bug that
 // hangs the process. UV_USE_IO_URING must be set before Node starts (libuv
@@ -141,6 +142,10 @@ async function runCli() {
     if (isCompletion) {
         cliContext.suppressUpgradeMessage();
     }
+
+    // In packaged CLI runs, escaped errors (uncaughtException, unhandledRejection)
+    // would otherwise exit without firing and flushing telemetry.
+    installProcessHandlers(cliContext, { isLocal });
 
     const exit = async () => {
         await cliContext.exit();

--- a/packages/cli/cli/src/telemetry/SentryClient.ts
+++ b/packages/cli/cli/src/telemetry/SentryClient.ts
@@ -2,14 +2,14 @@ import { setSentryRunIdTags } from "@fern-api/cli-telemetry";
 import { type CaptureExceptionOptions, CliError } from "@fern-api/task-context";
 import * as Sentry from "@sentry/node";
 
-import { isTelemetryDisabled } from "./isTelemetryDisabled.js";
+import { shouldInitializeTelemetry, type TelemetryInitializationOptions } from "./shouldInitializeTelemetry.js";
 
 export class SentryClient {
     private readonly sentry: Sentry.NodeClient | undefined;
 
-    constructor({ release }: { release: string }) {
+    constructor({ release, telemetry }: { release: string; telemetry: TelemetryInitializationOptions }) {
         const sentryDsn = process.env.SENTRY_DSN;
-        if (!isTelemetryDisabled() && sentryDsn != null && sentryDsn.length > 0) {
+        if (shouldInitializeTelemetry(telemetry) && sentryDsn != null && sentryDsn.length > 0) {
             const sentryEnvironment = process.env.SENTRY_ENVIRONMENT;
             if (sentryEnvironment == null || sentryEnvironment.length === 0) {
                 throw new CliError({

--- a/packages/cli/cli/src/telemetry/__test__/SentryClient.test.ts
+++ b/packages/cli/cli/src/telemetry/__test__/SentryClient.test.ts
@@ -35,10 +35,21 @@ vi.mock("@sentry/node", () => ({
 import { CliError } from "@fern-api/task-context";
 import { SentryClient } from "../SentryClient.js";
 
+function createSentryClient({ isLocal = false }: { isLocal?: boolean } = {}): SentryClient {
+    return new SentryClient({
+        release: "cli@1.2.3",
+        telemetry: {
+            cliName: "fern",
+            packageVersion: "1.2.3",
+            isLocal
+        }
+    });
+}
+
 describe("SentryClient (cli-v1)", () => {
     beforeEach(() => {
         process.env.SENTRY_DSN = "https://example@sentry.io/123";
-        process.env.SENTRY_ENVIRONMENT = "test";
+        process.env.SENTRY_ENVIRONMENT = "production";
         delete process.env.FERN_DISABLE_TELEMETRY;
         mockSentryCaptureException.mockClear();
         mockSentryFlush.mockClear();
@@ -56,14 +67,19 @@ describe("SentryClient (cli-v1)", () => {
     it("does not initialize Sentry when telemetry is disabled", () => {
         process.env.FERN_DISABLE_TELEMETRY = "true";
 
-        // eslint-disable-next-line no-new
-        new SentryClient({ release: "cli@1.2.3" });
+        createSentryClient();
+
+        expect(mockSentryInit).not.toHaveBeenCalled();
+    });
+
+    it("does not initialize Sentry when running local generation", () => {
+        createSentryClient({ isLocal: true });
 
         expect(mockSentryInit).not.toHaveBeenCalled();
     });
 
     it("captures exceptions with Sentry when enabled", async () => {
-        const client = new SentryClient({ release: "cli@1.2.3" });
+        const client = createSentryClient();
 
         await client.captureException(new Error("boom"));
 
@@ -73,7 +89,7 @@ describe("SentryClient (cli-v1)", () => {
     });
 
     it("sets tags on a Sentry scope when provided", () => {
-        const client = new SentryClient({ release: "cli@1.2.3" });
+        const client = createSentryClient();
         const error = new Error("something broke");
 
         client.captureException(error, { tags: { "error.code": CliError.Code.InternalError } });
@@ -83,7 +99,7 @@ describe("SentryClient (cli-v1)", () => {
     });
 
     it("sets context on a Sentry scope when provided", () => {
-        const client = new SentryClient({ release: "cli@1.2.3" });
+        const client = createSentryClient();
         const error = new Error("something broke");
 
         client.captureException(error, {
@@ -97,7 +113,7 @@ describe("SentryClient (cli-v1)", () => {
     });
 
     it("flushes the Sentry client", async () => {
-        const client = new SentryClient({ release: "cli@1.2.3" });
+        const client = createSentryClient();
 
         await client.flush();
 

--- a/packages/cli/cli/src/telemetry/processHandlers.ts
+++ b/packages/cli/cli/src/telemetry/processHandlers.ts
@@ -1,0 +1,62 @@
+/**
+ * Process-level safety net for packaged CLI runs.
+ *
+ * The normal failure path goes through `cliContext.failWithoutThrowing` ->
+ * `reportError`, which fires the relevant telemetry flow. Anything that
+ * escapes that flow - uncaught exceptions and unhandled promise rejections -
+ * would otherwise exit without flushing Sentry/PostHog, and in automation
+ * mode without reaching Slack or the automation dashboards.
+ *
+ * Signal-driven cancellation (SIGINT / SIGTERM) is handled separately by the
+ * CLI entrypoint and, for automation commands, by command-specific cleanup.
+ * We deliberately do not duplicate signal coverage here to avoid double-
+ * emitting completion events.
+ *
+ * Handlers are not installed for local/dev runs so Node's default crash
+ * behavior stays loud while developing. A one-shot re-entry guard prevents an
+ * emit-during-shutdown loop if the report path itself throws.
+ */
+import { CliError } from "@fern-api/task-context";
+import type { CliContext } from "../cli-context/CliContext.js";
+import { shouldInitializeTelemetry } from "./shouldInitializeTelemetry.js";
+
+export function installProcessHandlers(cliContext: CliContext, { isLocal }: { isLocal: boolean }): void {
+    if (
+        !shouldInitializeTelemetry({
+            cliName: cliContext.environment.cliName,
+            packageVersion: cliContext.environment.packageVersion,
+            isLocal
+        })
+    ) {
+        return;
+    }
+
+    let isHandlingFatal = false;
+
+    const handleFatal = async (label: string, error: unknown): Promise<void> => {
+        if (isHandlingFatal) {
+            // Re-entry: a second fatal landed while we were trying to flush
+            // the first. Bail out hard so we don't deadlock the runner.
+            process.exit(1);
+        }
+        isHandlingFatal = true;
+        try {
+            cliContext.failWithoutThrowing(label, error, { code: CliError.Code.InternalError });
+        } catch {
+            // Reporting itself failed; nothing we can do, fall through to exit.
+        }
+        try {
+            await cliContext.exit({ code: 1 });
+        } catch {
+            process.exit(1);
+        }
+    };
+
+    process.on("uncaughtException", (error) => {
+        void handleFatal("uncaught exception", error);
+    });
+
+    process.on("unhandledRejection", (reason) => {
+        void handleFatal("unhandled promise rejection", reason);
+    });
+}

--- a/packages/cli/cli/src/telemetry/shouldInitializeTelemetry.ts
+++ b/packages/cli/cli/src/telemetry/shouldInitializeTelemetry.ts
@@ -1,0 +1,21 @@
+import { isTelemetryDisabled } from "./isTelemetryDisabled.js";
+
+export interface TelemetryInitializationOptions {
+    cliName: string;
+    packageVersion: string;
+    isLocal: boolean;
+}
+
+export function shouldInitializeTelemetry({
+    cliName,
+    packageVersion,
+    isLocal
+}: TelemetryInitializationOptions): boolean {
+    if (isTelemetryDisabled() || isLocal) {
+        return false;
+    }
+
+    const isLocalDev = packageVersion === "0.0.0";
+    const isProductionCli = cliName === "fern" && process.env.SENTRY_ENVIRONMENT === "production";
+    return !isLocalDev && isProductionCli;
+}


### PR DESCRIPTION
## Description
Linear ticket: Refs

Report escaped fatal CLI errors through the existing telemetry path for packaged production CLI runs, while preserving local/dev crash behavior.

## Changes Made
- Added process-level handlers for `uncaughtException` and `unhandledRejection` in packaged production CLI runs.
- Shared the same telemetry initialization gate between the process handlers and Sentry setup, including `FERN_DISABLE_TELEMETRY`, `--local`, local dev builds, and production CLI detection.
- Updated SentryClient tests for the new initialization gate.
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

Tested with:
`pnpm --filter @fern-api/cli test -- src/telemetry/__test__/SentryClient.test.ts`

Made with [Cursor](https://cursor.com)