### PR TITLE
chore(ci): add zizmor linting for GitHub Actions workflows

### DIFF
--- a/.github/actions/apply-update-seed-patches/action.yaml
+++ b/.github/actions/apply-update-seed-patches/action.yaml
@@ -19,9 +19,10 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.checkout-ref }}
+        persist-credentials: false
 
     - name: Create artifacts downloads directory
       shell: bash
@@ -37,7 +38,7 @@ runs:
     # Merge-multiple is set so all patches are downloaded into the same folder. Otherwise
     # they are subfoldered into folders that match *.patch pattern and cause errors downstream
     - name: Download patches
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
       with:
         path: ./artifacts
         merge-multiple: true
@@ -53,7 +54,7 @@ runs:
       id: get-number-of-patches
       run: |
         # Apply patches per generator for multiple, separate, PRs
-        PATCHES_PATTERN="${{ inputs.patch-pattern }}"
+        PATCHES_PATTERN="${INPUTS_PATCH_PATTERN}"
         file_count=$(find ./artifacts -type f -name "$PATCHES_PATTERN" | wc -l)
         echo "Number of patches downloaded: $file_count"
         if [ "$file_count" -gt 0 ]; then
@@ -61,10 +62,14 @@ runs:
         else
           echo "HAS_PATCHES=false" >> $GITHUB_OUTPUT
         fi
+      env:
+        INPUTS_PATCH_PATTERN: ${{ inputs.patch-pattern }}
 
     - name: Apply patches
       shell: bash
       if: ${{ steps.get-number-of-patches.outputs.HAS_PATCHES == 'true' }}
       run: |
-        PATCHES_PATTERN="${{ inputs.patch-pattern }}"
+        PATCHES_PATTERN="${INPUTS_PATCH_PATTERN}"
         git apply artifacts/$PATCHES_PATTERN
+      env:
+        INPUTS_PATCH_PATTERN: ${{ inputs.patch-pattern }}

--- a/.github/actions/artifact-seed-metrics/action.yaml
+++ b/.github/actions/artifact-seed-metrics/action.yaml
@@ -25,13 +25,19 @@ runs:
       id: create-metrics
       shell: bash
       run: |
-        METRICS_FILE_NAME="seed-metrics-${{ inputs.sdk-name }}-${{ inputs.job-index }}.json"
+        METRICS_FILE_NAME="seed-metrics-${INPUTS_SDK_NAME}-${INPUTS_JOB_INDEX}.json"
         echo "file_name=$METRICS_FILE_NAME" >> $GITHUB_OUTPUT
-        echo "{\"index\":\"${{ inputs.job-index }}\",\"startTimeSeconds\":\"${{ inputs.start-time }}\",\"endTimeSeconds\":\"${{ inputs.end-time }}\",\"deterministic\":\"${{ inputs.deterministic }}\"}" > $METRICS_FILE_NAME
+        echo "{\"index\":\"${INPUTS_JOB_INDEX}\",\"startTimeSeconds\":\"${INPUTS_START_TIME}\",\"endTimeSeconds\":\"${INPUTS_END_TIME}\",\"deterministic\":\"${INPUTS_DETERMINISTIC}\"}" > $METRICS_FILE_NAME
+      env:
+        INPUTS_SDK_NAME: ${{ inputs.sdk-name }}
+        INPUTS_JOB_INDEX: ${{ inputs.job-index }}
+        INPUTS_START_TIME: ${{ inputs.start-time }}
+        INPUTS_END_TIME: ${{ inputs.end-time }}
+        INPUTS_DETERMINISTIC: ${{ inputs.deterministic }}
 
     # Save for at least a week to help track slowdowns if/when they show up
     - name: Upload Metrics File
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       with:
         name: ${{ steps.create-metrics.outputs.file_name }}
         path: ${{ steps.create-metrics.outputs.file_name }}

--- a/.github/actions/auto-approve/action.yaml
+++ b/.github/actions/auto-approve/action.yaml
@@ -25,12 +25,13 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.approver-gh-token }}
+        INPUTS_PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
       run: |
         echo "Waiting for all checks to finish running"
-        while echo $(gh pr checks ${{ inputs.pull-request-number }}) | grep -q 'pending'; do echo "$(gh pr checks 63 | grep pending | wc -l) check(s) still running"; sleep 30s; done
+        while echo $(gh pr checks ${INPUTS_PULL_REQUEST_NUMBER}) | grep -q 'pending'; do echo "$(gh pr checks 63 | grep pending | wc -l) check(s) still running"; sleep 30s; done
 
         echo "All checks done running, looking for failures"
-        if echo $(gh pr checks ${{ inputs.pull-request-number }}) | grep -q 'fail'; then echo "Some/All Checks Failed"; exit 1; else echo "All Checks Passed"; fi
+        if echo $(gh pr checks ${INPUTS_PULL_REQUEST_NUMBER}) | grep -q 'fail'; then echo "Some/All Checks Failed"; exit 1; else echo "All Checks Passed"; fi
 
         echo "PR Ready for approval"
 
@@ -39,15 +40,17 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.approver-gh-token }}
+        INPUTS_ENFORCED_CHECKS: ${{ inputs.enforced-checks }}
+        INPUTS_PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
       run: |
-        echo "Specifically checking status of: '${{ inputs.enforced-checks }}' checks"
-        for i in $(echo ${{ inputs.enforced-checks }} | sed "s/,/ /g")
+        echo "Specifically checking status of: '${INPUTS_ENFORCED_CHECKS}' checks"
+        for i in $(echo ${INPUTS_ENFORCED_CHECKS} | sed "s/,/ /g")
         do
             echo "Waiting for '$i' check to finish running"
-            while echo $(gh pr checks ${{ inputs.pull-request-number }} | grep $i) | grep -q 'pending'; do echo "$i check still running"; sleep 15s; done
+            while echo $(gh pr checks ${INPUTS_PULL_REQUEST_NUMBER} | grep $i) | grep -q 'pending'; do echo "$i check still running"; sleep 15s; done
 
             echo "Checking status of '$i'"
-            if echo $(gh pr checks ${{ inputs.pull-request-number }} | grep $i) | grep -q 'fail'; then echo "'$i' Failed"; exit 1; else echo "'$i' Succeeded"; fi
+            if echo $(gh pr checks ${INPUTS_PULL_REQUEST_NUMBER} | grep $i) | grep -q 'fail'; then echo "'$i' Failed"; exit 1; else echo "'$i' Succeeded"; fi
         done
 
         echo "PR Ready for approval"
@@ -56,6 +59,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.approver-gh-token }}
+        INPUTS_PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
       run: |
         echo "Approving PR"
-        gh pr review ${{ inputs.pull-request-number }} --approve
+        gh pr review ${INPUTS_PULL_REQUEST_NUMBER} --approve

--- a/.github/actions/auto-update-seed/action.yaml
+++ b/.github/actions/auto-update-seed/action.yaml
@@ -56,7 +56,7 @@ runs:
       id: check-changes
       shell: bash
       run: |
-        git add seed/${{ inputs.generator-name }}/*
+        git add seed/${INPUTS_GENERATOR_NAME}/*
         if git --no-pager diff --staged --exit-code; then
           echo "No changes detected for seed."
           echo "seed-changes-generated=false" >> $GITHUB_OUTPUT
@@ -64,6 +64,8 @@ runs:
           echo "Changes detected for seed."
           echo "seed-changes-generated=true" >> $GITHUB_OUTPUT
         fi
+      env:
+        INPUTS_GENERATOR_NAME: ${{ inputs.generator-name }}
 
     - name: Log if no changes
       if: steps.check-changes.outputs.seed-changes-generated == 'false'
@@ -76,12 +78,15 @@ runs:
       if: steps.check-changes.outputs.seed-changes-generated == 'true'
       shell: bash
       run: |
-        git diff --staged --binary --full-index > seed-${{ inputs.generator-name }}-${{ inputs.index }}.patch
+        git diff --staged --binary --full-index > seed-${INPUTS_GENERATOR_NAME}-${INPUTS_INDEX}.patch
+      env:
+        INPUTS_GENERATOR_NAME: ${{ inputs.generator-name }}
+        INPUTS_INDEX: ${{ inputs.index }}
 
     # Upload patch files as artifacts to be applied and committed by caller when all of seed is up to date
     - name: Upload Seed Artifacts
       if: steps.check-changes.outputs.seed-changes-generated == 'true'
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       with:
         name: seed-${{ inputs.generator-name }}-${{ inputs.index }}.patch
         path: seed-${{ inputs.generator-name }}-${{ inputs.index }}.patch

--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -38,7 +38,7 @@ runs:
     - name: Log in to Docker Hub
       id: docker-login
       if: ${{ inputs.dockerhub-username != '' }}
-      uses: docker/login-action@v4
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
       continue-on-error: true
       with:
         username: ${{ inputs.dockerhub-username }}
@@ -47,7 +47,7 @@ runs:
     - name: Retry Docker Hub login
       id: docker-login-retry
       if: ${{ inputs.dockerhub-username != '' && steps.docker-login.outcome == 'failure' }}
-      uses: docker/login-action@v4
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
       continue-on-error: true
       with:
         username: ${{ inputs.dockerhub-username }}
@@ -57,13 +57,16 @@ runs:
       if: ${{ inputs.dockerhub-username != '' }}
       shell: bash
       run: |
-        if [[ "${{ steps.docker-login.outcome }}" == "success" ]]; then
+        if [[ "${STEPS_DOCKER_LOGIN_OUTCOME}" == "success" ]]; then
           echo "Docker Hub login succeeded on first attempt"
-        elif [[ "${{ steps.docker-login-retry.outcome }}" == "success" ]]; then
+        elif [[ "${STEPS_DOCKER_LOGIN_RETRY_OUTCOME}" == "success" ]]; then
           echo "Docker Hub login succeeded on retry"
         else
           echo "::warning::Docker Hub login failed after 2 attempts — continuing without authentication (may hit rate limits)"
         fi
+      env:
+        STEPS_DOCKER_LOGIN_OUTCOME: ${{ steps.docker-login.outcome }}
+        STEPS_DOCKER_LOGIN_RETRY_OUTCOME: ${{ steps.docker-login-retry.outcome }}
 
     - name: Clear stale Docker image cache
       shell: bash
@@ -71,7 +74,7 @@ runs:
 
     - name: Cache Docker images
       id: docker-cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: /tmp/docker-cache
         key: ${{ runner.os }}-docker-${{ inputs.generator-name }}-${{ hashFiles('**/Dockerfile*') }}
@@ -112,14 +115,16 @@ runs:
       shell: bash
       env:
         FORCE_COLOR: "2"
+        INPUTS_FIXTURES_TO_RUN: ${{ inputs.fixtures-to-run }}
+        INPUTS_GENERATOR_NAME: ${{ inputs.generator-name }}
       run: |
         FORMATTED_FIXTURES_COMMAND=""
-        if [[ "${{ inputs.fixtures-to-run }}" != "all" ]]; then
-          FORMATTED_FIXTURES_COMMAND="--fixture ${{ inputs.fixtures-to-run }}"
+        if [[ "${INPUTS_FIXTURES_TO_RUN}" != "all" ]]; then
+          FORMATTED_FIXTURES_COMMAND="--fixture ${INPUTS_FIXTURES_TO_RUN}"
         fi
 
         SEED_CMD="pnpm seed:local test \
-          --generator ${{ inputs.generator-name }} \
+          --generator ${INPUTS_GENERATOR_NAME} \
           --parallel 16 \
           ${FORMATTED_FIXTURES_COMMAND} \
           ${{ inputs.skip-scripts == 'true' && '--skip-scripts' || '' }} \

--- a/.github/actions/check-and-run-leftover-seed-tests/action.yaml
+++ b/.github/actions/check-and-run-leftover-seed-tests/action.yaml
@@ -20,11 +20,11 @@ runs:
     - name: Install
       uses: ./.github/actions/install
 
-    - uses: bufbuild/buf-setup-action@v1.50.0
+    - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
       with:
         github_token: ${{ github.token }}
 
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: "stable"
 
@@ -49,10 +49,10 @@ runs:
       shell: bash
       run: |
         # Get the test set for the given generator from the command get-available-fixtures (will be current)
-        TESTS_FROM_CMD='${{ steps.parse-test-matrices.outputs.parsed }}'
+        TESTS_FROM_CMD='${STEPS_PARSE_TEST_MATRICES_OUTPUTS_PARSED}'
 
         # Get the test set for the given generator from the seed group JSON files (will only be synced to the latest successful nightly update)
-        TESTS_FROM_FILE=$(jq '[.groups[].fixtures[]] | unique | sort' .github/workflow-resource-files/seed-groups/${{ inputs.sdk-name }}-seed-groups.json)
+        TESTS_FROM_FILE=$(jq '[.groups[].fixtures[]] | unique | sort' .github/workflow-resource-files/seed-groups/${INPUTS_SDK_NAME}-seed-groups.json)
 
         # Determine which tests are only in one or the other. Only in cmd = newly added test. Only in file = newly removed test.
         # Note: file is parsed as JSON object, cmd line is parsed as JSON array
@@ -67,3 +67,6 @@ runs:
 
         echo "leftover-tests-to-run=$(echo "$ONLY_IN_CMD" | jq -c -s .)" >> $GITHUB_OUTPUT
         echo "tests-to-remove=$(echo "$ONLY_IN_FILE" | jq -c -s .)" >> $GITHUB_OUTPUT
+      env:
+        STEPS_PARSE_TEST_MATRICES_OUTPUTS_PARSED: ${{ steps.parse-test-matrices.outputs.parsed }}
+        INPUTS_SDK_NAME: ${{ inputs.sdk-name }}

--- a/.github/actions/check-for-changed-files/action.yaml
+++ b/.github/actions/check-for-changed-files/action.yaml
@@ -39,7 +39,7 @@ runs:
   steps:
     - name: Check for changes
       id: check-for-changes
-      uses: tj-actions/changed-files@v47
+      uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
       with:
         fetch_depth: ${{ inputs.fetch_depth }}
         base_sha: ${{ inputs.base_sha }}

--- a/.github/actions/fetch-benchmark-specs/action.yaml
+++ b/.github/actions/fetch-benchmark-specs/action.yaml
@@ -119,7 +119,7 @@ runs:
       shell: bash
       run: |
         SPECS=""
-        if [ "${{ steps.fetch-primary.outputs.primary-ok }}" = "true" ]; then
+        if [ "${STEPS_FETCH_PRIMARY_OUTPUTS_PRIMARY_OK}" = "true" ]; then
           SPECS="square"
         fi
         if [ -z "$SPECS" ]; then
@@ -128,5 +128,8 @@ runs:
         fi
         echo "specs-fetched=$SPECS" >> $GITHUB_OUTPUT
         echo "Successfully fetched specs: $SPECS"
-        VERSIONS="${{ steps.fetch-versions.outputs.versions-fetched }}"
+        VERSIONS="${STEPS_FETCH_VERSIONS_OUTPUTS_VERSIONS_FETCHED}"
         echo "Historical versions fetched: ${VERSIONS:-0}"
+      env:
+        STEPS_FETCH_PRIMARY_OUTPUTS_PRIMARY_OK: ${{ steps.fetch-primary.outputs.primary-ok }}
+        STEPS_FETCH_VERSIONS_OUTPUTS_VERSIONS_FETCHED: ${{ steps.fetch-versions.outputs.versions-fetched }}

--- a/.github/actions/get-test-matrix/action.yaml
+++ b/.github/actions/get-test-matrix/action.yaml
@@ -34,11 +34,11 @@ runs:
     - name: Install
       uses: ./.github/actions/install
 
-    - uses: bufbuild/buf-setup-action@v1.50.0
+    - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
       with:
         github_token: ${{ github.token }}
 
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: "stable"
 
@@ -57,18 +57,21 @@ runs:
       id: determine-test-setups
       shell: bash
       run: |
-        if [[ "${{inputs.package-alphabetically}}" == "false" || \
-        "${{ inputs.sdk-name }}" == "fastapi" || \
-        "${{ inputs.sdk-name }}" == "go-model" || \
-        "${{ inputs.sdk-name }}" == "openapi" || \
-        "${{ inputs.sdk-name }}" == "php-model" || \
-        "${{ inputs.sdk-name }}" == "ruby-sdk-v2" || \
-        "${{ inputs.sdk-name }}" == "rust-model" || \
+        if [[ "${INPUTS_PACKAGE_ALPHABETICALLY}" == "false" || \
+        "${INPUTS_SDK_NAME}" == "fastapi" || \
+        "${INPUTS_SDK_NAME}" == "go-model" || \
+        "${INPUTS_SDK_NAME}" == "openapi" || \
+        "${INPUTS_SDK_NAME}" == "php-model" || \
+        "${INPUTS_SDK_NAME}" == "ruby-sdk-v2" || \
+        "${INPUTS_SDK_NAME}" == "rust-model" || \
         false ]]; then
           echo "split-tests=false" >> $GITHUB_OUTPUT
         else
           echo "split-tests=true" >> $GITHUB_OUTPUT
         fi
+      env:
+        INPUTS_PACKAGE_ALPHABETICALLY: ${{inputs.package-alphabetically}}
+        INPUTS_SDK_NAME: ${{ inputs.sdk-name }}
 
     - name: Get test matrix for ${{ inputs.sdk-name }}
       if: (steps.determine-test-setups.outputs.split-tests == 'true' && inputs.package-alphabetically == 'true') || inputs.package-alphabetically == 'false'

--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -6,17 +6,17 @@ runs:
 
   steps:
     - name: ⎔ Setup pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
     - name: ⎔ Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: 24
         registry-url: "https://registry.npmjs.org"
         cache: pnpm
 
     - name: ⎔ Cache turbo build
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: .turbo
         key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}

--- a/.github/actions/package-test-matrix/action.yaml
+++ b/.github/actions/package-test-matrix/action.yaml
@@ -22,10 +22,10 @@ runs:
       shell: bash
       run: |
         # Unpacked JSON array for processing
-        PARSED_NAME=$(echo '${{ inputs.full-fixture-matrix }}' | jq -r '.[]')
+        PARSED_NAME=$(echo '${INPUTS_FULL_FIXTURE_MATRIX}' | jq -r '.[]')
         echo "Parsed name: $PARSED_NAME"
 
-        PACKAGE_AMOUNT=${{ inputs.package-amount }}
+        PACKAGE_AMOUNT=${INPUTS_PACKAGE_AMOUNT}
 
         # UNPACKED
 
@@ -75,3 +75,6 @@ runs:
 
         echo "Final packaged matrix: $PACKAGED_MATRIX"
         echo "packaged=$PACKAGED_MATRIX" >> $GITHUB_OUTPUT
+      env:
+        INPUTS_FULL_FIXTURE_MATRIX: ${{ inputs.full-fixture-matrix }}
+        INPUTS_PACKAGE_AMOUNT: ${{ inputs.package-amount }}

--- a/.github/actions/parse-test-matrix-output/action.yaml
+++ b/.github/actions/parse-test-matrix-output/action.yaml
@@ -23,12 +23,12 @@ runs:
       shell: bash
       run: |
         INCLUDE_OUTPUT_FOLDERS_OPTION=""
-        if [[ "${{inputs.include-output-folders}}" == "true" ]]; then
+        if [[ "${INPUTS_INCLUDE_OUTPUT_FOLDERS}" == "true" ]]; then
           INCLUDE_OUTPUT_FOLDERS_OPTION="--include-output-folders"
         fi
 
         # Get JSON output from get-available-fixtures command
-        COMMAND_OUTPUT=$(pnpm seed get-available-fixtures --generator ${{inputs.generator-name}} $INCLUDE_OUTPUT_FOLDERS_OPTION)
+        COMMAND_OUTPUT=$(pnpm seed get-available-fixtures --generator ${INPUTS_GENERATOR_NAME} $INCLUDE_OUTPUT_FOLDERS_OPTION)
 
         echo "${COMMAND_OUTPUT}"
 
@@ -42,3 +42,6 @@ runs:
         echo "$FIXTURES_FLAT_JSON" | jq .
 
         echo "fixture_list=$FIXTURES_FLAT_JSON" >> $GITHUB_OUTPUT
+      env:
+        INPUTS_INCLUDE_OUTPUT_FOLDERS: ${{inputs.include-output-folders}}
+        INPUTS_GENERATOR_NAME: ${{inputs.generator-name}}

--- a/.github/actions/process-grype-vulns/action.yml
+++ b/.github/actions/process-grype-vulns/action.yml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Process vulnerabilities and create PR
       id: process-vulns
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         CONTAINER_NAME: ${{ inputs.container_name }}
         IGNORED_CVES: ${{ inputs.ignored_cves }}

--- a/.github/actions/publish-generator/action.yaml
+++ b/.github/actions/publish-generator/action.yaml
@@ -38,13 +38,13 @@ runs:
       uses: ./.github/actions/install
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v4
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
       with:
         username: fernapi
         password: ${{ inputs.docker-pwd }}
@@ -66,9 +66,10 @@ runs:
         SENTRY_AUTH_TOKEN: ${{ inputs.sentry-auth-token }}
         SENTRY_DSN: ${{ inputs.sentry-dsn }}
         VERSIONS_FILE: ${{ inputs.version-file }}
+        INPUTS_GENERATOR_NAME: ${{ inputs.generator-name }}
       run: |
         echo $VERSIONS_FILE
-        echo ${{ inputs.generator-name }}
+        echo ${INPUTS_GENERATOR_NAME}
 
         previous_commit=$(git log -n 2 --pretty=format:"%h" -- ${VERSIONS_FILE} | tail -n 1)
         current_commit=$(git log -n 1 --pretty=format:"%h" -- ${VERSIONS_FILE})
@@ -84,12 +85,12 @@ runs:
         head ${VERSIONS_FILE}
 
         if [ $GIT_SHOW_STATUS -eq 0 ]; then
-          node --enable-source-maps packages/seed/dist/cli.cjs publish generator ${{ inputs.generator-name }} --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug
+          node --enable-source-maps packages/seed/dist/cli.cjs publish generator ${INPUTS_GENERATOR_NAME} --changelog $VERSIONS_FILE --previous-changelog tmp_previous_versions.yml --log-level debug
         else
           echo "No previous versions found, skipping publish."
         fi
 
-        node --enable-source-maps packages/seed/dist/cli.cjs register generator --generators ${{ inputs.generator-name }}
+        node --enable-source-maps packages/seed/dist/cli.cjs register generator --generators ${INPUTS_GENERATOR_NAME}
 
     - name: Run publish (manual)
       if: inputs.manual-trigger == 'true'
@@ -101,15 +102,17 @@ runs:
         DOCKER_PASSWORD: ${{ inputs.docker-pwd }}
         SENTRY_AUTH_TOKEN: ${{ inputs.sentry-auth-token }}
         SENTRY_DSN: ${{ inputs.sentry-dsn }}
+        INPUTS_GENERATOR_NAME: ${{ inputs.generator-name }}
+        INPUTS_VERSION: ${{ inputs.version }}
       run: |
-        node --enable-source-maps packages/seed/dist/cli.cjs publish generator ${{ inputs.generator-name }} --ver ${{ inputs.version }} --log-level debug
-        node --enable-source-maps packages/seed/dist/cli.cjs register generator --generators ${{ inputs.generator-name }}
+        node --enable-source-maps packages/seed/dist/cli.cjs publish generator ${INPUTS_GENERATOR_NAME} --ver ${INPUTS_VERSION} --log-level debug
+        node --enable-source-maps packages/seed/dist/cli.cjs register generator --generators ${INPUTS_GENERATOR_NAME}
 
     - name: Determine snippet package info
       id: snippet-info
       shell: bash
       run: |
-        GENERATOR_NAME="${{ inputs.generator-name }}"
+        GENERATOR_NAME="${INPUTS_GENERATOR_NAME}"
 
         # Map generator names to their corresponding snippet package names and directories
         case "$GENERATOR_NAME" in
@@ -154,6 +157,8 @@ runs:
 
         echo "snippet_package=$SNIPPET_PACKAGE" >> "$GITHUB_OUTPUT"
         echo "snippet_dir=$SNIPPET_DIR" >> "$GITHUB_OUTPUT"
+      env:
+        INPUTS_GENERATOR_NAME: ${{ inputs.generator-name }}
 
     - name: Determine version for snippet package (auto)
       id: snippet-version-auto
@@ -169,13 +174,13 @@ runs:
 
     - name: Setup for snippet package publishing
       if: steps.snippet-info.outputs.snippet_package != ''
-      uses: bufbuild/buf-setup-action@v1.50.0
+      uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
       with:
         github_token: ${{ github.token }}
 
     - name: Setup Go for snippet package publishing
       if: steps.snippet-info.outputs.snippet_package != ''
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: "stable"
 

--- a/.github/actions/run-benchmark/action.yaml
+++ b/.github/actions/run-benchmark/action.yaml
@@ -20,7 +20,7 @@ runs:
     - name: Run benchmark for ${{ inputs.generator }}
       shell: bash
       run: |
-        GENERATOR="${{ inputs.generator }}"
+        GENERATOR="${INPUTS_GENERATOR}"
         RESULTS_DIR="benchmark-results"
         mkdir -p "$RESULTS_DIR"
 
@@ -41,7 +41,7 @@ runs:
 
           # Run generation (--skip-scripts omits post-gen build/test for cleaner signal)
           SKIP_FLAG=""
-          if [ "${{ inputs.skip-scripts }}" = "true" ]; then
+          if [ "${INPUTS_SKIP_SCRIPTS}" = "true" ]; then
             SKIP_FLAG="--skip-scripts"
           fi
           LOG_FILE=$(mktemp)
@@ -76,6 +76,9 @@ runs:
 
           echo "::endgroup::"
         done
+      env:
+        INPUTS_GENERATOR: ${{ inputs.generator }}
+        INPUTS_SKIP_SCRIPTS: ${{ inputs.skip-scripts }}
 
     - name: Fail if any generation crashed
       shell: bash

--- a/.github/actions/run-seed-process/action.yaml
+++ b/.github/actions/run-seed-process/action.yaml
@@ -62,21 +62,27 @@ runs:
 
     - name: Echo package
       shell: bash
-      run: echo '${{ inputs.fixtures-to-run }}' | jq .
+      run: echo '${INPUTS_FIXTURES_TO_RUN}' | jq .
+      env:
+        INPUTS_FIXTURES_TO_RUN: ${{ inputs.fixtures-to-run }}
 
     # Format for seed tests
     - name: JSON to String
       id: json-to-string
       shell: bash
       run: |
-        json_data='${{ inputs.fixtures-to-run }}'
+        json_data='${INPUTS_FIXTURES_TO_RUN}'
         # Convert JSON array to space-separated string
         string_result=$(echo "$json_data" | jq -r '.[]' | tr '\n' ' ' | sed 's/ $//')
         echo "Generated string: '$string_result'"
         echo "as-string=$string_result" >> $GITHUB_OUTPUT
+      env:
+        INPUTS_FIXTURES_TO_RUN: ${{ inputs.fixtures-to-run }}
 
     - name: Checkout repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Run seed
       uses: ./.github/actions/cached-seed
@@ -98,7 +104,7 @@ runs:
           # Find string including new, unexpected failures
           UNEXPECTED_FAILURES=$(tail -n 200 output.log | tac | grep -m 1 "unexpected failures, including:" | sed -n 's/.*unexpected failures, including: \(.*\)\./\1/p' || echo "")
           if [ -n "$UNEXPECTED_FAILURES" ]; then
-            echo "**❌ ${{ inputs.sdk-name }} Unexpected Test Failures:** ${UNEXPECTED_FAILURES}" >> $GITHUB_STEP_SUMMARY
+            echo "**❌ ${INPUTS_SDK_NAME} Unexpected Test Failures:** ${UNEXPECTED_FAILURES}" >> $GITHUB_STEP_SUMMARY
           else
             echo "No unexpected errors parsed from output"
           fi
@@ -106,13 +112,15 @@ runs:
           # Find string including passing fixtures that are still in allowedFailures list
           UNEXPECTEDLY_PASSING=$(tail -n 200 output.log | tac | grep -m 1 "Consider removing the following fixtures from allowedFailures:" | sed -n 's/.*Consider removing the following fixtures from allowedFailures: \(.*\)\./\1/p' || echo "")
           if [ -n "$UNEXPECTEDLY_PASSING" ]; then
-            echo "**⚠️ ${{ inputs.sdk-name }} Passing Tests in Allowed Failures List:** ${UNEXPECTEDLY_PASSING}" >> $GITHUB_STEP_SUMMARY
+            echo "**⚠️ ${INPUTS_SDK_NAME} Passing Tests in Allowed Failures List:** ${UNEXPECTEDLY_PASSING}" >> $GITHUB_STEP_SUMMARY
           else
             echo "No passing tests found in allowedFailures list from output"
           fi 
         else 
           echo "No output available to parse for test group"
         fi
+      env:
+        INPUTS_SDK_NAME: ${{ inputs.sdk-name }}
 
     - name: Record end time
       id: end-seed-timer

--- a/.github/actions/update-fern-platform-dependency/action.yml
+++ b/.github/actions/update-fern-platform-dependency/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: "24"
 
@@ -30,7 +30,7 @@ runs:
       shell: bash
       run: |
         # Clone fern-platform repo
-        git clone https://x-access-token:${{ inputs.github-token }}@github.com/fern-api/fern-platform.git fern-platform-repo
+        git clone https://x-access-token:${INPUTS_GITHUB_TOKEN}@github.com/fern-api/fern-platform.git fern-platform-repo
         cd fern-platform-repo
 
         # Configure git
@@ -38,18 +38,18 @@ runs:
         git config user.email "bot@buildwithfern.com"
 
         # Configure git to use the token for push operations
-        git remote set-url origin https://x-access-token:${{ inputs.github-token }}@github.com/fern-api/fern-platform.git
+        git remote set-url origin https://x-access-token:${INPUTS_GITHUB_TOKEN}@github.com/fern-api/fern-platform.git
 
         # Sanitize package name for branch name (replace special characters)
-        SANITIZED_PKG=$(echo "${{ inputs.package-name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+        SANITIZED_PKG=$(echo "${INPUTS_PACKAGE_NAME}" | sed 's/[^a-zA-Z0-9._-]/-/g')
 
         # Create branch
-        BRANCH_NAME="devin/update-${SANITIZED_PKG}-to-${{ inputs.version }}"
+        BRANCH_NAME="devin/update-${SANITIZED_PKG}-to-${INPUTS_VERSION}"
         git checkout -b "$BRANCH_NAME"
 
         # Update the dependency in the snippets package
         cd packages/snippets
-        pnpm add "${{ inputs.package-name }}@${{ inputs.version }}"
+        pnpm add "${INPUTS_PACKAGE_NAME}@${INPUTS_VERSION}"
 
         # Install dependencies and update tests
         cd ../..
@@ -66,18 +66,21 @@ runs:
 
         # Commit and push (include lockfile and any test snapshot changes)
         git add packages/snippets/package.json pnpm-lock.yaml packages/snippets/src/__test__/
-        git commit -m "chore: update ${{ inputs.package-name }} to ${{ inputs.version }}"
+        git commit -m "chore: update ${INPUTS_PACKAGE_NAME} to ${INPUTS_VERSION}"
         git push origin "$BRANCH_NAME"
 
         # Create PR using GitHub CLI
-        PR_BODY="This PR updates \`${{ inputs.package-name }}\` to version \`${{ inputs.version }}\` in the \`@fern-api/snippets\` package.
+        PR_BODY="This PR updates \`${INPUTS_PACKAGE_NAME}\` to version \`${INPUTS_VERSION}\` in the \`@fern-api/snippets\` package.
 
-        This PR was automatically created after publishing ${{ inputs.package-name }}@${{ inputs.version }}."
+        This PR was automatically created after publishing ${INPUTS_PACKAGE_NAME}@${INPUTS_VERSION}."
 
         gh pr create \
-          --title "chore: update ${{ inputs.package-name }} to ${{ inputs.version }}" \
+          --title "chore: update ${INPUTS_PACKAGE_NAME} to ${INPUTS_VERSION}" \
           --body "$PR_BODY" \
           --base main \
           --head "$BRANCH_NAME"
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        INPUTS_GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUTS_PACKAGE_NAME: ${{ inputs.package-name }}
+        INPUTS_VERSION: ${{ inputs.version }}

--- a/.github/actions/verify-determinism/action.yaml
+++ b/.github/actions/verify-determinism/action.yaml
@@ -20,7 +20,7 @@ runs:
       shell: bash
       run: |
         # Parse JSON array and build exclude arguments
-        JSON_INPUT='${{ inputs.determinism-exclude-paths }}'
+        JSON_INPUT='${INPUTS_DETERMINISM_EXCLUDE_PATHS}'
         echo "Input JSON:"
         echo ${JSON_INPUT} | jq .
 
@@ -44,3 +44,5 @@ runs:
           git --no-pager diff -- "${EXCLUDE_ARGS[@]}" | head -50 || true
           echo "deterministic=false" >> $GITHUB_OUTPUT
         fi
+      env:
+        INPUTS_DETERMINISM_EXCLUDE_PATHS: ${{ inputs.determinism-exclude-paths }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
       - "generators/typescript/utils/**"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -55,3 +57,20 @@ updates:
     directory: "/generators/go"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+  # Keep GitHub Actions pins (SHA + trailing version comment) up to date.
+  # Pair with the `unpinned-uses` policy enforced by `.github/workflows/zizmor.yml`.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/backfill-issue-labels.yml
+++ b/.github/workflows/backfill-issue-labels.yml
@@ -23,7 +23,7 @@ jobs:
     name: Backfill labels on existing issues
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const dryRun = "${{ inputs.dry_run }}" === "true";

--- a/.github/workflows/benchmark-baseline.yml
+++ b/.github/workflows/benchmark-baseline.yml
@@ -18,6 +18,9 @@ env:
   TURBO_NO_UPDATE_NOTIFIER: "1"
   TURBO_DAEMON: "false"
 
+permissions:
+  contents: read
+
 jobs:
   # Fetch specs once and share via artifact (avoids 9x redundant downloads)
   fetch-specs:

--- a/.github/workflows/benchmark-baseline.yml
+++ b/.github/workflows/benchmark-baseline.yml
@@ -26,18 +26,19 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/fetch-benchmark-specs
             benchmarks/fern/apis
             benchmarks/fern/api-versions.txt
+          persist-credentials: false
 
       - name: Fetch benchmark OpenAPI specs
         uses: ./.github/actions/fetch-benchmark-specs
 
       - name: Upload specs as shared artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis/*/openapi.json
@@ -57,13 +58,15 @@ jobs:
           [ts-sdk, python-sdk, java-sdk, go-sdk, csharp-sdk, ruby-sdk-v2, php-sdk, swift-sdk, rust-sdk]
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Download shared specs
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis
@@ -76,7 +79,7 @@ jobs:
 
       - name: Upload baseline results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: benchmark-baseline-${{ matrix.generator }}
           path: benchmark-results/
@@ -97,13 +100,15 @@ jobs:
           [ts-sdk, python-sdk, java-sdk, go-sdk, csharp-sdk, ruby-sdk-v2, php-sdk, swift-sdk, rust-sdk]
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Download shared specs
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis
@@ -115,7 +120,7 @@ jobs:
 
       - name: Upload E2E results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: benchmark-e2e-${{ matrix.generator }}
           path: benchmark-results/
@@ -130,13 +135,15 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Download shared specs
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis
@@ -147,7 +154,7 @@ jobs:
           fern-token: ${{ secrets.FERN_FERN_TOKEN }}
 
       - name: Upload docs baseline results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: benchmark-docs-baseline
           path: benchmark-results/
@@ -165,21 +172,21 @@ jobs:
     permissions: {}
     steps:
       - name: Download generator-only baseline artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: benchmark-baseline-*
           path: baseline-results
           merge-multiple: true
 
       - name: Download E2E baseline artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: benchmark-e2e-*
           path: e2e-results
           merge-multiple: true
 
       - name: Download docs baseline artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: benchmark-docs-baseline
           path: docs-results
@@ -294,4 +301,4 @@ jobs:
     if: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - name: Log rejection
-        run: echo "Benchmark baseline only runs on main. Current ref:${{ github.ref }}"
+        run: echo "Benchmark baseline only runs on main. Current ref:${GITHUB_REF}"

--- a/.github/workflows/check-devin-pr-assignee.yml
+++ b/.github/workflows/check-devin-pr-assignee.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'devin-ai-integration[bot]' }}
     steps:
       - name: Auto-assign requester from PR description
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -28,13 +28,15 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/typescript-v2/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: 📥 Install
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -60,13 +62,15 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/python-v2/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: 📥 Install
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -92,13 +96,15 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/csharp/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: 📥 Install
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -124,13 +130,15 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/go-v2/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: 📥 Install
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -156,13 +164,15 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/ruby-v2/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: 📥 Install
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -188,13 +198,15 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/php/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: 📥 Install
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -220,13 +232,15 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/swift/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: 📥 Install
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -252,13 +266,15 @@ jobs:
     if: contains(github.event.pull_request.changed_files, 'generators/java-v2/dynamic-snippets/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: 📥 Install
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ env:
   TURBO_NO_UPDATE_NOTIFIER: "1"
   TURBO_DAEMON: "false"
 
+permissions:
+  contents: read
+
 jobs:
   # Detect whether this push only touched seed snapshot files.
   # If so, skip all CI jobs — seed changes cannot break the build.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           # Only consider skipping for pushes to main. PRs and dispatches always run CI.
-          if [[ "${{ github.event_name }}" != "push" || "${{ github.ref }}" != "refs/heads/main" ]]; then
+          if [[ "${{ github.event_name }}" != "push" || "${GITHUB_REF}" != "refs/heads/main" ]]; then
             echo "should-skip=false" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             /*
@@ -71,6 +71,7 @@ jobs:
             packages/seed/**
             docker/seed/**
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -84,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             /*
@@ -93,6 +94,7 @@ jobs:
             packages/seed/**
             docker/seed/**
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -106,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             /*
@@ -115,6 +117,7 @@ jobs:
             packages/seed/**
             docker/seed/**
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -128,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             /*
@@ -137,6 +140,7 @@ jobs:
             packages/seed/**
             docker/seed/**
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -150,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             /*
@@ -159,6 +163,7 @@ jobs:
             packages/seed/**
             docker/seed/**
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -186,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             /*
@@ -195,6 +200,7 @@ jobs:
             packages/seed/**
             docker/seed/**
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -209,15 +215,16 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           lfs: true
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -269,14 +276,16 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Log in to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY }}
         with:
@@ -288,7 +297,7 @@ jobs:
 
       - name: Cache Docker images
         id: docker-cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/docker-cache
           key: ${{ runner.os }}-docker-ete-${{ hashFiles('**/Dockerfile*') }}
@@ -305,7 +314,7 @@ jobs:
         run: docker images -q | sort -u > /tmp/docker-images-before.txt
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -386,7 +395,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -409,13 +420,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
 
@@ -446,13 +459,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
 

--- a/.github/workflows/definitions-validation.yml
+++ b/.github/workflows/definitions-validation.yml
@@ -14,6 +14,9 @@ env:
   TURBO_NO_UPDATE_NOTIFIER: "1"
   TURBO_DAEMON: "false"
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/definitions-validation.yml
+++ b/.github/workflows/definitions-validation.yml
@@ -19,7 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,11 +16,11 @@ env:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/docs-bundle-smoke-test.yml
+++ b/.github/workflows/docs-bundle-smoke-test.yml
@@ -28,6 +28,9 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: "buildwithfern"
 
+permissions:
+  contents: read
+
 jobs:
   build-cli:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-bundle-smoke-test.yml
+++ b/.github/workflows/docs-bundle-smoke-test.yml
@@ -34,7 +34,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/install
@@ -67,7 +69,7 @@ jobs:
           cat packages/cli/cli/dist/prod/package.json
 
       - name: Upload CLI artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: fern-cli
           path: packages/cli/cli/dist/prod/
@@ -108,17 +110,19 @@ jobs:
 
       - name: Checkout repository
         if: steps.node-check.outputs.available == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         if: steps.node-check.outputs.available == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Download CLI artifact
         if: steps.node-check.outputs.available == 'true'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: fern-cli
           path: cli-dist/
@@ -249,7 +253,7 @@ jobs:
             cd docs-preview-smoke-test/playwright && npx playwright test smoke.spec.ts --config playwright.config.ts
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always() && steps.node-check.outputs.available == 'true'
         continue-on-error: true
         with:

--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -17,6 +17,9 @@ env:
   TURBO_NO_UPDATE_NOTIFIER: "1"
   TURBO_DAEMON: "false"
 
+permissions:
+  contents: read
+
 jobs:
   fix-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -22,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -46,7 +48,7 @@ jobs:
       - name: Open PR with fixes
         if: steps.check-for-changes.outputs.lint-fixes == 'true'
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.ACTIONS_PAT }}
           commit-message: "fix(lint): auto-fix lint issues"
@@ -56,7 +58,7 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           token: ${{ secrets.ACTIONS_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/go-generator.yml
+++ b/.github/workflows/go-generator.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Compile
         working-directory: ./generators/go
@@ -26,7 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run Tests
         working-directory: ./generators/go

--- a/.github/workflows/go-generator.yml
+++ b/.github/workflows/go-generator.yml
@@ -11,6 +11,9 @@ on:
 env:
   DO_NOT_TRACK: "1"
 
+permissions:
+  contents: read
+
 jobs:
   compile:
     runs-on: ubuntu-latest

--- a/.github/workflows/infisical-testing.yml
+++ b/.github/workflows/infisical-testing.yml
@@ -5,6 +5,9 @@ name: Infisical-testing
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-admin:
     runs-on: ubuntu-latest

--- a/.github/workflows/infisical-testing.yml
+++ b/.github/workflows/infisical-testing.yml
@@ -13,9 +13,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" --jq '.permission')
-          echo "User ${{ github.actor }} has permission: $PERMISSION"
+          PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${GITHUB_ACTOR}/permission" --jq '.permission')
+          echo "User ${GITHUB_ACTOR} has permission: $PERMISSION"
           if [ "$PERMISSION" != "admin" ]; then
-            echo "::error::Only repository admins can run this workflow. ${{ github.actor }} has '$PERMISSION' permission."
+            echo "::error::Only repository admins can run this workflow. ${GITHUB_ACTOR} has '$PERMISSION' permission."
             exit 1
           fi

--- a/.github/workflows/ir-release.yml
+++ b/.github/workflows/ir-release.yml
@@ -11,6 +11,9 @@ on:
 env:
   DO_NOT_TRACK: "1"
 
+permissions:
+  contents: read
+
 jobs:
   node:
     runs-on: ubuntu-latest

--- a/.github/workflows/ir-release.yml
+++ b/.github/workflows/ir-release.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Fern
         run: npm install -g fern-api
@@ -33,7 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Fern
         run: npm install -g fern-api
@@ -51,7 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Fern
         run: npm install -g fern-api
@@ -68,7 +74,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Fern
         run: npm install -g fern-api
@@ -85,7 +93,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Fern
         run: npm install -g fern-api

--- a/.github/workflows/ir-validation.yml
+++ b/.github/workflows/ir-validation.yml
@@ -16,6 +16,9 @@ on:
 env:
   DO_NOT_TRACK: "1"
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/ir-validation.yml
+++ b/.github/workflows/ir-validation.yml
@@ -21,7 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -15,7 +15,7 @@ jobs:
     name: Apply labels from issue form
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/java-generator.yml
+++ b/.github/workflows/java-generator.yml
@@ -16,10 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: "adopt"
           java-version: "11"
@@ -32,10 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: "adopt"
           java-version: "11"
@@ -50,10 +54,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: "adopt"
           java-version: "11"

--- a/.github/workflows/java-generator.yml
+++ b/.github/workflows/java-generator.yml
@@ -11,6 +11,9 @@ on:
 env:
   DO_NOT_TRACK: "1"
 
+permissions:
+  contents: read
+
 jobs:
   compile:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -19,7 +19,7 @@ jobs:
     name: Lint PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         with:
           types: |
             fix

--- a/.github/workflows/nightly-seed-metrics.yml
+++ b/.github/workflows/nightly-seed-metrics.yml
@@ -15,6 +15,9 @@ concurrency:
 env:
   DO_NOT_TRACK: "1"
 
+permissions:
+  contents: read
+
 jobs:
   trigger-seed-snapshot-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-seed-metrics.yml
+++ b/.github/workflows/nightly-seed-metrics.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Note: this will trigger to the default branch of the repo, not the workflow_dispatch branch
       - name: Trigger Seed Tests with Metrics
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.ACTIONS_PAT }}
           event-type: seed-test-metrics

--- a/.github/workflows/publish-browser-compatible-fern-workspace.yml
+++ b/.github/workflows/publish-browser-compatible-fern-workspace.yml
@@ -26,13 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Setup Node for npm publish
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -20,8 +20,7 @@ on:
         type: string
 
 permissions:
-  contents: read # Required for checkout
-  id-token: write # Required for OIDC
+  contents: read
 
 env:
   DO_NOT_TRACK: "1"
@@ -59,6 +58,9 @@ jobs:
       group: publish-cli-dev
       cancel-in-progress: true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC trusted publishing to npm
     env:
       AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
       AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
@@ -128,6 +130,9 @@ jobs:
       group: publish-cli-release
       cancel-in-progress: false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC trusted publishing to npm
     env:
       AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
       AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
@@ -184,6 +189,9 @@ jobs:
     concurrency:
       group: publish-cli-release
       cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write # OIDC trusted publishing to npm
     env:
       AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
       AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -38,9 +38,10 @@ jobs:
       is_release_bump: ${{ steps.check_versions_yml.outputs.is_release_bump }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Check if versions.yml changed
         id: check_versions_yml
@@ -66,10 +67,11 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -100,7 +102,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -132,10 +136,11 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 20
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -187,9 +192,10 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.FERN_SENTRY_AUTH_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-tags: true
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -206,13 +212,16 @@ jobs:
 
       - name: Publish Dev CLI
         run: |
-          pnpm seed publish cli --ver ${{ inputs.version }} --dev --log-level debug
+          pnpm seed publish cli --ver ${INPUTS_VERSION} --dev --log-level debug
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: Publish + Register CLI
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          INPUTS_VERSION: ${{ inputs.version }}
         run: |
-          pnpm seed publish cli --ver ${{ inputs.version }} --log-level debug
+          pnpm seed publish cli --ver ${INPUTS_VERSION} --log-level debug
           pnpm seed register cli
 
   bulk-update-cli:
@@ -224,25 +233,30 @@ jobs:
       AUTOPILOT_HOST: ${{ vars.AUTOPILOT_HOST != '' && vars.AUTOPILOT_HOST || 'https://autopilot.buildwithfern.com' }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Get CLI version
         id: get_version
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
+          if [ -n "${INPUTS_VERSION}" ]; then
             # Manual publish - use the input version
-            echo "CLI_VERSION=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "CLI_VERSION=${INPUTS_VERSION}" >> $GITHUB_OUTPUT
           else
             # Automatic publish - extract from versions.yml
             version=$(head -n 20 packages/cli/cli/versions.yml | grep -m 1 "version:" | awk '{print $3}')
             echo "CLI_VERSION=${version}" >> $GITHUB_OUTPUT
           fi
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: Trigger bulk update
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          STEPS_GET_VERSION_OUTPUTS_CLI_VERSION: ${{ steps.get_version.outputs.CLI_VERSION }}
         run: |
-          version="${{ steps.get_version.outputs.CLI_VERSION }}"
+          version="${STEPS_GET_VERSION_OUTPUTS_CLI_VERSION}"
           host="${AUTOPILOT_HOST%/}"
           echo "Using autopilot host: ${host}"
           echo "Triggering bulk update for CLI version: ${version}"

--- a/.github/workflows/publish-docs-parsers-sdk.yml
+++ b/.github/workflows/publish-docs-parsers-sdk.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -32,5 +34,6 @@ jobs:
       - name: Generate docs parsers
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          STEPS_VERSION_OUTPUTS_NEXT_VERSION: ${{ steps.version.outputs.next_version }}
         run: |
-          fern generate --api fern-definition --group docs-parsers --version ${{ steps.version.outputs.next_version }}
+          fern generate --api fern-definition --group docs-parsers --version ${STEPS_VERSION_OUTPUTS_NEXT_VERSION}

--- a/.github/workflows/publish-docs-parsers-sdk.yml
+++ b/.github/workflows/publish-docs-parsers-sdk.yml
@@ -6,6 +6,9 @@ on:
 env:
   DO_NOT_TRACK: "1"
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -18,7 +18,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
 
 permissions:
-  id-token: write # Required for OIDC
   contents: read
 
 jobs:
@@ -73,6 +72,9 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.has_new_version == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC trusted publishing to npm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -28,9 +28,10 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
       has_new_version: ${{ steps.get_version.outputs.has_new_version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -73,7 +74,9 @@ jobs:
     if: needs.check-version.outputs.has_new_version == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -81,7 +84,8 @@ jobs:
       - name: Build CLI
         env:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
-        run: pnpm turbo run dist:cli --filter=${{ env.PACKAGE_NAME }} -- ${{ needs.check-version.outputs.version }}
+          NEEDS_CHECK_VERSION_OUTPUTS_VERSION: ${{ needs.check-version.outputs.version }}
+        run: pnpm turbo run dist:cli --filter=${{ env.PACKAGE_NAME }} -- ${NEEDS_CHECK_VERSION_OUTPUTS_VERSION}
 
       - name: Test
         env:
@@ -104,7 +108,9 @@ jobs:
     if: needs.check-version.outputs.has_new_version == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: 📥 Install Fern
         run: npm install -g fern-api

--- a/.github/workflows/publish-generator-csharp-model.yml
+++ b/.github/workflows/publish-generator-csharp-model.yml
@@ -27,10 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-csharp-sdk.yml
+++ b/.github/workflows/publish-generator-csharp-sdk.yml
@@ -26,10 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-fern-cli.yml
+++ b/.github/workflows/publish-generator-fern-cli.yml
@@ -26,10 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-go-model.yml
+++ b/.github/workflows/publish-generator-go-model.yml
@@ -27,10 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-go-sdk.yml
+++ b/.github/workflows/publish-generator-go-sdk.yml
@@ -26,10 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-java-model.yml
+++ b/.github/workflows/publish-generator-java-model.yml
@@ -27,10 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-java-sdk.yml
+++ b/.github/workflows/publish-generator-java-sdk.yml
@@ -30,10 +30,11 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -34,9 +34,10 @@ jobs:
       should_publish: ${{ steps.determine_version.outputs.should_publish }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 10
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -44,9 +45,9 @@ jobs:
       - name: Determine version
         id: determine_version
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
+          if [ -n "${INPUTS_VERSION}" ]; then
             # Manual workflow dispatch with explicit version
-            NEW_VERSION="${{ inputs.version }}"
+            NEW_VERSION="${INPUTS_VERSION}"
             SHOULD_PUBLISH="true"
           else
             # Automatic publish - check if package files changed
@@ -69,6 +70,8 @@ jobs:
           echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "should_publish=${SHOULD_PUBLISH}" >> $GITHUB_OUTPUT
           echo "Will publish version: ${NEW_VERSION} (should_publish=${SHOULD_PUBLISH})"
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
   publish-package:
     needs: check-version
@@ -76,7 +79,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -87,7 +92,7 @@ jobs:
           pnpm turbo run test --filter=${{ env.PACKAGE_NAME }}
 
       - name: Setup Node for npm publish
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -23,7 +23,6 @@ env:
   TURBO_DAEMON: "false"
 
 permissions:
-  id-token: write # Required for OIDC
   contents: read
 
 jobs:
@@ -77,6 +76,9 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC trusted publishing to npm
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/publish-generator-openapi.yml
+++ b/.github/workflows/publish-generator-openapi.yml
@@ -26,10 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-php-model.yml
+++ b/.github/workflows/publish-generator-php-model.yml
@@ -27,10 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-php-sdk.yml
+++ b/.github/workflows/publish-generator-php-sdk.yml
@@ -26,10 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-python-pydantic.yml
+++ b/.github/workflows/publish-generator-python-pydantic.yml
@@ -27,10 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-python-sdk.yml
+++ b/.github/workflows/publish-generator-python-sdk.yml
@@ -26,10 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-ruby-sdk.yml
+++ b/.github/workflows/publish-generator-ruby-sdk.yml
@@ -26,10 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-rust-model.yml
+++ b/.github/workflows/publish-generator-rust-model.yml
@@ -27,10 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-rust-sdk.yml
+++ b/.github/workflows/publish-generator-rust-sdk.yml
@@ -26,10 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-swift-sdk.yml
+++ b/.github/workflows/publish-generator-swift-sdk.yml
@@ -26,10 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
       - name: automated publish
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator

--- a/.github/workflows/publish-generator-ts-sdk.yml
+++ b/.github/workflows/publish-generator-ts-sdk.yml
@@ -26,10 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 10
+          persist-credentials: false
 
       # Pre-flight: build the validator image locally (single-arch, no push)
       # before publishing the generator. Docker Hub has no transactional
@@ -81,12 +82,14 @@ jobs:
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.version }}"
+            VERSION="${INPUTS_VERSION}"
           else
             VERSION=$(grep -m1 "^- version:" generators/typescript/sdk/versions.yml | sed 's/- version: //' | tr -d '"' | tr -d "'")
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Validator image version: $VERSION"
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: Build and publish validator image
         if: ${{ steps.validator-version.outputs.version != '' }}

--- a/.github/workflows/publish-local-cli.yml
+++ b/.github/workflows/publish-local-cli.yml
@@ -28,7 +28,9 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Fern CLI
         run: npm install -g fern-api
@@ -25,5 +27,6 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          INPUTS_VERSION: ${{ inputs.version }}
         run: |
-          fern generate --api public-api --group python-sdk --version ${{ inputs.version }} --log-level debug
+          fern generate --api public-api --group python-sdk --version ${INPUTS_VERSION} --log-level debug

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -11,6 +11,9 @@ on:
 env:
   DO_NOT_TRACK: "1"
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-snippets-core.yml
+++ b/.github/workflows/publish-snippets-core.yml
@@ -23,15 +23,16 @@ jobs:
     if: ${{ inputs.version != null }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-tags: true
+          persist-credentials: false
 
       - name: 📥 Install
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -55,6 +56,8 @@ jobs:
       - name: Publish @fern-api/snippets-core
         run: |
           cd packages/snippets/core
-          pnpm turbo run dist --filter=${{ env.PACKAGE_NAME }} -- ${{ inputs.version }}
+          pnpm turbo run dist --filter=${{ env.PACKAGE_NAME }} -- ${INPUTS_VERSION}
           cd dist
           npx -y npm@11 publish --access public --tag latest
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}

--- a/.github/workflows/publish-typescript-sdk.yml
+++ b/.github/workflows/publish-typescript-sdk.yml
@@ -11,6 +11,9 @@ on:
 env:
   DO_NOT_TRACK: "1"
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-typescript-sdk.yml
+++ b/.github/workflows/publish-typescript-sdk.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Fern CLI
         run: npm install -g fern-api
@@ -25,5 +27,6 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+          INPUTS_VERSION: ${{ inputs.version }}
         run: |
-          fern generate --api public-api --group node-sdk --version ${{ inputs.version }} --log-level debug
+          fern generate --api public-api --group node-sdk --version ${INPUTS_VERSION} --log-level debug

--- a/.github/workflows/python-generator.yml
+++ b/.github/workflows/python-generator.yml
@@ -16,10 +16,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: 2.1.4
 
@@ -39,10 +41,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: 2.1.4
 

--- a/.github/workflows/python-generator.yml
+++ b/.github/workflows/python-generator.yml
@@ -11,6 +11,9 @@ on:
 env:
   DO_NOT_TRACK: "1"
 
+permissions:
+  contents: read
+
 jobs:
   compile:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release-software.yml
+++ b/.github/workflows/release-software.yml
@@ -60,11 +60,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.ACTIONS_PAT }}
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Skip if triggered by own release commit
         id: skip-release-loop

--- a/.github/workflows/sdk-ete-tests.yml
+++ b/.github/workflows/sdk-ete-tests.yml
@@ -162,9 +162,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -183,10 +184,10 @@ jobs:
           pnpm turbo run dist:cli --filter @fern-api/go-sdk
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
@@ -354,7 +355,7 @@ jobs:
 
       - name: Comment on PR with branch info
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const testDefinition = '${{ inputs.test-definition }}' || 'exhaustive';

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -39,6 +39,9 @@ env:
   TURBO_NO_UPDATE_NOTIFIER: "1"
   TURBO_DAEMON: "false"
 
+permissions:
+  contents: read
+
 jobs:
   create-dependabot-prs:
     name: Check Dependabot alerts

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -47,11 +47,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Fetch Dependabot alerts
         id: fetch-alerts
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           ALERTS_FILE: ${{ runner.temp }}/dependabot-alerts.json
         with:
@@ -96,7 +98,7 @@ jobs:
       - name: Create PRs and send Slack notifications
         id: create-prs
         if: ${{ steps.fetch-alerts.outputs.alerts_count != '0' && inputs.scan_only != true }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           # ============================================================
           # DEVIN PROMPT CONFIGURATION
@@ -448,12 +450,13 @@ jobs:
             seed: ts-sdk
             container: typescript-sdk
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
         with:
           role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
           aws-region: "us-east-1"
@@ -523,7 +526,7 @@ jobs:
         run: grype "docker:$IMAGE" -o json > grype-report.json
 
       - name: Upload grype scan results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: grype-scan-results-${{ matrix.generator.container }}
           path: grype-report.json
@@ -565,18 +568,19 @@ jobs:
           - lang: php
           - lang: ts
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6
         with:
           role-to-assume: "arn:aws:iam::985111089818:role/github-ci"
           aws-region: "us-east-1"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build container
         env:
@@ -614,7 +618,7 @@ jobs:
         run: grype "docker:$IMAGE" -o json > grype-report.json
 
       - name: Upload grype scan results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: grype-scan-results-${{ matrix.seed.lang }}-seed
           path: grype-report.json

--- a/.github/workflows/seed-dockers.yml
+++ b/.github/workflows/seed-dockers.yml
@@ -47,6 +47,9 @@ env:
   DO_NOT_TRACK: "1"
   DOCKER_BUILDKIT: 1
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/seed-dockers.yml
+++ b/.github/workflows/seed-dockers.yml
@@ -58,10 +58,11 @@ jobs:
       php: ${{ steps.set-output.outputs.php }}
       go: ${{ steps.set-output.outputs.go }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 2
           fetch-tags: false
+          persist-credentials: false
 
       - name: Check for ts changes
         id: ts
@@ -129,7 +130,7 @@ jobs:
             fi
           else
             # Push event: use path-based change detection
-            if [[ "${{ steps.workflow.outputs.any_changed }}" == "true" ]]; then
+            if [[ "${STEPS_WORKFLOW_OUTPUTS_ANY_CHANGED}" == "true" ]]; then
               echo "ts=true" >> $GITHUB_OUTPUT
               echo "java=true" >> $GITHUB_OUTPUT
               echo "python=true" >> $GITHUB_OUTPUT
@@ -138,22 +139,32 @@ jobs:
               echo "go=true" >> $GITHUB_OUTPUT
               echo "Workflow changed, rebuilding all images"
             else
-              echo "ts=${{ steps.ts.outputs.any_changed }}" >> $GITHUB_OUTPUT
-              echo "java=${{ steps.java.outputs.any_changed }}" >> $GITHUB_OUTPUT
-              echo "python=${{ steps.python.outputs.any_changed }}" >> $GITHUB_OUTPUT
-              echo "csharp=${{ steps.csharp.outputs.any_changed }}" >> $GITHUB_OUTPUT
-              echo "php=${{ steps.php.outputs.any_changed }}" >> $GITHUB_OUTPUT
-              echo "go=${{ steps.go.outputs.any_changed }}" >> $GITHUB_OUTPUT
+              echo "ts=${STEPS_TS_OUTPUTS_ANY_CHANGED}" >> $GITHUB_OUTPUT
+              echo "java=${STEPS_JAVA_OUTPUTS_ANY_CHANGED}" >> $GITHUB_OUTPUT
+              echo "python=${STEPS_PYTHON_OUTPUTS_ANY_CHANGED}" >> $GITHUB_OUTPUT
+              echo "csharp=${STEPS_CSHARP_OUTPUTS_ANY_CHANGED}" >> $GITHUB_OUTPUT
+              echo "php=${STEPS_PHP_OUTPUTS_ANY_CHANGED}" >> $GITHUB_OUTPUT
+              echo "go=${STEPS_GO_OUTPUTS_ANY_CHANGED}" >> $GITHUB_OUTPUT
               echo "Set outputs based on individual file changes"
             fi
           fi
+        env:
+          STEPS_WORKFLOW_OUTPUTS_ANY_CHANGED: ${{ steps.workflow.outputs.any_changed }}
+          STEPS_TS_OUTPUTS_ANY_CHANGED: ${{ steps.ts.outputs.any_changed }}
+          STEPS_JAVA_OUTPUTS_ANY_CHANGED: ${{ steps.java.outputs.any_changed }}
+          STEPS_PYTHON_OUTPUTS_ANY_CHANGED: ${{ steps.python.outputs.any_changed }}
+          STEPS_CSHARP_OUTPUTS_ANY_CHANGED: ${{ steps.csharp.outputs.any_changed }}
+          STEPS_PHP_OUTPUTS_ANY_CHANGED: ${{ steps.php.outputs.any_changed }}
+          STEPS_GO_OUTPUTS_ANY_CHANGED: ${{ steps.go.outputs.any_changed }}
 
   generate-sha:
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.sha.outputs.sha }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - id: sha
         run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
@@ -173,16 +184,17 @@ jobs:
     needs: [changes, generate-sha]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: fernapi/ts-seed
           tags: |
@@ -190,13 +202,13 @@ jobs:
             type=raw,value=latest-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: ./docker/seed/Dockerfile.ts
@@ -222,16 +234,17 @@ jobs:
     needs: [changes, generate-sha]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: fernapi/java-seed
           tags: |
@@ -239,13 +252,13 @@ jobs:
             type=raw,value=latest-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: ./docker/seed/Dockerfile.java
@@ -271,16 +284,17 @@ jobs:
     needs: [changes, generate-sha]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: fernapi/python-seed
           tags: |
@@ -288,13 +302,13 @@ jobs:
             type=raw,value=latest-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: ./docker/seed/Dockerfile.python
@@ -320,16 +334,17 @@ jobs:
     needs: [changes, generate-sha]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: fernapi/csharp-seed
           tags: |
@@ -337,13 +352,13 @@ jobs:
             type=raw,value=latest-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: ./docker/seed/Dockerfile.csharp
@@ -369,16 +384,17 @@ jobs:
     needs: [changes, generate-sha]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: fernapi/php-seed
           tags: |
@@ -386,13 +402,13 @@ jobs:
             type=raw,value=latest-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: ./docker/seed/Dockerfile.php
@@ -418,16 +434,17 @@ jobs:
     needs: [changes, generate-sha]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: fernapi/go-seed
           tags: |
@@ -435,13 +452,13 @@ jobs:
             type=raw,value=latest-${{ matrix.arch }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: ./docker/seed/Dockerfile.go
@@ -458,10 +475,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: fernapi
           password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
@@ -470,31 +487,38 @@ jobs:
         id: build-list
         run: |
           packages=""
-          if [[ "${{ needs.changes.outputs.ts }}" == "true" ]]; then
+          if [[ "${NEEDS_CHANGES_OUTPUTS_TS}" == "true" ]]; then
             packages+="ts "
           fi
-          if [[ "${{ needs.changes.outputs.java }}" == "true" ]]; then
+          if [[ "${NEEDS_CHANGES_OUTPUTS_JAVA}" == "true" ]]; then
             packages+="java "
           fi
-          if [[ "${{ needs.changes.outputs.python }}" == "true" ]]; then
+          if [[ "${NEEDS_CHANGES_OUTPUTS_PYTHON}" == "true" ]]; then
             packages+="python "
           fi
-          if [[ "${{ needs.changes.outputs.csharp }}" == "true" ]]; then
+          if [[ "${NEEDS_CHANGES_OUTPUTS_CSHARP}" == "true" ]]; then
             packages+="csharp "
           fi
-          if [[ "${{ needs.changes.outputs.php }}" == "true" ]]; then
+          if [[ "${NEEDS_CHANGES_OUTPUTS_PHP}" == "true" ]]; then
             packages+="php "
           fi
-          if [[ "${{ needs.changes.outputs.go }}" == "true" ]]; then
+          if [[ "${NEEDS_CHANGES_OUTPUTS_GO}" == "true" ]]; then
             packages+="go "
           fi
           echo "packages=${packages% }" >> $GITHUB_OUTPUT
           echo "Building manifests for: ${packages% }"
+        env:
+          NEEDS_CHANGES_OUTPUTS_TS: ${{ needs.changes.outputs.ts }}
+          NEEDS_CHANGES_OUTPUTS_JAVA: ${{ needs.changes.outputs.java }}
+          NEEDS_CHANGES_OUTPUTS_PYTHON: ${{ needs.changes.outputs.python }}
+          NEEDS_CHANGES_OUTPUTS_CSHARP: ${{ needs.changes.outputs.csharp }}
+          NEEDS_CHANGES_OUTPUTS_PHP: ${{ needs.changes.outputs.php }}
+          NEEDS_CHANGES_OUTPUTS_GO: ${{ needs.changes.outputs.go }}
 
       - name: Create and push manifest
         run: |
-          packages='${{ steps.build-list.outputs.packages }}'
-          sha='${{ needs.generate-sha.outputs.sha }}'
+          packages='${STEPS_BUILD_LIST_OUTPUTS_PACKAGES}'
+          sha='${NEEDS_GENERATE_SHA_OUTPUTS_SHA}'
           for package in $packages; do
             docker buildx imagetools create -t fernapi/${package}-seed:latest \
               fernapi/${package}-seed:latest-amd64 \
@@ -504,3 +528,6 @@ jobs:
               fernapi/${package}-seed:${sha}-amd64 \
               fernapi/${package}-seed:${sha}-arm64
           done
+        env:
+          STEPS_BUILD_LIST_OUTPUTS_PACKAGES: ${{ steps.build-list.outputs.packages }}
+          NEEDS_GENERATE_SHA_OUTPUTS_SHA: ${{ needs.generate-sha.outputs.sha }}

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -28,6 +28,9 @@ env:
   TURBO_NO_UPDATE_NOTIFIER: "1"
   TURBO_DAEMON: "false"
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -40,14 +40,16 @@ jobs:
         shell: bash
         run: |
           echo "GitHub Event: ${{ github.event_name }}"
-          echo "GitHub Event Action: ${{ github.event.action }}"
-          if [[ "${{ github.event_name }}" == "repository_dispatch" && "${{ github.event.action }}" == "seed-test-metrics" ]]; then
+          echo "GitHub Event Action: ${GITHUB_EVENT_ACTION}"
+          if [[ "${{ github.event_name }}" == "repository_dispatch" && "${GITHUB_EVENT_ACTION}" == "seed-test-metrics" ]]; then
             echo "post-metrics=true" >> $GITHUB_OUTPUT
             echo "Set to collect metrics on this run"
           else
             echo "post-metrics=false" >> $GITHUB_OUTPUT
             echo "Will not collect metrics on this run"
           fi
+        env:
+          GITHUB_EVENT_ACTION: ${{ github.event.action }}
 
   check-orphaned-seed-folders:
     runs-on: ubuntu-latest
@@ -56,7 +58,9 @@ jobs:
     if: ${{ needs.get-all-test-matrices.outputs.seed-infrastructure-changed == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -114,7 +118,7 @@ jobs:
       benchmark-docs: ${{ steps.create-dynamic-matrix.outputs.benchmark-docs }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # fetch-depth: 2 ensures the merge commit's parents are available.
           # For PRs, HEAD is a merge commit; HEAD~1 is the base branch tip.
@@ -122,6 +126,7 @@ jobs:
           # and the affected detection falls back to diffing against the
           # (potentially stale) event payload SHA.
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -138,6 +143,7 @@ jobs:
         env:
           FORCE_COLOR: "2"
           GH_TOKEN: ${{ github.token }}
+          NEEDS_SETUP_OUTPUTS_POST_METRICS: ${{ needs.setup.outputs.post-metrics }}
         run: |
           # Determine base ref for affected detection.
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
@@ -176,7 +182,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "Manual dispatch — forcing all generators and fixtures to run."
             AFFECTED_JSON='{"allGeneratorsAffected":true,"allFixturesAffected":true,"generators":[],"generatorsWithAllFixtures":[],"fixtures":[],"summary":["Forced: workflow_dispatch event."]}'
-          elif [[ "${{ needs.setup.outputs.post-metrics }}" == "true" ]]; then
+          elif [[ "${NEEDS_SETUP_OUTPUTS_POST_METRICS}" == "true" ]]; then
             echo "Metrics collection mode — forcing all generators and fixtures to run."
             AFFECTED_JSON='{"allGeneratorsAffected":true,"allFixturesAffected":true,"generators":[],"generatorsWithAllFixtures":[],"fixtures":[],"summary":["Forced: metrics collection mode."]}'
           else
@@ -343,10 +349,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.ruby-sdk-v2) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -377,10 +384,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.pydantic) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -409,10 +417,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.python-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -442,10 +451,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.openapi) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -474,10 +484,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -507,10 +518,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.java-model) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -539,10 +551,11 @@ jobs:
         include: ${{ fromJson(needs.get-all-test-matrices.outputs.ts-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -573,10 +586,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-model) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -605,10 +619,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.go-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -638,10 +653,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-model) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -670,10 +686,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.csharp-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -703,10 +720,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-model) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -735,10 +753,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.php-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -767,10 +786,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.swift-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -800,10 +820,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-model) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -832,10 +853,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.rust-sdk) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -864,10 +886,11 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.cli) }}
     steps:
       - name: Checkout action file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/run-seed-process
+          persist-credentials: false
 
       - name: Run All Seed Tests
         uses: ./.github/actions/run-seed-process
@@ -897,18 +920,19 @@ jobs:
       }}
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/fetch-benchmark-specs
             benchmarks/fern/apis
             benchmarks/fern/api-versions.txt
+          persist-credentials: false
 
       - name: Fetch benchmark OpenAPI specs
         uses: ./.github/actions/fetch-benchmark-specs
 
       - name: Upload specs as shared artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis/*/openapi.json
@@ -930,14 +954,16 @@ jobs:
         include: ${{ fromJSON(needs.get-all-test-matrices.outputs.benchmark-generators) }}
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Log in to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY }}
         with:
@@ -949,7 +975,7 @@ jobs:
 
       - name: Cache Docker images
         id: docker-cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/docker-cache
           key: ${{ runner.os }}-docker-${{ matrix.generator }}-${{ hashFiles('**/Dockerfile*') }}
@@ -966,7 +992,7 @@ jobs:
         run: docker images -q | sort -u > /tmp/docker-images-before.txt
 
       - name: Download shared specs
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis
@@ -994,7 +1020,7 @@ jobs:
 
       - name: Upload PR results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: benchmark-pr-${{ matrix.generator }}
           path: benchmark-results/
@@ -1015,12 +1041,13 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: .github/scripts
+          persist-credentials: false
 
       - name: Download all PR benchmark artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: benchmark-pr-*
           path: benchmark-pr-results
@@ -1236,13 +1263,15 @@ jobs:
       }}
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Download shared specs
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis
@@ -1253,7 +1282,7 @@ jobs:
           fern-token: ${{ secrets.FERN_FERN_TOKEN }}
 
       - name: Upload PR docs benchmark results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           # Must not match the `benchmark-pr-*` pattern used by the SDK
           # benchmark report download, or docs jsonl rows (which have no
@@ -1277,12 +1306,13 @@ jobs:
       actions: read
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: .github/scripts
+          persist-credentials: false
 
       - name: Download PR docs benchmark artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: benchmark-docs-pr
           path: docs-pr-results
@@ -1656,7 +1686,9 @@ jobs:
       cli-allowed-failures-count: ${{ steps.extract-all-fixture-info.outputs.cli-allowed-failures-count }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -1764,7 +1796,7 @@ jobs:
           fi
 
       - name: Download Seed Test Time Artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           path: ${{ steps.artifacts-info.outputs.metrics_path }}
           pattern: ${{ steps.artifacts-info.outputs.metrics_pattern }}
@@ -1774,8 +1806,8 @@ jobs:
         shell: bash
         id: get-number-of-metric-artifacts
         run: |
-          METRICS_PATH="${{ steps.artifacts-info.outputs.metrics_path }}"
-          METRICS_PATTERN="${{ steps.artifacts-info.outputs.metrics_pattern }}"
+          METRICS_PATH="${STEPS_ARTIFACTS_INFO_OUTPUTS_METRICS_PATH}"
+          METRICS_PATTERN="${STEPS_ARTIFACTS_INFO_OUTPUTS_METRICS_PATTERN}"
           echo "Looking for files in: $METRICS_PATH"
           echo "Using pattern: $METRICS_PATTERN"
 
@@ -1787,18 +1819,23 @@ jobs:
             echo "Found 0 artifacts for seed metrics"
             exit 1
           fi
+        env:
+          STEPS_ARTIFACTS_INFO_OUTPUTS_METRICS_PATH: ${{ steps.artifacts-info.outputs.metrics_path }}
+          STEPS_ARTIFACTS_INFO_OUTPUTS_METRICS_PATTERN: ${{ steps.artifacts-info.outputs.metrics_pattern }}
 
       - name: Display Content of Metrics Artifacts Folder
         run: |
-          METRICS_PATH="${{ steps.artifacts-info.outputs.metrics_path }}"
+          METRICS_PATH="${STEPS_ARTIFACTS_INFO_OUTPUTS_METRICS_PATH}"
           echo "Content of '$METRICS_PATH' folder:"
           ls -R $METRICS_PATH/
+        env:
+          STEPS_ARTIFACTS_INFO_OUTPUTS_METRICS_PATH: ${{ steps.artifacts-info.outputs.metrics_path }}
 
       - name: Parse Seed Test Metrics
         id: parse-seed-test-metrics
         run: |
-          METRICS_PATH="${{ steps.artifacts-info.outputs.metrics_path }}"
-          METRICS_PATTERN="${{ steps.artifacts-info.outputs.metrics_pattern }}"
+          METRICS_PATH="${STEPS_ARTIFACTS_INFO_OUTPUTS_METRICS_PATH}"
+          METRICS_PATTERN="${STEPS_ARTIFACTS_INFO_OUTPUTS_METRICS_PATTERN}"
 
           # Combine all JSON files into an array and find min start time and max end time
           min_start=$(jq -r '.startTimeSeconds' ./$METRICS_PATH/$METRICS_PATTERN | sort | head -n 1)
@@ -1831,10 +1868,13 @@ jobs:
           fi
 
           echo "all_seed_files_deterministic=$all_seed_files_deterministic" >> $GITHUB_OUTPUT
+        env:
+          STEPS_ARTIFACTS_INFO_OUTPUTS_METRICS_PATH: ${{ steps.artifacts-info.outputs.metrics_path }}
+          STEPS_ARTIFACTS_INFO_OUTPUTS_METRICS_PATTERN: ${{ steps.artifacts-info.outputs.metrics_pattern }}
 
       - name: Post to PostHog
         # https://github.com/PostHog/posthog-github-action
-        uses: PostHog/posthog-github-action@v1
+        uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1
         with:
           posthog-token: ${{ secrets.POSTHOG_API_KEY }}
           event: "gh-actions-seed-test-metrics-event"

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -5,9 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  pull-requests: write
-  contents: write
-  issues: write
+  contents: read
 
 env:
   DO_NOT_TRACK: "1"
@@ -15,6 +13,9 @@ env:
 jobs:
   stale-prs-and-issues:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
@@ -30,6 +31,10 @@ jobs:
 
   stale-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: read
     steps:
       - uses: crs-k/stale-branches@865501af01284d43aef267d4b9aab0f9f1734b12 # v8.2.2
         with:

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -16,7 +16,7 @@ jobs:
   stale-prs-and-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           stale-issue-message: "This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 30 days."
           close-issue-message: "This issue was closed because it has been inactive for 30 days after being marked stale."
@@ -31,7 +31,7 @@ jobs:
   stale-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: crs-k/stale-branches@v8.2.2
+      - uses: crs-k/stale-branches@865501af01284d43aef267d4b9aab0f9f1734b12 # v8.2.2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           days-before-stale: 60

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -33,13 +33,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -28,6 +28,9 @@ env:
   TURBO_NO_UPDATE_NOTIFIER: "1"
   TURBO_DAEMON: "false"
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -37,6 +37,9 @@ env:
   TURBO_NO_UPDATE_NOTIFIER: "1"
   TURBO_DAEMON: "false"
 
+permissions:
+  contents: read
+
 jobs:
   # Determine which generator to test based on the triggering workflow
   determine-generator:

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
             # Map workflow name to generator
-            case "${{ github.event.workflow_run.name }}" in
+            case "${GITHUB_EVENT_WORKFLOW_RUN_NAME}" in
               "Publish TypeScript SDK Generator")
                 echo 'generators=["ts-sdk"]' >> $GITHUB_OUTPUT
                 ;;
@@ -64,7 +64,7 @@ jobs:
                 echo 'generators=["python-sdk"]' >> $GITHUB_OUTPUT
                 ;;
               *)
-                echo "Unknown workflow: ${{ github.event.workflow_run.name }}"
+                echo "Unknown workflow: ${GITHUB_EVENT_WORKFLOW_RUN_NAME}"
                 exit 1
                 ;;
             esac
@@ -72,6 +72,8 @@ jobs:
             # For schedule and workflow_dispatch, test all generators
             echo 'generators=["ts-sdk", "java-sdk", "go-sdk", "python-sdk"]' >> $GITHUB_OUTPUT
           fi
+        env:
+          GITHUB_EVENT_WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
 
   compile-and-build:
     needs: determine-generator
@@ -79,9 +81,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.branch || github.ref }}
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -96,14 +99,14 @@ jobs:
         run: pnpm seed:build
 
       - name: Upload Seed CLI
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: seed-cli
           path: packages/seed/dist/
           retention-days: 1
 
       - name: Upload Fern CLI
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: fern-cli
           path: packages/cli/cli/dist/prod/
@@ -126,21 +129,22 @@ jobs:
         generator: ${{ fromJson(needs.determine-generator.outputs.generators) }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.branch || github.ref }}
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Download Seed CLI
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: seed-cli
           path: packages/seed/dist/
 
       - name: Download Fern CLI
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: fern-cli
           path: packages/cli/cli/dist/prod/
@@ -149,7 +153,7 @@ jobs:
         run: chmod +x packages/cli/cli/dist/prod/cli.cjs packages/seed/dist/cli.cjs
 
       - name: Run Seed Test Remote-Local (${{ matrix.generator }})
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
           timeout_minutes: 30
           max_attempts: 5

--- a/.github/workflows/typescript-generator.yml
+++ b/.github/workflows/typescript-generator.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Fern
         run: npm install -g fern-api
@@ -25,5 +27,6 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
+          INPUTS_VERSION: ${{ inputs.version }}
         run: |
-          fern generate --api public-api --group node-sdk --version ${{ inputs.version }} --log-level debug
+          fern generate --api public-api --group node-sdk --version ${INPUTS_VERSION} --log-level debug

--- a/.github/workflows/typescript-generator.yml
+++ b/.github/workflows/typescript-generator.yml
@@ -11,6 +11,9 @@ on:
 env:
   DO_NOT_TRACK: "1"
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -74,14 +74,14 @@ jobs:
         id: set-update-options
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "refs/heads/main" ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${GITHUB_REF}" != "refs/heads/main" ]]; then
             echo "skip-scripts=true" >> $GITHUB_OUTPUT
             echo "update-by-push=true" >> $GITHUB_OUTPUT
             echo "update-by-pr=false" >> $GITHUB_OUTPUT
           else
             # For workflow_dispatch, check if skip-scripts checkbox is checked
             # For push events, default to false
-            if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.skip-scripts }}" == "true" ]]; then
+            if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${GITHUB_EVENT_INPUTS_SKIP_SCRIPTS}" == "true" ]]; then
               echo "skip-scripts=true" >> $GITHUB_OUTPUT
             else
               echo "skip-scripts=false" >> $GITHUB_OUTPUT
@@ -89,6 +89,8 @@ jobs:
             echo "update-by-push=false" >> $GITHUB_OUTPUT
             echo "update-by-pr=true" >> $GITHUB_OUTPUT
           fi
+        env:
+          GITHUB_EVENT_INPUTS_SKIP_SCRIPTS: ${{ github.event.inputs.skip-scripts }}
 
       - name: Set language filter
         id: set-language-filter
@@ -97,13 +99,15 @@ jobs:
           # For workflow_dispatch events, use the input language filter
           # For push events, default to 'all' to maintain existing behavior
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            SELECTED_LANGUAGE="${{ github.event.inputs.language }}"
+            SELECTED_LANGUAGE="${GITHUB_EVENT_INPUTS_LANGUAGE}"
             echo "Language filter from workflow_dispatch input: $SELECTED_LANGUAGE"
           else
             SELECTED_LANGUAGE="all"
             echo "Push event detected, running all languages"
           fi
           echo "selected-language=$SELECTED_LANGUAGE" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_EVENT_INPUTS_LANGUAGE: ${{ github.event.inputs.language }}
 
       - name: Set commit-on-failure option
         id: set-commit-on-failure
@@ -112,13 +116,15 @@ jobs:
           # For workflow_dispatch events, use the input commit-on-failure option
           # For push events, default to 'false' to maintain existing behavior
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            COMMIT_ON_FAILURE="${{ github.event.inputs.commit-on-failure }}"
+            COMMIT_ON_FAILURE="${GITHUB_EVENT_INPUTS_COMMIT_ON_FAILURE}"
             echo "Commit on failure option from workflow_dispatch input: $COMMIT_ON_FAILURE"
           else
             COMMIT_ON_FAILURE="false"
             echo "Push event detected, defaulting commit-on-failure to false"
           fi
           echo "commit-on-failure=$COMMIT_ON_FAILURE" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_EVENT_INPUTS_COMMIT_ON_FAILURE: ${{ github.event.inputs.commit-on-failure }}
 
       - name: Set fixture filter
         id: set-fixture-filter
@@ -127,13 +133,15 @@ jobs:
           # For workflow_dispatch events, use the input fixture filter
           # For push events, default to 'all' to maintain existing behavior
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            SELECTED_FIXTURE="${{ github.event.inputs.fixture }}"
+            SELECTED_FIXTURE="${GITHUB_EVENT_INPUTS_FIXTURE}"
             echo "Fixture filter from workflow_dispatch input: $SELECTED_FIXTURE"
           else
             SELECTED_FIXTURE="all"
             echo "Push event detected, running all fixtures"
           fi
           echo "selected-fixture=$SELECTED_FIXTURE" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_EVENT_INPUTS_FIXTURE: ${{ github.event.inputs.fixture }}
 
   changes:
     if: github.repository == 'fern-api/fern'
@@ -216,12 +224,13 @@ jobs:
 
     steps:
       - name: Checkout Files
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             ${{ matrix.files }}
             .github/
           fetch-tags: false
+          persist-credentials: false
 
       - name: Setup Base SHA
         id: setup-base-sha
@@ -230,7 +239,7 @@ jobs:
         run: |
           BASE_SHA=""
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.ref }}" != "refs/heads/main" ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${GITHUB_REF}" != "refs/heads/main" ]]; then
             # Use GitHub API to get merge base - git merge-base doesn't work with shallow clones
             CURRENT_SHA=$(git rev-parse HEAD)
             MAIN_SHA=$(gh api "/repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha')
@@ -268,7 +277,9 @@ jobs:
       - name: Set output
         id: set-output
         run: |
-          echo "${{ matrix.generator-name }}-changes=${{ steps.get-generator-changes.outputs.any_changed }}" >> $GITHUB_OUTPUT
+          echo "${{ matrix.generator-name }}-changes=${STEPS_GET_GENERATOR_CHANGES_OUTPUTS_ANY_CHANGED}" >> $GITHUB_OUTPUT
+        env:
+          STEPS_GET_GENERATOR_CHANGES_OUTPUTS_ANY_CHANGED: ${{ steps.get-generator-changes.outputs.any_changed }}
 
   get-all-test-matrices:
     runs-on: ubuntu-latest
@@ -293,7 +304,9 @@ jobs:
       rust-sdk: ${{ steps.create-dynamic-matrix.outputs.rust-sdk-test-matrix }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -307,7 +320,7 @@ jobs:
         id: create-dynamic-matrix
         shell: bash
         run: |
-          SELECTED_FIXTURE="${{ needs.setup.outputs.selected-fixture }}"
+          SELECTED_FIXTURE="${NEEDS_SETUP_OUTPUTS_SELECTED_FIXTURE}"
           
           # List of all generators.
           # Retired generators (pydantic v1 and the standalone *-model generators) are
@@ -336,6 +349,8 @@ jobs:
             echo "${GEN}-test-matrix=$MATRIX" >> $GITHUB_OUTPUT
             echo "Set output for $GEN: $MATRIX"
           done
+        env:
+          NEEDS_SETUP_OUTPUTS_SELECTED_FIXTURE: ${{ needs.setup.outputs.selected-fixture }}
 
   ruby-sdk-v2-seed-update:
     runs-on: ubuntu-latest
@@ -356,10 +371,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -393,10 +409,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -429,10 +446,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -465,10 +483,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -501,10 +520,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -538,10 +558,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -574,10 +595,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -611,10 +633,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -647,10 +670,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -684,10 +708,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -720,10 +745,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -757,10 +783,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -793,10 +820,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -829,10 +857,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -866,10 +895,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -902,10 +932,11 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/actions/
+          persist-credentials: false
 
       - name: Update seed
         uses: ./.github/actions/auto-update-seed
@@ -962,11 +993,12 @@ jobs:
 
       # Get action file specific to the running branch
       - name: Checkout Action File
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ steps.extract-branch.outputs.branch }}
           sparse-checkout: |
             .github/
+          persist-credentials: false
 
       # Match to all patch files, since we are committing all generator changes at once
       # Checkout the branch directly to avoid detaching the head so we can commit back changes
@@ -992,7 +1024,7 @@ jobs:
       # Commit all applied patches back to branch (will be checked out in apply-patches step)
       - name: Add and Commit Changes
         id: commit-changes
-        uses: EndBug/add-and-commit@v10
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10
         if: ${{ steps.apply-patches.outputs.has-patches == 'true' }}
         with:
           add: "seed/*"
@@ -1035,10 +1067,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Action File
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/
+          persist-credentials: false
 
       # Apply ALL seed patches at once (seed-*.patch matches every generator)
       - name: Apply Patches
@@ -1062,7 +1095,7 @@ jobs:
       - name: Create Pull Request
         if: steps.apply-patches.outputs.has-patches == 'true'
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           commit-message: "chore(seed): update all seed snapshots"
@@ -1085,11 +1118,13 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         shell: bash
         run: |
-          echo "PR Created: ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "PR Created: ${STEPS_CPR_OUTPUTS_PULL_REQUEST_URL}"
+        env:
+          STEPS_CPR_OUTPUTS_PULL_REQUEST_URL: ${{ steps.cpr.outputs.pull-request-url }}
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -45,8 +45,7 @@ concurrency:
 
 # These scope secrets.GITHUB_TOKEN
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 env:
   DO_NOT_TRACK: "1"
@@ -953,6 +952,8 @@ jobs:
   # Use always() to ensure this runs even if stages from needs are skipped.
   # By default, block on failures. If commit-on-failure is true, continue even if some seed runs fail.
   commit-seed-changes-by-push:
+    permissions:
+      contents: write # EndBug/add-and-commit pushes seed snapshots back to the branch
     if: >-
       ${{
         always() && !cancelled() && needs.setup.outputs.update-by-push == 'true' &&

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -15,6 +15,9 @@ env:
   TURBO_NO_UPDATE_NOTIFIER: "1"
   TURBO_DAEMON: "false"
 
+permissions:
+  contents: read
+
 jobs:
   update-test:
     if: github.repository == 'fern-api/fern' && github.ref != 'refs/heads/main'

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -22,15 +22,16 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           lfs: true
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -43,9 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -37,6 +37,9 @@ env:
   TURBO_NO_UPDATE_NOTIFIER: "1"
   TURBO_DAEMON: "false"
 
+permissions:
+  contents: read
+
 jobs:
   validate-changelogs:
     name: Validate Changelogs

--- a/.github/workflows/validate-ir-version-consistency.yml
+++ b/.github/workflows/validate-ir-version-consistency.yml
@@ -25,6 +25,9 @@ concurrency:
 env:
   DO_NOT_TRACK: "1"
 
+permissions:
+  contents: read
+
 jobs:
   validate-ir-versions:
     name: Validate IR Version Consistency

--- a/.github/workflows/validate-ir-version-consistency.yml
+++ b/.github/workflows/validate-ir-version-consistency.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             seed
@@ -39,6 +39,7 @@ jobs:
             scripts
             .github
           filter: tree:0
+          persist-credentials: false
 
       - name: Validate IR version consistency
         run: ./scripts/validate-ir-version-consistency.sh

--- a/.github/workflows/validate-versions-files.yml
+++ b/.github/workflows/validate-versions-files.yml
@@ -7,6 +7,9 @@ on:
 env:
   DO_NOT_TRACK: "1"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate versions.yml files

--- a/.github/workflows/validate-versions-files.yml
+++ b/.github/workflows/validate-versions-files.yml
@@ -13,84 +13,85 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             generators
             .github
+          persist-credentials: false
 
       - name: Validate go-sdk versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/go/sdk/versions.yml"
       - name: Validate go-model versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/go/model/versions.yml"
       - name: Validate python-sdk versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/python/sdk/versions.yml"
       - name: Validate pydantic versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/python/pydantic/versions.yml"
       - name: Validate ts-sdk versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/typescript/sdk/versions.yml"
       - name: Validate java-sdk versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/java/sdk/versions.yml"
       - name: Validate java-model versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/java/model/versions.yml"
       - name: Validate php-sdk versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/php/sdk/versions.yml"
       - name: Validate php-model versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/php/model/versions.yml"
       - name: Validate openapi versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/openapi/versions.yml"
       - name: Validate ruby-v2 versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/ruby-v2/sdk/versions.yml"
       - name: Validate csharp-sdk versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/csharp/sdk/versions.yml"
       - name: Validate csharp-model versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/csharp/model/versions.yml"
       - name: Validate rust-sdk versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/rust/sdk/versions.yml"
       - name: Validate rust-model versions.yml
-        uses: dsanders11/json-schema-validate-action@v2.0.0
+        uses: dsanders11/json-schema-validate-action@eddf079f55830cc9a916a3c512ba9086240d2fea # v2.0.0
         with:
           schema: "fern-versions-yml.schema.json"
           files: "generators/rust/model/versions.yml"

--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -24,9 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch of fern repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
+          persist-credentials: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -46,11 +47,12 @@ jobs:
           pnpm seed:local generate changelog cli -o ./changelogs/cli/ --clean-directory
 
       - name: Checkout main branch of docs repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: fern-api/docs
           ref: main
           path: docs
+          persist-credentials: false
 
       - name: update csharp-sdk changelog
         run: rsync -av --delete "changelogs/csharp-sdk/" "docs/fern/products/sdks/generators/csharp/changelog"
@@ -84,7 +86,7 @@ jobs:
 
       - name: create PR
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           commit-message: "update changelogs"
@@ -95,7 +97,7 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-number
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
@@ -106,4 +108,5 @@ jobs:
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
-        run: gh pr review ${{ steps.cpr.outputs.pull-request-number }} --repo fern-api/docs --approve
+          STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr review ${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER} --repo fern-api/docs --approve

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required to upload SARIF results to code scanning.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## Description

Linear ticket: n/a

Add the [zizmor](https://docs.zizmor.sh/) linter for GitHub Actions workflows, scoped via a new SARIF-uploading workflow at `.github/workflows/zizmor.yml`. Apply zizmor's safe auto-fixes across the existing workflow set, scope GitHub Actions permissions to the minimum needed per job, and add a `github-actions` Dependabot ecosystem with a 7-day cooldown so action SHA pins stay current without rapid churn.

## Changes Made

- New workflow `.github/workflows/zizmor.yml`. Runs on push to `main` and every PR; uploads findings to **Security → Code scanning** as SARIF. Pinned to `zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3`.
- `zizmor --fix=all` applied across 77 files (every workflow + composite action under `.github/`). Safe auto-fix categories:
    - `unpinned-uses`: all `uses:` references pinned to commit SHA + trailing version comment.
    - `artipacked` / `persist-credentials`: `actions/checkout` now sets `persist-credentials: false`.
    - `template-injection`: `${{ ... }}` inside `run:` blocks moved to `env:` and accessed via shell vars.
- One semantic change worth flagging from `--fix=all`: `.github/workflows/dependabot.yml` had `if: github.actor == 'dependabot[bot]'`; auto-fix rewrote it to `github.event.pull_request.user.login == 'dependabot[bot]'`. The new check is more robust — it survives maintainer re-runs (which flip `github.actor`).
- `excessive-permissions` scoping. Explicit `permissions:` blocks added to all 30 workflows that lacked them. Workflow-level default is `contents: read`; jobs that need more declare it at the job level:
    - `publish-cli.yml`, `publish-generator-cli.yml`, `publish-generator-migrations.yml`: `id-token: write` moved from workflow-level to the specific publishing jobs (OIDC trusted publishing to npm).
    - `stale-bot.yml`: split per-job — `issues: write` + `pull-requests: write` for the actions/stale job, `contents: write` + `issues: write` + `pull-requests: read` for the stale-branches job.
    - `update-seed.yml`: `contents: write` only on `commit-seed-changes-by-push` (the EndBug/add-and-commit step). The PR-creating job uses a PAT throughout so GITHUB_TOKEN only needs `contents: read`.
- `.github/dependabot.yml`: new `github-actions` ecosystem entry (weekly) and `cooldown.default-days: 7` added to npm + gomod (existing) and github-actions (new). Gives upstream releases time to soak for bugs before Dependabot proposes bumps.
- [ ] Updated README.md generator (if applicable) — n/a

### Findings count

| Stage | Count |
|---|---|
| Before any changes | 663 |
| After `--fix=all` | 111 |
| After permissions scoping | 6 |

All 105 `excessive-permissions` findings are resolved.

### Remaining 6 findings (out of scope for this PR)

- 2 `dangerous-triggers`: `lint-pr-title.yml` (uses `pull_request_target` with only `pull-requests: read` and no PR checkout — defensible) and `test-remote-vs-local-generation-parity.yml` (uses `workflow_run` with names pinned to trusted publish workflows — intended).
- 3 `template-injection` (Informational): complex rewrites in `sdk-ete-tests.yml` and `seed.yml` that the auto-fix didn't attempt.
- 1 `github-env` (Low confidence): constant-string append, not interpolated.

Each warrants a focused follow-up rather than a one-line edit.

## Testing

- [x] Local zizmor re-run after each commit. Final count: 0 `excessive-permissions` findings (down from 105).
- [x] YAML syntax validated across all 60 workflow files post-edit.
- [x] Full CI run — all required checks pass (`test`, `test-ete`, `compile`, `lint`, `biome`, `depcheck`, `Validate versions.yml`, `Lint PR title`).
- [x] zizmor workflow itself runs cleanly on this PR.

Link to Devin session: https://app.devin.ai/sessions/45278f18466b470c9e50479b07dacfdd
Requested by: @broady