### PR TITLE
fix(changelog): change fern.yml to docs.yml in 5.26.0 changelog entry

### DIFF
--- a/packages/cli/cli/changes/5.26.0/add-docs-check-links.yml
+++ b/packages/cli/cli/changes/5.26.0/add-docs-check-links.yml
@@ -1,7 +1,7 @@
 - summary: |
     Add `fern docs link check` command to validate links on live documentation sites.
     Supports text, JSON, and CSV output formats via `--output` flag.
-    Use `--url <url>` to specify which docs site to check, or auto-detect from fern.yml.
+    Use `--url <url>` to specify which docs site to check, or auto-detect from docs.yml.
   type: feat
 - summary: |
     Add progress bars matching `fern docs dev` style for `fern docs link check`.

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -40,7 +40,7 @@
     - summary: |
         Add `fern docs link check` command to validate links on live documentation sites.
         Supports text, JSON, and CSV output formats via `--output` flag.
-        Use `--url <url>` to specify which docs site to check, or auto-detect from fern.yml.
+        Use `--url <url>` to specify which docs site to check, or auto-detect from docs.yml.
       type: feat
     - summary: |
         Add progress bars matching `fern docs dev` style for `fern docs link check`.


### PR DESCRIPTION
## Description
Fix typo in the 5.26.0 CLI changelog entry: `fern.yml` → `docs.yml`. The `fern docs link check` command auto-detects from `docs.yml`, not `fern.yml`.

## Changes Made
- Fixed `fern.yml` → `docs.yml` in `packages/cli/cli/changes/5.26.0/add-docs-check-links.yml`
- Fixed `fern.yml` → `docs.yml` in `packages/cli/cli/versions.yml`

## Testing
- [x] Manual review — changelog text-only change

Link to Devin session: https://app.devin.ai/sessions/523bc7ee373141128f7eae98bcf71d21
Requested by: @Ryan-Amirthan