### PR TITLE
feat(cli): add retroactive changelog entry for docs link check command

### DIFF
--- a/packages/cli/cli/changes/unreleased/add-docs-link-check.yml
+++ b/packages/cli/cli/changes/unreleased/add-docs-link-check.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Add `fern docs link check` command for live site link validation
+  type: feat


### PR DESCRIPTION
## Description

Adds a retroactive changelog entry for the `fern docs link check` command that was merged in #15818 without a changelog file. This ensures the feature gets published in the CLI reference docs.

## Changes Made
- Added `packages/cli/cli/changes/unreleased/add-docs-link-check.yml` with a `feat` changelog entry for the link check command

## Testing
- [x] Changelog file follows `.template.yml` format
- [x] No code changes, only changelog metadata

Link to Devin session: https://app.devin.ai/sessions/9efa1680e25a4fdc8ec5ea526cd4d297
Requested by: @Ryan-Amirthan