### PR TITLE
fix(cli): docs ledger lazy file loading, stable tokens, ADR wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ generators/csharp/playground/**/obj/
 next-env.d.ts
 .vercel
 
+# python virtual envs (local dev tooling)
+.venv/
+**/.venv/
+
 # misc
 .DS_Store
 *.swp

--- a/packages/cli/cli/changes/unreleased/ledger-adr-0009-0011-0012.yml
+++ b/packages/cli/cli/changes/unreleased/ledger-adr-0009-0011-0012.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Wire CLI to docs-ledger publish contracts for ADRs 0009, 0011, and 0012:
+    structured git provenance (repoUrl, branch, commitSha), multi-domain
+    customDomains forwarding, and dedicated preview endpoint (/preview/init).
+  type: feat

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
@@ -1,4 +1,5 @@
 import type { APIV1Write } from "@fern-api/fdr-sdk";
+import type { FileManifestEntry } from "@fern-api/fdr-sdk/orpc-client";
 import { createHash } from "crypto";
 import { describe, expect, it } from "vitest";
 import { buildLedgerInput } from "../publishDocsLedger.js";
@@ -208,5 +209,71 @@ describe("buildLedgerInput", () => {
         // Round-trip: the blob content should deserialize to match the input map.
         const parsed = JSON.parse(manifestBuf?.toString("utf-8") ?? "");
         expect(parsed).toEqual({ "api-def-1": minimalApiDefinition });
+    });
+
+    it("forwards fileManifest unchanged and merges fileBlobs into the blob map", () => {
+        // Image entry — exercises width/height fields.
+        const imageBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]); // PNG header
+        const imageHash = createHash("sha256").update(new Uint8Array(imageBytes)).digest("hex");
+        const imageEntry: FileManifestEntry = {
+            hash: imageHash,
+            contentType: "image/png",
+            contentLength: imageBytes.byteLength,
+            filename: "logo.png",
+            width: 200,
+            height: 100
+        };
+
+        // Non-image entry — no width/height.
+        const docBytes = Buffer.from("hello world", "utf-8");
+        const docHash = createHash("sha256").update(new Uint8Array(docBytes)).digest("hex");
+        const docEntry: FileManifestEntry = {
+            hash: docHash,
+            contentType: "text/plain",
+            contentLength: docBytes.byteLength,
+            filename: "notes.txt"
+        };
+
+        const fileManifest: Record<string, FileManifestEntry> = {
+            "assets/logo.png": imageEntry,
+            "docs/notes.txt": docEntry
+        };
+        const fileBlobs = new Map<string, Buffer>([
+            [imageHash, imageBytes],
+            [docHash, docBytes]
+        ]);
+
+        const { input, blobs } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition(),
+            organization: "acme",
+            domain: "docs.acme.com",
+            basepath: undefined,
+            previewId: undefined,
+            apiDefinitions: new Map(),
+            fileManifest,
+            fileBlobs
+        });
+
+        // fileManifest round-trips unchanged.
+        expect(input.fileManifest).toEqual(fileManifest);
+
+        // File hashes show up in the returned blobs map alongside page/config blobs.
+        expect(blobs.get(imageHash)).toEqual(imageBytes);
+        expect(blobs.get(docHash)).toEqual(docBytes);
+    });
+
+    it("legacy behaviour: omitting fileManifest still works", () => {
+        const { input, blobs } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition({ pages: { "page-1": { markdown: "# hi" } } }),
+            organization: "acme",
+            domain: "docs.acme.com",
+            basepath: undefined,
+            previewId: undefined,
+            apiDefinitions: new Map()
+        });
+
+        expect(input.fileManifest).toBeUndefined();
+        // Blob map still contains the page + config blobs.
+        expect(blobs.size).toBeGreaterThan(0);
     });
 });

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
@@ -265,6 +265,58 @@ describe("buildLedgerInput", () => {
         expect(input.apiManifest).toBeNull();
     });
 
+    it("apiManifest blob hash is stable across Map insertion order (determinism guard)", () => {
+        // Reproduces the docs-ledger deterministic-hash bug: `apiDefinitions`
+        // is built by `Promise.all` of /api/register calls in CLI, so its Map
+        // insertion order is whichever round-trip completed first. Without
+        // `stableStringify`, byte-identical content would hash differently
+        // across publishes and the docs-ledger "no-op republish" fast-path
+        // would never fire. The two manifests below have identical entries
+        // inserted in opposite orders and MUST produce the same blob hash.
+        const minimalApiDefinition: APIV1Write.ApiDefinition = {
+            types: {},
+            subpackages: {},
+            rootPackage: {
+                endpoints: [],
+                types: [],
+                subpackages: [],
+                websockets: [],
+                webhooks: []
+            },
+            auth: undefined,
+            snippetsConfiguration: {},
+            globalHeaders: []
+        };
+
+        const forward = new Map<string, APIV1Write.ApiDefinition>();
+        forward.set("api-def-a", minimalApiDefinition);
+        forward.set("api-def-b", minimalApiDefinition);
+
+        const reverse = new Map<string, APIV1Write.ApiDefinition>();
+        reverse.set("api-def-b", minimalApiDefinition);
+        reverse.set("api-def-a", minimalApiDefinition);
+
+        const { input: inForward } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition(),
+            organization: "acme",
+            domain: "docs.acme.com",
+            basepath: undefined,
+            previewId: undefined,
+            apiDefinitions: forward
+        });
+        const { input: inReverse } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition(),
+            organization: "acme",
+            domain: "docs.acme.com",
+            basepath: undefined,
+            previewId: undefined,
+            apiDefinitions: reverse
+        });
+
+        expect(inForward.apiManifest?.hash).toBe(inReverse.apiManifest?.hash);
+        expect(inForward.apiManifest?.contentLength).toBe(inReverse.apiManifest?.contentLength);
+    });
+
     it("serializes apiManifest as a JSON blob ref when apiDefinitions is non-empty", () => {
         const minimalApiDefinition: APIV1Write.ApiDefinition = {
             types: {},

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
@@ -358,7 +358,7 @@ describe("buildLedgerInput", () => {
         expect(parsed).toEqual({ "api-def-1": minimalApiDefinition });
     });
 
-    it("forwards fileManifest unchanged and merges fileBlobs into the blob map", () => {
+    it("forwards fileManifest unchanged (file blobs are loaded lazily, not included in blob map)", () => {
         // Image entry — exercises width/height fields.
         const imageBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]); // PNG header
         const imageHash = createHash("sha256").update(new Uint8Array(imageBytes)).digest("hex");
@@ -385,10 +385,6 @@ describe("buildLedgerInput", () => {
             "assets/logo.png": imageEntry,
             "docs/notes.txt": docEntry
         };
-        const fileBlobs = new Map<string, Buffer>([
-            [imageHash, imageBytes],
-            [docHash, docBytes]
-        ]);
 
         const { input, blobs } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
@@ -397,16 +393,16 @@ describe("buildLedgerInput", () => {
             basepath: undefined,
             previewId: undefined,
             apiDefinitions: new Map(),
-            fileManifest,
-            fileBlobs
+            fileManifest
         });
 
         // fileManifest round-trips unchanged.
         expect(input.fileManifest).toEqual(fileManifest);
 
-        // File hashes show up in the returned blobs map alongside page/config blobs.
-        expect(blobs.get(imageHash)).toEqual(imageBytes);
-        expect(blobs.get(docHash)).toEqual(docBytes);
+        // File blobs are NOT in the blob map — they are loaded lazily during
+        // the upload step via filePaths (hash → absolute path).
+        expect(blobs.has(imageHash)).toBe(false);
+        expect(blobs.has(docHash)).toBe(false);
     });
 
     it("legacy behaviour: omitting fileManifest still works", () => {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
@@ -423,4 +423,87 @@ describe("buildLedgerInput", () => {
         // Blob map still contains the page + config blobs.
         expect(blobs.size).toBeGreaterThan(0);
     });
+
+    // ── ADR 0011: git provenance ──────────────────────────────────────
+
+    it("forwards git into DocsPublishInput when provided", () => {
+        const git = {
+            repoUrl: "https://github.com/acme/docs",
+            branch: "main",
+            commitSha: "abc123"
+        };
+        const { input } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition(),
+            organization: "acme",
+            domain: "docs.acme.com",
+            basepath: undefined,
+            previewId: undefined,
+            git,
+            apiDefinitions: new Map()
+        });
+
+        expect(input.git).toEqual(git);
+    });
+
+    it("omits git from DocsPublishInput when not provided", () => {
+        const { input } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition(),
+            organization: "acme",
+            domain: "docs.acme.com",
+            basepath: undefined,
+            previewId: undefined,
+            apiDefinitions: new Map()
+        });
+
+        expect(input.git).toBeUndefined();
+    });
+
+    it("forwards git without commitSha when commitSha is omitted", () => {
+        const git = {
+            repoUrl: "https://gitlab.com/acme/docs",
+            branch: "feature/x"
+        };
+        const { input } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition(),
+            organization: "acme",
+            domain: "docs.acme.com",
+            basepath: undefined,
+            previewId: undefined,
+            git,
+            apiDefinitions: new Map()
+        });
+
+        expect(input.git).toEqual(git);
+        expect(input.git?.commitSha).toBeUndefined();
+    });
+
+    // ── ADR 0009: customDomains ───────────────────────────────────────
+
+    it("forwards customDomains into DocsPublishInput", () => {
+        const customDomains = ["docs.acme.com", "alt.acme.com/v2"];
+        const { input } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition(),
+            organization: "acme",
+            domain: "acme.docs.buildwithfern.com",
+            basepath: undefined,
+            previewId: undefined,
+            customDomains,
+            apiDefinitions: new Map()
+        });
+
+        expect(input.customDomains).toEqual(customDomains);
+    });
+
+    it("defaults customDomains to [] when omitted", () => {
+        const { input } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition(),
+            organization: "acme",
+            domain: "docs.acme.com",
+            basepath: undefined,
+            previewId: undefined,
+            apiDefinitions: new Map()
+        });
+
+        expect(input.customDomains).toEqual([]);
+    });
 });

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
@@ -68,8 +68,8 @@ describe("buildLedgerInput", () => {
         expect(Object.keys(input.pages)).toHaveLength(0);
     });
 
-    it("serializes config as a JSON blob ref", () => {
-        const { input, blobs } = buildLedgerInput({
+    it("passes config through inline (not a CAS blob)", () => {
+        const { input } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
             organization: "acme",
             domain: "docs.acme.com",
@@ -78,12 +78,11 @@ describe("buildLedgerInput", () => {
             apiDefinitions: new Map()
         });
 
+        // Per the docs-ledger contract, config is sent inline as a permissive
+        // object (not a BlobRef). The DocsConfig shape passes through; the
+        // server transform extracts only the LedgerConfig-shaped fields.
         expect(input.config).toBeDefined();
-        expect(input.config?.contentType).toBe("application/json");
-        // The blob should exist and round-trip back to the config.
-        const configBuf = blobs.get(input.config?.hash ?? "");
-        expect(configBuf).toBeDefined();
-        expect(JSON.parse(configBuf?.toString("utf-8") ?? "")).toEqual({ root: MINIMAL_ROOT });
+        expect(input.config).toEqual({ root: MINIMAL_ROOT });
     });
 
     it("passes through org, domain, basepath, previewId", () => {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
@@ -68,7 +68,7 @@ describe("buildLedgerInput", () => {
         expect(Object.keys(input.pages)).toHaveLength(0);
     });
 
-    it("passes config through inline (not a CAS blob)", () => {
+    it("omits config (TODO: Track B mapping)", () => {
         const { input } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
             organization: "acme",
@@ -78,11 +78,11 @@ describe("buildLedgerInput", () => {
             apiDefinitions: new Map()
         });
 
-        // Per the docs-ledger contract, config is sent inline as a permissive
-        // object (not a BlobRef). The DocsConfig shape passes through; the
-        // server transform extracts only the LedgerConfig-shaped fields.
-        expect(input.config).toBeDefined();
-        expect(input.config).toEqual({ root: MINIMAL_ROOT });
+        // DocsConfig → LedgerConfig mapping is Track B in the PRD. Until that
+        // lands, we send `config: undefined` so the publish passes FDR's
+        // LedgerConfigSchema validation. FDR's transform handles missing
+        // config gracefully.
+        expect(input.config).toBeUndefined();
     });
 
     it("passes through org, domain, basepath, previewId", () => {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
@@ -68,7 +68,7 @@ describe("buildLedgerInput", () => {
         expect(Object.keys(input.pages)).toHaveLength(0);
     });
 
-    it("omits config (TODO: Track B mapping)", () => {
+    it("maps a minimal DocsConfig to a LedgerConfig shape (mostly empty fields)", () => {
         const { input } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
             organization: "acme",
@@ -78,11 +78,107 @@ describe("buildLedgerInput", () => {
             apiDefinitions: new Map()
         });
 
-        // DocsConfig → LedgerConfig mapping is Track B in the PRD. Until that
-        // lands, we send `config: undefined` so the publish passes FDR's
-        // LedgerConfigSchema validation. FDR's transform handles missing
-        // config gracefully.
-        expect(input.config).toBeUndefined();
+        // With only `root` set on the source DocsConfig every LedgerConfig
+        // field is `undefined` — but `input.config` itself is the populated
+        // ledger object (not `undefined`), unlike the prior workaround.
+        expect(input.config).toBeDefined();
+        expect(input.config?.title).toBeUndefined();
+        expect(input.config?.colorsV3).toBeUndefined();
+        expect(input.config?.metadata).toBeUndefined();
+        expect(input.config?.redirects).toBeUndefined();
+    });
+
+    it("translates a DocsConfig logo FileId into a LedgerConfig ImageRef using fileManifest dimensions", () => {
+        // Source DocsConfig: colorsV3.dark.logo points to a FileId that
+        // matches a fileManifest entry's fullPath (current FDR behaviour).
+        const docsDefinition = {
+            pages: {},
+            config: {
+                root: MINIMAL_ROOT,
+                colorsV3: {
+                    type: "dark" as const,
+                    accentPrimary: { r: 1, g: 2, b: 3 },
+                    logo: "assets/logo.png"
+                }
+            }
+        } as unknown as Parameters<typeof buildLedgerInput>[0]["docsDefinition"];
+
+        const fileManifest: Record<string, FileManifestEntry> = {
+            "assets/logo.png": {
+                hash: "deadbeef",
+                contentType: "image/png",
+                contentLength: 1234,
+                filename: "logo.png",
+                width: 320,
+                height: 160
+            }
+        };
+
+        const { input } = buildLedgerInput({
+            docsDefinition,
+            organization: "acme",
+            domain: "docs.acme.com",
+            basepath: undefined,
+            previewId: undefined,
+            apiDefinitions: new Map(),
+            fileManifest,
+            // Identity map: fileId === sanitizedPath in the current FDR flow.
+            fileIdToPath: new Map([["assets/logo.png", "assets/logo.png"]])
+        });
+
+        expect(input.config?.colorsV3).toEqual({
+            type: "dark",
+            accentPrimary: { r: 1, g: 2, b: 3 },
+            logo: { path: "assets/logo.png", width: 320, height: 160 }
+        });
+    });
+
+    it("drops a logo ImageRef when the file is not measured (no width/height in manifest)", () => {
+        const docsDefinition = {
+            pages: {},
+            config: {
+                root: MINIMAL_ROOT,
+                colorsV3: {
+                    type: "light" as const,
+                    accentPrimary: { r: 4, g: 5, b: 6 },
+                    logo: "assets/unmeasured.svg"
+                }
+            }
+        } as unknown as Parameters<typeof buildLedgerInput>[0]["docsDefinition"];
+
+        const fileManifest: Record<string, FileManifestEntry> = {
+            "assets/unmeasured.svg": {
+                hash: "cafef00d",
+                contentType: "image/svg+xml",
+                contentLength: 42,
+                filename: "unmeasured.svg"
+                // width/height intentionally omitted
+            }
+        };
+
+        const { input } = buildLedgerInput({
+            docsDefinition,
+            organization: "acme",
+            domain: "docs.acme.com",
+            basepath: undefined,
+            previewId: undefined,
+            apiDefinitions: new Map(),
+            fileManifest,
+            fileIdToPath: new Map([["assets/unmeasured.svg", "assets/unmeasured.svg"]])
+        });
+
+        // Logo absent rather than emitted with placeholder dimensions.
+        expect(input.config?.colorsV3).toEqual({
+            type: "light",
+            accentPrimary: { r: 4, g: 5, b: 6 },
+            logo: undefined,
+            backgroundImage: undefined,
+            background: undefined,
+            border: undefined,
+            sidebarBackground: undefined,
+            headerBackground: undefined,
+            cardBackground: undefined
+        });
     });
 
     it("passes through org, domain, basepath, previewId", () => {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/normalizeRepoUrl.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/normalizeRepoUrl.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRepoUrlToHttps } from "../normalizeRepoUrl.js";
+
+describe("normalizeRepoUrlToHttps", () => {
+    it("converts GitHub slug to HTTPS URL", () => {
+        expect(normalizeRepoUrlToHttps("acme/docs", "github")).toBe("https://github.com/acme/docs");
+    });
+
+    it("converts GitLab slug to HTTPS URL", () => {
+        expect(normalizeRepoUrlToHttps("acme/docs", "gitlab")).toBe("https://gitlab.com/acme/docs");
+    });
+
+    it("converts Bitbucket slug to HTTPS URL", () => {
+        expect(normalizeRepoUrlToHttps("acme/docs", "bitbucket")).toBe("https://bitbucket.org/acme/docs");
+    });
+
+    it("passes through an HTTPS URL unchanged", () => {
+        const url = "https://github.enterprise.com/acme/docs";
+        expect(normalizeRepoUrlToHttps(url, "github")).toBe(url);
+    });
+
+    it("passes through an HTTP URL unchanged", () => {
+        const url = "http://gitlab.internal/acme/docs";
+        expect(normalizeRepoUrlToHttps(url, "gitlab")).toBe(url);
+    });
+});

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/resolveVersionFallback.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/resolveVersionFallback.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveVersionFallback } from "../runRemoteGenerationForGenerator.js";
+import { buildSnippetsConfigForSdk, resolveVersionFallback } from "../runRemoteGenerationForGenerator.js";
 
 describe("resolveVersionFallback", () => {
     it("returns the version when an explicit version is provided", () => {
@@ -29,5 +29,69 @@ describe("resolveVersionFallback", () => {
 
     it("returns a v-prefixed version as-is (stripping is handled elsewhere)", () => {
         expect(resolveVersionFallback("v2.0.0")).toBe("v2.0.0");
+    });
+});
+
+describe("buildSnippetsConfigForSdk", () => {
+    it("builds a typed snippets payload for typescript", () => {
+        expect(
+            buildSnippetsConfigForSdk({
+                language: "typescript",
+                packageName: "@acme/sdk",
+                version: "1.2.3"
+            })
+        ).toEqual({
+            typescriptSdk: {
+                package: "@acme/sdk",
+                version: "1.2.3"
+            }
+        });
+    });
+
+    it("maps java package names to coordinates", () => {
+        expect(
+            buildSnippetsConfigForSdk({
+                language: "java",
+                packageName: "com.acme:sdk",
+                version: "2.0.0"
+            })
+        ).toEqual({
+            javaSdk: {
+                coordinate: "com.acme:sdk",
+                version: "2.0.0"
+            }
+        });
+    });
+
+    it("drops AUTO versions from snippet payloads", () => {
+        expect(
+            buildSnippetsConfigForSdk({
+                language: "go",
+                packageName: "github.com/acme/sdk",
+                version: "AUTO"
+            })
+        ).toEqual({
+            goSdk: {
+                githubRepo: "github.com/acme/sdk",
+                version: undefined
+            }
+        });
+    });
+
+    it("returns an empty object when language or package name is missing", () => {
+        expect(
+            buildSnippetsConfigForSdk({
+                language: undefined,
+                packageName: "@acme/sdk",
+                version: "1.2.3"
+            })
+        ).toEqual({});
+        expect(
+            buildSnippetsConfigForSdk({
+                language: "typescript",
+                packageName: undefined,
+                version: "1.2.3"
+            })
+        ).toEqual({});
     });
 });

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/mapDocsConfigToLedgerConfig.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/mapDocsConfigToLedgerConfig.ts
@@ -1,0 +1,291 @@
+import type { DocsV1Write } from "@fern-api/fdr-sdk";
+import type { FileManifestEntry, ImageRef, LedgerConfig, PathOrUrl } from "@fern-api/fdr-sdk/orpc-client";
+
+type DocsConfig = DocsV1Write.DocsConfig;
+
+/**
+ * Resolve a FileId reference produced by the classic docs publish flow
+ * (FDR's startDocsRegister) to the `fullPath` string that the ledger flow
+ * uses to identify file artifacts.
+ *
+ * In the current FDR behaviour (`extractFileId` in publishDocs.ts), the
+ * "fileId" returned by FDR for a freshly-uploaded file is the same
+ * sanitized path used as the ledger fileManifest key, so the lookup is
+ * effectively the identity function. We still consult `fileIdToPath`
+ * first to remain forward-compatible with the legacy server response
+ * shape ({ uploadUrl, fileId }) where fileId is a separate UUID.
+ *
+ * Returns undefined when the FileId can't be mapped — callers MUST
+ * treat that as "field absent" rather than fabricating a path string.
+ */
+function resolveFileIdToPath(
+    fileId: string | undefined,
+    fileIdToPath: Map<string, string> | undefined
+): string | undefined {
+    if (fileId == null) {
+        return undefined;
+    }
+    const mapped = fileIdToPath?.get(fileId);
+    if (mapped != null) {
+        return mapped;
+    }
+    // Fallback: in the current FDR flow the fileId IS the sanitized path,
+    // so we can pass it through unchanged.
+    return fileId;
+}
+
+function toImageRef(
+    fileId: string | undefined,
+    fileManifest: Record<string, FileManifestEntry> | undefined,
+    fileIdToPath: Map<string, string> | undefined
+): ImageRef | undefined {
+    const path = resolveFileIdToPath(fileId, fileIdToPath);
+    if (path == null) {
+        return undefined;
+    }
+    const entry = fileManifest?.[path];
+    if (entry?.width == null || entry?.height == null) {
+        // Dimensions are required for ImageRef (next/image layout reservation).
+        // If the file wasn't measured (e.g. SVG or missing manifest entry) we
+        // drop the logo from the ledger config rather than send a half-valid
+        // ref that would fail server-side validation.
+        return undefined;
+    }
+    return { path, width: entry.width, height: entry.height };
+}
+
+function toPathOrUrl(
+    fileIdOrUrl: { type: "fileId"; value: string } | { type: "url"; value: string } | undefined,
+    fileIdToPath: Map<string, string> | undefined
+): PathOrUrl | undefined {
+    if (fileIdOrUrl == null) {
+        return undefined;
+    }
+    if (fileIdOrUrl.type === "url") {
+        return { type: "url", value: fileIdOrUrl.value };
+    }
+    const path = resolveFileIdToPath(fileIdOrUrl.value, fileIdToPath);
+    if (path == null) {
+        return undefined;
+    }
+    return { type: "path", value: path };
+}
+
+type ThemeWithImages = Extract<NonNullable<DocsConfig["colorsV3"]>, { type: "dark" } | { type: "light" }>;
+
+function mapTheme(
+    theme: ThemeWithImages | NonNullable<Extract<DocsConfig["colorsV3"], { type: "darkAndLight" }>>["dark"],
+    fileManifest: Record<string, FileManifestEntry> | undefined,
+    fileIdToPath: Map<string, string> | undefined
+): {
+    logo?: ImageRef;
+    backgroundImage?: string;
+    accentPrimary: { r: number; g: number; b: number; a?: number };
+    background?: { type: "solid"; r: number; g: number; b: number; a?: number } | { type: "gradient" };
+    border?: { r: number; g: number; b: number; a?: number };
+    sidebarBackground?: { r: number; g: number; b: number; a?: number };
+    headerBackground?: { r: number; g: number; b: number; a?: number };
+    cardBackground?: { r: number; g: number; b: number; a?: number };
+} {
+    // DocsConfig's per-theme `background` is a plain RGBA; LedgerConfig
+    // wraps it in a `solid` discriminated-union variant. We do not produce
+    // the `gradient` variant because DocsConfig has no source for it.
+    const background = theme.background != null ? { type: "solid" as const, ...theme.background } : undefined;
+    const backgroundImagePath = resolveFileIdToPath(theme.backgroundImage, fileIdToPath);
+    return {
+        logo: toImageRef(theme.logo, fileManifest, fileIdToPath),
+        backgroundImage: backgroundImagePath,
+        accentPrimary: theme.accentPrimary,
+        background,
+        border: theme.border,
+        sidebarBackground: theme.sidebarBackground,
+        headerBackground: theme.headerBackground,
+        cardBackground: theme.cardBackground
+    };
+}
+
+function mapColorsV3(
+    colors: DocsConfig["colorsV3"],
+    fileManifest: Record<string, FileManifestEntry> | undefined,
+    fileIdToPath: Map<string, string> | undefined
+): LedgerConfig["colorsV3"] {
+    if (colors == null) {
+        return undefined;
+    }
+    if (colors.type === "dark" || colors.type === "light") {
+        return {
+            type: colors.type,
+            ...mapTheme(colors, fileManifest, fileIdToPath)
+        };
+    }
+    return {
+        type: "darkAndLight",
+        dark: mapTheme(colors.dark, fileManifest, fileIdToPath),
+        light: mapTheme(colors.light, fileManifest, fileIdToPath)
+    };
+}
+
+function mapMetadata(
+    metadata: DocsConfig["metadata"],
+    fileIdToPath: Map<string, string> | undefined
+): LedgerConfig["metadata"] {
+    if (metadata == null) {
+        return undefined;
+    }
+    // Strip image fields and re-add them under PathOrUrl shape.
+    const {
+        "og:image": ogImage,
+        "og:logo": ogLogo,
+        "twitter:image": twitterImage,
+        "og:background-image": ogBackgroundImage,
+        "og:dynamic:background-image": ogDynamicBackgroundImage,
+        ...rest
+    } = metadata;
+    const mapped: Record<string, unknown> = { ...rest };
+    const ogImageMapped = toPathOrUrl(ogImage, fileIdToPath);
+    if (ogImageMapped != null) {
+        mapped["og:image"] = ogImageMapped;
+    }
+    const ogLogoMapped = toPathOrUrl(ogLogo, fileIdToPath);
+    if (ogLogoMapped != null) {
+        mapped["og:logo"] = ogLogoMapped;
+    }
+    const twitterImageMapped = toPathOrUrl(twitterImage, fileIdToPath);
+    if (twitterImageMapped != null) {
+        mapped["twitter:image"] = twitterImageMapped;
+    }
+    const ogBackgroundImageMapped = toPathOrUrl(ogBackgroundImage, fileIdToPath);
+    if (ogBackgroundImageMapped != null) {
+        mapped["og:background-image"] = ogBackgroundImageMapped;
+    }
+    const ogDynamicBackgroundImageMapped = toPathOrUrl(ogDynamicBackgroundImage, fileIdToPath);
+    if (ogDynamicBackgroundImageMapped != null) {
+        mapped["og:dynamic:background-image"] = ogDynamicBackgroundImageMapped;
+    }
+    return mapped as LedgerConfig["metadata"];
+}
+
+function mapJsFiles(js: DocsConfig["js"], fileIdToPath: Map<string, string> | undefined): LedgerConfig["js"] {
+    if (js == null) {
+        return undefined;
+    }
+    type LedgerJsFile = NonNullable<LedgerConfig["js"]>["files"] extends Array<infer T> | undefined ? T : never;
+    const files: LedgerJsFile[] = [];
+    for (const file of js.files) {
+        const path = resolveFileIdToPath(file.fileId, fileIdToPath);
+        if (path == null) {
+            continue;
+        }
+        files.push({ path, strategy: file.strategy });
+    }
+    return {
+        remote: js.remote?.map((r) => ({ url: r.url, strategy: r.strategy })),
+        files,
+        inline: js.inline
+    };
+}
+
+function mapTypography(
+    typography: DocsConfig["typographyV2"],
+    fileIdToPath: Map<string, string> | undefined
+): LedgerConfig["typographyV2"] {
+    if (typography == null) {
+        return undefined;
+    }
+    const mapFont = <F extends NonNullable<DocsConfig["typographyV2"]>["bodyFont"]>(font: F) => {
+        if (font == null) {
+            return undefined;
+        }
+        return {
+            type: "custom" as const,
+            name: font.name,
+            variants: font.variants.map((variant) => ({
+                fontFile: resolveFileIdToPath(variant.fontFile, fileIdToPath) ?? variant.fontFile,
+                weight: variant.weight,
+                style: variant.style
+            })),
+            display: font.display,
+            fallback: font.fallback,
+            fontVariationSettings: font.fontVariationSettings
+        };
+    };
+    return {
+        headingsFont: mapFont(typography.headingsFont),
+        bodyFont: mapFont(typography.bodyFont),
+        codeFont: mapFont(typography.codeFont)
+    };
+}
+
+function mapAgents(agents: DocsConfig["agents"]): LedgerConfig["agents"] {
+    if (agents == null) {
+        return undefined;
+    }
+    // llmsTxt / llmsFullTxt are intentionally dropped — the ledger contract
+    // serves these well-known files by convention via file artifact lookup
+    // (see LedgerConfigSchema doc comment in docs-ledger/contract.ts).
+    return {
+        pageDirective: agents.pageDirective,
+        pageDescriptionSource: agents.pageDescriptionSource,
+        siteDescription: agents.siteDescription
+    };
+}
+
+/**
+ * Map a classic DocsConfig (FileId-based) into the ledger-native LedgerConfig
+ * (path-based) shape.
+ *
+ * The two schemas have diverged:
+ * - DocsConfig.colorsV3.{dark,light}.logo: FileId  → LedgerConfig: ImageRef { path, width, height }
+ * - DocsConfig.colorsV3.{dark,light}.backgroundImage: FileId → LedgerConfig: string (path)
+ * - DocsConfig.metadata image fields: FileIdOrUrl → LedgerConfig: PathOrUrl
+ * - DocsConfig.js.files[].fileId → LedgerConfig.js.files[].path
+ * - DocsConfig.typographyV2.*.variants[].fontFile: FileId → LedgerConfig: string (path)
+ *
+ * Dimensions for ImageRef come from `fileManifest` (populated by the
+ * publishDocs uploadFiles callback using `measureImageSizes`). If an image
+ * has no measured dimensions, the corresponding logo field is dropped rather
+ * than emitted with placeholder values.
+ *
+ * Fields that exist only in DocsConfig (favicon, agents.llmsTxt, integrations,
+ * languages, navigation, root, logoV2, colors, colorsV2, typography (v1),
+ * hideNavLinks, globalTheme, backgroundImage at the top level, logo at the
+ * top level) are intentionally omitted: LedgerConfig either exposes them by
+ * convention (favicon, llms*) or has dropped them (legacy v1/v2 variants).
+ */
+export function mapDocsConfigToLedgerConfig({
+    docsConfig,
+    fileManifest,
+    fileIdToPath
+}: {
+    docsConfig: DocsConfig;
+    fileManifest: Record<string, FileManifestEntry> | undefined;
+    fileIdToPath: Map<string, string> | undefined;
+}): LedgerConfig {
+    return {
+        title: docsConfig.title,
+        defaultLanguage: docsConfig.defaultLanguage,
+        translations: docsConfig.translations,
+        announcement: docsConfig.announcement,
+        navbarLinks: docsConfig.navbarLinks,
+        footerLinks: docsConfig.footerLinks,
+        logoHeight: docsConfig.logoHeight,
+        logoHref: docsConfig.logoHref,
+        logoRightText: docsConfig.logoRightText,
+        agents: mapAgents(docsConfig.agents),
+        metadata: mapMetadata(docsConfig.metadata, fileIdToPath),
+        redirects: docsConfig.redirects,
+        colorsV3: mapColorsV3(docsConfig.colorsV3, fileManifest, fileIdToPath),
+        layout: docsConfig.layout,
+        theme: docsConfig.theme,
+        settings: docsConfig.settings,
+        typographyV2: mapTypography(docsConfig.typographyV2, fileIdToPath),
+        analyticsConfig: docsConfig.analyticsConfig,
+        css: docsConfig.css,
+        js: mapJsFiles(docsConfig.js, fileIdToPath),
+        aiChatConfig: docsConfig.aiChatConfig,
+        pageActions: docsConfig.pageActions,
+        editThisPageLaunch: docsConfig.editThisPageLaunch,
+        header: docsConfig.header,
+        footer: docsConfig.footer
+    };
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/normalizeRepoUrl.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/normalizeRepoUrl.ts
@@ -1,0 +1,21 @@
+/**
+ * Converts a CI-source repo slug (e.g. "owner/repo") into an HTTPS URL
+ * suitable for the docs-ledger `git.repoUrl` field.
+ *
+ * If the value is already a full URL it is returned as-is.
+ */
+export function normalizeRepoUrlToHttps(repo: string, provider: "github" | "gitlab" | "bitbucket"): string {
+    // Already a URL — passthrough.
+    if (repo.startsWith("https://") || repo.startsWith("http://")) {
+        return repo;
+    }
+
+    switch (provider) {
+        case "github":
+            return `https://github.com/${repo}`;
+        case "gitlab":
+            return `https://gitlab.com/${repo}`;
+        case "bitbucket":
+            return `https://bitbucket.org/${repo}`;
+    }
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -282,12 +282,16 @@ export async function publishDocs({
         // Collect API definitions (keyed by FDR definition ID) for the ledger manifest.
         const apiDefinitionCollector = new Map<string, APIV1Write.ApiDefinition>();
 
-        // Collect per-file manifest entries + raw bytes for the ledger publish.
+        // Collect per-file manifest entries for the ledger publish.
         // The manifest is keyed by `sanitizedPath` (fern-host-relative file path),
         // which matches the `fullPath` used by the FDR register handler when
         // routing fileManifest entries to file artifacts.
+        //
+        // File content is NOT kept in memory. Instead, ledgerFilePaths maps
+        // each content hash to the file's absolute path so that uploadMissingBlobs
+        // can re-read only the files the server actually needs.
         const ledgerFileManifest: Record<string, FileManifestEntry> = {};
-        const ledgerFileBlobs = new Map<string, Buffer>();
+        const ledgerFilePaths = new Map<string, AbsoluteFilePath>();
         // FileId → fullPath lookup used by mapDocsConfigToLedgerConfig to
         // translate DocsConfig's FileId-based references (e.g. colorsV3.dark.logo)
         // into LedgerConfig path strings.
@@ -364,7 +368,7 @@ export async function publishDocs({
                             height: image.height
                             // blurDataURL: not populated yet (caching is a separate concern)
                         };
-                        ledgerFileBlobs.set(hash, buffer);
+                        ledgerFilePaths.set(hash, filePath.absoluteFilePath);
 
                         const obj = {
                             filePath: CjsFdrSdk.docs.v1.write.FilePath(
@@ -412,7 +416,7 @@ export async function publishDocs({
                             filename: basename(file.sanitizedPath)
                             // width/height/blurDataURL omitted: non-image
                         };
-                        ledgerFileBlobs.set(hash, buffer);
+                        ledgerFilePaths.set(hash, file.absoluteFilePath);
 
                         return {
                             path: CjsFdrSdk.docs.v1.write.FilePath(
@@ -816,7 +820,7 @@ export async function publishDocs({
                         context,
                         apiDefinitions: apiDefinitionCollector,
                         fileManifest: Object.keys(ledgerFileManifest).length > 0 ? ledgerFileManifest : undefined,
-                        fileBlobs: ledgerFileBlobs.size > 0 ? ledgerFileBlobs : undefined,
+                        filePaths: ledgerFilePaths.size > 0 ? ledgerFilePaths : undefined,
                         fileIdToPath: ledgerFileIdToPath.size > 0 ? ledgerFileIdToPath : undefined
                     });
                     // In ledger-only mode the preview URL comes from the ledger;
@@ -840,7 +844,7 @@ export async function publishDocs({
                         context,
                         apiDefinitions: apiDefinitionCollector,
                         fileManifest: Object.keys(ledgerFileManifest).length > 0 ? ledgerFileManifest : undefined,
-                        fileBlobs: ledgerFileBlobs.size > 0 ? ledgerFileBlobs : undefined,
+                        filePaths: ledgerFilePaths.size > 0 ? ledgerFilePaths : undefined,
                         fileIdToPath: ledgerFileIdToPath.size > 0 ? ledgerFileIdToPath : undefined
                     });
                     context.logger.info(

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -17,7 +17,7 @@ import {
     wrapWithHttps
 } from "@fern-api/docs-resolver";
 import { APIV1Write, FdrAPI as CjsFdrSdk, DocsV1Write, DocsV2Write, FdrClient } from "@fern-api/fdr-sdk";
-import type { FileManifestEntry } from "@fern-api/fdr-sdk/orpc-client";
+import type { DocsPublishGitInput, FileManifestEntry } from "@fern-api/fdr-sdk/orpc-client";
 
 type DynamicIr = APIV1Write.DynamicIr;
 type DynamicIRUpload = APIV1Write.DynamicIRUpload;
@@ -50,7 +50,9 @@ import terminalLink from "terminal-link";
 import { getDocsDeployMode } from "./docsDeployMode.js";
 import { getDynamicGeneratorConfig } from "./getDynamicGeneratorConfig.js";
 import { measureImageSizes } from "./measureImageSizes.js";
+import { normalizeRepoUrlToHttps } from "./normalizeRepoUrl.js";
 import { publishDocsViaLedger } from "./publishDocsLedger.js";
+import { publishDocsViaLedgerPreview } from "./publishDocsLedgerPreview.js";
 import { asyncPool } from "./utils/asyncPool.js";
 
 const MEASURE_IMAGE_BATCH_SIZE = 10;
@@ -288,8 +290,13 @@ export async function publishDocs({
         const ledgerFileBlobs = new Map<string, Buffer>();
         // FileId → fullPath lookup used by mapDocsConfigToLedgerConfig to
         // translate DocsConfig's FileId-based references (e.g. colorsV3.dark.logo)
-        // into LedgerConfig path strings. Populated from FDR's startDocsRegister
-        // response in the uploadFiles callback below.
+        // into LedgerConfig path strings.
+        //
+        // Populated by the uploadFiles callback below:
+        //   - ledger mode: identity map (fullPath → fullPath) — the FileId we
+        //     emit IS the sanitizedPath, so the lookup just round-trips it.
+        //   - dual/legacy: keyed by the UUID FileId returned by FDR's
+        //     startDocsRegister/startDocsPreviewRegister response.
         const ledgerFileIdToPath = new Map<string, string>();
 
         const resolver = new DocsDefinitionResolver({
@@ -417,6 +424,53 @@ export async function publishDocs({
                 );
                 const hashNonImageTime = performance.now() - hashNonImageStart;
                 context.logger.debug(`Hashed ${filepaths.length} non-image files in ${hashNonImageTime.toFixed(0)}ms`);
+
+                // ── Ledger-only path ─────────────────────────────────────
+                // In ledger mode we do NOT call fdr.docs.v2.write.startDocsRegister
+                // / startDocsPreviewRegister. The legacy V2 register mints fresh
+                // FileId UUIDs per request even for byte-identical inputs, which
+                // then leak into the substituted markdown (via
+                // replaceImagePathsAndUrls below) and rotate the deployment hash
+                // on every publish — defeating the ledger's deployment-level dedup.
+                //
+                // Instead, we synthesize UploadedFile entries whose `fileId` is
+                // the file's sanitized fern-host-relative path. The resolver
+                // substitutes `file:<sanitizedPath>` into the markdown, which:
+                //   - is byte-identical across publishes of byte-identical
+                //     inputs (sanitizedPath is deterministic), so pages dedup
+                //     at the CAS layer; and
+                //   - resolves directly through the existing path-keyed ledger
+                //     reader endpoints (`fileArtifact`/`fileMetadata`, both
+                //     keyed on `fullPath` ≡ sanitizedPath) — no new server-
+                //     side resolver is needed.
+                //
+                // File bytes are uploaded later by the ledger missing-blobs
+                // step in publishDocsViaLedger / publishDocsViaLedgerPreview;
+                // they do not need a separate V2 upload round-trip.
+                if (deployMode === "ledger") {
+                    const uploadedFiles: UploadedFile[] = [];
+                    for (const file of filesWithSanitizedPaths) {
+                        const manifestEntry = ledgerFileManifest[file.sanitizedPath];
+                        if (manifestEntry == null) {
+                            continue;
+                        }
+                        // mapDocsConfigToLedgerConfig keys this lookup by
+                        // whatever string the DocsConfig stores as a FileId.
+                        // In ledger mode the FileId we emit IS the fullPath,
+                        // so the map is identity (fullPath → fullPath) — kept
+                        // populated for parity with the dual/legacy paths.
+                        ledgerFileIdToPath.set(file.sanitizedPath, file.sanitizedPath);
+                        uploadedFiles.push({
+                            relativeFilePath: file.relativeFilePath,
+                            absoluteFilePath: file.absoluteFilePath,
+                            fileId: file.sanitizedPath
+                        });
+                    }
+                    context.logger.debug(
+                        `[ledger] Skipping V2 startDocsRegister; resolved ${uploadedFiles.length} files by sanitizedPath`
+                    );
+                    return uploadedFiles;
+                }
 
                 if (preview) {
                     let startDocsRegisterResponse;
@@ -733,25 +787,66 @@ export async function publishDocs({
 
         // ── Ledger publish path (dual-write or ledger-only) ──────────
         if (deployMode === "dual" || deployMode === "ledger") {
+            // Build structured git provenance from the CI environment (ADR 0011).
+            // The X-CI-Source header is still sent for other telemetry sinks; this
+            // puts the same data into the DocsPublishInput so the ledger persists it.
+            const ledgerGit: DocsPublishGitInput | undefined =
+                ciSource?.repo != null && ciSource?.branch != null
+                    ? {
+                          repoUrl: normalizeRepoUrlToHttps(ciSource.repo, ciSource.type),
+                          branch: ciSource.branch,
+                          commitSha: ciSource.commitSha
+                      }
+                    : undefined;
+
             try {
-                const ledgerResult = await publishDocsViaLedger({
-                    docsDefinition,
-                    organization,
-                    domain,
-                    basepath: basePath,
-                    previewId,
-                    token: token.value,
-                    fdrOrigin,
-                    headers,
-                    context,
-                    apiDefinitions: apiDefinitionCollector,
-                    fileManifest: Object.keys(ledgerFileManifest).length > 0 ? ledgerFileManifest : undefined,
-                    fileBlobs: ledgerFileBlobs.size > 0 ? ledgerFileBlobs : undefined,
-                    fileIdToPath: ledgerFileIdToPath.size > 0 ? ledgerFileIdToPath : undefined
-                });
-                context.logger.info(
-                    `[ledger] Deployment ${ledgerResult.reusedDeployment ? "reused" : "created"}: ${ledgerResult.deploymentId}`
-                );
+                if (preview) {
+                    // ADR 0012: preview publishes go through the dedicated
+                    // /preview/init endpoint so they land on the server-generated
+                    // preview hostname instead of the production domain.
+                    const previewResult = await publishDocsViaLedgerPreview({
+                        docsDefinition,
+                        organization,
+                        basePath,
+                        previewId: previewId != null ? sanitizePreviewId(previewId) : previewId,
+                        git: ledgerGit,
+                        token: token.value,
+                        fdrOrigin,
+                        headers,
+                        context,
+                        apiDefinitions: apiDefinitionCollector,
+                        fileManifest: Object.keys(ledgerFileManifest).length > 0 ? ledgerFileManifest : undefined,
+                        fileBlobs: ledgerFileBlobs.size > 0 ? ledgerFileBlobs : undefined,
+                        fileIdToPath: ledgerFileIdToPath.size > 0 ? ledgerFileIdToPath : undefined
+                    });
+                    // In ledger-only mode the preview URL comes from the ledger;
+                    // in dual mode the V2 URL was already set above.
+                    if (deployMode === "ledger") {
+                        urlToOutput = previewResult.previewUrl;
+                    }
+                    context.logger.info(`[ledger] Preview deployment created: ${previewResult.deploymentId}`);
+                } else {
+                    const ledgerResult = await publishDocsViaLedger({
+                        docsDefinition,
+                        organization,
+                        domain,
+                        basepath: basePath,
+                        previewId,
+                        customDomains,
+                        git: ledgerGit,
+                        token: token.value,
+                        fdrOrigin,
+                        headers,
+                        context,
+                        apiDefinitions: apiDefinitionCollector,
+                        fileManifest: Object.keys(ledgerFileManifest).length > 0 ? ledgerFileManifest : undefined,
+                        fileBlobs: ledgerFileBlobs.size > 0 ? ledgerFileBlobs : undefined,
+                        fileIdToPath: ledgerFileIdToPath.size > 0 ? ledgerFileIdToPath : undefined
+                    });
+                    context.logger.info(
+                        `[ledger] Deployment ${ledgerResult.reusedDeployment ? "reused" : "created"}: ${ledgerResult.deploymentId}`
+                    );
+                }
             } catch (error) {
                 if (deployMode === "ledger") {
                     return context.failAndThrow("Failed to publish docs via ledger to " + domain, error, {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -1280,10 +1280,10 @@ async function checkAndDownloadExistingSdkDynamicIRs({
     }
 
     try {
+        // TODO: thread snippetConfigWithVersions into FDR call — current shape change broke the integration.
         const response = await fdr.api.register.checkSdkDynamicIrExists({
             orgId: CjsFdrSdk.OrgId(organization),
-            apiId: "",
-            irVersions: []
+            snippetConfiguration: {}
         });
 
         const existingDynamicIrs = response.existingDynamicIrs ?? {};

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -286,6 +286,11 @@ export async function publishDocs({
         // routing fileManifest entries to file artifacts.
         const ledgerFileManifest: Record<string, FileManifestEntry> = {};
         const ledgerFileBlobs = new Map<string, Buffer>();
+        // FileId → fullPath lookup used by mapDocsConfigToLedgerConfig to
+        // translate DocsConfig's FileId-based references (e.g. colorsV3.dark.logo)
+        // into LedgerConfig path strings. Populated from FDR's startDocsRegister
+        // response in the uploadFiles callback below.
+        const ledgerFileIdToPath = new Map<string, string>();
 
         const resolver = new DocsDefinitionResolver({
             domain,
@@ -457,11 +462,18 @@ export async function publishDocs({
                             context.logger.debug(`No files to upload (all ${skippedCount} up to date)`);
                         }
                     }
-                    return convertToFilePathPairs(
+                    const uploadedFiles = convertToFilePathPairs(
                         startDocsRegisterResponse.uploadUrls,
                         docsWorkspace.absoluteFilePath,
                         sanitizedToAbsoluteMap
                     );
+                    for (const uploaded of uploadedFiles) {
+                        const sanitizedPath = filesMap.get(uploaded.absoluteFilePath)?.sanitizedPath;
+                        if (sanitizedPath != null) {
+                            ledgerFileIdToPath.set(uploaded.fileId, sanitizedPath);
+                        }
+                    }
+                    return uploadedFiles;
                 } else {
                     let startDocsRegisterResponse;
                     try {
@@ -513,11 +525,18 @@ export async function publishDocs({
                             context.logger.info("No files to upload (all up to date)");
                         }
                     }
-                    return convertToFilePathPairs(
+                    const uploadedFiles = convertToFilePathPairs(
                         startDocsRegisterResponse.uploadUrls,
                         docsWorkspace.absoluteFilePath,
                         sanitizedToAbsoluteMap
                     );
+                    for (const uploaded of uploadedFiles) {
+                        const sanitizedPath = filesMap.get(uploaded.absoluteFilePath)?.sanitizedPath;
+                        if (sanitizedPath != null) {
+                            ledgerFileIdToPath.set(uploaded.fileId, sanitizedPath);
+                        }
+                    }
+                    return uploadedFiles;
                 }
             },
             registerApi: async ({
@@ -727,7 +746,8 @@ export async function publishDocs({
                     context,
                     apiDefinitions: apiDefinitionCollector,
                     fileManifest: Object.keys(ledgerFileManifest).length > 0 ? ledgerFileManifest : undefined,
-                    fileBlobs: ledgerFileBlobs.size > 0 ? ledgerFileBlobs : undefined
+                    fileBlobs: ledgerFileBlobs.size > 0 ? ledgerFileBlobs : undefined,
+                    fileIdToPath: ledgerFileIdToPath.size > 0 ? ledgerFileIdToPath : undefined
                 });
                 context.logger.info(
                     `[ledger] Deployment ${ledgerResult.reusedDeployment ? "reused" : "created"}: ${ledgerResult.deploymentId}`

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -1300,10 +1300,9 @@ async function checkAndDownloadExistingSdkDynamicIRs({
     }
 
     try {
-        // TODO: thread snippetConfigWithVersions into FDR call — current shape change broke the integration.
         const response = await fdr.api.register.checkSdkDynamicIrExists({
             orgId: CjsFdrSdk.OrgId(organization),
-            snippetConfiguration: {}
+            snippetConfiguration: snippetConfigWithVersions
         });
 
         const existingDynamicIrs = response.existingDynamicIrs ?? {};

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -17,6 +17,7 @@ import {
     wrapWithHttps
 } from "@fern-api/docs-resolver";
 import { APIV1Write, FdrAPI as CjsFdrSdk, DocsV1Write, DocsV2Write, FdrClient } from "@fern-api/fdr-sdk";
+import type { FileManifestEntry } from "@fern-api/fdr-sdk/orpc-client";
 
 type DynamicIr = APIV1Write.DynamicIr;
 type DynamicIRUpload = APIV1Write.DynamicIRUpload;
@@ -44,6 +45,7 @@ import { createHash } from "crypto";
 import { readFile } from "fs/promises";
 import { chunk } from "lodash-es";
 import * as mime from "mime-types";
+import { basename } from "path";
 import terminalLink from "terminal-link";
 import { getDocsDeployMode } from "./docsDeployMode.js";
 import { getDynamicGeneratorConfig } from "./getDynamicGeneratorConfig.js";
@@ -114,6 +116,17 @@ interface FileWithSanitizedPathAndMimeType extends FileWithMimeType {
 export async function calculateFileHash(absoluteFilePath: AbsoluteFilePath | string): Promise<string> {
     const fileBuffer = await readFile(absoluteFilePath);
     return createHash("sha256").update(new Uint8Array(fileBuffer)).digest("hex");
+}
+
+/**
+ * Read a file once and return its bytes + sha256 hash. Avoids the double-read
+ * we'd otherwise do for files that need both hashing (legacy register) and
+ * inclusion in the ledger CAS blob map (publishDocsViaLedger).
+ */
+async function readAndHashFile(absoluteFilePath: AbsoluteFilePath | string): Promise<{ buffer: Buffer; hash: string }> {
+    const buffer = await readFile(absoluteFilePath);
+    const hash = createHash("sha256").update(new Uint8Array(buffer)).digest("hex");
+    return { buffer, hash };
 }
 
 export function sanitizeRelativePathForS3(relativeFilePath: RelativeFilePath): RelativeFilePath {
@@ -267,6 +280,13 @@ export async function publishDocs({
         // Collect API definitions (keyed by FDR definition ID) for the ledger manifest.
         const apiDefinitionCollector = new Map<string, APIV1Write.ApiDefinition>();
 
+        // Collect per-file manifest entries + raw bytes for the ledger publish.
+        // The manifest is keyed by `sanitizedPath` (fern-host-relative file path),
+        // which matches the `fullPath` used by the FDR register handler when
+        // routing fileManifest entries to file artifacts.
+        const ledgerFileManifest: Record<string, FileManifestEntry> = {};
+        const ledgerFileBlobs = new Map<string, Buffer>();
+
         const resolver = new DocsDefinitionResolver({
             domain,
             docsWorkspace: effectiveWorkspace,
@@ -317,6 +337,23 @@ export async function publishDocs({
                         }
 
                         const sanitizedPath = filePath.sanitizedPath;
+                        const { buffer, hash } = await readAndHashFile(filePath.absoluteFilePath);
+
+                        // Populate the ledger file manifest entry for this image.
+                        // mediaType is guaranteed non-false here because the file passed
+                        // the mime.lookup filter upstream; fall back defensively anyway.
+                        const contentType = mime.lookup(filePath.absoluteFilePath) || "application/octet-stream";
+                        ledgerFileManifest[sanitizedPath] = {
+                            hash,
+                            contentType,
+                            contentLength: buffer.byteLength,
+                            filename: basename(filePath.sanitizedPath),
+                            width: image.width,
+                            height: image.height
+                            // blurDataURL: not populated yet (caching is a separate concern)
+                        };
+                        ledgerFileBlobs.set(hash, buffer);
+
                         const obj = {
                             filePath: CjsFdrSdk.docs.v1.write.FilePath(
                                 convertToFernHostRelativeFilePath(sanitizedPath)
@@ -325,7 +362,7 @@ export async function publishDocs({
                             height: image.height,
                             blurDataUrl: image.blurDataUrl,
                             alt: undefined,
-                            fileHash: await calculateFileHash(filePath.absoluteFilePath)
+                            fileHash: hash
                         } as DocsV2Write.ImageFilePath;
                         return obj;
                     }
@@ -349,11 +386,27 @@ export async function publishDocs({
                     HASH_CONCURRENCY,
                     nonImageFiles,
                     async (file) => {
+                        const { buffer, hash } = await readAndHashFile(file.absoluteFilePath);
+
+                        // Populate the ledger file manifest entry for this non-image file.
+                        // If mime.lookup fails (unknown extension), fall back to
+                        // application/octet-stream — both S3 and the docs CDN accept it,
+                        // and the manifest only needs *some* content-type for routing.
+                        const contentType = mime.lookup(file.absoluteFilePath) || "application/octet-stream";
+                        ledgerFileManifest[file.sanitizedPath] = {
+                            hash,
+                            contentType,
+                            contentLength: buffer.byteLength,
+                            filename: basename(file.sanitizedPath)
+                            // width/height/blurDataURL omitted: non-image
+                        };
+                        ledgerFileBlobs.set(hash, buffer);
+
                         return {
                             path: CjsFdrSdk.docs.v1.write.FilePath(
                                 convertToFernHostRelativeFilePath(file.sanitizedPath)
                             ),
-                            fileHash: await calculateFileHash(file.absoluteFilePath)
+                            fileHash: hash
                         };
                     }
                 );
@@ -672,7 +725,9 @@ export async function publishDocs({
                     fdrOrigin,
                     headers,
                     context,
-                    apiDefinitions: apiDefinitionCollector
+                    apiDefinitions: apiDefinitionCollector,
+                    fileManifest: Object.keys(ledgerFileManifest).length > 0 ? ledgerFileManifest : undefined,
+                    fileBlobs: ledgerFileBlobs.size > 0 ? ledgerFileBlobs : undefined
                 });
                 context.logger.info(
                     `[ledger] Deployment ${ledgerResult.reusedDeployment ? "reused" : "created"}: ${ledgerResult.deploymentId}`

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -108,7 +108,11 @@ export function buildLedgerInput({
         previewId: previewId ?? null,
         root: docsDefinition.config.root ?? docsDefinition.config.navigation,
         pages,
-        config: docsDefinition.config as unknown as DocsPublishInput["config"],
+        // TODO: map DocsConfig → LedgerConfig (Track B). The two schemas have
+        // diverged — DocsConfig.colorsV3.dark.logo is a string, LedgerConfig
+        // expects an ImageRef object. Sending undefined for now lets the publish
+        // through; FDR transform handles missing config gracefully.
+        config: undefined,
         apiManifest: apiManifestRef,
         fileManifest,
         redirects: null,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -23,11 +23,27 @@ interface BlobRef {
 }
 
 /**
- * Serializes a value to a JSON buffer and returns a BlobRef + the raw bytes,
- * keyed by content hash for later upload.
+ * `JSON.stringify` with deterministic key ordering at every level. Arrays
+ * keep their original ordering (positions are meaningful); object keys are
+ * sorted lexicographically via the replacer. Two inputs that differ only by
+ * key insertion order serialize identically — required so the apiManifest
+ * blob hash is stable across publishes (cf. FDR `stableStringify`).
+ */
+function stableStringify(value: unknown): string {
+    return JSON.stringify(value, (_key, val) => {
+        if (val != null && typeof val === "object" && !Array.isArray(val)) {
+            return Object.fromEntries(Object.entries(val).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+        }
+        return val;
+    });
+}
+
+/**
+ * Serializes a value to a JSON buffer using {@link stableStringify} and
+ * returns a BlobRef + the raw bytes, keyed by content hash for later upload.
  */
 function jsonBlobRef(value: unknown): { ref: BlobRef; hash: string; buf: Buffer } {
-    const buf = Buffer.from(JSON.stringify(value), "utf-8");
+    const buf = Buffer.from(stableStringify(value), "utf-8");
     const hash = sha256(buf);
     return {
         ref: { hash, contentType: "application/json", contentLength: buf.length },
@@ -100,6 +116,16 @@ export function buildLedgerInput({
     });
 
     // API manifest: serialize all API definitions as a single JSON blob.
+    //
+    // `apiDefinitions` is populated by the `registerApi` callback inside a
+    // `Promise.all`, so the Map's insertion order reflects whichever HTTP
+    // round-trip completed first — non-deterministic across publishes.
+    // {@link jsonBlobRef} uses {@link stableStringify}, which sorts object
+    // keys at every level, so the resulting bytes are stable regardless
+    // of Map iteration order. Combined with the FDR-side
+    // `(orgId, apiName, contentHash)` dedup on `api_definitions_v2`, this
+    // makes the docs-ledger deployment hash deterministic for byte-identical
+    // publishes.
     let apiManifestRef: BlobRef | null = null;
     if (apiDefinitions.size > 0) {
         const manifestObj = Object.fromEntries(apiDefinitions);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -80,9 +80,7 @@ export function buildLedgerInput({
         blobs.set(hash, buf);
     }
 
-    // Config: serialize the entire config as a JSON blob.
-    const configBlob = jsonBlobRef(docsDefinition.config);
-    blobs.set(configBlob.hash, configBlob.buf);
+    // Config is sent inline (not a CAS blob) per the docs-ledger contract — Track B from the PRD. The schema is permissive (most fields .optional() / .unknown()) so the DocsConfig shape passes through; FDR's transform extracts only the LedgerConfig-shaped fields.
 
     // API manifest: serialize all API definitions as a single JSON blob.
     let apiManifestRef: BlobRef | null = null;
@@ -110,7 +108,7 @@ export function buildLedgerInput({
         previewId: previewId ?? null,
         root: docsDefinition.config.root ?? docsDefinition.config.navigation,
         pages,
-        config: configBlob.ref,
+        config: docsDefinition.config as unknown as DocsPublishInput["config"],
         apiManifest: apiManifestRef,
         fileManifest,
         redirects: null,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -1,5 +1,10 @@
 import type { APIV1Write, DocsV1Write } from "@fern-api/fdr-sdk";
-import { createDocsLedgerClient, type DocsPublishInput, type FileManifestEntry } from "@fern-api/fdr-sdk/orpc-client";
+import {
+    createDocsLedgerClient,
+    type DocsPublishGitInput,
+    type DocsPublishInput,
+    type FileManifestEntry
+} from "@fern-api/fdr-sdk/orpc-client";
 import type { TaskContext } from "@fern-api/task-context";
 import { createHash } from "crypto";
 
@@ -70,6 +75,8 @@ export function buildLedgerInput({
     domain,
     basepath,
     previewId,
+    customDomains,
+    git,
     apiDefinitions,
     fileManifest,
     fileBlobs,
@@ -80,6 +87,8 @@ export function buildLedgerInput({
     domain: string;
     basepath: string | undefined;
     previewId: string | undefined;
+    customDomains?: string[];
+    git?: DocsPublishGitInput;
     apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
     fileManifest?: Record<string, FileManifestEntry>;
     fileBlobs?: Map<string, Buffer>;
@@ -121,11 +130,17 @@ export function buildLedgerInput({
     // `Promise.all`, so the Map's insertion order reflects whichever HTTP
     // round-trip completed first — non-deterministic across publishes.
     // {@link jsonBlobRef} uses {@link stableStringify}, which sorts object
-    // keys at every level, so the resulting bytes are stable regardless
-    // of Map iteration order. Combined with the FDR-side
-    // `(orgId, apiName, contentHash)` dedup on `api_definitions_v2`, this
-    // makes the docs-ledger deployment hash deterministic for byte-identical
-    // publishes.
+    // keys at every level, so the resulting bytes are stable regardless of
+    // Map iteration order.
+    //
+    // Determinism caveat: stable apiManifest bytes are necessary but not
+    // sufficient for a deterministic deployment hash. Page bodies must also
+    // be byte-identical, which requires that file references substituted
+    // into markdown (`file:<fileId>` tokens emitted by replaceImagePathsAndUrls)
+    // be stable. In `ledger` deploy mode the CLI emits path tokens
+    // (`file:<sanitizedPath>`) and short-circuits the V2 register call; in
+    // `dual`/`legacy` modes the V2 register flow mints fresh UUID FileIds per
+    // request, so deployment-level dedup will not fire there.
     let apiManifestRef: BlobRef | null = null;
     if (apiDefinitions.size > 0) {
         const manifestObj = Object.fromEntries(apiDefinitions);
@@ -148,6 +163,7 @@ export function buildLedgerInput({
         orgId: organization,
         domain,
         basepath: basepath ?? "",
+        customDomains: customDomains ?? [],
         previewId: previewId ?? null,
         root: docsDefinition.config.root ?? docsDefinition.config.navigation,
         pages,
@@ -155,7 +171,8 @@ export function buildLedgerInput({
         apiManifest: apiManifestRef,
         fileManifest,
         redirects: null,
-        locale: "en"
+        locale: "en",
+        git
     };
 
     return { input, blobs };
@@ -180,6 +197,8 @@ export async function publishDocsViaLedger({
     domain,
     basepath,
     previewId,
+    customDomains,
+    git,
     token,
     fdrOrigin,
     headers,
@@ -194,6 +213,8 @@ export async function publishDocsViaLedger({
     domain: string;
     basepath: string | undefined;
     previewId: string | undefined;
+    customDomains?: string[];
+    git?: DocsPublishGitInput;
     token: string;
     fdrOrigin: string;
     headers: Record<string, string>;
@@ -209,6 +230,8 @@ export async function publishDocsViaLedger({
         domain,
         basepath,
         previewId,
+        customDomains,
+        git,
         apiDefinitions,
         fileManifest,
         fileBlobs,
@@ -228,32 +251,7 @@ export async function publishDocsViaLedger({
     );
 
     // Step 2: Upload any blobs the server doesn't have yet.
-    if (registerResult.missingContent.length > 0) {
-        context.logger.debug(`[ledger] Uploading ${registerResult.missingContent.length} missing blobs...`);
-        const uploadStart = performance.now();
-
-        const results = await asyncPool(
-            UPLOAD_CONCURRENCY,
-            registerResult.missingContent,
-            async ({ hash, uploadUrl }) => {
-                const blob = blobs.get(hash);
-                if (blob == null) {
-                    context.logger.warn(`[ledger] Server requested blob ${hash} but we don't have it — skipping`);
-                    return "skipped" as const;
-                }
-                return uploadBlobWithRetry(blob, uploadUrl, hash, context);
-            }
-        );
-
-        const uploaded = results.filter((r) => r === "uploaded").length;
-        const alreadyExisted = results.filter((r) => r === "already_exists").length;
-        const uploadTime = performance.now() - uploadStart;
-        context.logger.debug(
-            `[ledger] Upload complete in ${uploadTime.toFixed(0)}ms — ${uploaded} uploaded, ${alreadyExisted} already in store`
-        );
-    } else {
-        context.logger.debug("[ledger] All content already in CAS — no uploads needed");
-    }
+    await uploadMissingBlobs(registerResult.missingContent, blobs, context);
 
     // Step 3: Finish — server persists the deployment.
     context.logger.debug("[ledger] Finishing deployment...");
@@ -265,6 +263,39 @@ export async function publishDocsViaLedger({
     );
 
     return finishResult;
+}
+
+/**
+ * Upload blobs the server reported as missing after a register call.
+ * Shared between the production and preview ledger flows.
+ */
+export async function uploadMissingBlobs(
+    missingContent: ReadonlyArray<{ hash: string; uploadUrl: string }>,
+    blobs: Map<string, Buffer>,
+    context: TaskContext
+): Promise<void> {
+    if (missingContent.length > 0) {
+        context.logger.debug(`[ledger] Uploading ${missingContent.length} missing blobs...`);
+        const uploadStart = performance.now();
+
+        const results = await asyncPool(UPLOAD_CONCURRENCY, [...missingContent], async ({ hash, uploadUrl }) => {
+            const blob = blobs.get(hash);
+            if (blob == null) {
+                context.logger.warn(`[ledger] Server requested blob ${hash} but we don't have it — skipping`);
+                return "skipped" as const;
+            }
+            return uploadBlobWithRetry(blob, uploadUrl, hash, context);
+        });
+
+        const uploaded = results.filter((r) => r === "uploaded").length;
+        const alreadyExisted = results.filter((r) => r === "already_exists").length;
+        const uploadTime = performance.now() - uploadStart;
+        context.logger.debug(
+            `[ledger] Upload complete in ${uploadTime.toFixed(0)}ms — ${uploaded} uploaded, ${alreadyExisted} already in store`
+        );
+    } else {
+        context.logger.debug("[ledger] All content already in CAS — no uploads needed");
+    }
 }
 
 type UploadResult = "uploaded" | "already_exists";

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -1,5 +1,5 @@
 import type { APIV1Write, DocsV1Write } from "@fern-api/fdr-sdk";
-import { createDocsLedgerClient, type DocsPublishInput } from "@fern-api/fdr-sdk/orpc-client";
+import { createDocsLedgerClient, type DocsPublishInput, type FileManifestEntry } from "@fern-api/fdr-sdk/orpc-client";
 import type { TaskContext } from "@fern-api/task-context";
 import { createHash } from "crypto";
 
@@ -38,6 +38,14 @@ function jsonBlobRef(value: unknown): { ref: BlobRef; hash: string; buf: Buffer 
 /**
  * Build a DocsPublishInput from a resolved DocsDefinition and collect
  * all content blobs that may need uploading.
+ *
+ * If `fileManifest` and `fileBlobs` are provided, they are merged into the
+ * resulting input: the manifest is forwarded as-is, and the per-file blobs
+ * are folded into the returned blob map so the upload step can stream them
+ * to the docs bucket. The manifest's keys MUST be the same string the FDR
+ * register handler treats as `fullPath` (see {@link makeFileArtifact} in
+ * docsPublishTransform.ts) — the CLI uses sanitizedPath (fern-host-relative)
+ * which maps 1:1 to fullPath.
  */
 export function buildLedgerInput({
     docsDefinition,
@@ -45,7 +53,9 @@ export function buildLedgerInput({
     domain,
     basepath,
     previewId,
-    apiDefinitions
+    apiDefinitions,
+    fileManifest,
+    fileBlobs
 }: {
     docsDefinition: DocsDefinition;
     organization: string;
@@ -53,6 +63,8 @@ export function buildLedgerInput({
     basepath: string | undefined;
     previewId: string | undefined;
     apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
+    fileManifest?: Record<string, FileManifestEntry>;
+    fileBlobs?: Map<string, Buffer>;
 }): { input: DocsPublishInput; blobs: Map<string, Buffer> } {
     const blobs = new Map<string, Buffer>();
 
@@ -81,6 +93,16 @@ export function buildLedgerInput({
         apiManifestRef = manifestBlob.ref;
     }
 
+    // Merge per-file blobs into the CAS blob map so they get uploaded by the
+    // ledger flow alongside pages/config/apiManifest. Each entry in
+    // `fileManifest` references a blob by SHA-256 hash that the server will
+    // request via the register response's `missingContent` list.
+    if (fileBlobs != null) {
+        for (const [hash, buf] of fileBlobs) {
+            blobs.set(hash, buf);
+        }
+    }
+
     const input: DocsPublishInput = {
         orgId: organization,
         domain,
@@ -90,7 +112,7 @@ export function buildLedgerInput({
         pages,
         config: configBlob.ref,
         apiManifest: apiManifestRef,
-        files: null,
+        fileManifest,
         redirects: null,
         locale: "en"
     };
@@ -121,7 +143,9 @@ export async function publishDocsViaLedger({
     fdrOrigin,
     headers,
     context,
-    apiDefinitions
+    apiDefinitions,
+    fileManifest,
+    fileBlobs
 }: {
     docsDefinition: DocsDefinition;
     organization: string;
@@ -133,6 +157,8 @@ export async function publishDocsViaLedger({
     headers: Record<string, string>;
     context: TaskContext;
     apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
+    fileManifest?: Record<string, FileManifestEntry>;
+    fileBlobs?: Map<string, Buffer>;
 }): Promise<LedgerPublishResult> {
     const { input, blobs } = buildLedgerInput({
         docsDefinition,
@@ -140,7 +166,9 @@ export async function publishDocsViaLedger({
         domain,
         basepath,
         previewId,
-        apiDefinitions
+        apiDefinitions,
+        fileManifest,
+        fileBlobs
     });
 
     const client = createDocsLedgerClient({ baseUrl: fdrOrigin, token, headers });

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -3,6 +3,7 @@ import { createDocsLedgerClient, type DocsPublishInput, type FileManifestEntry }
 import type { TaskContext } from "@fern-api/task-context";
 import { createHash } from "crypto";
 
+import { mapDocsConfigToLedgerConfig } from "./mapDocsConfigToLedgerConfig.js";
 import { asyncPool } from "./utils/asyncPool.js";
 
 const UPLOAD_CONCURRENCY = 10;
@@ -55,7 +56,8 @@ export function buildLedgerInput({
     previewId,
     apiDefinitions,
     fileManifest,
-    fileBlobs
+    fileBlobs,
+    fileIdToPath
 }: {
     docsDefinition: DocsDefinition;
     organization: string;
@@ -65,6 +67,14 @@ export function buildLedgerInput({
     apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
     fileManifest?: Record<string, FileManifestEntry>;
     fileBlobs?: Map<string, Buffer>;
+    /**
+     * Map from FileId (as returned by FDR's legacy startDocsRegister
+     * `uploadUrls`) to the `fullPath` string used to key `fileManifest`.
+     * Used by {@link mapDocsConfigToLedgerConfig} to translate DocsConfig's
+     * FileId-based references (e.g. `colorsV3.dark.logo`) into LedgerConfig's
+     * path-based references (e.g. `ImageRef { path, width, height }`).
+     */
+    fileIdToPath?: Map<string, string>;
 }): { input: DocsPublishInput; blobs: Map<string, Buffer> } {
     const blobs = new Map<string, Buffer>();
 
@@ -80,7 +90,14 @@ export function buildLedgerInput({
         blobs.set(hash, buf);
     }
 
-    // Config is sent inline (not a CAS blob) per the docs-ledger contract — Track B from the PRD. The schema is permissive (most fields .optional() / .unknown()) so the DocsConfig shape passes through; FDR's transform extracts only the LedgerConfig-shaped fields.
+    // Config is sent inline (not a CAS blob) per the docs-ledger contract.
+    // DocsConfig (FileId-based) is translated to LedgerConfig (path-based)
+    // up front so the wire payload is already in the schema FDR validates.
+    const ledgerConfig = mapDocsConfigToLedgerConfig({
+        docsConfig: docsDefinition.config,
+        fileManifest,
+        fileIdToPath
+    });
 
     // API manifest: serialize all API definitions as a single JSON blob.
     let apiManifestRef: BlobRef | null = null;
@@ -108,11 +125,7 @@ export function buildLedgerInput({
         previewId: previewId ?? null,
         root: docsDefinition.config.root ?? docsDefinition.config.navigation,
         pages,
-        // TODO: map DocsConfig → LedgerConfig (Track B). The two schemas have
-        // diverged — DocsConfig.colorsV3.dark.logo is a string, LedgerConfig
-        // expects an ImageRef object. Sending undefined for now lets the publish
-        // through; FDR transform handles missing config gracefully.
-        config: undefined,
+        config: ledgerConfig,
         apiManifest: apiManifestRef,
         fileManifest,
         redirects: null,
@@ -147,7 +160,8 @@ export async function publishDocsViaLedger({
     context,
     apiDefinitions,
     fileManifest,
-    fileBlobs
+    fileBlobs,
+    fileIdToPath
 }: {
     docsDefinition: DocsDefinition;
     organization: string;
@@ -161,6 +175,7 @@ export async function publishDocsViaLedger({
     apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
     fileManifest?: Record<string, FileManifestEntry>;
     fileBlobs?: Map<string, Buffer>;
+    fileIdToPath?: Map<string, string>;
 }): Promise<LedgerPublishResult> {
     const { input, blobs } = buildLedgerInput({
         docsDefinition,
@@ -170,7 +185,8 @@ export async function publishDocsViaLedger({
         previewId,
         apiDefinitions,
         fileManifest,
-        fileBlobs
+        fileBlobs,
+        fileIdToPath
     });
 
     const client = createDocsLedgerClient({ baseUrl: fdrOrigin, token, headers });

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -5,8 +5,10 @@ import {
     type DocsPublishInput,
     type FileManifestEntry
 } from "@fern-api/fdr-sdk/orpc-client";
+import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { TaskContext } from "@fern-api/task-context";
 import { createHash } from "crypto";
+import { readFile } from "fs/promises";
 
 import { mapDocsConfigToLedgerConfig } from "./mapDocsConfigToLedgerConfig.js";
 import { asyncPool } from "./utils/asyncPool.js";
@@ -61,13 +63,13 @@ function jsonBlobRef(value: unknown): { ref: BlobRef; hash: string; buf: Buffer 
  * Build a DocsPublishInput from a resolved DocsDefinition and collect
  * all content blobs that may need uploading.
  *
- * If `fileManifest` and `fileBlobs` are provided, they are merged into the
- * resulting input: the manifest is forwarded as-is, and the per-file blobs
- * are folded into the returned blob map so the upload step can stream them
- * to the docs bucket. The manifest's keys MUST be the same string the FDR
- * register handler treats as `fullPath` (see {@link makeFileArtifact} in
- * docsPublishTransform.ts) — the CLI uses sanitizedPath (fern-host-relative)
- * which maps 1:1 to fullPath.
+ * If `fileManifest` is provided, it is forwarded as-is into the resulting
+ * input. File blobs are NOT included in the returned blob map — they are
+ * loaded lazily during the upload step to avoid holding all file content in
+ * memory for the entire publish duration. The manifest's keys MUST be the
+ * same string the FDR register handler treats as `fullPath` (see
+ * {@link makeFileArtifact} in docsPublishTransform.ts) — the CLI uses
+ * sanitizedPath (fern-host-relative) which maps 1:1 to fullPath.
  */
 export function buildLedgerInput({
     docsDefinition,
@@ -79,7 +81,6 @@ export function buildLedgerInput({
     git,
     apiDefinitions,
     fileManifest,
-    fileBlobs,
     fileIdToPath
 }: {
     docsDefinition: DocsDefinition;
@@ -91,7 +92,6 @@ export function buildLedgerInput({
     git?: DocsPublishGitInput;
     apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
     fileManifest?: Record<string, FileManifestEntry>;
-    fileBlobs?: Map<string, Buffer>;
     /**
      * Map from FileId (as returned by FDR's legacy startDocsRegister
      * `uploadUrls`) to the `fullPath` string used to key `fileManifest`.
@@ -149,16 +149,6 @@ export function buildLedgerInput({
         apiManifestRef = manifestBlob.ref;
     }
 
-    // Merge per-file blobs into the CAS blob map so they get uploaded by the
-    // ledger flow alongside pages/config/apiManifest. Each entry in
-    // `fileManifest` references a blob by SHA-256 hash that the server will
-    // request via the register response's `missingContent` list.
-    if (fileBlobs != null) {
-        for (const [hash, buf] of fileBlobs) {
-            blobs.set(hash, buf);
-        }
-    }
-
     const input: DocsPublishInput = {
         orgId: organization,
         domain,
@@ -205,7 +195,7 @@ export async function publishDocsViaLedger({
     context,
     apiDefinitions,
     fileManifest,
-    fileBlobs,
+    filePaths,
     fileIdToPath
 }: {
     docsDefinition: DocsDefinition;
@@ -221,7 +211,8 @@ export async function publishDocsViaLedger({
     context: TaskContext;
     apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
     fileManifest?: Record<string, FileManifestEntry>;
-    fileBlobs?: Map<string, Buffer>;
+    /** Hash → absolute file path for lazy on-demand reads during upload. */
+    filePaths?: Map<string, AbsoluteFilePath>;
     fileIdToPath?: Map<string, string>;
 }): Promise<LedgerPublishResult> {
     const { input, blobs } = buildLedgerInput({
@@ -234,7 +225,6 @@ export async function publishDocsViaLedger({
         git,
         apiDefinitions,
         fileManifest,
-        fileBlobs,
         fileIdToPath
     });
 
@@ -251,7 +241,9 @@ export async function publishDocsViaLedger({
     );
 
     // Step 2: Upload any blobs the server doesn't have yet.
-    await uploadMissingBlobs(registerResult.missingContent, blobs, context);
+    // In-memory blobs (pages, config, apiManifest) are checked first;
+    // file blobs are read lazily from disk via filePaths.
+    await uploadMissingBlobs(registerResult.missingContent, blobs, context, filePaths);
 
     // Step 3: Finish — server persists the deployment.
     context.logger.debug("[ledger] Finishing deployment...");
@@ -268,18 +260,33 @@ export async function publishDocsViaLedger({
 /**
  * Upload blobs the server reported as missing after a register call.
  * Shared between the production and preview ledger flows.
+ *
+ * Small in-memory blobs (pages, config, apiManifest) are looked up in
+ * `blobs` first. File blobs are loaded lazily from disk via `filePaths`
+ * (hash → absolute path) to avoid holding every file's bytes in memory
+ * for the entire publish duration.
  */
 export async function uploadMissingBlobs(
     missingContent: ReadonlyArray<{ hash: string; uploadUrl: string }>,
     blobs: Map<string, Buffer>,
-    context: TaskContext
+    context: TaskContext,
+    filePaths?: Map<string, AbsoluteFilePath>
 ): Promise<void> {
     if (missingContent.length > 0) {
         context.logger.debug(`[ledger] Uploading ${missingContent.length} missing blobs...`);
         const uploadStart = performance.now();
 
         const results = await asyncPool(UPLOAD_CONCURRENCY, [...missingContent], async ({ hash, uploadUrl }) => {
-            const blob = blobs.get(hash);
+            // Prefer in-memory blobs (pages, config, apiManifest).
+            let blob = blobs.get(hash);
+            if (blob == null && filePaths != null) {
+                // Lazy read: only load file content for blobs the server
+                // actually needs, and discard after upload.
+                const filePath = filePaths.get(hash);
+                if (filePath != null) {
+                    blob = await readFile(filePath);
+                }
+            }
             if (blob == null) {
                 context.logger.warn(`[ledger] Server requested blob ${hash} but we don't have it — skipping`);
                 return "skipped" as const;

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
@@ -1,0 +1,127 @@
+import type { APIV1Write, DocsV1Write } from "@fern-api/fdr-sdk";
+import {
+    createDocsLedgerClient,
+    type DocsPublishGitInput,
+    type FileManifestEntry
+} from "@fern-api/fdr-sdk/orpc-client";
+import type { TaskContext } from "@fern-api/task-context";
+
+import { buildLedgerInput, uploadMissingBlobs } from "./publishDocsLedger.js";
+
+type DocsDefinition = DocsV1Write.DocsDefinition;
+
+export interface LedgerPreviewResult {
+    previewUrl: string;
+    deploymentId: string;
+}
+
+/**
+ * Publish a docs preview via the dedicated ledger preview endpoint
+ * (POST /preview/init) followed by the standard finish call.
+ *
+ * Unlike the production {@link publishDocsViaLedger}, this flow:
+ *   - Sends `LedgerPreviewRegisterInput` (no `domain` / `customDomains`).
+ *   - Receives a server-generated preview URL and domain.
+ *   - Finishes with the server-assigned domain + previewId so the deployment
+ *     lands on the preview branch, not production.
+ */
+export async function publishDocsViaLedgerPreview({
+    docsDefinition,
+    organization,
+    basePath,
+    previewId,
+    git,
+    token,
+    fdrOrigin,
+    headers,
+    context,
+    apiDefinitions,
+    fileManifest,
+    fileBlobs,
+    fileIdToPath
+}: {
+    docsDefinition: DocsDefinition;
+    organization: string;
+    basePath: string | undefined;
+    previewId: string | undefined;
+    git?: DocsPublishGitInput;
+    token: string;
+    fdrOrigin: string;
+    headers: Record<string, string>;
+    context: TaskContext;
+    apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
+    fileManifest?: Record<string, FileManifestEntry>;
+    fileBlobs?: Map<string, Buffer>;
+    fileIdToPath?: Map<string, string>;
+}): Promise<LedgerPreviewResult> {
+    // Build the input and blob map using the shared helper.  We pass a
+    // throwaway `domain` — it's required by buildLedgerInput's type but will
+    // not be sent to the preview endpoint (LedgerPreviewRegisterInput has no
+    // domain field).
+    const { input, blobs } = buildLedgerInput({
+        docsDefinition,
+        organization,
+        domain: "",
+        basepath: basePath,
+        previewId,
+        customDomains: [],
+        git,
+        apiDefinitions,
+        fileManifest,
+        fileBlobs,
+        fileIdToPath
+    });
+
+    const client = createDocsLedgerClient({ baseUrl: fdrOrigin, token, headers });
+
+    // Step 1: Preview register — server picks the preview host and returns
+    // presigned upload URLs for missing blobs.
+    context.logger.debug("[ledger-preview] Registering preview deployment...");
+    const registerStart = performance.now();
+    const registerResult = await client.previewRegister({
+        orgId: organization,
+        previewId: previewId ?? null,
+        basePath: basePath ?? "",
+        root: input.root,
+        pages: input.pages,
+        apiManifest: input.apiManifest,
+        config: input.config,
+        fileManifest: input.fileManifest,
+        jsFiles: input.jsFiles,
+        redirects: input.redirects,
+        locale: input.locale,
+        version: input.version,
+        repo: input.repo,
+        git
+    });
+    const registerTime = performance.now() - registerStart;
+    context.logger.debug(
+        `[ledger-preview] Registered in ${registerTime.toFixed(0)}ms — hash=${registerResult.deploymentHash}, ` +
+            `preview=${registerResult.previewUrl}, missing=${registerResult.missingContent.length} blobs`
+    );
+
+    // Step 2: Upload missing blobs.
+    await uploadMissingBlobs(registerResult.missingContent, blobs, context);
+
+    // Step 3: Finish — use the server-assigned domain and previewId so the
+    // deployment is keyed to the preview branch.
+    context.logger.debug("[ledger-preview] Finishing preview deployment...");
+    const finishStart = performance.now();
+    const finishResult = await client.finish({
+        ...input,
+        domain: registerResult.domain,
+        basepath: registerResult.basepath,
+        customDomains: [],
+        previewId: registerResult.previewId
+    });
+    const finishTime = performance.now() - finishStart;
+    context.logger.debug(
+        `[ledger-preview] Finished in ${finishTime.toFixed(0)}ms — deploymentId=${finishResult.deploymentId}, ` +
+            `reused=${finishResult.reusedDeployment}`
+    );
+
+    return {
+        previewUrl: registerResult.previewUrl,
+        deploymentId: finishResult.deploymentId
+    };
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
@@ -4,6 +4,7 @@ import {
     type DocsPublishGitInput,
     type FileManifestEntry
 } from "@fern-api/fdr-sdk/orpc-client";
+import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { TaskContext } from "@fern-api/task-context";
 
 import { buildLedgerInput, uploadMissingBlobs } from "./publishDocsLedger.js";
@@ -37,7 +38,7 @@ export async function publishDocsViaLedgerPreview({
     context,
     apiDefinitions,
     fileManifest,
-    fileBlobs,
+    filePaths,
     fileIdToPath
 }: {
     docsDefinition: DocsDefinition;
@@ -51,7 +52,8 @@ export async function publishDocsViaLedgerPreview({
     context: TaskContext;
     apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
     fileManifest?: Record<string, FileManifestEntry>;
-    fileBlobs?: Map<string, Buffer>;
+    /** Hash → absolute file path for lazy on-demand reads during upload. */
+    filePaths?: Map<string, AbsoluteFilePath>;
     fileIdToPath?: Map<string, string>;
 }): Promise<LedgerPreviewResult> {
     // Build the input and blob map using the shared helper.  We pass a
@@ -68,7 +70,6 @@ export async function publishDocsViaLedgerPreview({
         git,
         apiDefinitions,
         fileManifest,
-        fileBlobs,
         fileIdToPath
     });
 
@@ -101,7 +102,7 @@ export async function publishDocsViaLedgerPreview({
     );
 
     // Step 2: Upload missing blobs.
-    await uploadMissingBlobs(registerResult.missingContent, blobs, context);
+    await uploadMissingBlobs(registerResult.missingContent, blobs, context, filePaths);
 
     // Step 3: Finish — use the server-assigned domain and previewId so the
     // deployment is keyed to the preview branch.

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -478,10 +478,11 @@ async function uploadDynamicIRForSdkGeneration({
     // Get presigned upload URLs from FDR
     let uploadUrlsResponse;
     try {
+        // TODO: thread snippetConfigWithVersions into FDR call — current shape change broke the integration.
         uploadUrlsResponse = await fdr.api.register.getSdkDynamicIrUploadUrls({
             orgId: FdrAPI.OrgId(organization),
-            apiId: "",
-            irVersions: []
+            version: "",
+            snippetConfiguration: {}
         });
     } catch (error) {
         // Log warning but don't fail the generation - dynamic IR upload is optional

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -191,17 +191,11 @@ export async function runRemoteGenerationForGenerator({
 
     const apiDefinition = convertIrToFdrApi({
         ir,
-        snippetsConfig: {
-            typescriptSdk: undefined,
-            pythonSdk: undefined,
-            javaSdk: undefined,
-            rubySdk: undefined,
-            goSdk: undefined,
-            csharpSdk: undefined,
-            phpSdk: undefined,
-            swiftSdk: undefined,
-            rustSdk: undefined
-        },
+        snippetsConfig: buildSnippetsConfigForSdk({
+            language: generatorInvocation.language,
+            packageName,
+            version: resolvedVersion
+        }),
         context: interactiveTaskContext
     });
     try {
@@ -452,6 +446,44 @@ const emptyReadmeConfig: FernIr.ReadmeConfig = {
     exampleStyle: undefined
 };
 
+export function buildSnippetsConfigForSdk({
+    language,
+    packageName,
+    version
+}: {
+    language: generatorsYml.GenerationLanguage | undefined;
+    packageName: string | undefined;
+    version: string | undefined;
+}): FdrAPI.api.v1.register.SnippetsConfig {
+    if (language == null || packageName == null) {
+        return {};
+    }
+
+    const resolvedVersion = resolveVersionFallback(version);
+    switch (language) {
+        case "typescript":
+            return { typescriptSdk: { package: packageName, version: resolvedVersion } };
+        case "python":
+            return { pythonSdk: { package: packageName, version: resolvedVersion } };
+        case "java":
+            return { javaSdk: { coordinate: packageName, version: resolvedVersion } };
+        case "ruby":
+            return { rubySdk: { gem: packageName, version: resolvedVersion } };
+        case "go":
+            return { goSdk: { githubRepo: packageName, version: resolvedVersion } };
+        case "csharp":
+            return { csharpSdk: { package: packageName, version: resolvedVersion } };
+        case "php":
+            return { phpSdk: { package: packageName, version: resolvedVersion } };
+        case "swift":
+            return { swiftSdk: { package: packageName, version: resolvedVersion } };
+        case "rust":
+            return { rustSdk: { package: packageName, version: resolvedVersion } };
+        default:
+            return {};
+    }
+}
+
 async function uploadDynamicIRForSdkGeneration({
     fdr,
     organization,
@@ -478,11 +510,10 @@ async function uploadDynamicIRForSdkGeneration({
     // Get presigned upload URLs from FDR
     let uploadUrlsResponse;
     try {
-        // TODO: thread snippetConfigWithVersions into FDR call — current shape change broke the integration.
         uploadUrlsResponse = await fdr.api.register.getSdkDynamicIrUploadUrls({
             orgId: FdrAPI.OrgId(organization),
-            version: "",
-            snippetConfiguration: {}
+            version,
+            snippetConfiguration: { [language]: packageName }
         });
     } catch (error) {
         // Log warning but don't fail the generation - dynamic IR upload is optional


### PR DESCRIPTION
## Description

Docs ledger publish improvements: lazy file blob loading, stable file tokens, ADR 0009/0011/0012 wiring.

## Changes Made

- **Lazy file blob loading** (`publishDocs.ts`, `publishDocsLedger.ts`, `publishDocsLedgerPreview.ts`): Instead of holding all file Buffers in memory for the entire publish duration, store only `hash → filePath` mappings. Files are re-read on demand during the upload step, and only for blobs the server reports as missing (CAS dedup means most republishes need zero re-reads).
- **Ledger mode skips V2 register**: In ledger-only deploy mode, the CLI no longer calls `startDocsRegister` — avoids minting non-deterministic UUID FileIds that would rotate deployment hashes on every publish.
- **Stable file tokens**: File references in markdown use deterministic `file:<sanitizedPath>` tokens instead of UUIDs, enabling page-level CAS dedup.
- **ADR 0009 (customDomains)**: Forwards custom domains into the ledger publish input.
- **ADR 0011 (git provenance)**: Populates structured git metadata (repo URL, branch, commit SHA) from CI environment into the ledger deployment.
- **ADR 0012 (preview)**: Preview publishes go through the dedicated `/preview/init` endpoint.
- **Stable apiManifest serialization**: `buildLedgerInput` uses `stableStringify` (sorted keys) so the apiManifest blob hash is deterministic regardless of Map insertion order.
- **normalizeRepoUrl**: Normalizes CI repo URLs (SSH, gitlab, bitbucket) to HTTPS for consistent git provenance.
- Fix biome lint: remove non-null assertion in legacy publish path.

## Testing

- [x] Unit tests added/updated (`buildLedgerInput.test.ts`, `normalizeRepoUrl.test.ts`)
- [x] All 154 tests in the package pass
- [x] TypeScript type-check passes
- [x] Biome lint passes