### PR TITLE
fix(cli): gracefully handle docs resolution failures in missing-redirects rule

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-missing-redirects-crash.yml
+++ b/packages/cli/cli/changes/unreleased/fix-missing-redirects-crash.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix missing-redirects rule crashing during initialization when the docs
+    definition resolver fails (e.g. after a major CLI upgrade that changes
+    type naming). The rule now gracefully skips with a warning instead of
+    producing a fatal violation.
+  type: fix

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
@@ -1,4 +1,5 @@
 import { getToken } from "@fern-api/auth";
+import { assertNever } from "@fern-api/core-utils";
 import { DocsDefinitionResolver } from "@fern-api/docs-resolver";
 import { FernNavigation } from "@fern-api/fdr-sdk";
 import { createLogger, type LogLevel } from "@fern-api/logger";
@@ -219,5 +220,7 @@ function makeSkipVisitor(fetchResult: Exclude<FetchResult, { type: "success" }>)
                     }
                 ]
             };
+        default:
+            assertNever(fetchResult);
     }
 }

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
@@ -19,7 +19,7 @@ import {
  * Captures the last `error`-level message routed through the mock task context
  * so we can surface it in the warning when `DocsDefinitionResolver.resolve()`
  * aborts via `failAndThrow`. The mock's `failAndThrow` throws a
- * `TaskAbortSignal` (a non-Error class) and logs the actual reason — without
+ * `TaskAbortSignal` (a non-Error sentinel class) and logs the actual reason — without
  * this capture the rule would only see `[object Object]`.
  */
 function createResolverContext(): { context: TaskContext; getLastErrorMessage: () => string | undefined } {


### PR DESCRIPTION
## Description

Follow-up to #15853 which added the core try-catch fix for the missing-redirects rule. This PR adds the `assertNever` exhaustiveness guard to the `makeSkipVisitor` switch statement per CLAUDE.md conventions, and includes a changelog entry.

## Changes Made

- Added `default: assertNever(fetchResult)` to the `makeSkipVisitor` switch on the `FetchResult` discriminated union, ensuring compile-time safety when new variants are added
- Added `assertNever` import from `@fern-api/core-utils`
- Added unreleased changelog entry for the fix

## Testing

- [x] All 145 unit tests in `@fern-api/docs-validator` pass
- [x] `pnpm lint:biome` passes
- [x] `pnpm format` passes
- [x] TypeScript compilation succeeds


Link to Devin session: https://app.devin.ai/sessions/9e60e54a91c84401a1d139ae7e2fb655
Requested by: @paarthfern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->