### PR TITLE
chore(deps): fix krb5, curl, gnutls, and expat CVEs across generator containers

### DIFF
--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -37,10 +37,9 @@ ENV PATH=$PNPM_HOME:$PATH
 # vulnerabilities (perl-base, liblzma5, libgnutls30, libpam*, libc*, gpgv,
 # libsystemd0, libudev1, libcap2, libtasn1-6, login/passwd, etc.) are
 # resolved on top of the base image.
-# Security update 2026-05-18: trixie's openssl (3.5.5) and expat (2.7.1)
-# are vulnerable to CVE-2026-28387/28388/28389/28390/31790/2673 (openssl)
-# and CVE-2026-45186 (expat). Pin sid as a low-priority source and pull
-# the fixed packages from there.
+# Security update 2026-05-18: trixie's openssl (3.5.5) is vulnerable to
+# CVE-2026-28387/28388/28389/28390/31790/2673. Pin sid as a low-priority
+# source and pull the fixed package from there.
 RUN apt-get update \
   && apt-get -y upgrade \
   && apt-get -y autoremove \
@@ -53,7 +52,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && echo 'Package: *\nPin: release n=sid\nPin-Priority: 100' > /etc/apt/preferences.d/sid-low \
     && apt-get update \
     && apt-get install -y --no-install-recommends -t sid \
-       libssl3t64 libexpat1 \
+       libssl3t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -37,24 +37,10 @@ ENV PATH=$PNPM_HOME:$PATH
 # vulnerabilities (perl-base, liblzma5, libgnutls30, libpam*, libc*, gpgv,
 # libsystemd0, libudev1, libcap2, libtasn1-6, login/passwd, etc.) are
 # resolved on top of the base image.
-# Security update 2026-05-18: trixie's openssl (3.5.5) is vulnerable to
-# CVE-2026-28387/28388/28389/28390/31790/2673. Pin sid as a low-priority
-# source and pull the fixed package from there.
 RUN apt-get update \
   && apt-get -y upgrade \
   && apt-get -y autoremove \
   && rm -rf /var/lib/apt/lists/*
-RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
-    && echo "URIs: http://deb.debian.org/debian" >> /etc/apt/sources.list.d/sid.sources \
-    && echo "Suites: sid" >> /etc/apt/sources.list.d/sid.sources \
-    && echo "Components: main" >> /etc/apt/sources.list.d/sid.sources \
-    && echo "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg" >> /etc/apt/sources.list.d/sid.sources \
-    && echo 'Package: *\nPin: release n=sid\nPin-Priority: 100' > /etc/apt/preferences.d/sid-low \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends -t sid \
-       libssl3t64 \
-    && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
-    && rm -rf /var/lib/apt/lists/*
 
 # Upgrade bundled npm to 11.14.1 to pick up patched transitive dependencies
 # (picomatch 4.0.4, brace-expansion 5.0.5, minimatch 10.2.5, tar 7.5.13).

--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -37,10 +37,25 @@ ENV PATH=$PNPM_HOME:$PATH
 # vulnerabilities (perl-base, liblzma5, libgnutls30, libpam*, libc*, gpgv,
 # libsystemd0, libudev1, libcap2, libtasn1-6, login/passwd, etc.) are
 # resolved on top of the base image.
+# Security update 2026-05-18: trixie's openssl (3.5.5) and expat (2.7.1)
+# are vulnerable to CVE-2026-28387/28388/28389/28390/31790/2673 (openssl)
+# and CVE-2026-45186 (expat). Pin sid as a low-priority source and pull
+# the fixed packages from there.
 RUN apt-get update \
   && apt-get -y upgrade \
   && apt-get -y autoremove \
   && rm -rf /var/lib/apt/lists/*
+RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
+    && echo "URIs: http://deb.debian.org/debian" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Suites: sid" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Components: main" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg" >> /etc/apt/sources.list.d/sid.sources \
+    && echo 'Package: *\nPin: release n=sid\nPin-Priority: 100' > /etc/apt/preferences.d/sid-low \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends -t sid \
+       libssl3t64 libexpat1 \
+    && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
+    && rm -rf /var/lib/apt/lists/*
 
 # Upgrade bundled npm to 11.14.1 to pick up patched transitive dependencies
 # (picomatch 4.0.4, brace-expansion 5.0.5, minimatch 10.2.5, tar 7.5.13).

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -75,7 +75,10 @@ RUN rm -f /opt/gradle/lib/plugins/bcpg-jdk18on-*.jar \
 # (CVE-2026-4046, iconv() assertion failure when converting IBM1390/IBM1399
 # inputs; fixed in glibc 2.34-231.amzn2023.0.4)
 # Security update 2026-05-18: add libgcrypt (CVE-2026-41989, heap-based
-# buffer overflow in gcry_pk_decrypt; fixed in 1.10.2-1.amzn2023.0.3)
+# buffer overflow in gcry_pk_decrypt; fixed in 1.10.2-1.amzn2023.0.3),
+# krb5-libs (CVE-2026-40356 integer underflow OOB read, CVE-2026-40355
+# NULL pointer dereference in gss_accept_sec_context; fixed in
+# 1.21.3-7.amzn2023.0.1)
 RUN dnf --releasever=latest update -y \
     openssl-fips-provider-latest \
     openssl-libs \
@@ -99,7 +102,8 @@ RUN dnf --releasever=latest update -y \
     glibc \
     glibc-common \
     glibc-minimal-langpack \
-    libgcrypt && \
+    libgcrypt \
+    krb5-libs && \
     dnf remove -y git-lfs wget || true && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/generators/java/sdk/changes/unreleased/fix-krb5-cves.yml
+++ b/generators/java/sdk/changes/unreleased/fix-krb5-cves.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Update krb5-libs in the Java SDK generator container to fix
+    CVE-2026-40356 (integer underflow OOB read) and CVE-2026-40355
+    (NULL pointer dereference) in MIT Kerberos 5.
+  type: chore

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -4,9 +4,8 @@ FROM node:24.15-trixie-slim
 # Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
 # and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
 # CVE-2026-40356 (krb5), CVE-2026-1965/4873/5545/6253/6429 (curl),
-# CVE-2026-3832 (gnutls28), and
-# CVE-2026-28387/28388/28389/28390/31790/2673 (openssl). Pin sid as a
-# low-priority source and pull the fixed packages from there.
+# and CVE-2026-3832 (gnutls28). Pin sid as a low-priority source and
+# pull the fixed packages from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \
@@ -21,7 +20,6 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
-       libssl3t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack /opt/yarn-*

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -4,7 +4,7 @@ FROM node:24.15-trixie-slim
 # Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
 # and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
 # CVE-2026-40356 (krb5), CVE-2026-1965/4873/5545/6253/6429 (curl),
-# CVE-2026-3832 (gnutls28), CVE-2026-45186 (expat), and
+# CVE-2026-3832 (gnutls28), and
 # CVE-2026-28387/28388/28389/28390/31790/2673 (openssl). Pin sid as a
 # low-priority source and pull the fixed packages from there.
 RUN apt-get update \
@@ -21,7 +21,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
-       libexpat1 libssl3t64 \
+       libssl3t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack /opt/yarn-*

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -1,12 +1,12 @@
 # Bundled npm globals are removed below so npm's JS dependencies cannot be
 # flagged or invoked at runtime — this image only runs the bundled CLI via node.
 FROM node:24.15-trixie-slim
-# Security update 2026-05-18: trixie's krb5 (1.21.3-5) and curl (8.14.1)
-# are still vulnerable to CVE-2026-40355, CVE-2026-40356 (krb5
-# gss_accept_sec_context integer underflow & NULL deref) and
-# CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-# CVE-2026-6429 (curl). Pin sid as a low-priority source and pull the
-# fixed krb5 1.22.1+ and curl 8.20.0+ from there.
+# Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
+# and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
+# CVE-2026-40356 (krb5 gss_accept_sec_context integer underflow & NULL
+# deref), CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
+# CVE-2026-6429 (curl), and CVE-2026-3832 (gnutls28). Pin sid as a
+# low-priority source and pull the fixed packages from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \
@@ -20,7 +20,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get update \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
-       curl libcurl4t64 \
+       curl libcurl4t64 libgnutls30t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack /opt/yarn-*

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -1,14 +1,27 @@
 # Bundled npm globals are removed below so npm's JS dependencies cannot be
 # flagged or invoked at runtime — this image only runs the bundled CLI via node.
 FROM node:24.15-trixie-slim
-# Security update 2026-05-18: explicitly upgrade libkrb5-3 and curl to fix
-# CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context) and
+# Security update 2026-05-18: trixie's krb5 (1.21.3-5) and curl (8.14.1)
+# are still vulnerable to CVE-2026-40355, CVE-2026-40356 (krb5
+# gss_accept_sec_context integer underflow & NULL deref) and
 # CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-# CVE-2026-6429 (curl)
+# CVE-2026-6429 (curl). Pin sid as a low-priority source and pull the
+# fixed krb5 1.22.1+ and curl 8.20.0+ from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \
-       libkrb5-3 libcurl4 \
+    && rm -rf /var/lib/apt/lists/*
+RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
+    && echo "URIs: http://deb.debian.org/debian" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Suites: sid" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Components: main" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg" >> /etc/apt/sources.list.d/sid.sources \
+    && echo 'Package: *\nPin: release n=sid\nPin-Priority: 100' > /etc/apt/preferences.d/sid-low \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends -t sid \
+       libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
+       curl libcurl4t64 \
+    && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack /opt/yarn-*
 RUN curl -LsSf https://astral.sh/ruff/0.15.7/install.sh | sh

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -1,9 +1,14 @@
 # Bundled npm globals are removed below so npm's JS dependencies cannot be
 # flagged or invoked at runtime — this image only runs the bundled CLI via node.
 FROM node:24.15-trixie-slim
+# Security update 2026-05-18: explicitly upgrade libkrb5-3 and curl to fix
+# CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context) and
+# CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
+# CVE-2026-6429 (curl)
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \
+       libkrb5-3 libcurl4 \
     && rm -rf /var/lib/apt/lists/*
 RUN rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack /opt/yarn-*
 RUN curl -LsSf https://astral.sh/ruff/0.15.7/install.sh | sh

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -3,9 +3,9 @@
 FROM node:24.15-trixie-slim
 # Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
 # and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
-# CVE-2026-40356 (krb5 gss_accept_sec_context integer underflow & NULL
-# deref), CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-# CVE-2026-6429 (curl), and CVE-2026-3832 (gnutls28). Pin sid as a
+# CVE-2026-40356 (krb5), CVE-2026-1965/4873/5545/6253/6429 (curl),
+# CVE-2026-3832 (gnutls28), CVE-2026-45186 (expat), and
+# CVE-2026-28387/28388/28389/28390/31790/2673 (openssl). Pin sid as a
 # low-priority source and pull the fixed packages from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
@@ -21,6 +21,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
+       libexpat1 libssl3t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack /opt/yarn-*

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -1,10 +1,10 @@
 FROM node:24.15-trixie-slim
-# Security update 2026-05-18: trixie's krb5 (1.21.3-5) and curl (8.14.1)
-# are still vulnerable to CVE-2026-40355, CVE-2026-40356 (krb5
-# gss_accept_sec_context integer underflow & NULL deref) and
-# CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-# CVE-2026-6429 (curl). Pin sid as a low-priority source and pull the
-# fixed krb5 1.22.1+ and curl 8.20.0+ from there.
+# Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
+# and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
+# CVE-2026-40356 (krb5 gss_accept_sec_context integer underflow & NULL
+# deref), CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
+# CVE-2026-6429 (curl), and CVE-2026-3832 (gnutls28). Pin sid as a
+# low-priority source and pull the fixed packages from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \
@@ -18,7 +18,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get update \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
-       curl libcurl4t64 \
+       curl libcurl4t64 libgnutls30t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -LsSf https://astral.sh/ruff/0.15.7/install.sh | sh

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:24.15-trixie-slim
 # Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
 # and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
-# CVE-2026-40356 (krb5 gss_accept_sec_context integer underflow & NULL
-# deref), CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-# CVE-2026-6429 (curl), and CVE-2026-3832 (gnutls28). Pin sid as a
+# CVE-2026-40356 (krb5), CVE-2026-1965/4873/5545/6253/6429 (curl),
+# CVE-2026-3832 (gnutls28), CVE-2026-45186 (expat), and
+# CVE-2026-28387/28388/28389/28390/31790/2673 (openssl). Pin sid as a
 # low-priority source and pull the fixed packages from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
@@ -19,6 +19,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
+       libexpat1 libssl3t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -LsSf https://astral.sh/ruff/0.15.7/install.sh | sh

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:24.15-trixie-slim
+# Security update 2026-05-18: explicitly upgrade libkrb5-3 and curl to fix
+# CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context) and
+# CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
+# CVE-2026-6429 (curl)
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \
+       libkrb5-3 libcurl4 \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -LsSf https://astral.sh/ruff/0.15.7/install.sh | sh
 ENV PATH="/root/.local/bin:${PATH}"

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -1,12 +1,25 @@
 FROM node:24.15-trixie-slim
-# Security update 2026-05-18: explicitly upgrade libkrb5-3 and curl to fix
-# CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context) and
+# Security update 2026-05-18: trixie's krb5 (1.21.3-5) and curl (8.14.1)
+# are still vulnerable to CVE-2026-40355, CVE-2026-40356 (krb5
+# gss_accept_sec_context integer underflow & NULL deref) and
 # CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-# CVE-2026-6429 (curl)
+# CVE-2026-6429 (curl). Pin sid as a low-priority source and pull the
+# fixed krb5 1.22.1+ and curl 8.20.0+ from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \
-       libkrb5-3 libcurl4 \
+    && rm -rf /var/lib/apt/lists/*
+RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
+    && echo "URIs: http://deb.debian.org/debian" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Suites: sid" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Components: main" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg" >> /etc/apt/sources.list.d/sid.sources \
+    && echo 'Package: *\nPin: release n=sid\nPin-Priority: 100' > /etc/apt/preferences.d/sid-low \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends -t sid \
+       libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
+       curl libcurl4t64 \
+    && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -LsSf https://astral.sh/ruff/0.15.7/install.sh | sh
 ENV PATH="/root/.local/bin:${PATH}"

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -2,8 +2,7 @@ FROM node:24.15-trixie-slim
 # Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
 # and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
 # CVE-2026-40356 (krb5), CVE-2026-1965/4873/5545/6253/6429 (curl),
-# CVE-2026-3832 (gnutls28), CVE-2026-45186 (expat), and
-# CVE-2026-28387/28388/28389/28390/31790/2673 (openssl). Pin sid as a
+# CVE-2026-3832 (gnutls28). Pin sid as a
 # low-priority source and pull the fixed packages from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
@@ -19,7 +18,6 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
-       libexpat1 libssl3t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -LsSf https://astral.sh/ruff/0.15.7/install.sh | sh

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -13,8 +13,7 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
 # Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
 # and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
 # CVE-2026-40356 (krb5), CVE-2026-1965/4873/5545/6253/6429 (curl),
-# CVE-2026-3832 (gnutls28), CVE-2026-45186 (expat), and
-# CVE-2026-28387/28388/28389/28390/31790/2673 (openssl). Pin sid as a
+# CVE-2026-3832 (gnutls28), and CVE-2026-45186 (expat). Pin sid as a
 # low-priority source and pull the fixed packages from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
@@ -31,7 +30,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
-       libexpat1 libssl3t64 \
+       libexpat1 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN node --version

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -12,9 +12,9 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
 
 # Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
 # and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
-# CVE-2026-40356 (krb5 gss_accept_sec_context integer underflow & NULL
-# deref), CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-# CVE-2026-6429 (curl), and CVE-2026-3832 (gnutls28). Pin sid as a
+# CVE-2026-40356 (krb5), CVE-2026-1965/4873/5545/6253/6429 (curl),
+# CVE-2026-3832 (gnutls28), CVE-2026-45186 (expat), and
+# CVE-2026-28387/28388/28389/28390/31790/2673 (openssl). Pin sid as a
 # low-priority source and pull the fixed packages from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
@@ -31,6 +31,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
+       libexpat1 libssl3t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN node --version

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -10,9 +10,14 @@ COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
+# Security update 2026-05-18: explicitly upgrade libkrb5-3 and curl to fix
+# CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context) and
+# CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
+# CVE-2026-6429 (curl)
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl git \
+       libkrb5-3 libcurl4 \
     && apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/*
 RUN node --version

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -10,15 +10,28 @@ COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
-# Security update 2026-05-18: explicitly upgrade libkrb5-3 and curl to fix
-# CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context) and
+# Security update 2026-05-18: trixie's krb5 (1.21.3-5) and curl (8.14.1)
+# are still vulnerable to CVE-2026-40355, CVE-2026-40356 (krb5
+# gss_accept_sec_context integer underflow & NULL deref) and
 # CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-# CVE-2026-6429 (curl)
+# CVE-2026-6429 (curl). Pin sid as a low-priority source and pull the
+# fixed krb5 1.22.1+ and curl 8.20.0+ from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl git \
-       libkrb5-3 libcurl4 \
     && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
+RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
+    && echo "URIs: http://deb.debian.org/debian" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Suites: sid" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Components: main" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg" >> /etc/apt/sources.list.d/sid.sources \
+    && echo 'Package: *\nPin: release n=sid\nPin-Priority: 100' > /etc/apt/preferences.d/sid-low \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends -t sid \
+       libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
+       curl libcurl4t64 \
+    && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN node --version
 RUN npm --version

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -10,12 +10,12 @@ COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
-# Security update 2026-05-18: trixie's krb5 (1.21.3-5) and curl (8.14.1)
-# are still vulnerable to CVE-2026-40355, CVE-2026-40356 (krb5
-# gss_accept_sec_context integer underflow & NULL deref) and
-# CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-# CVE-2026-6429 (curl). Pin sid as a low-priority source and pull the
-# fixed krb5 1.22.1+ and curl 8.20.0+ from there.
+# Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
+# and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
+# CVE-2026-40356 (krb5 gss_accept_sec_context integer underflow & NULL
+# deref), CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
+# CVE-2026-6429 (curl), and CVE-2026-3832 (gnutls28). Pin sid as a
+# low-priority source and pull the fixed packages from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl git \
@@ -30,7 +30,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get update \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
-       curl libcurl4t64 \
+       curl libcurl4t64 libgnutls30t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN node --version

--- a/generators/python/sdk/changes/unreleased/fix-krb5-curl-cves.yml
+++ b/generators/python/sdk/changes/unreleased/fix-krb5-curl-cves.yml
@@ -2,6 +2,5 @@
     Update OS packages in the Python SDK generator container from Debian sid to fix
     krb5 (CVE-2026-40355, CVE-2026-40356), curl (CVE-2026-1965, CVE-2026-4873,
     CVE-2026-5545, CVE-2026-6253, CVE-2026-6429), gnutls28 (CVE-2026-3832),
-    expat (CVE-2026-45186), and openssl (CVE-2026-28387, CVE-2026-28388,
-    CVE-2026-28389, CVE-2026-28390, CVE-2026-31790, CVE-2026-2673).
+    and expat (CVE-2026-45186).
   type: chore

--- a/generators/python/sdk/changes/unreleased/fix-krb5-curl-cves.yml
+++ b/generators/python/sdk/changes/unreleased/fix-krb5-curl-cves.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Update krb5 and curl packages in the Python SDK generator container to fix
+    CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context) and
+    CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
+    CVE-2026-6429 (curl).
+  type: chore

--- a/generators/python/sdk/changes/unreleased/fix-krb5-curl-cves.yml
+++ b/generators/python/sdk/changes/unreleased/fix-krb5-curl-cves.yml
@@ -1,6 +1,7 @@
 - summary: |
-    Update krb5, curl, and gnutls packages in the Python SDK generator container to fix
-    CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context),
-    CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-    CVE-2026-6429 (curl), and CVE-2026-3832 (gnutls28).
+    Update OS packages in the Python SDK generator container from Debian sid to fix
+    krb5 (CVE-2026-40355, CVE-2026-40356), curl (CVE-2026-1965, CVE-2026-4873,
+    CVE-2026-5545, CVE-2026-6253, CVE-2026-6429), gnutls28 (CVE-2026-3832),
+    expat (CVE-2026-45186), and openssl (CVE-2026-28387, CVE-2026-28388,
+    CVE-2026-28389, CVE-2026-28390, CVE-2026-31790, CVE-2026-2673).
   type: chore

--- a/generators/python/sdk/changes/unreleased/fix-krb5-curl-cves.yml
+++ b/generators/python/sdk/changes/unreleased/fix-krb5-curl-cves.yml
@@ -1,6 +1,6 @@
 - summary: |
-    Update krb5 and curl packages in the Python SDK generator container to fix
-    CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context) and
+    Update krb5, curl, and gnutls packages in the Python SDK generator container to fix
+    CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context),
     CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-    CVE-2026-6429 (curl).
+    CVE-2026-6429 (curl), and CVE-2026-3832 (gnutls28).
   type: chore

--- a/generators/typescript/sdk/changes/unreleased/fix-krb5-curl-cves.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-krb5-curl-cves.yml
@@ -1,6 +1,6 @@
 - summary: |
-    Update krb5 and curl packages in the TypeScript SDK generator container to fix
-    CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context) and
+    Update krb5, curl, and gnutls packages in the TypeScript SDK generator container to fix
+    CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context),
     CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-    CVE-2026-6429 (curl).
+    CVE-2026-6429 (curl), and CVE-2026-3832 (gnutls28).
   type: chore

--- a/generators/typescript/sdk/changes/unreleased/fix-krb5-curl-cves.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-krb5-curl-cves.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Update krb5 and curl packages in the TypeScript SDK generator container to fix
+    CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context) and
+    CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
+    CVE-2026-6429 (curl).
+  type: chore

--- a/generators/typescript/sdk/changes/unreleased/fix-krb5-curl-cves.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-krb5-curl-cves.yml
@@ -1,6 +1,7 @@
 - summary: |
-    Update krb5, curl, and gnutls packages in the TypeScript SDK generator container to fix
-    CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context),
-    CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-    CVE-2026-6429 (curl), and CVE-2026-3832 (gnutls28).
+    Update OS packages in the TypeScript SDK generator container from Debian sid to fix
+    krb5 (CVE-2026-40355, CVE-2026-40356), curl (CVE-2026-1965, CVE-2026-4873,
+    CVE-2026-5545, CVE-2026-6253, CVE-2026-6429), gnutls28 (CVE-2026-3832),
+    expat (CVE-2026-45186), and openssl (CVE-2026-28387, CVE-2026-28388,
+    CVE-2026-28389, CVE-2026-28390, CVE-2026-31790, CVE-2026-2673).
   type: chore

--- a/generators/typescript/sdk/changes/unreleased/fix-krb5-curl-cves.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-krb5-curl-cves.yml
@@ -2,6 +2,5 @@
     Update OS packages in the TypeScript SDK generator container from Debian sid to fix
     krb5 (CVE-2026-40355, CVE-2026-40356), curl (CVE-2026-1965, CVE-2026-4873,
     CVE-2026-5545, CVE-2026-6253, CVE-2026-6429), gnutls28 (CVE-2026-3832),
-    expat (CVE-2026-45186), and openssl (CVE-2026-28387, CVE-2026-28388,
-    CVE-2026-28389, CVE-2026-28390, CVE-2026-31790, CVE-2026-2673).
+    and expat (CVE-2026-45186).
   type: chore

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -35,15 +35,28 @@ FROM node:24.15-trixie-slim
 # (bookworm publishes the upstream fixes only via the next-stable
 # branch), so the base-image choice — not just dist-upgrade — is what
 # clears the AWS Inspector findings.
-# Security update 2026-05-18: explicitly upgrade libkrb5-3 and curl to fix
-# CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context) and
+# Security update 2026-05-18: trixie's krb5 (1.21.3-5) and curl (8.14.1)
+# are still vulnerable to CVE-2026-40355, CVE-2026-40356 (krb5
+# gss_accept_sec_context integer underflow & NULL deref) and
 # CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-# CVE-2026-6429 (curl)
+# CVE-2026-6429 (curl). Pin sid as a low-priority source and pull the
+# fixed krb5 1.22.1+ and curl 8.20.0+ from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates git zip \
-       libkrb5-3 curl libcurl4 \
     && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
+RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
+    && echo "URIs: http://deb.debian.org/debian" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Suites: sid" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Components: main" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg" >> /etc/apt/sources.list.d/sid.sources \
+    && echo 'Package: *\nPin: release n=sid\nPin-Priority: 100' > /etc/apt/preferences.d/sid-low \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends -t sid \
+       libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
+       curl libcurl4t64 \
+    && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -38,8 +38,7 @@ FROM node:24.15-trixie-slim
 # Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
 # and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
 # CVE-2026-40356 (krb5), CVE-2026-1965/4873/5545/6253/6429 (curl),
-# CVE-2026-3832 (gnutls28), CVE-2026-45186 (expat), and
-# CVE-2026-28387/28388/28389/28390/31790/2673 (openssl). Pin sid as a
+# CVE-2026-3832 (gnutls28), and CVE-2026-45186 (expat). Pin sid as a
 # low-priority source and pull the fixed packages from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
@@ -56,7 +55,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
-       libexpat1 libssl3t64 \
+       libexpat1 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -35,9 +35,14 @@ FROM node:24.15-trixie-slim
 # (bookworm publishes the upstream fixes only via the next-stable
 # branch), so the base-image choice — not just dist-upgrade — is what
 # clears the AWS Inspector findings.
+# Security update 2026-05-18: explicitly upgrade libkrb5-3 and curl to fix
+# CVE-2026-40355, CVE-2026-40356 (krb5 gss_accept_sec_context) and
+# CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
+# CVE-2026-6429 (curl)
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates git zip \
+       libkrb5-3 curl libcurl4 \
     && apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/*
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -35,12 +35,12 @@ FROM node:24.15-trixie-slim
 # (bookworm publishes the upstream fixes only via the next-stable
 # branch), so the base-image choice — not just dist-upgrade — is what
 # clears the AWS Inspector findings.
-# Security update 2026-05-18: trixie's krb5 (1.21.3-5) and curl (8.14.1)
-# are still vulnerable to CVE-2026-40355, CVE-2026-40356 (krb5
-# gss_accept_sec_context integer underflow & NULL deref) and
-# CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-# CVE-2026-6429 (curl). Pin sid as a low-priority source and pull the
-# fixed krb5 1.22.1+ and curl 8.20.0+ from there.
+# Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
+# and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
+# CVE-2026-40356 (krb5 gss_accept_sec_context integer underflow & NULL
+# deref), CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
+# CVE-2026-6429 (curl), and CVE-2026-3832 (gnutls28). Pin sid as a
+# low-priority source and pull the fixed packages from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates git zip \
@@ -55,7 +55,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get update \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
-       curl libcurl4t64 \
+       curl libcurl4t64 libgnutls30t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -37,9 +37,9 @@ FROM node:24.15-trixie-slim
 # clears the AWS Inspector findings.
 # Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
 # and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
-# CVE-2026-40356 (krb5 gss_accept_sec_context integer underflow & NULL
-# deref), CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253,
-# CVE-2026-6429 (curl), and CVE-2026-3832 (gnutls28). Pin sid as a
+# CVE-2026-40356 (krb5), CVE-2026-1965/4873/5545/6253/6429 (curl),
+# CVE-2026-3832 (gnutls28), CVE-2026-45186 (expat), and
+# CVE-2026-28387/28388/28389/28390/31790/2673 (openssl). Pin sid as a
 # low-priority source and pull the fixed packages from there.
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
@@ -56,6 +56,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
+       libexpat1 libssl3t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \


### PR DESCRIPTION
## Description

Addresses medium- and high-severity CVEs found by AWS Inspector / Vanta across multiple generator container images. Only containers explicitly flagged in the Vanta report receive each fix — unflagged containers are left unchanged to avoid unnecessary image churn.

**krb5 (CVE-2026-40356, CVE-2026-40355)** — MIT Kerberos 5 integer underflow OOB read and NULL pointer dereference in `gss_accept_sec_context()`.

**curl (CVE-2026-1965, CVE-2026-4873, CVE-2026-5545, CVE-2026-6253, CVE-2026-6429)** — Multiple curl vulnerabilities.

**gnutls28 (CVE-2026-3832)** — GnuTLS vulnerability in `libgnutls30t64`. Trixie ships `3.8.9`; fixed in sid's `3.8.13-1`.

**expat (CVE-2026-45186)** — Expat XML parser vulnerability. Trixie ships `2.7.1`; fixed in sid's `2.8.0-2`. Flagged for python-sdk and typescript-sdk only.

> **Note — openssl not included:** An earlier revision of this PR attempted to fix openssl CVEs (CVE-2026-28387 et al.) by installing `libssl3t64` from sid. Container scans confirmed this did not resolve the CVEs, so those changes were reverted. OpenSSL will be addressed in a follow-up PR.

## Changes Made

**Java SDK generator** (`generators/java/sdk/Dockerfile` — Amazon Linux 2023):
- Added `krb5-libs` to the existing `dnf --releasever=latest update` command (fix version `0:1.21.3-7.amzn2023.0.1`)

**Debian trixie-based generators** — temporarily pin Debian sid as a low-priority (`Pin-Priority: 100`) apt source, install only the specific flagged packages from sid, then remove the sid source. Each container receives only the packages it needs:

| Dockerfile | krb5 | curl | gnutls | expat |
|---|---|---|---|---|
| `generators/python/sdk/Dockerfile` | ✓ | ✓ | ✓ | ✓ |
| `generators/python-v2/sdk/Dockerfile` | ✓ | ✓ | ✓ | — |
| `generators/python-v2/pydantic-model/Dockerfile` | ✓ | ✓ | ✓ | — |
| `generators/typescript/sdk/cli/Dockerfile` | ✓ | ✓ | ✓ | ✓ |

**Changelog entries** added for java-sdk, python-sdk, and typescript-sdk generators.

## Testing

- [x] Verified `git clone` over HTTPS works in both images after the upgrade
- [x] Verified `curl` HTTPS, `pip install`, `poetry`, `ruff`, `node` HTTPS requests all work
- [x] Verified sid source is properly removed after install (`/etc/apt/sources.list.d/sid.sources` does not exist in final image)
- [x] Vanta container scans confirmed krb5, curl, gnutls, and expat CVEs are resolved after image rebuild
- [x] CI passing

## Items NOT addressed by this PR

- `openssl:3.5.5` (6 CVEs) across multiple containers — `libssl3t64` from sid did not resolve these in scanning; needs a different approach in a follow-up PR
- `github.com/docker/docker` Go module × php-sdk, python-sdk — compiled into Go binaries, cannot be fixed by OS package upgrades

## Human Review Checklist

> ⚠️ **Pulling select packages from Debian sid (unstable)**: This is a pragmatic workaround since trixie hasn't released patches yet. The risk is mitigated by pinning sid to priority 100 (only explicitly requested packages are pulled) and removing the sid source after install.
- [ ] **Pin file newlines**: The `echo 'Package: *\nPin: ...\nPin-Priority: 100'` uses `\n` inside single quotes. Docker `RUN` executes via `/bin/sh -c` (dash on Debian), where `echo` interprets `\n` as newlines by default — verify the resulting preferences file has proper newlines during the Docker build.
- [ ] **Removal of sid source**: Confirm `rm -f /etc/apt/sources.list.d/sid.sources` cleanup runs so the final image never pulls from sid again.
- [ ] **Per-container package scope**: Verify each Dockerfile installs only the packages flagged for that container in the Vanta report (see table above). Notably, `python-v2/sdk` and `pydantic-model` get krb5/curl/gnutls only (no expat), while `python/sdk` and `typescript/sdk` add expat.

Link to Devin session: https://app.devin.ai/sessions/77687bda4fc249b5b66139daf9728e3b
Requested by: @davidkonigsberg