### PR TITLE
fix(cli): add `packages` field to generated `pnpm-workspace.yaml` for pnpm 10+ compat

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-pnpm10-workspace-packages-field.yml
+++ b/packages/cli/cli/changes/unreleased/fix-pnpm10-workspace-packages-field.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix `fern docs dev` failing with pnpm 10+ due to missing `packages` field in
+    generated `pnpm-workspace.yaml`. pnpm 10 requires this field, and its absence
+    caused "packages field missing or empty" during esbuild installation.
+  type: fix

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -529,8 +529,16 @@ export async function downloadBundle({
             }
 
             const workspaceConfigPath = path.join(absolutePathToBundleFolder, "pnpm-workspace.yaml");
+            const workspaceConfigContent = "packages:\n  - '.'\nonlyBuiltDependencies:\n  - esbuild\n";
             if (!existsSync(workspaceConfigPath)) {
-                await writeFile(workspaceConfigPath, "onlyBuiltDependencies:\n  - esbuild\n");
+                await writeFile(workspaceConfigPath, workspaceConfigContent);
+            } else {
+                // Ensure existing workspace config has the required `packages` field
+                // (pnpm 10+ errors with "packages field missing or empty" without it)
+                const existing = (await readFile(workspaceConfigPath)).toString();
+                if (!existing.includes("packages:")) {
+                    await writeFile(workspaceConfigPath, workspaceConfigContent);
+                }
             }
 
             try {


### PR DESCRIPTION
## Description

Fixes `fern docs dev` failing with pnpm 10+ with the error:
```
ERROR  packages field missing or empty
For help, run: pnpm help add
```

followed by a secondary ENOENT for `node-polyfills.cjs` because the bundle directory gets cleaned up after the install failure.

## Changes Made

- Added the required `packages` field to the generated `pnpm-workspace.yaml` in the docs preview bundle directory. pnpm 10+ requires this field ([pnpm/pnpm#8968](https://github.com/pnpm/pnpm/issues/8968)), and its absence caused `pnpm i esbuild` to fail during bundle setup.
- Also handles the case where an existing `pnpm-workspace.yaml` is missing the `packages` field by rewriting it with the correct content.

### Root Cause

During `fern docs dev`, `downloadLocalDocsBundle.ts` creates a `pnpm-workspace.yaml` with only `onlyBuiltDependencies` (no `packages` field). pnpm 10 made `packages` mandatory in workspace configs, so `pnpm i esbuild` fails immediately. The error is caught internally by `downloadBundle`, which removes the preview folder and returns `{ type: "failure" }`. The server startup continues (the return value isn't checked), hitting ENOENT when writing `node-polyfills.cjs` to the now-deleted `.next` directory.

The issue is intermittent because cached bundles (ETag match) skip the install step entirely.

## Testing

- [x] Lint passes (`pnpm run check`)
- [x] Verified the generated YAML content includes both `packages` and `onlyBuiltDependencies`


Link to Devin session: https://app.devin.ai/sessions/bb08e4cc609b4a9985d212946a81aa95
Requested by: @fern-support