### PR TITLE
chore(deps): bump @fern-api/replay to 0.15.2 in generator-cli

### DIFF
--- a/packages/cli/cli/changes/unreleased/bump-generator-cli-0.9.30.yml
+++ b/packages/cli/cli/changes/unreleased/bump-generator-cli-0.9.30.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.30, which includes @fern-api/replay
+    0.15.2 with a fix for customer commits on merged regen branches surviving
+    replay detection.
+  type: chore

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -41,7 +41,7 @@
     "@fern-api/docker-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-api/replay": "0.15.1",
+    "@fern-api/replay": "0.15.2",
     "@fern-api/task-context": "workspace:*",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Bump @fern-api/replay to 0.15.2.
+      type: chore
+  createdAt: "2026-05-17"
+  version: 0.9.30
+
+- changelogEntry:
+    - summary: |
         Bump @fern-api/replay to 0.15.1.
       type: chore
   createdAt: "2026-05-17"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7939,8 +7939,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/logging-execa
       '@fern-api/replay':
-        specifier: 0.15.1
-        version: 0.15.1
+        specifier: 0.15.2
+        version: 0.15.2
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../cli/task-context
@@ -9459,8 +9459,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@fern-api/replay@0.15.1':
-    resolution: {integrity: sha512-s48EkuzdFccAE5Wn4DztgfJoFcnRIFCrQjPlGd9ULt42v3wEBom2s6c+NyN7fQzgL3H1BrM/cwqC/uhdvr0XXw==}
+  '@fern-api/replay@0.15.2':
+    resolution: {integrity: sha512-B9eTCbYhr4UKCnuLIVEVA8aFC8uMp9f4eV1Sv+yL+OCkrNhaNGbuzi15mU+18/m8iOiuJ/IYXntImlS/JT5KYw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16408,7 +16408,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fern-api/replay@0.15.1':
+  '@fern-api/replay@0.15.2':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description
Linear ticket: Refs https://github.com/fern-api/fern-replay/actions/runs/26005079136

Bumps `@fern-api/replay` from 0.15.1 to 0.15.2 in generator-cli, releasing as generator-cli 0.9.30.

## Changes Made
- `packages/generator-cli/package.json`: `@fern-api/replay` 0.15.1 → 0.15.2
- `packages/generator-cli/versions.yml`: new 0.9.30 entry
- `packages/cli/cli/changes/unreleased/bump-generator-cli-0.9.30.yml`: CLI changelog entry

Replay 0.15.2 includes:
- fix(detector): use `--no-merges` so customer commits on merged regen PRs survive (FER-10498)

## Follow-up
After this merges and 0.9.30 publishes to npm:
1. Bump `pnpm-workspace.yaml` catalog pin to 0.9.30
2. Bump fiddle Dockerfile to 0.9.30

## Testing
- [x] No code changes — dependency bump only
- [x] Lock file regenerated cleanly

Link to Devin session: https://app.devin.ai/sessions/d3544d0689dd4c8583ce9eac22cb7cbf
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->