### PR TITLE
chore(java): fix CVE-2026-41989 by updating libgcrypt in Docker image

### DIFF
--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -74,6 +74,8 @@ RUN rm -f /opt/gradle/lib/plugins/bcpg-jdk18on-*.jar \
 # Security update 2026-05-04: add glibc/glibc-common/glibc-minimal-langpack
 # (CVE-2026-4046, iconv() assertion failure when converting IBM1390/IBM1399
 # inputs; fixed in glibc 2.34-231.amzn2023.0.4)
+# Security update 2026-05-18: add libgcrypt (CVE-2026-41989, heap-based
+# buffer overflow in gcry_pk_decrypt; fixed in 1.10.2-1.amzn2023.0.3)
 RUN dnf --releasever=latest update -y \
     openssl-fips-provider-latest \
     openssl-libs \
@@ -96,7 +98,8 @@ RUN dnf --releasever=latest update -y \
     libnghttp2 \
     glibc \
     glibc-common \
-    glibc-minimal-langpack && \
+    glibc-minimal-langpack \
+    libgcrypt && \
     dnf remove -y git-lfs wget || true && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/generators/java/sdk/changes/unreleased/fix-cve-2026-41989-libgcrypt.yml
+++ b/generators/java/sdk/changes/unreleased/fix-cve-2026-41989-libgcrypt.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Fix CVE-2026-41989: update libgcrypt in Docker image to patch heap-based
+    buffer overflow in gcry_pk_decrypt.
+  type: chore


### PR DESCRIPTION
## Description

Addresses CVE-2026-41989 (`libgcrypt` heap-based buffer overflow in `gcry_pk_decrypt`) flagged by AWS ECR container scanning on the `dev/java-sdk-generator` image.

- **CVE**: [CVE-2026-41989](https://nvd.nist.gov/vuln/detail/CVE-2026-41989) (Medium, CVSS 6.7)
- **Affected package**: `libgcrypt` 1.10.2-1.amzn2023.0.2
- **Fixed version**: 1.10.2-1.amzn2023.0.3

## Changes Made

- Added `libgcrypt` to the existing `dnf --releasever=latest update` command in `generators/java/sdk/Dockerfile`
- Added a changelog entry under `generators/java/sdk/changes/unreleased/`

## Human Review Checklist

- [ ] Verify no other Amazon Linux-based Dockerfiles in the repo also ship `libgcrypt` and need the same patch (the Java model generator uses Ubuntu/jammy, so it is not affected)
- [ ] Confirm the `dnf update` line ordering and `&&` placement are syntactically correct

## Testing

- [ ] No unit tests — this is a Dockerfile-only change; validation happens at image build time when the `dnf update` pulls the patched package

Link to Devin session: https://app.devin.ai/sessions/93764b1458844577ac0a79714ee6c8f4
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->