### PR TITLE
chore(python): bump generator-cli to 0.9.30

### DIFF
--- a/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.30.yml
+++ b/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.30.yml
@@ -1,5 +1,5 @@
 - summary: |
     Bump @fern-api/generator-cli to 0.9.30, which includes @fern-api/replay
     0.15.2 with a fix for customer commits on merged regen branches surviving
-    replay detection (FER-10498).
+    replay detection.
   type: chore

--- a/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.30.yml
+++ b/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.30.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.30, which includes @fern-api/replay
+    0.15.2 with a fix for customer commits on merged regen branches surviving
+    replay detection (FER-10498).
+  type: chore


### PR DESCRIPTION
## Description

Bumps the Python SDK generator to pick up `@fern-api/generator-cli` 0.9.30 (which includes `@fern-api/replay` 0.15.2).

## Changes Made
- Added unreleased changelog entry for Python SDK generator (`generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.30.yml`)

This triggers a new Docker image build that will bundle the latest catalog-pinned generator-cli (0.9.30).

Key fix in this chain:
- **replay 0.15.2**: Customer commits on merged regen branches now survive replay detection

## Testing
- [x] No code changes — changelog entry only to trigger Docker rebuild
- [x] Generator will pick up generator-cli 0.9.30 via catalog pin

Link to Devin session: https://app.devin.ai/sessions/d3544d0689dd4c8583ce9eac22cb7cbf
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->