### PR TITLE
fix(generator-cli): publish 0.9.28 with commit attribution fix for GHE

### DIFF
--- a/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.28.yml
+++ b/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.28.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.28, which sets explicit author and
+    committer on API-created commits to the Fern bot identity. Fixes commit
+    attribution on GitHub Enterprise where PAT-based authentication previously
+    attributed commits to the PAT-owning service account instead of fern-api[bot].
+  type: fix

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,17 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Set explicit author and committer on API-created commits to the Fern bot
+        identity (`fern-api` / `115122769+fern-api[bot]@users.noreply.github.com`).
+        Previously, `octokit.git.createCommit()` defaulted to the authenticated user,
+        which for PAT-based authentication (e.g. GitHub Enterprise) attributed commits
+        to the PAT-owning service account instead of a stable bot identity.
+      type: fix
+  createdAt: "2026-05-06"
+  version: 0.9.28
+
+- changelogEntry:
+    - summary: |
         Fix `createReplayBranch` crashing with `fatal: <sha> is not a valid object`
         when the lockfile's `previousGenerationSha` is unreachable (squash-merged
         and deleted prior PR branch). Tag update is skipped with a warning; the


### PR DESCRIPTION
## Description

PR #15893 fixed the commit attribution issue (API-created commits defaulting to PAT owner instead of `fern-api[bot]`) but **never published it as a new generator-cli version**. The fix landed on `main` in the source code but was never released to npm, so generator Docker images couldn't pick it up.

This PR:
1. Adds a `0.9.28` version entry to `packages/generator-cli/versions.yml` — triggers npm publish via CI on merge
2. Adds a Python SDK changelog entry so the next Python SDK release includes generator-cli 0.9.28

## Changes Made
- `packages/generator-cli/versions.yml` — Added 0.9.28 version entry for the commit attribution fix
- `generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.28.yml` — Changelog entry for Python SDK

## Follow-up Required
After this merges and CI publishes `@fern-api/generator-cli@0.9.28` to npm:
1. Bump the catalog pin in `pnpm-workspace.yaml` from `0.9.27` to `0.9.28`
2. This will cause the next Python SDK Docker rebuild to bundle generator-cli 0.9.28

## Context
- The user's Python SDK (running via `fern generate --runner podman --local`) bundles generator-cli inside the Docker image
- The generator Docker image does the `octokit.git.createCommit()` call, not the CLI
- So CLI upgrade alone wasn't enough — the generator Docker image needs to be rebuilt with the fixed generator-cli

## Testing
- [x] No code changes — only version metadata and changelog entries
- [x] Pre-commit hooks pass (pnpm install resolves correctly since catalog pin stays at 0.9.27)

Link to Devin session: https://app.devin.ai/sessions/d6f0693ed3d54dc59a04619b58f2a599
Requested by: @iamnamananand996