### PR TITLE
chore(deps): bump @fern-api/replay to 0.15.1 in generator-cli

### DIFF
--- a/packages/cli/cli/changes/unreleased/bump-generator-cli-0.9.29.yml
+++ b/packages/cli/cli/changes/unreleased/bump-generator-cli-0.9.29.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.29, which includes @fern-api/replay
+    0.15.1 with fixes for fallback patch anchoring, composite-patch survival,
+    and FileOwnership divergence.
+  type: chore

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -41,7 +41,7 @@
     "@fern-api/docker-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-api/replay": "0.15.0",
+    "@fern-api/replay": "0.15.1",
     "@fern-api/task-context": "workspace:*",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Bump @fern-api/replay to 0.15.1.
+      type: chore
+  createdAt: "2026-05-17"
+  version: 0.9.29
+
+- changelogEntry:
+    - summary: |
         Set explicit author and committer on API-created commits to the Fern bot
         identity (`fern-api` / `115122769+fern-api[bot]@users.noreply.github.com`).
         Previously, `octokit.git.createCommit()` defaulted to the authenticated user,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7939,8 +7939,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/logging-execa
       '@fern-api/replay':
-        specifier: 0.15.0
-        version: 0.15.0
+        specifier: 0.15.1
+        version: 0.15.1
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../cli/task-context
@@ -9456,6 +9456,11 @@ packages:
 
   '@fern-api/replay@0.15.0':
     resolution: {integrity: sha512-F5EcUoVLsVYW5qmwag0S87ZAIf7ldc+vlHEbg4MdImd2m4W5WVKIL1vy60DDPucD2QnGTzavDv9Hi6IaOlyYCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@fern-api/replay@0.15.1':
+    resolution: {integrity: sha512-s48EkuzdFccAE5Wn4DztgfJoFcnRIFCrQjPlGd9ULt42v3wEBom2s6c+NyN7fQzgL3H1BrM/cwqC/uhdvr0XXw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16395,6 +16400,15 @@ snapshots:
       - supports-color
 
   '@fern-api/replay@0.15.0':
+    dependencies:
+      minimatch: 10.2.5
+      node-diff3: 3.2.0
+      simple-git: 3.36.0
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fern-api/replay@0.15.1':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description
Linear ticket: Refs https://github.com/fern-api/fern-replay/actions/runs/26003111446

Bumps `@fern-api/replay` from 0.15.0 to 0.15.1 in generator-cli, releasing as generator-cli 0.9.29.

## Changes Made
- `packages/generator-cli/package.json`: `@fern-api/replay` 0.15.0 → 0.15.1
- `packages/generator-cli/versions.yml`: new 0.9.29 entry
- `packages/cli/cli/changes/unreleased/bump-generator-cli-0.9.29.yml`: CLI changelog entry

Replay 0.15.1 includes:
- fix(detector): anchor fallback patches on recorded generations
- Regression-prevent composite-patch survival + collapse FileOwnership divergence
- ReplayDetector consolidation + path-4 .fern/ filter fix

## Follow-up
After this merges and 0.9.29 publishes to npm:
1. Bump `pnpm-workspace.yaml` catalog pin to 0.9.29
2. Bump fiddle Dockerfile to 0.9.29

## Testing
- [x] No code changes — dependency bump only
- [x] Lock file regenerated cleanly

Link to Devin session: https://app.devin.ai/sessions/d3544d0689dd4c8583ce9eac22cb7cbf
Requested by: @tstanmay13