### PR TITLE
fix(docs): prefer stored login token over env var for global theme fetch in dev mode

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-global-theme-token-in-dev.yml
+++ b/packages/cli/cli/changes/unreleased/fix-global-theme-token-in-dev.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix `fern docs dev` failing to load global themes when the local dev stack is active.
+    The stored `fern login` token is now preferred over the `FERN_TOKEN` env var, which
+    is often set to a mock token by the local dev stack.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/fix-global-theme-token-in-dev.yml
+++ b/packages/cli/cli/changes/unreleased/fix-global-theme-token-in-dev.yml
@@ -1,7 +1,5 @@
 # yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
 
 - summary: |
-    Fix `fern docs dev` failing to load global themes when the local dev stack is active.
-    The stored `fern login` token is now preferred over the `FERN_TOKEN` env var, which
-    is often set to a mock token by the local dev stack.
+    Fix `fern docs dev` grabbing the local fern token for authentication when loading a global theme
   type: fix

--- a/packages/cli/docs-preview/package.json
+++ b/packages/cli/docs-preview/package.json
@@ -32,6 +32,7 @@
     "test:update": "vitest --run -u"
   },
   "dependencies": {
+    "@fern-api/auth": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-markdown-utils": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -1,3 +1,4 @@
+import { getUserToken } from "@fern-api/auth";
 import { extractErrorMessage, replaceEnvVariables } from "@fern-api/core-utils";
 import {
     isValidRelativeSlug,
@@ -419,7 +420,9 @@ async function applyGlobalThemeIfNeeded(
     if (themeName == null) {
         return docsWorkspace;
     }
-    const token = process.env.FERN_TOKEN;
+    // Prefer the stored fern login token; fall back to env var (used in CI).
+    const storedToken = await getUserToken();
+    const token = storedToken?.value ?? process.env.FERN_TOKEN;
     if (token == null) {
         context.logger.warn(
             `docs.yml declares global-theme "${themeName}" but FERN_TOKEN is not set — ` +

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5353,6 +5353,9 @@ importers:
 
   packages/cli/docs-preview:
     dependencies:
+      '@fern-api/auth':
+        specifier: workspace:*
+        version: link:../auth
       '@fern-api/core-utils':
         specifier: workspace:*
         version: link:../../commons/core-utils


### PR DESCRIPTION
## Context

When running `fern docs dev` locally with the local dev stack active, the `FERN_TOKEN` env var is set to a mock token — causing a 403 when fetching a customer's global theme and crashing the preview to a blank page.

The fix: prefer the stored token from `fern login` (~/.fern/token) over the env var. The env var is still used as a fallback (e.g. in CI).

## What's Changed

- `previewDocs.ts`: use `getUserToken()` first, fall back to `process.env.FERN_TOKEN`
- `docs-preview/package.json`: add `@fern-api/auth` dependency

## Testing

Reproduced blank-page failure with a mock `FERN_TOKEN` and a docs site declaring a global theme. After fix, the stored prod token is used — theme fetches successfully and preview starts cleanly.