### PR TITLE
fix(cli): CLI-4W CLI-4X CLI-4T handle unresolved FDR example types

### DIFF
--- a/.devin/automation/sentry-triage/ledger/CLI-4T.json
+++ b/.devin/automation/sentry-triage/ledger/CLI-4T.json
@@ -1,0 +1,9 @@
+{
+  "title": "Failed to find PronunciationItem",
+  "problemSignature": "FDR SDK example generation failed to locate a referenced type during endpoint example call generation.",
+  "disposition": "shipped",
+  "rationale": "Docs API conversion now detects unresolved type references before FDR fallback example generation can throw, and supplies placeholder examples only for affected generated example paths.",
+  "fixSummary": "Add converter-side fallback examples for unresolved FDR generated example type references.",
+  "prOrIssue": "https://github.com/fern-api/fern/pull/15952",
+  "lastAnalyzed": "2026-05-16"
+}

--- a/.devin/automation/sentry-triage/ledger/CLI-4W.json
+++ b/.devin/automation/sentry-triage/ledger/CLI-4W.json
@@ -1,0 +1,9 @@
+{
+  "title": "Failed to find NorthErrorType",
+  "problemSignature": "FDR SDK example generation failed to locate a referenced type during endpoint example call generation.",
+  "disposition": "shipped",
+  "rationale": "Docs API conversion now detects unresolved type references before FDR fallback example generation can throw, and supplies placeholder examples only for affected generated example paths.",
+  "fixSummary": "Add converter-side fallback examples for unresolved FDR generated example type references.",
+  "prOrIssue": "https://github.com/fern-api/fern/pull/15952",
+  "lastAnalyzed": "2026-05-16"
+}

--- a/.devin/automation/sentry-triage/ledger/CLI-4X.json
+++ b/.devin/automation/sentry-triage/ledger/CLI-4X.json
@@ -1,0 +1,9 @@
+{
+  "title": "Failed to find Error type",
+  "problemSignature": "FDR SDK example generation failed to locate a referenced type during endpoint example call generation.",
+  "disposition": "shipped",
+  "rationale": "Docs API conversion now detects unresolved type references before FDR fallback example generation can throw, and supplies placeholder examples only for affected generated example paths.",
+  "fixSummary": "Add converter-side fallback examples for unresolved FDR generated example type references.",
+  "prOrIssue": "https://github.com/fern-api/fern/pull/15952",
+  "lastAnalyzed": "2026-05-16"
+}

--- a/packages/cli/cli/changes/unreleased/fix-fdr-unresolved-example-types.yml
+++ b/packages/cli/cli/changes/unreleased/fix-fdr-unresolved-example-types.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Prevent docs API conversion from failing when fallback example generation encounters unresolved type references.
+  type: fix

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/convertIrToFdrApi.test.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/convertIrToFdrApi.test.ts
@@ -3,15 +3,87 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 
 import { SourceResolverImpl } from "@fern-api/cli-source-resolver";
+import { FdrAPI as FdrCjsSdk } from "@fern-api/fdr-sdk";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 // import { loadApis } from "@fern-api/project-loader"; // Commented out to avoid cyclic dependency
 import { createMockTaskContext } from "@fern-api/task-context";
 import { readdir } from "fs/promises";
 import path from "path";
-
-// import { loadAPIWorkspace } from "../../../../workspace/loader/src/loadAPIWorkspace"; // Commented out to avoid cyclic dependency
 import { convertIrToFdrApi } from "../convertIrToFdrApi.js";
+// import { loadAPIWorkspace } from "../../../../workspace/loader/src/loadAPIWorkspace"; // Commented out to avoid cyclic dependency
+import { withFallbackExamplesForUnresolvedTypeReferences } from "../convertPackage.js";
+
+describe("withFallbackExamplesForUnresolvedTypeReferences", () => {
+    it("adds placeholder examples only for unresolved generated example paths", () => {
+        const endpoint = {
+            slug: undefined,
+            availability: undefined,
+            auth: undefined,
+            authV2: undefined,
+            multiAuth: undefined,
+            defaultEnvironment: undefined,
+            environments: undefined,
+            method: "GET",
+            id: FdrCjsSdk.EndpointId("getThing"),
+            originalEndpointId: "getThing",
+            name: "Get Thing",
+            description: undefined,
+            path: {
+                parts: [{ type: "literal", value: "/thing" }],
+                pathParameters: []
+            },
+            queryParameters: [],
+            headers: [],
+            responseHeaders: undefined,
+            request: undefined,
+            requestsV2: { requests: undefined },
+            response: {
+                statusCode: 200,
+                description: undefined,
+                type: {
+                    type: "reference",
+                    value: {
+                        type: "id",
+                        value: FdrCjsSdk.TypeId("MissingSuccessType"),
+                        default: undefined
+                    }
+                }
+            },
+            responsesV2: { responses: undefined },
+            errors: undefined,
+            errorsV2: [
+                {
+                    statusCode: 404,
+                    description: undefined,
+                    availability: undefined,
+                    headers: undefined,
+                    isWildcard: undefined,
+                    name: "Missing",
+                    examples: [],
+                    type: {
+                        type: "alias",
+                        value: {
+                            type: "id",
+                            value: FdrCjsSdk.TypeId("MissingErrorType"),
+                            default: undefined
+                        }
+                    }
+                }
+            ],
+            examples: [],
+            protocol: { type: "rest" },
+            includeInApiExplorer: true
+        } satisfies FdrCjsSdk.api.v1.register.EndpointDefinition;
+
+        const result = withFallbackExamplesForUnresolvedTypeReferences(endpoint, new Set());
+
+        expect(result.examples).toHaveLength(2);
+        expect(result.examples.map((example) => example.responseStatusCode)).toEqual([200, 404]);
+        expect(result.examples[0]?.path).toBe("/thing");
+        expect(endpoint.examples).toHaveLength(0);
+    });
+});
 
 // Temporarily disabled to avoid cyclic dependency with @fern-api/project-loader
 // biome-ignore lint/suspicious/noSkippedTests: Intentionally disabled due to cyclic dependency

--- a/packages/cli/register/src/ir-to-fdr-converter/convertPackage.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/convertPackage.ts
@@ -28,7 +28,8 @@ export function convertPackage(
             : undefined;
 
     // Convert REST endpoints
-    const restEndpoints = service != null ? convertService(service, ir) : [];
+    const knownTypeIds = new Set([...Object.keys(ir.types), ...Object.keys(graphqlTypes ?? {})]);
+    const restEndpoints = service != null ? convertService(service, ir, knownTypeIds) : [];
 
     return {
         endpoints: restEndpoints,
@@ -94,7 +95,8 @@ function convertWebhookGroup(webhookGroup: Ir.webhooks.WebhookGroup): FdrCjsSdk.
 
 function convertService(
     irService: Ir.http.HttpService,
-    ir: Ir.ir.IntermediateRepresentation
+    ir: Ir.ir.IntermediateRepresentation,
+    knownTypeIds: ReadonlySet<string>
 ): FdrCjsSdk.api.v1.register.EndpointDefinition[] {
     const endpoints: FdrCjsSdk.api.v1.register.EndpointDefinition[] = [];
     for (const irEndpoint of irService.endpoints) {
@@ -293,9 +295,261 @@ function convertService(
             }),
             includeInApiExplorer: irEndpoint.apiPlayground
         };
-        endpoints.push(endpoint);
+        endpoints.push(withFallbackExamplesForUnresolvedTypeReferences(endpoint, knownTypeIds));
     }
     return endpoints;
+}
+
+export function withFallbackExamplesForUnresolvedTypeReferences(
+    endpoint: FdrCjsSdk.api.v1.register.EndpointDefinition,
+    knownTypeIds: ReadonlySet<string>
+): FdrCjsSdk.api.v1.register.EndpointDefinition {
+    const examples = [...endpoint.examples];
+    const existingErrorExampleStatusCodes = new Set(
+        examples.filter((example) => example.responseStatusCode >= 400).map((example) => example.responseStatusCode)
+    );
+    const hasSuccessExample = examples.some((example) => example.responseStatusCode < 400);
+    const baseHasUnresolvedTypeReferences = endpointBaseHasUnresolvedTypeReferences(endpoint, knownTypeIds);
+
+    if (
+        !hasSuccessExample &&
+        (baseHasUnresolvedTypeReferences ||
+            (endpoint.response != null &&
+                responseBodyHasUnresolvedTypeReferences(endpoint.response.type, knownTypeIds)))
+    ) {
+        examples.push(createFallbackEndpointExample(endpoint, endpoint.response?.statusCode ?? 200));
+    }
+
+    for (const errorDeclaration of endpoint.errorsV2 ?? []) {
+        if (
+            !existingErrorExampleStatusCodes.has(errorDeclaration.statusCode) &&
+            (baseHasUnresolvedTypeReferences ||
+                (errorDeclaration.type != null &&
+                    typeShapeHasUnresolvedTypeReferences(errorDeclaration.type, knownTypeIds)))
+        ) {
+            examples.push(createFallbackEndpointExample(endpoint, errorDeclaration.statusCode));
+        }
+    }
+
+    if (examples.length === endpoint.examples.length) {
+        return endpoint;
+    }
+    return { ...endpoint, examples };
+}
+
+function endpointBaseHasUnresolvedTypeReferences(
+    endpoint: FdrCjsSdk.api.v1.register.EndpointDefinition,
+    knownTypeIds: ReadonlySet<string>
+): boolean {
+    return (
+        endpoint.path.pathParameters.some((pathParameter) =>
+            typeReferenceHasUnresolvedTypeReferences(pathParameter.type, knownTypeIds)
+        ) ||
+        endpoint.queryParameters.some((queryParameter) =>
+            typeReferenceHasUnresolvedTypeReferences(queryParameter.type, knownTypeIds)
+        ) ||
+        endpoint.headers.some((header) => typeReferenceHasUnresolvedTypeReferences(header.type, knownTypeIds)) ||
+        (endpoint.request != null && requestBodyHasUnresolvedTypeReferences(endpoint.request.type, knownTypeIds))
+    );
+}
+
+function requestBodyHasUnresolvedTypeReferences(
+    request: FdrCjsSdk.api.v1.register.HttpRequestBodyShape,
+    knownTypeIds: ReadonlySet<string>
+): boolean {
+    switch (request.type) {
+        case "object":
+            return objectTypeHasUnresolvedTypeReferences(request, knownTypeIds);
+        case "reference":
+            return typeReferenceHasUnresolvedTypeReferences(request.value, knownTypeIds);
+        case "json":
+            return requestJsonBodyHasUnresolvedTypeReferences(request.shape, knownTypeIds);
+        case "fileUpload":
+            return (
+                request.value?.properties.some((property) =>
+                    formDataPropertyHasUnresolvedTypeReferences(property, knownTypeIds)
+                ) ?? false
+            );
+        case "formData":
+            return request.properties.some((property) =>
+                formDataPropertyHasUnresolvedTypeReferences(property, knownTypeIds)
+            );
+        case "bytes":
+            return false;
+        default:
+            assertNever(request);
+    }
+}
+
+function requestJsonBodyHasUnresolvedTypeReferences(
+    request: FdrCjsSdk.api.v1.register.JsonRequestBody["shape"],
+    knownTypeIds: ReadonlySet<string>
+): boolean {
+    switch (request.type) {
+        case "object":
+            return objectTypeHasUnresolvedTypeReferences(request, knownTypeIds);
+        case "reference":
+            return typeReferenceHasUnresolvedTypeReferences(request.value, knownTypeIds);
+        default:
+            assertNever(request);
+    }
+}
+
+function formDataPropertyHasUnresolvedTypeReferences(
+    property: FdrCjsSdk.api.v1.register.FormDataProperty,
+    knownTypeIds: ReadonlySet<string>
+): boolean {
+    switch (property.type) {
+        case "file":
+            return false;
+        case "bodyProperty":
+            return typeReferenceHasUnresolvedTypeReferences(property.valueType, knownTypeIds);
+        default:
+            assertNever(property);
+    }
+}
+
+function responseBodyHasUnresolvedTypeReferences(
+    response: FdrCjsSdk.api.v1.register.HttpResponseBodyShape,
+    knownTypeIds: ReadonlySet<string>
+): boolean {
+    switch (response.type) {
+        case "object":
+            return objectTypeHasUnresolvedTypeReferences(response, knownTypeIds);
+        case "reference":
+            return typeReferenceHasUnresolvedTypeReferences(response.value, knownTypeIds);
+        case "stream":
+            return responseBodyStreamShapeHasUnresolvedTypeReferences(response.shape, knownTypeIds);
+        case "streamCondition":
+            return (
+                responseBodyHasUnresolvedTypeReferences(response.response.shape, knownTypeIds) ||
+                responseBodyHasUnresolvedTypeReferences(response.streamResponse.shape, knownTypeIds)
+            );
+        case "fileDownload":
+        case "streamingText":
+            return false;
+        default:
+            assertNever(response);
+    }
+}
+
+function responseBodyStreamShapeHasUnresolvedTypeReferences(
+    shape: FdrCjsSdk.api.v1.register.StreamResponse["shape"],
+    knownTypeIds: ReadonlySet<string>
+): boolean {
+    switch (shape.type) {
+        case "object":
+            return objectTypeHasUnresolvedTypeReferences(shape, knownTypeIds);
+        case "reference":
+            return typeReferenceHasUnresolvedTypeReferences(shape.value, knownTypeIds);
+        default:
+            assertNever(shape);
+    }
+}
+
+function typeShapeHasUnresolvedTypeReferences(
+    shape: FdrCjsSdk.api.v1.register.TypeShape,
+    knownTypeIds: ReadonlySet<string>
+): boolean {
+    switch (shape.type) {
+        case "alias":
+            return typeReferenceHasUnresolvedTypeReferences(shape.value, knownTypeIds);
+        case "object":
+            return objectTypeHasUnresolvedTypeReferences(shape, knownTypeIds);
+        case "undiscriminatedUnion":
+            return shape.variants.some((variant) =>
+                typeReferenceHasUnresolvedTypeReferences(variant.type, knownTypeIds)
+            );
+        case "discriminatedUnion":
+            return shape.variants.some((variant) =>
+                objectTypeHasUnresolvedTypeReferences(variant.additionalProperties, knownTypeIds)
+            );
+        case "enum":
+            return false;
+        default:
+            assertNever(shape);
+    }
+}
+
+function objectTypeHasUnresolvedTypeReferences(
+    object: FdrCjsSdk.api.v1.register.ObjectType,
+    knownTypeIds: ReadonlySet<string>
+): boolean {
+    return (
+        object.extends.some((typeId) => !knownTypeIds.has(typeId)) ||
+        object.properties.some((property) =>
+            typeReferenceHasUnresolvedTypeReferences(property.valueType, knownTypeIds)
+        ) ||
+        (object.extraProperties != null &&
+            typeReferenceHasUnresolvedTypeReferences(object.extraProperties, knownTypeIds))
+    );
+}
+
+function typeReferenceHasUnresolvedTypeReferences(
+    reference: FdrCjsSdk.api.v1.register.TypeReference,
+    knownTypeIds: ReadonlySet<string>
+): boolean {
+    switch (reference.type) {
+        case "id":
+            return !knownTypeIds.has(reference.value);
+        case "optional":
+        case "nullable":
+        case "list":
+        case "set":
+            return typeReferenceHasUnresolvedTypeReferences(reference.itemType, knownTypeIds);
+        case "map":
+            return (
+                typeReferenceHasUnresolvedTypeReferences(reference.keyType, knownTypeIds) ||
+                typeReferenceHasUnresolvedTypeReferences(reference.valueType, knownTypeIds)
+            );
+        case "primitive":
+        case "literal":
+        case "unknown":
+            return false;
+        default:
+            assertNever(reference);
+    }
+}
+
+function createFallbackEndpointExample(
+    endpoint: FdrCjsSdk.api.v1.register.EndpointDefinition,
+    responseStatusCode: number
+): FdrCjsSdk.api.v1.register.ExampleEndpointCall {
+    const pathParameters = Object.fromEntries(
+        endpoint.path.pathParameters.map((pathParameter) => [pathParameter.key, `:${pathParameter.key}`])
+    );
+    return {
+        description: undefined,
+        name: undefined,
+        path: generatePathWithFallbackParameters(endpoint.path.parts, pathParameters),
+        pathParameters,
+        queryParameters: {},
+        headers: {},
+        requestBody: undefined,
+        requestBodyV3: undefined,
+        responseStatusCode,
+        responseBody: undefined,
+        responseBodyV3: undefined,
+        codeSamples: undefined
+    };
+}
+
+function generatePathWithFallbackParameters(
+    parts: FdrCjsSdk.api.v1.register.EndpointDefinition["path"]["parts"],
+    pathParameters: Record<string, string>
+): string {
+    return parts
+        .map((part) => {
+            switch (part.type) {
+                case "literal":
+                    return part.value;
+                case "pathParameter":
+                    return pathParameters[part.value] ?? `:${part.value}`;
+                default:
+                    assertNever(part);
+            }
+        })
+        .join("");
 }
 
 function convertWebSocketChannel(


### PR DESCRIPTION
## Summary
- Add a narrow fallback in FDR API conversion for endpoints whose SDK-generated examples would otherwise resolve a missing type ID.
- Preserve normal generated examples when all referenced types are present, and only add placeholder examples for affected success/error status paths.
- Add a focused unit test and CLI changelog entry.

## Solved Sentry Issues
- CLI-4W: avoids aborting docs conversion when fallback error example generation cannot resolve `NorthErrorType`.
- CLI-4X: avoids aborting docs conversion when fallback error example generation cannot resolve `Error`.
- CLI-4T: avoids aborting docs conversion when fallback example generation cannot resolve `PronunciationItem`.

## Test plan
- pnpm install --ignore-scripts
- pnpm turbo run compile --filter @fern-api/register
- pnpm turbo run test --filter @fern-api/register

Made with [Cursor](https://cursor.com)