### PR TITLE
feat(cli-v2): wire up npm + GitHub Release binary release pipeline

### DIFF
--- a/.github/workflows/release-cli-v2.yml
+++ b/.github/workflows/release-cli-v2.yml
@@ -5,10 +5,12 @@ name: Release Fern CLI v2
 #   - GitHub Release: per-platform tarballs/zips + SHA256SUMS + provenance attestation
 #
 # Triggers:
-#   - push of a tag matching `cli-v2/v*` (e.g. `cli-v2/v0.1.0`, `cli-v2/v0.2.0-rc.1`)
+#   - push of a tag matching `cli-v2/v*` (e.g. `cli-v2/v6.0.0`, `cli-v2/v6.1.0-rc.1`)
 #   - manual `workflow_dispatch` for build-only dry runs (no publish / no release)
 #
-# See packages/cli/cli-v2/CLAUDE.md for the release runbook.
+# Versioning: CLI v2 starts at 6.0.0, continuing from where CLI v1 (fern-api) left off
+# at 5.x. On the first stable release, fern-api is deprecated on npm pointing users
+# to @fern-api/fern. See packages/cli/cli-v2/CLAUDE.md for the release runbook.
 
 on:
   push:
@@ -17,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build (e.g. 0.1.0). For manual / dry-run testing — does not push a tag."
+        description: "Version to build (e.g. 6.0.0). For manual / dry-run testing — does not push a tag."
         required: true
         type: string
       dry_run:
@@ -255,3 +257,18 @@ jobs:
           set -euo pipefail
           cd dist-npm/wrapper
           npm publish --access public --provenance --tag "$NPM_TAG"
+
+      # On stable releases, mark the legacy fern-api package as deprecated so users
+      # are directed to @fern-api/fern. fern-api is not configured for OIDC trusted
+      # publishing, so this step uses a classic npm token stored as the repository
+      # secret FERN_API_NPM_TOKEN (Settings → Secrets → Actions). Add this secret
+      # before the first stable release or this step will fail.
+      - name: Deprecate legacy fern-api package
+        if: ${{ needs.plan.outputs.is_prerelease == 'false' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.FERN_API_NPM_TOKEN }}
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: |
+          set -euo pipefail
+          npm deprecate fern-api \
+            "fern-api has moved to @fern-api/fern. Please update your install: npm install -g @fern-api/fern@${VERSION}"

--- a/.github/workflows/release-cli-v2.yml
+++ b/.github/workflows/release-cli-v2.yml
@@ -1,0 +1,257 @@
+name: Release Fern CLI v2
+
+# Builds and publishes the Fern CLI v2 binaries:
+#   - npm: @fern-api/fern (wrapper) + @fern-api/fern-<os>-<cpu> (5 platforms)
+#   - GitHub Release: per-platform tarballs/zips + SHA256SUMS + provenance attestation
+#
+# Triggers:
+#   - push of a tag matching `cli-v2/v*` (e.g. `cli-v2/v0.1.0`, `cli-v2/v0.2.0-rc.1`)
+#   - manual `workflow_dispatch` for build-only dry runs (no publish / no release)
+#
+# See packages/cli/cli-v2/CLAUDE.md for the release runbook.
+
+on:
+  push:
+    tags:
+      - "cli-v2/v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build (e.g. 0.1.0). For manual / dry-run testing — does not push a tag."
+        required: true
+        type: string
+      dry_run:
+        description: "Build artifacts but skip GitHub Release and npm publish."
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  DO_NOT_TRACK: "1"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_NO_UPDATE_NOTIFIER: "1"
+  TURBO_DAEMON: "false"
+
+concurrency:
+  group: release-cli-v2-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Compute release plan
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.plan.outputs.version }}
+      dry_run: ${{ steps.plan.outputs.dry_run }}
+      npm_tag: ${{ steps.plan.outputs.npm_tag }}
+      is_prerelease: ${{ steps.plan.outputs.is_prerelease }}
+    steps:
+      - name: Compute version, npm dist-tag, and dry-run flag
+        id: plan
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+            DRY_RUN="$INPUT_DRY_RUN"
+          else
+            # Tag push: refs/tags/cli-v2/vX.Y.Z[-prerelease]
+            VERSION="${GITHUB_REF#refs/tags/cli-v2/v}"
+            DRY_RUN="false"
+          fi
+          if [[ "$VERSION" == *-* ]]; then
+            IS_PRERELEASE="true"
+            # Use the prerelease identifier as the npm dist-tag (e.g. "rc", "next", "beta").
+            LABEL="${VERSION#*-}"
+            NPM_TAG="${LABEL%%.*}"
+          else
+            IS_PRERELEASE="false"
+            NPM_TAG="latest"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "Plan: version=$VERSION dry_run=$DRY_RUN npm_tag=$NPM_TAG is_prerelease=$IS_PRERELEASE"
+
+  build:
+    name: Build binaries + assemble artifacts
+    needs: plan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # for build provenance attestation
+      attestations: write
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install repo
+        uses: ./.github/actions/install
+
+      - name: Build cli-v2 dev bundle
+        run: pnpm turbo run dist:cli:dev --filter @fern-api/cli-v2
+
+      - name: Cross-compile binaries (Bun)
+        run: pnpm --filter @fern-api/cli-v2 dist:bin
+
+      - name: Assemble npm packages + archives
+        run: |
+          cd packages/cli/cli-v2
+          node build.npm.mjs --version=${{ needs.plan.outputs.version }}
+
+      - name: Attest build provenance for binaries and archives
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            packages/cli/cli-v2/dist/bin/*
+            packages/cli/cli-v2/dist/archives/*.tar.gz
+            packages/cli/cli-v2/dist/archives/*.zip
+
+      - name: Upload archives artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: cli-v2-archives
+          path: packages/cli/cli-v2/dist/archives/
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload npm packages artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: cli-v2-npm-packages
+          path: packages/cli/cli-v2/dist/npm/
+          if-no-files-found: error
+          retention-days: 14
+
+  github-release:
+    name: Create GitHub Release
+    needs: [plan, build]
+    if: ${{ needs.plan.outputs.dry_run != 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Download archives
+        uses: actions/download-artifact@v5
+        with:
+          name: cli-v2-archives
+          path: archives/
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.plan.outputs.version }}
+          IS_PRERELEASE: ${{ needs.plan.outputs.is_prerelease }}
+        run: |
+          set -euo pipefail
+          TAG="cli-v2/v${VERSION}"
+          PRERELEASE_FLAG=""
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          NOTES=$(cat <<EOF
+          Fern CLI v2 — v${VERSION}
+
+          ## Install
+
+          \`\`\`sh
+          npm install -g @fern-api/fern@${VERSION}
+          \`\`\`
+
+          Or download a tarball/zip below and run the binary directly. Each
+          archive ships a \`.sha256\` checksum and a [build provenance
+          attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+          you can verify with the \`gh\` CLI:
+
+          \`\`\`sh
+          gh attestation verify <archive> --repo fern-api/fern
+          \`\`\`
+
+          ## Verify checksums
+
+          \`\`\`sh
+          sha256sum -c SHA256SUMS
+          \`\`\`
+          EOF
+          )
+          gh release create "$TAG" archives/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Fern CLI v2 v${VERSION}" \
+            --notes "$NOTES" \
+            $PRERELEASE_FLAG
+
+  publish-npm:
+    name: Publish to npm
+    needs: [plan, build]
+    if: ${{ needs.plan.outputs.dry_run != 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # for npm trusted publishing (OIDC) + provenance
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      # npm >= 11.5.1 is required for OIDC trusted publishing.
+      # Two-step upgrade works around Node 22.22.2 regression (npm/cli#9151).
+      # See publish-cli.yml for the same workaround in the v1 CLI flow.
+      - name: Update npm for OIDC publishing
+        run: npm install -g npm@10.9.8 && npm install -g npm@11
+
+      - name: Download npm packages
+        uses: actions/download-artifact@v5
+        with:
+          name: cli-v2-npm-packages
+          path: dist-npm/
+
+      # Publish platform packages BEFORE the wrapper so the wrapper's
+      # optionalDependencies resolve correctly for users installing in the
+      # narrow window between the two publishes.
+      - name: Publish platform packages
+        env:
+          NPM_TAG: ${{ needs.plan.outputs.npm_tag }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          dirs=(dist-npm/fern-*)
+          if [ ${#dirs[@]} -eq 0 ]; then
+            echo "No platform packages found in dist-npm/" >&2
+            exit 1
+          fi
+          for dir in "${dirs[@]}"; do
+            echo "::group::Publish $(basename "$dir")"
+            (cd "$dir" && npm publish --access public --provenance --tag "$NPM_TAG")
+            echo "::endgroup::"
+          done
+
+      - name: Publish wrapper
+        env:
+          NPM_TAG: ${{ needs.plan.outputs.npm_tag }}
+        run: |
+          set -euo pipefail
+          cd dist-npm/wrapper
+          npm publish --access public --provenance --tag "$NPM_TAG"

--- a/package.json
+++ b/package.json
@@ -146,7 +146,9 @@
     "!**/generated",
     "!packages/cli/cli/dist/local",
     "!packages/cli/cli/dist/dev",
-    "!packages/cli/cli/dist/prod"
+    "!packages/cli/cli/dist/prod",
+    "!packages/cli/cli-v2/dist/**",
+    "!packages/cli/cli-v2/npm/**"
   ],
   "dependencies": {
     "js-yaml": "catalog:"

--- a/packages/cli/cli-v2/.gitignore
+++ b/packages/cli/cli-v2/.gitignore
@@ -1,1 +1,2 @@
 *.bun-build
+dist/

--- a/packages/cli/cli-v2/CLAUDE.md
+++ b/packages/cli/cli-v2/CLAUDE.md
@@ -121,14 +121,29 @@ Build pipeline:
 `dist:npm` requires `--version`, e.g.
 `node build.npm.mjs --version=0.1.0`. See `build.npm.mjs` and `npm/README.md`.
 
+### Versioning strategy
+
+CLI v2 starts at **6.0.0**, continuing the semver timeline from where CLI v1
+(`fern-api`) left off at 5.x. This keeps the version history coherent for
+users migrating from `fern-api` to `@fern-api/fern`.
+
+- Pre-releases before the stable launch use `6.0.0-rc.1`, `6.0.0-rc.2`, etc.
+- The first stable tag must be `cli-v2/v6.0.0`.
+- On the first stable release, CI automatically runs `npm deprecate fern-api`
+  to redirect users to `@fern-api/fern`. This requires a classic npm token
+  with publish access to `fern-api` stored as the **`FERN_API_NPM_TOKEN`**
+  repository secret (Settings → Secrets → Actions). Add this secret before
+  cutting the first stable release.
+
 ### Cutting a release
 
-1. **Pick a version.** Use SemVer. Pre-releases use a dash: `0.2.0-rc.1` →
-   npm dist-tag `rc`. Stable releases get dist-tag `latest`.
+1. **Pick a version.** Use SemVer starting from 6.0.0. Pre-releases use a
+   dash: `6.0.0-rc.1` → npm dist-tag `rc`. Stable releases get dist-tag
+   `latest`.
 2. **Tag and push.** Tag scheme is `cli-v2/v<version>`:
    ```sh
-   git tag cli-v2/v0.1.0
-   git push origin cli-v2/v0.1.0
+   git tag cli-v2/v6.0.0
+   git push origin cli-v2/v6.0.0
    ```
 3. **CI does the rest.** `.github/workflows/release-cli-v2.yml` triggers on
    `cli-v2/v*` tags and:
@@ -138,6 +153,8 @@ Build pipeline:
      and a build provenance attestation
    - publishes to npm via OIDC trusted publishing (no token), with npm
      package provenance
+   - on stable releases only: deprecates `fern-api` on npm, pointing users
+     to `@fern-api/fern` (requires `FERN_API_NPM_TOKEN` secret)
 
 ### Dry-run / smoke test
 
@@ -151,7 +168,7 @@ Locally:
 pnpm --filter @fern-api/cli-v2 dist:cli:dev
 pnpm --filter @fern-api/cli-v2 dist:bin
 cd packages/cli/cli-v2
-node build.npm.mjs --version=0.0.0-dev
+node build.npm.mjs --version=6.0.0-dev
 cd dist/npm/wrapper && npm pack --dry-run
 ```
 

--- a/packages/cli/cli-v2/CLAUDE.md
+++ b/packages/cli/cli-v2/CLAUDE.md
@@ -85,3 +85,91 @@ expect(getStderr()).toContain("expected message");
 ```
 
 Test utilities live in `src/__test__/utils/`. Command tests live in `src/commands/*/__test__/`.
+
+## Releasing
+
+CLI v2 ships as **platform-specific native binaries** distributed via npm and GitHub Releases.
+
+### Layout
+
+```
+@fern-api/fern                                    # wrapper (thin Node launcher)
+@fern-api/fern-darwin-arm64                       # platform packages
+@fern-api/fern-darwin-x64                         #   one per supported OS/arch
+@fern-api/fern-linux-arm64                        #   pinned to the same version
+@fern-api/fern-linux-x64                          #   as the wrapper
+@fern-api/fern-win32-x64
+```
+
+`bun build --compile` produces one self-contained binary per platform from
+`dist/dev/cli.cjs`. The wrapper has the five platform packages as
+`optionalDependencies` with `os`/`cpu` fields set, so npm installs only the
+package matching the current platform. The wrapper's `bin/fern` Node launcher
+resolves `@fern-api/fern-<os>-<cpu>/bin/fern[.exe]` and execs it. This is the
+same pattern used by `@bufbuild/buf`, `esbuild`, `@rollup/rollup-*`, and
+`@swc/core-*`.
+
+Build pipeline:
+
+| script                  | what it does                                                      |
+| ----------------------- | ----------------------------------------------------------------- |
+| `pnpm dist:cli:dev`     | `tsup` bundle → `dist/dev/cli.cjs`                                |
+| `pnpm dist:bin`         | `bun --compile` × 5 → `dist/bin/fern-<plat>[.exe]`                 |
+| `pnpm dist:npm`         | template + binaries → `dist/npm/{wrapper,fern-<plat>}/` + archives |
+| `pnpm dist:release`     | runs all three end-to-end                                          |
+
+`dist:npm` requires `--version`, e.g.
+`node build.npm.mjs --version=0.1.0`. See `build.npm.mjs` and `npm/README.md`.
+
+### Cutting a release
+
+1. **Pick a version.** Use SemVer. Pre-releases use a dash: `0.2.0-rc.1` →
+   npm dist-tag `rc`. Stable releases get dist-tag `latest`.
+2. **Tag and push.** Tag scheme is `cli-v2/v<version>`:
+   ```sh
+   git tag cli-v2/v0.1.0
+   git push origin cli-v2/v0.1.0
+   ```
+3. **CI does the rest.** `.github/workflows/release-cli-v2.yml` triggers on
+   `cli-v2/v*` tags and:
+   - cross-compiles all 5 binaries with Bun
+   - assembles `@fern-api/fern` + 5 platform packages
+   - creates a GitHub Release with platform tarballs/zips, SHA256 checksums,
+     and a build provenance attestation
+   - publishes to npm via OIDC trusted publishing (no token), with npm
+     package provenance
+
+### Dry-run / smoke test
+
+Use the workflow's `workflow_dispatch` with `dry_run=true` to build everything
+without publishing or creating a release. Artifacts (`cli-v2-archives` and
+`cli-v2-npm-packages`) are uploaded so you can download and inspect.
+
+Locally:
+
+```sh
+pnpm --filter @fern-api/cli-v2 dist:cli:dev
+pnpm --filter @fern-api/cli-v2 dist:bin
+cd packages/cli/cli-v2
+node build.npm.mjs --version=0.0.0-dev
+cd dist/npm/wrapper && npm pack --dry-run
+```
+
+### Supported platforms
+
+Bun cross-compiles for `darwin-arm64`, `darwin-x64`, `linux-arm64`,
+`linux-x64`, and `win32-x64`. There is no `linux-x64-musl` cross target
+yet; Alpine users should install `gcompat` to run the glibc binary:
+
+```sh
+apk add gcompat
+```
+
+### Naming, signing, and what's next
+
+- **Phase 1 (this workflow):** unsigned binaries, npm with provenance,
+  GitHub Release with checksums + attestation, tag-driven.
+- **Phase 2:** macOS notarization + Windows Authenticode signing.
+- **Phase 3:** Homebrew tap, Scoop bucket, winget manifest (all consume the
+  GitHub Release artifacts).
+- **Phase 4:** binary-aware in-CLI auto-update.

--- a/packages/cli/cli-v2/build.npm.mjs
+++ b/packages/cli/cli-v2/build.npm.mjs
@@ -1,0 +1,289 @@
+// Assembles the npm packages and GitHub Release archives for the Fern CLI v2
+// from the Bun-compiled binaries in `dist/bin/`.
+//
+// Output:
+//   dist/npm/wrapper/                         → @fern-api/fern
+//   dist/npm/fern-<os>-<cpu>/                 → @fern-api/fern-<os>-<cpu>
+//   dist/archives/fern-cli-v2-<v>-<plat>.tar.gz (or .zip on windows)
+//   dist/archives/fern-cli-v2-<v>-<plat>.<ext>.sha256
+//   dist/archives/SHA256SUMS
+//
+// Usage:
+//   node build.npm.mjs --version=0.1.0           # full build (npm + archives)
+//   node build.npm.mjs --version=0.1.0 --npm-only
+//   node build.npm.mjs --version=0.1.0 --archives-only
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+
+// Keep this in lockstep with build.compile.mjs (TARGETS) and
+// npm/wrapper/bin/fern (PLATFORM_PACKAGES).
+//
+//   binaryName   — file under dist/bin/ produced by build.compile.mjs
+//   pkgSlug      — slug used in the platform package name (@fern-api/fern-<slug>)
+//                  and in archive filenames. Must match the npm os-cpu
+//                  convention (process.platform / process.arch values).
+//   archiveSlug  — slug used in the archive filename (kept identical to
+//                  pkgSlug for now, but we leave a separate field in case we
+//                  ever want to diverge for marketing/UX reasons).
+//   os           — npm `os` field value (matches process.platform).
+//   cpu          — npm `cpu` field value (matches process.arch).
+//   binFile      — name of the binary inside the platform package's bin/.
+//   archiveType  — "tar.gz" or "zip".
+const PLATFORMS = [
+    {
+        binaryName: "fern-darwin-arm64",
+        pkgSlug: "darwin-arm64",
+        archiveSlug: "darwin-arm64",
+        os: "darwin",
+        cpu: "arm64",
+        binFile: "fern",
+        archiveType: "tar.gz"
+    },
+    {
+        binaryName: "fern-darwin-x64",
+        pkgSlug: "darwin-x64",
+        archiveSlug: "darwin-x64",
+        os: "darwin",
+        cpu: "x64",
+        binFile: "fern",
+        archiveType: "tar.gz"
+    },
+    {
+        binaryName: "fern-linux-arm64",
+        pkgSlug: "linux-arm64",
+        archiveSlug: "linux-arm64",
+        os: "linux",
+        cpu: "arm64",
+        binFile: "fern",
+        archiveType: "tar.gz"
+    },
+    {
+        binaryName: "fern-linux-x64",
+        pkgSlug: "linux-x64",
+        archiveSlug: "linux-x64",
+        os: "linux",
+        cpu: "x64",
+        binFile: "fern",
+        archiveType: "tar.gz"
+    },
+    {
+        binaryName: "fern-windows-x64.exe",
+        pkgSlug: "win32-x64",
+        archiveSlug: "win32-x64",
+        os: "win32",
+        cpu: "x64",
+        binFile: "fern.exe",
+        archiveType: "zip"
+    }
+];
+
+function parseArgs() {
+    const args = { version: null, npmOnly: false, archivesOnly: false };
+    for (const arg of process.argv.slice(2)) {
+        if (arg.startsWith("--version=")) {
+            args.version = arg.slice("--version=".length);
+        } else if (arg === "--npm-only") {
+            args.npmOnly = true;
+        } else if (arg === "--archives-only") {
+            args.archivesOnly = true;
+        } else if (arg === "--help" || arg === "-h") {
+            process.stdout.write("Usage: node build.npm.mjs --version=X.Y.Z [--npm-only|--archives-only]\n");
+            process.exit(0);
+        } else {
+            process.stderr.write(`Unknown argument: ${arg}\n`);
+            process.exit(1);
+        }
+    }
+    if (args.version == null || args.version === "") {
+        process.stderr.write("Missing required --version=X.Y.Z flag.\n");
+        process.exit(1);
+    }
+    if (args.npmOnly && args.archivesOnly) {
+        process.stderr.write("--npm-only and --archives-only are mutually exclusive.\n");
+        process.exit(1);
+    }
+    return args;
+}
+
+function ensureBinariesExist(missingBinariesOk) {
+    const binDir = path.join(__dirname, "dist", "bin");
+    if (!existsSync(binDir)) {
+        process.stderr.write(`Binary directory not found: ${binDir}\n`);
+        process.stderr.write("Run 'pnpm dist:bin' first.\n");
+        process.exit(1);
+    }
+    const missing = [];
+    for (const platform of PLATFORMS) {
+        const p = path.join(binDir, platform.binaryName);
+        if (!existsSync(p)) {
+            missing.push(platform.binaryName);
+        }
+    }
+    if (missing.length > 0 && !missingBinariesOk) {
+        process.stderr.write(`Missing binaries in dist/bin/: ${missing.join(", ")}\n`);
+        process.stderr.write("Run 'pnpm dist:bin' first.\n");
+        process.exit(1);
+    }
+    return missing;
+}
+
+function replacePlaceholders(content, replacements) {
+    let out = content;
+    for (const [from, to] of Object.entries(replacements)) {
+        out = out.split(from).join(to);
+    }
+    return out;
+}
+
+function writeWrapperPackage(version, outDir) {
+    const srcDir = path.join(__dirname, "npm", "wrapper");
+    rmSync(outDir, { recursive: true, force: true });
+    mkdirSync(outDir, { recursive: true });
+    cpSync(srcDir, outDir, { recursive: true });
+
+    const pkgJsonPath = path.join(outDir, "package.json");
+    const pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+    pkgJson.version = version;
+    for (const slug of PLATFORMS.map((p) => p.pkgSlug)) {
+        pkgJson.optionalDependencies[`@fern-api/fern-${slug}`] = version;
+    }
+    writeFileSync(pkgJsonPath, `${JSON.stringify(pkgJson, null, 2)}\n`);
+
+    cpSync(path.join(REPO_ROOT, "LICENSE"), path.join(outDir, "LICENSE"));
+
+    // Make sure bin/fern is executable. npm preserves the mode bits at publish
+    // time, so this matters for the published tarball.
+    const launcher = path.join(outDir, "bin", "fern");
+    execFileSync("chmod", ["+x", launcher]);
+}
+
+function writePlatformPackage(version, platform, outDir) {
+    const srcDir = path.join(__dirname, "npm", "platform");
+    rmSync(outDir, { recursive: true, force: true });
+    mkdirSync(path.join(outDir, "bin"), { recursive: true });
+
+    const replacements = {
+        PLATFORM_PLACEHOLDER: platform.pkgSlug,
+        OS_PLACEHOLDER: platform.os,
+        CPU_PLACEHOLDER: platform.cpu,
+        "0.0.0-PLACEHOLDER": version
+    };
+
+    const pkgJson = replacePlaceholders(readFileSync(path.join(srcDir, "package.json"), "utf8"), replacements);
+    writeFileSync(path.join(outDir, "package.json"), pkgJson);
+
+    const readme = replacePlaceholders(readFileSync(path.join(srcDir, "README.md"), "utf8"), replacements);
+    writeFileSync(path.join(outDir, "README.md"), readme);
+
+    cpSync(path.join(REPO_ROOT, "LICENSE"), path.join(outDir, "LICENSE"));
+
+    const binSrc = path.join(__dirname, "dist", "bin", platform.binaryName);
+    const binDst = path.join(outDir, "bin", platform.binFile);
+    cpSync(binSrc, binDst);
+    if (platform.os !== "win32") {
+        execFileSync("chmod", ["+x", binDst]);
+    }
+}
+
+function sha256(filePath) {
+    const buf = readFileSync(filePath);
+    return createHash("sha256").update(buf).digest("hex");
+}
+
+function writeArchive(version, platform, archivesDir) {
+    mkdirSync(archivesDir, { recursive: true });
+
+    const archiveStem = `fern-cli-v2-${version}-${platform.archiveSlug}`;
+    const archiveName = `${archiveStem}.${platform.archiveType}`;
+    const archivePath = path.join(archivesDir, archiveName);
+
+    // Stage the contents in a tmp dir so the archive root is a clean
+    // (binary + LICENSE + README) bundle.
+    const stagingDir = path.join(archivesDir, `staging-${platform.archiveSlug}`);
+    rmSync(stagingDir, { recursive: true, force: true });
+    mkdirSync(stagingDir, { recursive: true });
+
+    cpSync(path.join(__dirname, "dist", "bin", platform.binaryName), path.join(stagingDir, platform.binFile));
+    if (platform.os !== "win32") {
+        execFileSync("chmod", ["+x", path.join(stagingDir, platform.binFile)]);
+    }
+    cpSync(path.join(REPO_ROOT, "LICENSE"), path.join(stagingDir, "LICENSE"));
+
+    const readmePath = path.join(__dirname, "npm", "wrapper", "README.md");
+    if (existsSync(readmePath)) {
+        cpSync(readmePath, path.join(stagingDir, "README.md"));
+    }
+
+    if (platform.archiveType === "tar.gz") {
+        execFileSync("tar", ["-czf", archivePath, "-C", stagingDir, "."]);
+    } else if (platform.archiveType === "zip") {
+        // -j strips leading directories so the binary is at the archive root.
+        execFileSync("zip", ["-j", "-q", archivePath, ...readdirSync(stagingDir).map((f) => path.join(stagingDir, f))]);
+    } else {
+        throw new Error(`Unknown archive type: ${platform.archiveType}`);
+    }
+
+    rmSync(stagingDir, { recursive: true, force: true });
+
+    const checksum = sha256(archivePath);
+    writeFileSync(path.join(archivesDir, `${archiveName}.sha256`), `${checksum}  ${archiveName}\n`);
+
+    return { archiveName, checksum, size: statSync(archivePath).size };
+}
+
+function formatSize(bytes) {
+    const mb = bytes / (1024 * 1024);
+    return `${mb.toFixed(1)} MB`;
+}
+
+function main() {
+    const args = parseArgs();
+    const version = args.version;
+
+    process.stdout.write(`Building Fern CLI v2 npm packages and archives @ ${version}\n\n`);
+
+    ensureBinariesExist(false);
+
+    const distNpm = path.join(__dirname, "dist", "npm");
+    const distArchives = path.join(__dirname, "dist", "archives");
+
+    if (!args.archivesOnly) {
+        rmSync(distNpm, { recursive: true, force: true });
+        process.stdout.write("npm packages:\n");
+        const wrapperDir = path.join(distNpm, "wrapper");
+        writeWrapperPackage(version, wrapperDir);
+        process.stdout.write(`  ✓ @fern-api/fern → ${path.relative(REPO_ROOT, wrapperDir)}\n`);
+        for (const platform of PLATFORMS) {
+            const platformDir = path.join(distNpm, `fern-${platform.pkgSlug}`);
+            writePlatformPackage(version, platform, platformDir);
+            process.stdout.write(`  ✓ @fern-api/fern-${platform.pkgSlug} → ${path.relative(REPO_ROOT, platformDir)}\n`);
+        }
+        process.stdout.write("\n");
+    }
+
+    if (!args.npmOnly) {
+        rmSync(distArchives, { recursive: true, force: true });
+        mkdirSync(distArchives, { recursive: true });
+        process.stdout.write("archives:\n");
+        const sumsLines = [];
+        for (const platform of PLATFORMS) {
+            const { archiveName, checksum, size } = writeArchive(version, platform, distArchives);
+            process.stdout.write(`  ✓ ${archiveName} (${formatSize(size)})\n`);
+            sumsLines.push(`${checksum}  ${archiveName}`);
+        }
+        writeFileSync(path.join(distArchives, "SHA256SUMS"), sumsLines.join("\n") + "\n");
+        process.stdout.write(`  ✓ SHA256SUMS\n`);
+        process.stdout.write("\n");
+    }
+
+    process.stdout.write("Done.\n");
+}
+
+main();

--- a/packages/cli/cli-v2/npm/README.md
+++ b/packages/cli/cli-v2/npm/README.md
@@ -1,0 +1,19 @@
+# NPM Distribution Layout
+
+This directory holds the templates that drive `build.npm.mjs`. The script
+assembles six publishable npm packages from the Bun-compiled binaries in
+`dist/bin/`:
+
+- **Wrapper** `@fern-api/fern` — `npm/wrapper/` is copied to `dist/npm/wrapper/`
+  with `version` and `optionalDependencies` versions stamped at build time.
+  It contains a tiny Node launcher (`bin/fern`) that resolves the platform-
+  specific package and execs its binary.
+- **Platform packages** `@fern-api/fern-<os>-<cpu>` — `npm/platform/` is the
+  template; one copy per supported (os, cpu) pair is stamped out under
+  `dist/npm/fern-<os>-<cpu>/`. Each contains a single binary and a
+  `package.json` with `os` and `cpu` set so npm only installs the matching
+  one when a user installs the wrapper.
+
+This is the same layout used by `@bufbuild/buf`, `esbuild`, `@rollup/rollup-*`,
+`@swc/core-*`, `lightningcss-*`, `@biomejs/biome`, and so on. See FER-8626 and
+`docs/release-cli-v2.md` for details.

--- a/packages/cli/cli-v2/npm/platform/README.md
+++ b/packages/cli/cli-v2/npm/platform/README.md
@@ -1,0 +1,11 @@
+# @fern-api/fern-PLATFORM_PLACEHOLDER
+
+The OS_PLACEHOLDER/CPU_PLACEHOLDER binary for the [Fern](https://buildwithfern.com) CLI.
+
+This package is installed automatically as an optional dependency of
+[`@fern-api/fern`](https://www.npmjs.com/package/@fern-api/fern). You should
+not need to depend on it directly.
+
+## License
+
+[Apache 2.0](https://github.com/fern-api/fern/blob/main/LICENSE)

--- a/packages/cli/cli-v2/npm/platform/package.json
+++ b/packages/cli/cli-v2/npm/platform/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@fern-api/fern-PLATFORM_PLACEHOLDER",
+  "version": "0.0.0-PLACEHOLDER",
+  "description": "OS_PLACEHOLDER/CPU_PLACEHOLDER binary for the Fern CLI.",
+  "homepage": "https://github.com/fern-api/fern#readme",
+  "bugs": {
+    "url": "https://github.com/fern-api/fern/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fern-api/fern.git",
+    "directory": "packages/cli/cli-v2"
+  },
+  "os": ["OS_PLACEHOLDER"],
+  "cpu": ["CPU_PLACEHOLDER"],
+  "files": ["bin", "LICENSE", "README.md"],
+  "preferUnplugged": true
+}

--- a/packages/cli/cli-v2/npm/wrapper/README.md
+++ b/packages/cli/cli-v2/npm/wrapper/README.md
@@ -1,0 +1,52 @@
+# @fern-api/fern
+
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+The [Fern](https://buildwithfern.com) CLI: build SDKs and developer docs for your API.
+
+## Install
+
+```sh
+npm install -g @fern-api/fern
+```
+
+This installs the platform-specific binary for your machine via npm's
+`optionalDependencies` mechanism. Supported platforms:
+
+| Package                          | OS      | CPU    |
+| -------------------------------- | ------- | ------ |
+| `@fern-api/fern-darwin-arm64`    | macOS   | arm64  |
+| `@fern-api/fern-darwin-x64`      | macOS   | x86_64 |
+| `@fern-api/fern-linux-arm64`     | Linux   | arm64  |
+| `@fern-api/fern-linux-x64`       | Linux   | x86_64 |
+| `@fern-api/fern-win32-x64`       | Windows | x86_64 |
+
+If you're on Alpine or another musl-based Linux distro, install `gcompat`
+first so the glibc binary can run:
+
+```sh
+apk add gcompat
+```
+
+## Use
+
+```sh
+fern --help
+fern --version
+```
+
+You can also run without installing globally:
+
+```sh
+npx @fern-api/fern --help
+```
+
+## Direct download (no Node required)
+
+Each release also ships a tarball/zip per platform on the
+[GitHub Releases page](https://github.com/fern-api/fern/releases). Each archive
+is accompanied by a `.sha256` checksum and a build provenance attestation.
+
+## License
+
+[Apache 2.0](https://github.com/fern-api/fern/blob/main/LICENSE)

--- a/packages/cli/cli-v2/npm/wrapper/bin/fern
+++ b/packages/cli/cli-v2/npm/wrapper/bin/fern
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Launcher for the Fern CLI binary.
+//
+// This script resolves the platform-specific `@fern-api/fern-<os>-<arch>`
+// package that was installed via the `optionalDependencies` of `@fern-api/fern`
+// and execs its binary with the user's args. The platform packages contain
+// pre-compiled native binaries; `os` and `cpu` fields in their package.json
+// cause npm/pnpm/yarn to only install the package matching the current
+// platform.
+//
+// Modeled after esbuild and @bufbuild/buf.
+
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+
+// Map of (process.platform, process.arch) → platform package name and binary subpath.
+const PLATFORM_PACKAGES = {
+    "darwin arm64": { pkg: "@fern-api/fern-darwin-arm64", bin: "bin/fern" },
+    "darwin x64": { pkg: "@fern-api/fern-darwin-x64", bin: "bin/fern" },
+    "linux arm64": { pkg: "@fern-api/fern-linux-arm64", bin: "bin/fern" },
+    "linux x64": { pkg: "@fern-api/fern-linux-x64", bin: "bin/fern" },
+    "win32 x64": { pkg: "@fern-api/fern-win32-x64", bin: "bin/fern.exe" }
+};
+
+function resolvePlatform() {
+    const key = `${process.platform} ${process.arch}`;
+    const entry = PLATFORM_PACKAGES[key];
+    if (entry == null) {
+        const supported = Object.keys(PLATFORM_PACKAGES).join(", ");
+        const err = new Error(
+            `Unsupported platform: ${key}.\n` +
+                `The Fern CLI is published for: ${supported}.\n` +
+                `If you believe your platform should be supported, please file an issue at\n` +
+                `https://github.com/fern-api/fern/issues.`
+        );
+        err.code = "EFERNUNSUPPORTED";
+        throw err;
+    }
+    return entry;
+}
+
+function resolveBinaryPath() {
+    const { pkg, bin } = resolvePlatform();
+    try {
+        return require.resolve(`${pkg}/${bin}`);
+    } catch (_err) {
+        const installCmd = `npm install ${pkg}`;
+        const err = new Error(
+            `Could not find the Fern binary for your platform.\n` +
+                `The package ${pkg} should have been installed as an optional dependency of @fern-api/fern, but it is missing.\n` +
+                `\n` +
+                `This can happen if you used --no-optional or --omit=optional when installing,\n` +
+                `or if your package manager skipped the optional dependency.\n` +
+                `\n` +
+                `Try reinstalling with:\n` +
+                `  ${installCmd}\n` +
+                `or rerun your install without skipping optional dependencies.`
+        );
+        err.code = "EFERNMISSING";
+        throw err;
+    }
+}
+
+let binaryPath;
+try {
+    binaryPath = resolveBinaryPath();
+} catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+}
+
+const result = spawnSync(binaryPath, process.argv.slice(2), { stdio: "inherit" });
+if (result.error != null) {
+    process.stderr.write(`Failed to launch Fern CLI: ${result.error.message}\n`);
+    process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/packages/cli/cli-v2/npm/wrapper/index.js
+++ b/packages/cli/cli-v2/npm/wrapper/index.js
@@ -1,0 +1,10 @@
+// @fern-api/fern — the Fern CLI.
+//
+// This is the wrapper package. The actual binary lives in
+// @fern-api/fern-<platform>-<arch> and is invoked via bin/fern.
+// This file exists so that `require("@fern-api/fern")` resolves cleanly
+// for tooling that imports the wrapper's metadata.
+
+"use strict";
+
+module.exports = {};

--- a/packages/cli/cli-v2/npm/wrapper/install.js
+++ b/packages/cli/cli-v2/npm/wrapper/install.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Postinstall validator for @fern-api/fern.
+//
+// Verifies that the platform-specific binary package was installed alongside
+// this wrapper (via npm's optionalDependencies + os/cpu fields). If it wasn't
+// (e.g. because the user passed --no-optional / --omit=optional, or because
+// the package manager skipped the optional), prints a clear error message
+// without failing the install so that the user can decide how to recover.
+//
+// The actual launcher (bin/fern) will produce the same diagnostic at execution
+// time if the binary is genuinely missing.
+
+"use strict";
+
+const PLATFORM_PACKAGES = {
+    "darwin arm64": "@fern-api/fern-darwin-arm64",
+    "darwin x64": "@fern-api/fern-darwin-x64",
+    "linux arm64": "@fern-api/fern-linux-arm64",
+    "linux x64": "@fern-api/fern-linux-x64",
+    "win32 x64": "@fern-api/fern-win32-x64"
+};
+
+const key = `${process.platform} ${process.arch}`;
+const pkg = PLATFORM_PACKAGES[key];
+
+if (pkg == null) {
+    process.stderr.write(
+        `[fern] Warning: unsupported platform ${key}.\n` +
+            `       The Fern CLI is published for: ${Object.keys(PLATFORM_PACKAGES).join(", ")}.\n` +
+            `       If you believe your platform should be supported, please file an issue at\n` +
+            `       https://github.com/fern-api/fern/issues.\n`
+    );
+    // Do not fail the install — let users discover the limitation when they
+    // actually try to run `fern`.
+    process.exit(0);
+}
+
+const subpath = process.platform === "win32" ? "bin/fern.exe" : "bin/fern";
+
+try {
+    require.resolve(`${pkg}/${subpath}`);
+} catch (_err) {
+    process.stderr.write(
+        `[fern] Warning: could not find the Fern binary for your platform.\n` +
+            `       The package ${pkg} was not installed alongside @fern-api/fern.\n` +
+            `\n` +
+            `       This usually happens when --no-optional or --omit=optional was passed at install time,\n` +
+            `       or when your package manager skipped the optional dependency.\n` +
+            `\n` +
+            `       Try reinstalling with:\n` +
+            `         npm install ${pkg}\n` +
+            `       or rerun the install without skipping optional dependencies.\n`
+    );
+    // Do not fail the postinstall — CI installs sometimes intentionally strip
+    // optionals, and we still want package metadata to be installable. The
+    // launcher (bin/fern) will produce a clearer error at run time.
+    process.exit(0);
+}

--- a/packages/cli/cli-v2/npm/wrapper/package.json
+++ b/packages/cli/cli-v2/npm/wrapper/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@fern-api/fern",
+  "version": "0.0.0-PLACEHOLDER",
+  "description": "The Fern CLI: build SDKs and developer docs for your API.",
+  "homepage": "https://github.com/fern-api/fern#readme",
+  "bugs": {
+    "url": "https://github.com/fern-api/fern/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fern-api/fern.git",
+    "directory": "packages/cli/cli-v2"
+  },
+  "main": "index.js",
+  "bin": {
+    "fern": "./bin/fern"
+  },
+  "files": ["bin", "index.js", "install.js", "LICENSE", "README.md"],
+  "scripts": {
+    "postinstall": "node ./install.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "optionalDependencies": {
+    "@fern-api/fern-darwin-arm64": "0.0.0-PLACEHOLDER",
+    "@fern-api/fern-darwin-x64": "0.0.0-PLACEHOLDER",
+    "@fern-api/fern-linux-arm64": "0.0.0-PLACEHOLDER",
+    "@fern-api/fern-linux-x64": "0.0.0-PLACEHOLDER",
+    "@fern-api/fern-win32-x64": "0.0.0-PLACEHOLDER"
+  }
+}

--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -30,6 +30,8 @@
     "dist:bin": "node build.compile.mjs",
     "dist:bin:local": "node build.compile.mjs --target=local",
     "dist:cli:dev": "node build.dev.mjs",
+    "dist:npm": "node build.npm.mjs",
+    "dist:release": "pnpm dist:cli:dev && pnpm dist:bin && pnpm dist:npm",
     "format": "prettier --write --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "format:check": "prettier --check --ignore-unknown --ignore-path ../../../shared/.prettierignore \"**\"",
     "lint:eslint": "eslint --max-warnings 0 . --ignore-pattern=../../../.eslintignore",

--- a/packages/cli/cli/changes/unreleased/cli-v2-binary-release.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-binary-release.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Add npm publication and GitHub Release pipeline for the Fern CLI v2.
+    Cross-compiled Bun binaries for darwin-arm64/x64, linux-arm64/x64, and
+    win32-x64 are published as a wrapper package (@fern-api/fern) plus
+    five platform-specific packages (@fern-api/fern-<os>-<cpu>) using the
+    optionalDependencies pattern, alongside per-platform tarballs/zips on
+    GitHub Releases with SHA256 checksums and build provenance attestations.
+  type: internal

--- a/packages/cli/cli/changes/unreleased/cli-v2-binary-release.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-binary-release.yml
@@ -3,8 +3,8 @@
 - summary: |
     Add npm publication and GitHub Release pipeline for the Fern CLI v2.
     Cross-compiled Bun binaries for darwin-arm64/x64, linux-arm64/x64, and
-    win32-x64 are published as a wrapper package (@fern-api/fern) plus
-    five platform-specific packages (@fern-api/fern-<os>-<cpu>) using the
+    win32-x64 are published as a wrapper package (`@fern-api/fern`) plus
+    five platform-specific packages (`@fern-api/fern-<os>-<cpu>`) using the
     optionalDependencies pattern, alongside per-platform tarballs/zips on
     GitHub Releases with SHA256 checksums and build provenance attestations.
   type: internal

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,8 @@ packages:
   - "!packages/cli/cli/dist/local"
   - "!packages/cli/cli/dist/dev"
   - "!packages/cli/cli/dist/prod"
-  - "!packages/cli/cli-v2/dist/local"
-  - "!packages/cli/cli-v2/dist/dev"
-  - "!packages/cli/cli-v2/dist/prod"
+  - "!packages/cli/cli-v2/dist/**"
+  - "!packages/cli/cli-v2/npm/**"
 
 # Supply chain security settings
 # See: https://pnpm.io/settings


### PR DESCRIPTION
## Description

Linear ticket: Closes FER-8626

Wires up the Fern CLI v2 binary release process described in [FER-8626](https://linear.app/buildwithfern/issue/FER-8626/cli-v2-design-the-binary-release-process). Phase 1 targets npm + GitHub Releases (unsigned binaries), modelled on the two references called out in the ticket:

- npm distribution mirrors [`@bufbuild/buf`](https://www.npmjs.com/package/@bufbuild/buf) — a wrapper package with `optionalDependencies` pinned to platform-specific binary packages that use `os`/`cpu` filtering so npm only downloads the binary for the user's platform.
- Release orchestration mirrors [`googleworkspace/cli`](https://github.com/googleworkspace/cli/blob/a3768d0e82ad83cca2da97724e46bea4ff0e6dbd/.github/workflows/release.yml) — tag-driven pipeline that builds, attests, releases, and publishes.

This is intentionally scoped to npm + GitHub Releases. Homebrew, Scoop, and winget can ship later — they all consume the GitHub Release artifacts so we don't have to rework anything to add them.

## Changes Made

- **NPM distribution layout** under `packages/cli/cli-v2/npm/`:
  - `wrapper/` — `@fern-api/fern` (~7 KB tarball, Node launcher only, no embedded binary). `bin/fern` resolves `@fern-api/fern-<os>-<arch>/bin/fern[.exe]` via `require.resolve` and execs it.
  - `platform/` — template stamped into `@fern-api/fern-{darwin-arm64,darwin-x64,linux-arm64,linux-x64,win32-x64}` (~30–60 MB each, narrowed by `os`/`cpu`).
  - `install.js` postinstall — diagnoses missing optional-dep installs without failing the install (non-fatal warning), so e.g. `--omit=optional` doesn't break unrelated workflows.
- **`packages/cli/cli-v2/build.npm.mjs`** — assembles the publishable layout from `dist/bin/`:
  - Stamps the wrapper's `optionalDependencies` and each platform `package.json` (`version`, `os`, `cpu`, `description`) from a single `--version` arg.
  - Generates `.tar.gz` (Unix) and `.zip` (Windows) release archives, with per-file `.sha256` checksums and a top-level `SHA256SUMS`.
  - Supports `--npm-only` and `--archives-only` for partial rebuilds.
- **`.github/workflows/release-cli-v2.yml`** — 4-job pipeline:
  - `plan` — derives version, npm dist-tag, and prerelease flag from the tag (`cli-v2/vX.Y.Z[-prerelease]`) or `workflow_dispatch` inputs.
  - `build` — installs the repo, `pnpm dist:cli:dev`, `dist:bin` (Bun cross-compile × 5), `dist:npm`, attests build provenance for all binaries/archives via `actions/attest-build-provenance@v3`, uploads two artifacts.
  - `github-release` — downloads archives and creates a GitHub Release with install instructions, checksum verification snippet, and attestation verification snippet. Skipped on dry runs.
  - `publish-npm` — npm OIDC trusted publishing (same workaround as `publish-cli.yml` for npm@11 + Node 22 regression), platform packages first, wrapper last. Skipped on dry runs.
- **`packages/cli/cli-v2/package.json`** — new scripts:
  - `dist:npm` → `node build.npm.mjs`
  - `dist:release` → `pnpm dist:cli:dev && pnpm dist:bin && pnpm dist:npm`
- **`packages/cli/cli-v2/.gitignore`** — adds `dist/` so generated archives/packages don't leak into commits.
- **`pnpm-workspace.yaml` + root `package.json` `workspaces`** — exclude `packages/cli/cli-v2/dist/**` and `packages/cli/cli-v2/npm/**` so the template (placeholder `os`/`cpu`) and dist outputs aren't treated as workspace projects by pnpm or npm.
- **`packages/cli/cli-v2/CLAUDE.md`** — new "Releasing" section documenting the layout, build pipeline, tag scheme, dry-run flow, supported platforms, and the gcompat workaround for Alpine.
- **`packages/cli/cli/changes/unreleased/cli-v2-binary-release.yml`** — `type: internal` changelog entry (this PR touches the v2 CLI's release plumbing, not user-visible v1 behavior).
- [x] Updated README.md generator (N/A — release plumbing, no SDK/docs surface)

### What this PR does NOT do (deferred)

- macOS notarization + Windows Authenticode signing
- Homebrew / Scoop / winget
- Wiring CLI v2 versions into the existing `release-config.json` / `release-software.yml` autorelease flow (this PR uses manual tag-driven releases; the autorelease integration is a follow-up once we've shipped the first manual release and know what dates/changelog conventions we want for v2)
- In-CLI auto-update

## Testing

Manual end-to-end validation locally:

```sh
# Full pipeline
pnpm --filter @fern-api/cli-v2 dist:cli:dev        # 33 MB tsup bundle ✓
pnpm --filter @fern-api/cli-v2 dist:bin            # 5 binaries, 80–170 MB ✓
cd packages/cli/cli-v2
node build.npm.mjs --version=0.0.0-devin-test     # 6 npm packages + 5 archives + SHA256SUMS ✓

# Verify wrapper packs cleanly
cd dist/npm/wrapper && npm pack --dry-run         # 6.9 KB tarball, 6 files ✓
cd ../fern-linux-x64 && npm pack --dry-run        # 66 MB tarball, 178 MB unpacked ✓

# End-to-end install + run
npm install ./fern-api-fern-linux-x64-*.tgz ./fern-api-fern-0.0.0-devin-test.tgz
./node_modules/.bin/fern --help                    # prints full v2 CLI help ✓

# Missing optional dep (e.g. `--omit=optional`)
npm install --omit=optional ./fern-api-fern-*.tgz
./node_modules/.bin/fern --help                    # actionable error: "package
                                                   #   @fern-api/fern-linux-x64
                                                   #   should have been installed
                                                   #   ... try: npm install @fern-api/fern-linux-x64"
```

Lint/format:

```sh
pnpm biome check .github/workflows/release-cli-v2.yml \
                 packages/cli/cli-v2/build.npm.mjs \
                 packages/cli/cli-v2/npm/ \
                 packages/cli/cli-v2/CLAUDE.md \
                 packages/cli/cli-v2/package.json \
                 packages/cli/cli-v2/.gitignore \
                 packages/cli/cli/changes/unreleased/cli-v2-binary-release.yml \
                 package.json \
                 pnpm-workspace.yaml
# Checked 7 files in 24ms. No fixes applied. ✓
```

`pnpm --filter @fern-api/cli-v2 lint:eslint` crashes on `main` too with `TypeError: Cannot set properties of undefined (setting 'defaultMeta')` — pre-existing eslintrc/Node 24 incompatibility, unrelated to this PR.

- [ ] Unit tests added/updated — N/A (release plumbing; the build script is exercised by the workflow's dry-run mode)
- [x] Manual testing completed (local pipeline produces installable, runnable packages; verified end-to-end install + execute path; postinstall and launcher error paths verified)

The first real validation is a dry-run via `workflow_dispatch` → `dry_run=true` after this merges; the first wet release is a `cli-v2/v0.0.1` tag push.


Link to Devin session: https://app.devin.ai/sessions/ca1ab83561a44f14890b1c3bc332924b
Requested by: @iamnamananand996