### PR TITLE
fix(cli): CLI-3Y handle missing browser opener during login

### DIFF
--- a/.devin/automation/sentry-triage/ledger/CLI-3Y.json
+++ b/.devin/automation/sentry-triage/ledger/CLI-3Y.json
@@ -1,9 +1,9 @@
 {
   "title": "spawn xdg-open ENOENT uncaught exception",
-  "disposition": "keep_sentry",
-  "rationale": "ENOENT from spawn xdg-open escapes normal error handling as uncaught exception; reaches Sentry via onUncaughtExceptionIntegration. Needs boundary-level wrapping at the spawn call site.",
-  "fixSummary": "—",
-  "prOrIssue": "Keep in Sentry until boundary-level fix",
+  "disposition": "shipped",
+  "rationale": "Browser opener failures during Auth0 login are local environment/tool failures and are now caught at the login browser-launch boundary instead of escaping as uncaught exceptions.",
+  "fixSummary": "Upgrade open to v11 and catch browser-launch spawn failures in login/logout so missing xdg-open shows manual URLs instead of uncaught exceptions.",
+  "prOrIssue": "https://github.com/fern-api/fern/pull/15942",
   "lastAnalyzed": "2026-05-16",
   "problemSignature": "Uncaught exception with ENOENT errno from spawn xdg-open bypassed resolveErrorCode and reached Sentry as raw exception."
 }

--- a/packages/cli/cli/changes/unreleased/fix-login-browser-open-fallback.yml
+++ b/packages/cli/cli/changes/unreleased/fix-login-browser-open-fallback.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Prevent login from reporting missing browser opener tools as internal errors.
+    Upgrade `open` to v11 so spawn failures reject the returned promise, and handle
+    them inline in redirect, device-code, and logout flows.
+  type: fix

--- a/packages/cli/login/src/auth0-login/doAuth0DeviceAuthorizationFlow.ts
+++ b/packages/cli/login/src/auth0-login/doAuth0DeviceAuthorizationFlow.ts
@@ -51,7 +51,11 @@ export async function doAuth0DeviceAuthorizationFlow({
         context.failAndThrow("Failed to authenticate", deviceCodeResponse.data, { code: CliError.Code.AuthError });
     }
 
-    await open(deviceCodeResponse.data.verification_uri_complete);
+    try {
+        await open(deviceCodeResponse.data.verification_uri_complete);
+    } catch {
+        // URL and login code are printed below.
+    }
 
     context.logger.info(
         [

--- a/packages/cli/login/src/auth0-login/doAuth0LoginFlow.ts
+++ b/packages/cli/login/src/auth0-login/doAuth0LoginFlow.ts
@@ -1,4 +1,4 @@
-import { CliError } from "@fern-api/task-context";
+import { CliError, type TaskContext } from "@fern-api/task-context";
 import axios from "axios";
 import { IncomingMessage, Server } from "http";
 import open from "open";
@@ -19,12 +19,14 @@ export interface Auth0TokenResponse {
 }
 
 export async function doAuth0LoginFlow({
+    context,
     auth0Domain,
     auth0ClientId,
     audience,
     forceReauth = false,
     connection
 }: {
+    context: TaskContext;
     auth0Domain: string;
     auth0ClientId: string;
     audience: string;
@@ -34,12 +36,22 @@ export async function doAuth0LoginFlow({
     connection?: string;
 }): Promise<Auth0TokenResponse> {
     const { origin, server } = await createServer();
-    const { code } = await getCode({ server, auth0Domain, auth0ClientId, origin, audience, forceReauth, connection });
+    const { code } = await getCode({
+        context,
+        server,
+        auth0Domain,
+        auth0ClientId,
+        origin,
+        audience,
+        forceReauth,
+        connection
+    });
     server.close();
     return await getTokenFromCode({ auth0Domain, auth0ClientId, code, origin });
 }
 
 function getCode({
+    context,
     server,
     auth0Domain,
     auth0ClientId,
@@ -48,6 +60,7 @@ function getCode({
     forceReauth,
     connection
 }: {
+    context: TaskContext;
     server: Server;
     auth0Domain: string;
     auth0ClientId: string;
@@ -57,8 +70,7 @@ function getCode({
     connection?: string;
 }) {
     return new Promise<{ code: string }>((resolve) => {
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        server.addListener("request", async (request, response) => {
+        server.addListener("request", (request, response) => {
             const code = parseCodeFromUrl(request, origin);
             if (code == null) {
                 request.socket.end();
@@ -70,7 +82,18 @@ function getCode({
             }
         });
 
-        void open(constructAuth0Url({ auth0ClientId, auth0Domain, origin, audience, forceReauth, connection }));
+        const loginUrl = constructAuth0Url({ auth0ClientId, auth0Domain, origin, audience, forceReauth, connection });
+        void open(loginUrl).catch(() => {
+            context.logger.info(
+                [
+                    "",
+                    "Couldn't open a browser automatically.",
+                    "If you're running fern on this machine, open this link to log in:",
+                    loginUrl,
+                    ""
+                ].join("\n")
+            );
+        });
     });
 }
 

--- a/packages/cli/login/src/login.ts
+++ b/packages/cli/login/src/login.ts
@@ -55,6 +55,7 @@ export async function getTokenFromAuth0(
             email
         });
         return await doAuth0LoginFlow({
+            context,
             auth0Domain: AUTH0_DOMAIN,
             auth0ClientId: AUTH0_CLIENT_ID,
             audience: VENUS_AUDIENCE,
@@ -64,6 +65,7 @@ export async function getTokenFromAuth0(
 
     try {
         return await doAuth0LoginFlow({
+            context,
             auth0Domain: AUTH0_DOMAIN,
             auth0ClientId: AUTH0_CLIENT_ID,
             audience: VENUS_AUDIENCE,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,8 +436,8 @@ catalogs:
       specifier: ^3.0.0
       version: 3.0.0
     open:
-      specifier: ^8.4.0
-      version: 8.4.2
+      specifier: ^11.0.0
+      version: 11.0.0
     ora:
       specifier: ^7.0.1
       version: 7.0.1
@@ -6601,7 +6601,7 @@ importers:
         version: 9.3.8(@types/node@22.19.17)
       open:
         specifier: 'catalog:'
-        version: 8.4.2
+        version: 11.0.0
       qs:
         specifier: 6.15.0
         version: 6.15.0
@@ -11407,6 +11407,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -11809,6 +11813,14 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
@@ -11816,9 +11828,9 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
-  define-lazy-prop@2.0.0:
-    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
-    engines: {node: '>=8'}
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
@@ -12732,9 +12744,9 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
-  is-docker@2.2.1:
-    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
-    engines: {node: '>=8'}
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
   is-extendable@0.1.1:
@@ -12755,6 +12767,15 @@ packages:
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -12823,9 +12844,9 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
 
-  is-wsl@2.2.0:
-    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
-    engines: {node: '>=8'}
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -13528,9 +13549,9 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  open@8.4.2:
-    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
-    engines: {node: '>=12'}
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
@@ -13818,6 +13839,10 @@ packages:
     peerDependenciesMeta:
       rxjs:
         optional: true
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -14112,6 +14137,10 @@ packages:
     resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   run-async@3.0.0:
     resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
@@ -15074,6 +15103,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
 
   xdg-basedir@5.1.0:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
@@ -18424,6 +18457,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
       esbuild: 0.27.7
@@ -18837,6 +18874,13 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
@@ -18847,7 +18891,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  define-lazy-prop@2.0.0: {}
+  define-lazy-prop@3.0.0: {}
 
   defu@6.1.7: {}
 
@@ -19944,7 +19988,7 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
-  is-docker@2.2.1: {}
+  is-docker@3.0.0: {}
 
   is-extendable@0.1.1: {}
 
@@ -19957,6 +20001,12 @@ snapshots:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
+
+  is-in-ssh@1.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-interactive@1.0.0: {}
 
@@ -19994,9 +20044,9 @@ snapshots:
 
   is-unicode-supported@2.1.0: {}
 
-  is-wsl@2.2.0:
+  is-wsl@3.1.1:
     dependencies:
-      is-docker: 2.2.1
+      is-inside-container: 1.0.0
 
   isarray@1.0.0: {}
 
@@ -20988,11 +21038,14 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  open@8.4.2:
+  open@11.0.0:
     dependencies:
-      define-lazy-prop: 2.0.0
-      is-docker: 2.2.1
-      is-wsl: 2.2.0
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
 
   openapi-types@12.1.3: {}
 
@@ -21280,6 +21333,8 @@ snapshots:
       '@posthog/core': 1.25.1
     optionalDependencies:
       rxjs: 7.8.2
+
+  powershell-utils@0.1.0: {}
 
   prelude-ls@1.2.1: {}
 
@@ -21705,6 +21760,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.60.4
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
+
+  run-applescript@7.1.0: {}
 
   run-async@3.0.0: {}
 
@@ -22767,6 +22824,11 @@ snapshots:
       signal-exit: 4.1.0
 
   ws@8.20.1: {}
+
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
 
   xdg-basedir@5.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -208,7 +208,7 @@ catalog:
   node-fetch: 2.7.0
   number-to-words: 1.2.4
   object-hash: ^3.0.0
-  open: ^8.4.0
+  open: ^11.0.0
   ora: ^7.0.1
   package-json-type: ^1.0.3
   path-to-regexp: 6.3.0


### PR DESCRIPTION
## Description
Refs CLI-3Y

Prevents Auth0 browser-launch failures (e.g. missing `xdg-open` on Linux) from escaping as uncaught internal errors in Sentry.

## Changes Made
- Upgrade catalog `open` dependency from `^8.4.0` to `^11.0.0` so spawn failures reject the returned promise (v8 emitted ENOENT asynchronously and could not be caught).
- **Redirect login** (`fern login`): catch browser-open failures and print a manual login link for local use.
- **Device-code login** (`fern login --device-code`): catch silently; URL and code are already printed next.
- **Logout** (`fern logout`): keep existing try/catch with manual logout URL on failure.
- Mark `CLI-3Y` as shipped in the Sentry triage ledger.
- [ ] Updated README.md generator (if applicable)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed:
  - `pnpm turbo run compile dist:cli:prod --filter @fern-api/cli... --force`
  - Redirect login with simulated missing `open`: manual link shown, no crash, login completes
  - Device-code login with simulated missing `open`: device code UI only, no crash
  - Logout with simulated missing `open`: warning + logout URL, no crash

Solved Sentry short IDs:
- **CLI-3Y**: `spawn xdg-open ENOENT` during login no longer crashes the CLI or reports as an internal error.