### PR TITLE
fix(cli): gracefully handle resolve() failures in missing-redirects rule

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-missing-redirects-resolve-crash.yml
+++ b/packages/cli/cli/changes/unreleased/fix-missing-redirects-resolve-crash.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix the missing-redirects check crashing when the docs definition
+    resolver fails (e.g. after a major CLI version upgrade that changes
+    how API types are named). The rule now emits a warning and skips
+    gracefully instead of causing `fern check` to fail with a fatal error.
+  type: fix

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
@@ -28,7 +28,8 @@ type FetchResult =
     | { type: "no-token" }
     | { type: "no-instance-url" }
     | { type: "fetch-failed"; reason: string }
-    | { type: "first-publish" };
+    | { type: "first-publish" }
+    | { type: "resolve-failed"; reason: string };
 
 /**
  * Fetches the currently published markdown entries from FDR's slug table.
@@ -115,14 +116,22 @@ export const MissingRedirectsRule: Rule = {
             targetAudiences: undefined
         });
 
-        const resolvedDocsDefinition = await docsDefinitionResolver.resolve();
-        const configRoot = resolvedDocsDefinition.config.root;
-        if (!configRoot || !isV1RootNode(configRoot)) {
-            return {};
+        let localPageIdToSlug: Map<string, string>;
+        try {
+            const resolvedDocsDefinition = await docsDefinitionResolver.resolve();
+            const configRoot = resolvedDocsDefinition.config.root;
+            if (!configRoot || !isV1RootNode(configRoot)) {
+                return {};
+            }
+
+            const root = FernNavigation.migrate.FernNavigationV1ToLatest.create().root(configRoot);
+            localPageIdToSlug = buildPageIdToSlugMap(root);
+        } catch (error) {
+            const reason = error instanceof Error ? error.message : String(error);
+            logger.debug(`[missing-redirects] Failed to resolve docs definition: ${reason}`);
+            return makeSkipVisitor({ type: "resolve-failed", reason });
         }
 
-        const root = FernNavigation.migrate.FernNavigationV1ToLatest.create().root(configRoot);
-        const localPageIdToSlug = buildPageIdToSlugMap(root);
         const latestEntries = keepLatestEntryPerPageId(result.entries);
         const removedSlugs = findRemovedSlugs(latestEntries, localPageIdToSlug);
 
@@ -175,6 +184,18 @@ function makeSkipVisitor(fetchResult: Exclude<FetchResult, { type: "success" }>)
                         message:
                             `Missing redirects check skipped: could not reach FDR (${fetchResult.reason}). ` +
                             "The check requires network access to compare against previously published docs."
+                    }
+                ]
+            };
+        case "resolve-failed":
+            return {
+                file: () => [
+                    {
+                        severity: "warning",
+                        message:
+                            `Missing redirects check skipped: failed to resolve docs definition (${fetchResult.reason}). ` +
+                            "This can happen after a major CLI version upgrade that changes how API types are named. " +
+                            "The check will work correctly after the next successful publish."
                     }
                 ]
             };


### PR DESCRIPTION
## Description

Fixes the `missing-redirects` check rule crashing with a fatal error when `DocsDefinitionResolver.resolve()` throws during initialization — for example, after a major CLI version upgrade (v4 → v5) that changes how API types are named from inline response schemas.

Previously, if `resolve()` threw (e.g. because old per-endpoint enum types like `#/components/responses/errorModel` are no longer generated in v5), the exception would propagate out of the rule's `create()` method and get caught by `validateDocsWorkspace` as a `"fatal"` severity violation — causing `fern check` to fail entirely.

## Changes Made

- Wrapped the `docsDefinitionResolver.resolve()` call and navigation tree building in a try-catch within the missing-redirects rule's `create` method
- Added a new `resolve-failed` variant to the `FetchResult` discriminated union
- When the resolver fails, the rule now emits a helpful warning instead of crashing: explains this can happen after a major CLI version upgrade and that the check will work correctly after the next successful publish
- Added unreleased changelog entry

## Testing

- [x] Verified lint passes (`pnpm check:fix`)
- [x] Existing `missing-redirects` unit tests are unaffected (they test the logic functions directly)
- [x] The fix is defensive — it only catches errors from `resolve()` and delegates to the existing `makeSkipVisitor` pattern already used for network/auth failures

Link to Devin session: https://app.devin.ai/sessions/5900ae720164449eb603a87e6088caed
Requested by: @fern-support