### PR TITLE
chore(deps): bump @fern-api/generator-cli catalog pin to 0.9.30

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.28
-      version: 0.9.28
+      specifier: 0.9.30
+      version: 0.9.30
     '@fern-api/venus-api-sdk':
       specifier: 0.22.34
       version: 0.22.34
@@ -630,7 +630,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.28
+        version: 0.9.30
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0
@@ -699,7 +699,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.28
+        version: 0.9.30
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2466,7 +2466,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.28
+        version: 0.9.30
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9450,13 +9450,8 @@ packages:
   '@fern-api/fdr-sdk@1.2.4-f661387fb2':
     resolution: {integrity: sha512-wlk1lTCIZ7biND4vQf8jvhUw9P/rBQ5pXASCrumv8R96up0B3DY6yiY1C4VmFyHmp/kPhcjzc5T9TvHZZxFdrA==}
 
-  '@fern-api/generator-cli@0.9.28':
-    resolution: {integrity: sha512-XWotnNAkiMIIKFE4xujI3O31Cd0PDljogKqUytGgnJH+a74rtMtGrSGWG58ryfDBCoJtLsjS1Q/B9vUlkceAJQ==}
-    hasBin: true
-
-  '@fern-api/replay@0.15.0':
-    resolution: {integrity: sha512-F5EcUoVLsVYW5qmwag0S87ZAIf7ldc+vlHEbg4MdImd2m4W5WVKIL1vy60DDPucD2QnGTzavDv9Hi6IaOlyYCg==}
-    engines: {node: '>=18'}
+  '@fern-api/generator-cli@0.9.30':
+    resolution: {integrity: sha512-CYleXiJH4OVEQooc4A1sldn3lClQijVpvCq+z8Qic5wc2RWqxrHnTNrN47aoqSIOKVcyJT21+tjhD1IrHQvJ8g==}
     hasBin: true
 
   '@fern-api/replay@0.15.2':
@@ -16388,23 +16383,14 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.28':
+  '@fern-api/generator-cli@0.9.30':
     dependencies:
       '@boundaryml/baml': 0.219.0
-      '@fern-api/replay': 0.15.0
+      '@fern-api/replay': 0.15.2
       '@octokit/rest': 22.0.1
       es-toolkit: 1.45.1
       semver: 7.7.4
       tmp-promise: 3.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@fern-api/replay@0.15.0':
-    dependencies:
-      minimatch: 10.2.5
-      node-diff3: 3.2.0
-      simple-git: 3.36.0
-      yaml: 2.8.3
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.2.4-f661387fb2
-  "@fern-api/generator-cli": 0.9.28
+  "@fern-api/generator-cli": 0.9.30
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description
Linear ticket: Refs https://github.com/fern-api/fern/pull/15960

Bumps the `pnpm-workspace.yaml` catalog pin for `@fern-api/generator-cli` from 0.9.28 → 0.9.30, picking up `@fern-api/replay` 0.15.2.

Supersedes closed #15959 (which targeted 0.9.29 but conflicted after 0.9.30 merged).

## Changes Made
- Updated `pnpm-workspace.yaml` catalog: `@fern-api/generator-cli` 0.9.28 → 0.9.30
- Updated `pnpm-lock.yaml` accordingly

## Testing
- [x] No code changes — dependency pin bump only
- [x] Lock file regenerated cleanly

Link to Devin session: https://app.devin.ai/sessions/d3544d0689dd4c8583ce9eac22cb7cbf
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->