### PR TITLE
chore(generator-cli): bump catalog pin to 0.9.28

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.27
-      version: 0.9.27
+      specifier: 0.9.28
+      version: 0.9.28
     '@fern-api/venus-api-sdk':
       specifier: 0.22.34
       version: 0.22.34
@@ -630,7 +630,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.27
+        version: 0.9.28
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0
@@ -699,7 +699,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.27
+        version: 0.9.28
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2466,7 +2466,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.27
+        version: 0.9.28
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9450,8 +9450,8 @@ packages:
   '@fern-api/fdr-sdk@1.2.4-f661387fb2':
     resolution: {integrity: sha512-wlk1lTCIZ7biND4vQf8jvhUw9P/rBQ5pXASCrumv8R96up0B3DY6yiY1C4VmFyHmp/kPhcjzc5T9TvHZZxFdrA==}
 
-  '@fern-api/generator-cli@0.9.27':
-    resolution: {integrity: sha512-01GBGwtXm5gZ06amH/V8Bb7sGSWiSBMQnG6hUyTbJK2qaXNUHygNGqOjOIF5XDwjXww6DZLLsJfEoEAzaUFflg==}
+  '@fern-api/generator-cli@0.9.28':
+    resolution: {integrity: sha512-XWotnNAkiMIIKFE4xujI3O31Cd0PDljogKqUytGgnJH+a74rtMtGrSGWG58ryfDBCoJtLsjS1Q/B9vUlkceAJQ==}
     hasBin: true
 
   '@fern-api/replay@0.15.0':
@@ -16383,7 +16383,7 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.27':
+  '@fern-api/generator-cli@0.9.28':
     dependencies:
       '@boundaryml/baml': 0.219.0
       '@fern-api/replay': 0.15.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.2.4-f661387fb2
-  "@fern-api/generator-cli": 0.9.27
+  "@fern-api/generator-cli": 0.9.28
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description

Follow-up to #15925. Bumps the `@fern-api/generator-cli` catalog pin from `0.9.27` to `0.9.28` now that 0.9.28 is published to npm.

This ensures that the next time any generator's Docker image is rebuilt (e.g. Python SDK 5.12.9, which was just released via the changelog entry in #15925), it bundles generator-cli 0.9.28 with the commit attribution fix.

## Changes Made
- `pnpm-workspace.yaml`: catalog pin `0.9.27` → `0.9.28`
- `pnpm-lock.yaml`: updated lockfile

## Testing
- [x] `pnpm install` resolves correctly (0.9.28 is now published to npm)
- [x] No code changes — dependency pin only

Link to Devin session: https://app.devin.ai/sessions/d6f0693ed3d54dc59a04619b58f2a599
Requested by: @iamnamananand996