### PR TITLE
fix(cli): clean up stale docs preview bundles and strip packageManager field

### DIFF
--- a/packages/cli/cli/changes/unreleased/cleanup-stale-docs-bundles.yml
+++ b/packages/cli/cli/changes/unreleased/cleanup-stale-docs-bundles.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Clean up stale docs preview bundles from ~/.fern/ on startup and strip
+    packageManager field from cached bundles to prevent corepack from
+    activating old pnpm versions.
+  type: fix

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -375,9 +375,13 @@ export async function downloadBundle({
         }
         if (currentETag != null && currentETag === eTag) {
             logger.debug("ETag matches. Using already downloaded bundle");
+
             // Strip packageManager from cached bundle to prevent corepack conflicts
             const cachedBundleFolder = getPathToBundleFolder({ app });
             await stripPackageManagerField(cachedBundleFolder, logger);
+            const cachedStandaloneDir = path.join(cachedBundleFolder, STANDALONE_FOLDER_NAME);
+            await stripPackageManagerField(cachedStandaloneDir, logger);
+
             return {
                 type: "success"
             };

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -7,7 +7,7 @@ import { execSync } from "child_process";
 import cliProgress from "cli-progress";
 import decompress from "decompress";
 import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, symlinkSync } from "fs";
-import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
+import { mkdir, readdir, readFile, rename, rm, writeFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
 import tmp from "tmp-promise";
@@ -280,6 +280,62 @@ export declare namespace DownloadLocalBundle {
     }
 }
 
+/**
+ * Removes stale old bundle directories (e.g. app-preview-old-<timestamp>) that
+ * accumulate in ~/.fern/ when previous async cleanup attempts failed.
+ */
+async function cleanupStaleBundles(logger: Logger): Promise<void> {
+    const storageFolder = getLocalStorageFolder();
+    if (!(await doesPathExist(storageFolder))) {
+        return;
+    }
+
+    try {
+        const entries = await readdir(storageFolder);
+        const stalePatterns = [`${APP_PREVIEW_FOLDER_NAME}-old-`, `${PREVIEW_FOLDER_NAME}-old-`];
+        const staleEntries = entries.filter((entry) => stalePatterns.some((pattern) => entry.startsWith(pattern)));
+
+        for (const entry of staleEntries) {
+            const fullPath = path.join(storageFolder, entry);
+            logger.debug(`Removing stale bundle directory: ${fullPath}`);
+            await rm(fullPath, { recursive: true }).catch((error) => {
+                logger.debug(`Failed to remove stale bundle ${fullPath}: ${error}`);
+            });
+        }
+
+        if (staleEntries.length > 0) {
+            logger.debug(
+                `Cleaned up ${staleEntries.length} stale bundle director${staleEntries.length === 1 ? "y" : "ies"}`
+            );
+        }
+    } catch (error) {
+        logger.debug(`Failed to scan for stale bundles: ${error}`);
+    }
+}
+
+/**
+ * Strips the packageManager field from the bundle's package.json to prevent
+ * corepack from activating an old pnpm version bundled with a previous release.
+ */
+async function stripPackageManagerField(bundleFolder: string, logger: Logger): Promise<void> {
+    const packageJsonPath = path.join(bundleFolder, "package.json");
+    if (!existsSync(packageJsonPath)) {
+        return;
+    }
+
+    try {
+        const content = await readFile(packageJsonPath, "utf-8");
+        const parsed = JSON.parse(content);
+        if (parsed.packageManager != null) {
+            logger.debug(`Stripping packageManager field (${parsed.packageManager}) from bundle package.json`);
+            delete parsed.packageManager;
+            await writeFile(packageJsonPath, JSON.stringify(parsed, null, 2) + "\n");
+        }
+    } catch (error) {
+        logger.debug(`Failed to strip packageManager from bundle: ${error}`);
+    }
+}
+
 export async function downloadBundle({
     bucketUrl,
     logger,
@@ -294,6 +350,9 @@ export async function downloadBundle({
     tryTar?: boolean;
 }): Promise<DownloadLocalBundle.Result> {
     logger.debug("Setting up docs preview bundle...");
+
+    // Clean up any stale old bundle directories from previous runs
+    await cleanupStaleBundles(logger);
     const response = await fetch(bucketUrl);
     if (!response.ok) {
         return {
@@ -316,7 +375,9 @@ export async function downloadBundle({
         }
         if (currentETag != null && currentETag === eTag) {
             logger.debug("ETag matches. Using already downloaded bundle");
-            // The bundle is already downloaded
+            // Strip packageManager from cached bundle to prevent corepack conflicts
+            const cachedBundleFolder = getPathToBundleFolder({ app });
+            await stripPackageManagerField(cachedBundleFolder, logger);
             return {
                 type: "success"
             };
@@ -494,6 +555,11 @@ export async function downloadBundle({
                 symlinkProgressBar.stop();
             }
         }
+
+        // Strip packageManager field to prevent corepack from using stale pnpm versions
+        await stripPackageManagerField(absolutePathToBundleFolder, logger);
+        const standaloneDir = path.join(absolutePathToBundleFolder, STANDALONE_FOLDER_NAME);
+        await stripPackageManagerField(standaloneDir, logger);
 
         // write etag
         await writeFile(eTagFilepath, eTag);


### PR DESCRIPTION
## Description

Fixes stale `~/.fern/` artifacts left behind by `fern docs dev` that can cause pnpm version conflicts (e.g. corepack activating pnpm v9 from an old bundle when the user has pnpm v11).

## Changes Made

- Added `cleanupStaleBundles()` that removes leftover `app-preview-old-*` and `preview-old-*` directories from `~/.fern/` on startup. These accumulate when the async fire-and-forget deletion of old bundles fails silently.
- Added `stripPackageManagerField()` that removes the `packageManager` field from the bundle's `package.json` (both at the bundle root and standalone subfolder) after extraction. This prevents corepack from detecting an old pnpm version in the bundle and activating it, which would leave stale symlinks in the user's environment.
- The `packageManager` stripping also runs when using a cached bundle (ETag match), so existing cached bundles from before this fix are cleaned up too.

## Testing

- [x] Compiles cleanly (`pnpm turbo run compile --filter=@fern-api/docs-preview`)
- [x] Passes lint (`pnpm lint:biome`)
- [x] Manual code review of the logic

Link to Devin session: https://app.devin.ai/sessions/034eb17180944403bf30b9fe48da2bbe
Requested by: @thesandlord