### PR TITLE
feat(cli): add docs-ledger multi-locale translation publishing

### DIFF
--- a/packages/cli/cli/changes/unreleased/ledger-localization.yml
+++ b/packages/cli/cli/changes/unreleased/ledger-localization.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Add multi-locale support to docs-ledger publishing. When translations
+    are configured, the ledger path now publishes translated pages as
+    locale-specific segments via the finishTranslation endpoint instead
+    of duplicating entire blobs per locale.
+  type: feat

--- a/packages/cli/cli/changes/unreleased/ledger-localization.yml
+++ b/packages/cli/cli/changes/unreleased/ledger-localization.yml
@@ -1,8 +1,8 @@
 - summary: |
-    Add multi-locale support to docs-ledger publishing. Extracts the
-    shared MDX translation pipeline (snippet resolution, image rewrites,
-    nav overlays) into a reusable module used by both V2 and ledger paths.
-    The ledger path now publishes translated pages as locale-specific
-    segments via the finishTranslation endpoint, with parallel locale
-    publishing. Preview mode also supports translations.
+    Add multi-locale support to docs-ledger publishing. All locales are
+    built upfront and published in a single register → upload → finish
+    flow. Translations are passed inline to the finish call, eliminating
+    per-locale finishTranslation round-trips. Extracts the shared MDX
+    translation pipeline into a reusable module used by both V2 and
+    ledger paths. Preview mode also supports translations.
   type: feat

--- a/packages/cli/cli/changes/unreleased/ledger-localization.yml
+++ b/packages/cli/cli/changes/unreleased/ledger-localization.yml
@@ -1,6 +1,8 @@
 - summary: |
-    Add multi-locale support to docs-ledger publishing. When translations
-    are configured, the ledger path now publishes translated pages as
-    locale-specific segments via the finishTranslation endpoint instead
-    of duplicating entire blobs per locale.
+    Add multi-locale support to docs-ledger publishing. Extracts the
+    shared MDX translation pipeline (snippet resolution, image rewrites,
+    nav overlays) into a reusable module used by both V2 and ledger paths.
+    The ledger path now publishes translated pages as locale-specific
+    segments via the finishTranslation endpoint, with parallel locale
+    publishing. Preview mode also supports translations.
   type: feat

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/buildTranslatedDocsDefinition.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/buildTranslatedDocsDefinition.ts
@@ -1,0 +1,174 @@
+import {
+    applyTranslatedFrontmatterToNavTree,
+    applyTranslatedNavigationOverlays,
+    type DocsDefinitionResolver,
+    getTranslatedAnnouncement,
+    replaceImagePathsAndUrls,
+    replaceReferencedCode,
+    replaceReferencedMarkdown,
+    stripMdxComments,
+    transformAtPrefixImports
+} from "@fern-api/docs-resolver";
+import type { DocsV1Write } from "@fern-api/fdr-sdk";
+import { AbsoluteFilePath, doesPathExist, RelativeFilePath, relative, resolve } from "@fern-api/fs-utils";
+import type { TaskContext } from "@fern-api/task-context";
+import { readFile } from "fs/promises";
+
+type DocsDefinition = DocsV1Write.DocsDefinition;
+
+/**
+ * Build a translated DocsDefinition by overlaying translated pages and
+ * navigation on top of the base definition. Applies the full MDX processing
+ * pipeline shared by both the V2 and ledger translation paths:
+ *
+ *  1. Locale-aware snippet resolution (prefers translated snippets)
+ *  2. `<Code src="..."/>` reference resolution
+ *  3. `@/` import transforms
+ *  4. MDX comment stripping
+ *  5. Image path rewrites (using base page location)
+ *  6. `editThisPageUrl` rewriting to point to the translated file
+ *  7. Nav tree overlay (translated sidebar titles from frontmatter + docs.yml)
+ *  8. Translated announcement and navbar links
+ */
+export async function buildTranslatedDocsDefinition({
+    docsDefinition,
+    locale,
+    localePages,
+    translationNavigationOverlays,
+    resolver,
+    context
+}: {
+    docsDefinition: DocsDefinition;
+    locale: string;
+    localePages: Record<string, string>;
+    translationNavigationOverlays:
+        | Record<string, import("@fern-api/configuration").docsYml.TranslationNavigationOverlay>
+        | undefined;
+    resolver: DocsDefinitionResolver;
+    context: TaskContext;
+}): Promise<DocsDefinition> {
+    const collectedFileIds = resolver.getCollectedFileIds();
+    const docsWorkspacePath = resolver.getDocsWorkspacePath();
+
+    const resolveLocalePath = async (filepath: AbsoluteFilePath): Promise<AbsoluteFilePath> => {
+        const relPath = relative(docsWorkspacePath, filepath);
+        const translatedPath = resolve(docsWorkspacePath, RelativeFilePath.of(`translations/${locale}/${relPath}`));
+        return (await doesPathExist(translatedPath)) ? translatedPath : filepath;
+    };
+
+    const localeAwareMarkdownLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
+        const pathToRead = await resolveLocalePath(filepath);
+        const raw = await readFile(pathToRead, "utf-8");
+        const fmMatch = raw.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+        return fmMatch != null ? raw.slice(fmMatch[0].length) : raw;
+    };
+
+    const localeAwareFileLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
+        const pathToRead = await resolveLocalePath(filepath);
+        return readFile(pathToRead, "utf-8");
+    };
+
+    const translatedPageEntries = await Promise.all(
+        Object.entries(localePages).map(async ([path, rawMarkdown]) => {
+            try {
+                const basePage = docsDefinition.pages[path as DocsV1Write.PageId];
+                const absolutePathToMarkdownFile = resolve(docsWorkspacePath, RelativeFilePath.of(path));
+
+                const { markdown: markdownResolved } = await replaceReferencedMarkdown({
+                    markdown: rawMarkdown,
+                    absolutePathToFernFolder: docsWorkspacePath,
+                    absolutePathToMarkdownFile,
+                    context,
+                    markdownLoader: localeAwareMarkdownLoader
+                });
+
+                const codeResolved = await replaceReferencedCode({
+                    markdown: markdownResolved,
+                    absolutePathToFernFolder: docsWorkspacePath,
+                    absolutePathToMarkdownFile,
+                    context,
+                    fileLoader: localeAwareFileLoader
+                });
+
+                const importsResolved = transformAtPrefixImports({
+                    markdown: codeResolved,
+                    absolutePathToFernFolder: docsWorkspacePath,
+                    absolutePathToMarkdownFile
+                });
+
+                let processedMarkdown = stripMdxComments(importsResolved);
+
+                processedMarkdown = replaceImagePathsAndUrls(
+                    processedMarkdown,
+                    collectedFileIds,
+                    {},
+                    {
+                        absolutePathToMarkdownFile,
+                        absolutePathToFernFolder: docsWorkspacePath
+                    },
+                    context
+                );
+
+                let editThisPageUrl = basePage?.editThisPageUrl;
+                if (editThisPageUrl != null) {
+                    const fernPathPattern = `/fern/${path}`;
+                    const translatedPathStr = `/fern/translations/${locale}/${path}`;
+                    editThisPageUrl = editThisPageUrl.replace(
+                        fernPathPattern,
+                        translatedPathStr
+                    ) as typeof editThisPageUrl;
+                }
+
+                return [
+                    path,
+                    {
+                        markdown: processedMarkdown,
+                        rawMarkdown: processedMarkdown,
+                        editThisPageUrl,
+                        editThisPageLaunch: basePage?.editThisPageLaunch
+                    }
+                ];
+            } catch (pageError) {
+                context.logger.warn(
+                    `Failed to process translated page "${path}" for locale "${locale}": ${String(pageError)}. Falling back to base page.`
+                );
+                return undefined;
+            }
+        })
+    );
+
+    const translatedPages = {
+        ...docsDefinition.pages,
+        ...Object.fromEntries(
+            translatedPageEntries.filter((entry): entry is NonNullable<typeof entry> => entry != null)
+        )
+    };
+
+    let updatedRoot = applyTranslatedFrontmatterToNavTree(
+        docsDefinition.config.root,
+        localePages as Record<string, string>,
+        context
+    );
+
+    const localeNavOverlay = translationNavigationOverlays?.[locale];
+    let translatedAnnouncement = docsDefinition.config.announcement;
+    let translatedNavbarLinks = docsDefinition.config.navbarLinks;
+    if (localeNavOverlay != null) {
+        updatedRoot = applyTranslatedNavigationOverlays(updatedRoot, localeNavOverlay);
+        translatedAnnouncement = getTranslatedAnnouncement(localeNavOverlay) ?? translatedAnnouncement;
+        if (localeNavOverlay.navbarLinks != null) {
+            translatedNavbarLinks = localeNavOverlay.navbarLinks;
+        }
+    }
+
+    return {
+        ...docsDefinition,
+        pages: translatedPages,
+        config: {
+            ...docsDefinition.config,
+            root: updatedRoot,
+            announcement: translatedAnnouncement,
+            navbarLinks: translatedNavbarLinks
+        }
+    };
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -845,7 +845,8 @@ export async function publishDocs({
                         apiDefinitions: apiDefinitionCollector,
                         fileManifest: Object.keys(ledgerFileManifest).length > 0 ? ledgerFileManifest : undefined,
                         filePaths: ledgerFilePaths.size > 0 ? ledgerFilePaths : undefined,
-                        fileIdToPath: ledgerFileIdToPath.size > 0 ? ledgerFileIdToPath : undefined
+                        fileIdToPath: ledgerFileIdToPath.size > 0 ? ledgerFileIdToPath : undefined,
+                        resolver
                     });
                     context.logger.info(
                         `[ledger] Deployment ${ledgerResult.reusedDeployment ? "reused" : "created"}: ${ledgerResult.deploymentId}`
@@ -862,13 +863,15 @@ export async function publishDocs({
             }
         }
 
-        // Register translated page content for each configured locale.
+        // Register translated page content for each configured locale via the V2 endpoint.
+        // In ledger-only mode, translations are handled by publishDocsViaLedger (above),
+        // so this block only runs for legacy and dual-write modes.
         // In preview mode, register translations against the preview URL (not the production domain)
         // so that translated docs are visible in preview without overwriting production translations.
         const translationPages = resolver.getTranslationPages();
         const translationNavigationOverlays = resolver.getTranslationNavigationOverlays();
         const translationDomain = preview ? urlToOutput : domain;
-        if (translationPages != null && Object.keys(translationPages).length > 0) {
+        if (deployMode !== "ledger" && translationPages != null && Object.keys(translationPages).length > 0) {
             context.logger.info(`Registering translations for ${Object.keys(translationPages).length} locale(s)...`);
             await Promise.all(
                 Object.entries(translationPages).map(async ([locale, localePages]) => {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -3,19 +3,7 @@ import { SourceResolverImpl } from "@fern-api/cli-source-resolver";
 import { docsYml, generatorsYml } from "@fern-api/configuration";
 import { createFdrService } from "@fern-api/core";
 import { MediaType, replaceEnvVariables } from "@fern-api/core-utils";
-import {
-    applyTranslatedFrontmatterToNavTree,
-    applyTranslatedNavigationOverlays,
-    DocsDefinitionResolver,
-    getTranslatedAnnouncement,
-    replaceImagePathsAndUrls,
-    replaceReferencedCode,
-    replaceReferencedMarkdown,
-    stripMdxComments,
-    transformAtPrefixImports,
-    UploadedFile,
-    wrapWithHttps
-} from "@fern-api/docs-resolver";
+import { DocsDefinitionResolver, UploadedFile, wrapWithHttps } from "@fern-api/docs-resolver";
 import { APIV1Write, FdrAPI as CjsFdrSdk, DocsV1Write, DocsV2Write, FdrClient } from "@fern-api/fdr-sdk";
 import type { DocsPublishGitInput, FileManifestEntry } from "@fern-api/fdr-sdk/orpc-client";
 
@@ -25,14 +13,7 @@ type SnippetsConfig = APIV1Write.SnippetsConfig;
 type DocsDefinition = DocsV1Write.DocsDefinition;
 
 import { stitchGlobalTheme } from "@fern-api/docs-resolver";
-import {
-    AbsoluteFilePath,
-    convertToFernHostRelativeFilePath,
-    doesPathExist,
-    RelativeFilePath,
-    relative,
-    resolve
-} from "@fern-api/fs-utils";
+import { AbsoluteFilePath, convertToFernHostRelativeFilePath, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { convertIrToDynamicSnippetsIr, generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { getOriginalName } from "@fern-api/ir-utils";
 import { detectAirGappedMode, OSSWorkspace } from "@fern-api/lazy-fern-workspace";
@@ -47,6 +28,7 @@ import { chunk } from "lodash-es";
 import * as mime from "mime-types";
 import { basename } from "path";
 import terminalLink from "terminal-link";
+import { buildTranslatedDocsDefinition } from "./buildTranslatedDocsDefinition.js";
 import { getDocsDeployMode } from "./docsDeployMode.js";
 import { getDynamicGeneratorConfig } from "./getDynamicGeneratorConfig.js";
 import { measureImageSizes } from "./measureImageSizes.js";
@@ -821,7 +803,8 @@ export async function publishDocs({
                         apiDefinitions: apiDefinitionCollector,
                         fileManifest: Object.keys(ledgerFileManifest).length > 0 ? ledgerFileManifest : undefined,
                         filePaths: ledgerFilePaths.size > 0 ? ledgerFilePaths : undefined,
-                        fileIdToPath: ledgerFileIdToPath.size > 0 ? ledgerFileIdToPath : undefined
+                        fileIdToPath: ledgerFileIdToPath.size > 0 ? ledgerFileIdToPath : undefined,
+                        resolver
                     });
                     // In ledger-only mode the preview URL comes from the ledger;
                     // in dual mode the V2 URL was already set above.
@@ -866,6 +849,11 @@ export async function publishDocs({
         // Register translated page content for each configured locale via the V2 endpoint.
         // In ledger-only mode, translations are handled by publishDocsViaLedger (above),
         // so this block only runs for legacy and dual-write modes.
+        // In dual mode, translations are intentionally published through BOTH the V2
+        // endpoint (here) and the ledger finishTranslation endpoint (inside
+        // publishDocsViaLedger above). This ensures migration parity — both stores
+        // receive identical translated content until the ledger path is promoted to
+        // sole owner.
         // In preview mode, register translations against the preview URL (not the production domain)
         // so that translated docs are visible in preview without overwriting production translations.
         const translationPages = resolver.getTranslationPages();
@@ -876,160 +864,15 @@ export async function publishDocs({
             await Promise.all(
                 Object.entries(translationPages).map(async ([locale, localePages]) => {
                     try {
-                        // Build a translated DocsDefinition by taking the base definition,
-                        // overriding translated pages, and updating the nav tree to reflect
-                        // any sidebar-title / slug frontmatter in the translated pages.
-                        //
-                        // For each translated page, we apply the same transformations as default locale pages:
-                        // 1. Resolve <Markdown src="..."/> and <Code src="..."/> snippet references
-                        // 2. Transform @/ prefix imports to relative paths
-                        // 3. Strip MDX comments to prevent leakage
-                        // 4. Replace relative image paths with file IDs (using base page path for resolution)
-                        // 5. Preserve editThisPageUrl/editThisPageLaunch from the base page
-                        const collectedFileIds = resolver.getCollectedFileIds();
-                        const docsWorkspacePath = resolver.getDocsWorkspacePath();
-
-                        // Create a locale-aware file loader that prefers translated snippets
-                        // (e.g., translations/zh/snippets/foo.mdx) over base snippets.
-                        const resolveLocalePath = async (filepath: AbsoluteFilePath): Promise<AbsoluteFilePath> => {
-                            const relPath = relative(docsWorkspacePath, filepath);
-                            const translatedPath = resolve(
-                                docsWorkspacePath,
-                                RelativeFilePath.of(`translations/${locale}/${relPath}`)
-                            );
-                            return (await doesPathExist(translatedPath)) ? translatedPath : filepath;
-                        };
-
-                        const localeAwareMarkdownLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
-                            const pathToRead = await resolveLocalePath(filepath);
-                            const raw = await readFile(pathToRead, "utf-8");
-                            // Strip frontmatter (---\n...\n---) from snippet files
-                            const fmMatch = raw.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
-                            return fmMatch != null ? raw.slice(fmMatch[0].length) : raw;
-                        };
-
-                        const localeAwareFileLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
-                            const pathToRead = await resolveLocalePath(filepath);
-                            return readFile(pathToRead, "utf-8");
-                        };
-
-                        const translatedPageEntries = await Promise.all(
-                            Object.entries(localePages).map(async ([path, rawMarkdown]) => {
-                                try {
-                                    const basePage = docsDefinition.pages[path as DocsV1Write.PageId];
-                                    const absolutePathToMarkdownFile = resolve(
-                                        docsWorkspacePath,
-                                        RelativeFilePath.of(path)
-                                    );
-
-                                    // Resolve <Markdown src="..."/> snippets (must happen before image processing).
-                                    // Uses locale-aware loader to prefer translated snippets when available.
-                                    const { markdown: markdownResolved } = await replaceReferencedMarkdown({
-                                        markdown: rawMarkdown,
-                                        absolutePathToFernFolder: docsWorkspacePath,
-                                        absolutePathToMarkdownFile,
-                                        context,
-                                        markdownLoader: localeAwareMarkdownLoader
-                                    });
-
-                                    // Resolve <Code src="..."/> references (also locale-aware)
-                                    const codeResolved = await replaceReferencedCode({
-                                        markdown: markdownResolved,
-                                        absolutePathToFernFolder: docsWorkspacePath,
-                                        absolutePathToMarkdownFile,
-                                        context,
-                                        fileLoader: localeAwareFileLoader
-                                    });
-
-                                    // Transform @/ prefix imports to relative paths
-                                    const importsResolved = transformAtPrefixImports({
-                                        markdown: codeResolved,
-                                        absolutePathToFernFolder: docsWorkspacePath,
-                                        absolutePathToMarkdownFile
-                                    });
-
-                                    // Strip MDX comments
-                                    let processedMarkdown = stripMdxComments(importsResolved);
-
-                                    // Replace image paths using the base page's location for resolution
-                                    // (translated pages reference the same images as the default locale)
-                                    processedMarkdown = replaceImagePathsAndUrls(
-                                        processedMarkdown,
-                                        collectedFileIds,
-                                        {}, // markdownFilesToPathName not needed for translations
-                                        {
-                                            absolutePathToMarkdownFile,
-                                            absolutePathToFernFolder: docsWorkspacePath
-                                        },
-                                        context
-                                    );
-
-                                    // Rewrite editThisPageUrl to point to the translated file
-                                    let editThisPageUrl = basePage?.editThisPageUrl;
-                                    if (editThisPageUrl != null) {
-                                        const fernPathPattern = `/fern/${path}`;
-                                        const translatedPath = `/fern/translations/${locale}/${path}`;
-                                        editThisPageUrl = editThisPageUrl.replace(
-                                            fernPathPattern,
-                                            translatedPath
-                                        ) as typeof editThisPageUrl;
-                                    }
-                                    return [
-                                        path,
-                                        {
-                                            markdown: processedMarkdown,
-                                            rawMarkdown: processedMarkdown,
-                                            editThisPageUrl,
-                                            editThisPageLaunch: basePage?.editThisPageLaunch
-                                        }
-                                    ];
-                                } catch (pageError) {
-                                    context.logger.warn(
-                                        `Failed to process translated page "${path}" for locale "${locale}": ${String(pageError)}. Falling back to base page.`
-                                    );
-                                    return undefined;
-                                }
-                            })
-                        );
-
-                        const translatedPages = {
-                            ...docsDefinition.pages,
-                            ...Object.fromEntries(
-                                translatedPageEntries.filter(
-                                    (entry): entry is NonNullable<typeof entry> => entry != null
-                                )
-                            )
-                        };
-                        let updatedRoot = applyTranslatedFrontmatterToNavTree(
-                            docsDefinition.config.root,
-                            // localePages is Record<RelativeFilePath, string> (path -> raw markdown)
-                            localePages as Record<string, string>,
+                        const translatedDefinition = await buildTranslatedDocsDefinition({
+                            docsDefinition,
+                            locale,
+                            localePages,
+                            translationNavigationOverlays,
+                            resolver,
                             context
-                        );
+                        });
 
-                        // Apply navigation overlay (translated display-names, titles, etc.)
-                        const localeNavOverlay = translationNavigationOverlays?.[locale];
-                        let translatedAnnouncement = docsDefinition.config.announcement;
-                        let translatedNavbarLinks = docsDefinition.config.navbarLinks;
-                        if (localeNavOverlay != null) {
-                            updatedRoot = applyTranslatedNavigationOverlays(updatedRoot, localeNavOverlay);
-                            translatedAnnouncement =
-                                getTranslatedAnnouncement(localeNavOverlay) ?? translatedAnnouncement;
-                            if (localeNavOverlay.navbarLinks != null) {
-                                translatedNavbarLinks = localeNavOverlay.navbarLinks;
-                            }
-                        }
-
-                        const translatedDefinition: DocsDefinition = {
-                            ...docsDefinition,
-                            pages: translatedPages,
-                            config: {
-                                ...docsDefinition.config,
-                                root: updatedRoot,
-                                announcement: translatedAnnouncement,
-                                navbarLinks: translatedNavbarLinks
-                            }
-                        };
                         const pageCount = Object.keys(localePages).length;
                         context.logger.debug(
                             `Sending translation for locale "${locale}" (${pageCount} page${pageCount === 1 ? "" : "s"})`

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -770,12 +770,12 @@ export async function publishDocs({
         }
 
         // ── Legacy publish path ──────────────────────────────────────
-        if (deployMode !== "ledger") {
+        if (deployMode !== "ledger" && docsRegistrationId != null) {
             context.logger.info("Publishing docs to FDR...");
             const publishStart = performance.now();
             try {
                 await fdr.docs.v2.write.finishDocsRegister({
-                    docsRegistrationId: docsRegistrationId!,
+                    docsRegistrationId,
                     docsDefinition,
                     excludeApis,
                     ...(isBasepathAware && !preview && { basepathAware: true })

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -1,11 +1,3 @@
-import type { APIV1Write, DocsV1Write } from "@fern-api/fdr-sdk";
-import {
-    createDocsLedgerClient,
-    type DocsPublishGitInput,
-    type DocsPublishInput,
-    type FileManifestEntry,
-    type FinishTranslationInput
-} from "@fern-api/fdr-sdk/orpc-client";
 import {
     applyTranslatedFrontmatterToNavTree,
     applyTranslatedNavigationOverlays,
@@ -17,6 +9,14 @@ import {
     stripMdxComments,
     transformAtPrefixImports
 } from "@fern-api/docs-resolver";
+import type { APIV1Write, DocsV1Write } from "@fern-api/fdr-sdk";
+import {
+    createDocsLedgerClient,
+    type DocsPublishGitInput,
+    type DocsPublishInput,
+    type FileManifestEntry,
+    type FinishTranslationInput
+} from "@fern-api/fdr-sdk/orpc-client";
 import { AbsoluteFilePath, doesPathExist, RelativeFilePath, relative, resolve } from "@fern-api/fs-utils";
 import type { TaskContext } from "@fern-api/task-context";
 import { createHash } from "crypto";

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -5,7 +5,7 @@ import {
     type DocsPublishGitInput,
     type DocsPublishInput,
     type FileManifestEntry,
-    type FinishTranslationInput
+    type TranslationEntry
 } from "@fern-api/fdr-sdk/orpc-client";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { TaskContext } from "@fern-api/task-context";
@@ -272,6 +272,8 @@ export async function publishDocsViaLedger({
     }
 
     // ── Phase 2: Single register → upload → finish ─────────────────────
+    // Translations are passed inline to the finish call so the server
+    // persists base + all locale segments in a single request.
 
     const client = createDocsLedgerClient({ baseUrl: fdrOrigin, token, headers });
 
@@ -290,50 +292,41 @@ export async function publishDocsViaLedger({
     // lazily from disk via filePaths.
     await uploadMissingBlobs(registerResult.missingContent, blobs, context, filePaths);
 
-    // Finish — server persists the base deployment.
+    // Build the translations array for the finish call. Each entry
+    // carries only the content fields + locale — orgId/domain/basepath
+    // are inherited from the base input on the server side.
+    const translations: TranslationEntry[] = builtTranslations.map((t) => ({
+        locale: t.locale,
+        root: t.input.root,
+        pages: t.input.pages,
+        apiManifest: t.input.apiManifest,
+        config: t.input.config,
+        fileManifest: t.input.fileManifest,
+        jsFiles: t.input.jsFiles,
+        redirects: t.input.redirects,
+        version: t.input.version,
+        repo: t.input.repo,
+        git: t.input.git
+    }));
+
+    // Finish — server persists the base deployment + all translations
+    // in a single call.
+    const finishInput: DocsPublishInput = {
+        ...input,
+        translations: translations.length > 0 ? translations : undefined
+    };
     context.logger.debug("[ledger] Finishing deployment...");
     const finishStart = performance.now();
-    const finishResult = await client.finish(input);
+    const finishResult = await client.finish(finishInput);
     const finishTime = performance.now() - finishStart;
     context.logger.debug(
         `[ledger] Finished in ${finishTime.toFixed(0)}ms — deploymentId=${finishResult.deploymentId}, reused=${finishResult.reusedDeployment}`
     );
 
-    // ── Phase 3: Attach translations to the deployment ─────────────────
-    // Translation blobs are already uploaded. Each finishTranslation call
-    // registers the locale's content hashes, uploads any remaining blobs
-    // the base register didn't cover, and attaches locale-specific
-    // segments to the existing deployment.
-
-    if (builtTranslations.length > 0) {
-        context.logger.info(`[ledger] Attaching translations for ${builtTranslations.length} locale(s)...`);
-
-        for (const t of builtTranslations) {
-            // Register translation to discover any blobs not covered by
-            // the base register (translation pages have different hashes).
-            const localeRegister = await client.register(t.input);
-            await uploadMissingBlobs(localeRegister.missingContent, t.blobs, context, filePaths);
-
-            const finishInput: FinishTranslationInput = {
-                orgId: organization,
-                domain,
-                basepath: basepath ?? "",
-                deploymentId: finishResult.deploymentId,
-                locale: t.locale,
-                root: t.translatedDefinition.config.root ?? t.translatedDefinition.config.navigation,
-                pages: t.input.pages,
-                apiManifest: t.input.apiManifest,
-                config: t.input.config,
-                fileManifest: t.input.fileManifest,
-                jsFiles: t.input.jsFiles,
-                redirects: t.input.redirects,
-                git: t.input.git
-            };
-
-            const result = await client.finishTranslation(finishInput);
-            context.logger.info(
-                `[ledger] Locale "${t.locale}": ${Object.keys(t.localePages).length} page(s), ${result.segmentsAdded} segment(s) added`
-            );
+    // Log translation results if any were processed.
+    if (finishResult.translationsProcessed != null) {
+        for (const tp of finishResult.translationsProcessed) {
+            context.logger.info(`[ledger] Locale "${tp.locale}": ${tp.segmentsAdded} segment(s) added`);
         }
     }
 

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -451,7 +451,7 @@ async function publishTranslationsViaLedger({
     const localeEntries = Object.entries(translationPages);
     context.logger.info(`[ledger] Publishing translations for ${localeEntries.length} locale(s)...`);
 
-    await Promise.all(
+    const localeResults = await Promise.all(
         localeEntries.map(async ([locale, localePages]) => {
             try {
                 const translatedDefinition = await buildTranslatedDocsDefinition({
@@ -507,7 +507,16 @@ async function publishTranslationsViaLedger({
                 );
             } catch (error) {
                 context.logger.warn(`[ledger] Failed to publish translations for locale "${locale}": ${String(error)}`);
+                return locale;
             }
+            return undefined;
         })
     );
+
+    const failedLocales = localeResults.filter((l): l is string => l != null);
+    if (failedLocales.length > 0) {
+        context.logger.warn(
+            `[ledger] ${failedLocales.length}/${localeEntries.length} locale(s) failed: ${failedLocales.join(", ")}`
+        );
+    }
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -184,6 +184,12 @@ export interface LedgerPublishResult {
 /**
  * Publish docs via the new docs-ledger register → upload → finish flow.
  *
+ * All locales (base + translations) are built upfront before any network
+ * calls. If any locale fails to build, the entire publish aborts. After
+ * building, a single register → upload → finish pipeline runs for the
+ * base locale, and then finishTranslation is called for each translation
+ * locale (blobs are already uploaded from the combined pool).
+ *
  * This is a self-contained function that can run alongside (dual-write)
  * or instead of (ledger-only) the legacy finishDocsRegister path.
  */
@@ -224,6 +230,10 @@ export async function publishDocsViaLedger({
     /** Resolver instance for accessing translation pages/overlays. Optional. */
     resolver?: DocsDefinitionResolver;
 }): Promise<LedgerPublishResult> {
+    // ── Phase 1: Build all locales upfront ──────────────────────────────
+    // If any locale fails to build, the entire publish aborts before any
+    // network calls are made.
+
     const { input, blobs } = buildLedgerInput({
         docsDefinition,
         organization,
@@ -237,10 +247,36 @@ export async function publishDocsViaLedger({
         fileIdToPath
     });
 
+    const translationInputs = buildAllTranslationInputs({
+        docsDefinition,
+        organization,
+        domain,
+        basepath,
+        git,
+        apiDefinitions,
+        fileManifest,
+        fileIdToPath,
+        resolver,
+        context
+    });
+
+    // Wait for all translation builds to complete (fail-fast).
+    const builtTranslations = await translationInputs;
+
+    // Merge all translation blobs into the base blob pool so the single
+    // upload phase covers everything.
+    for (const t of builtTranslations) {
+        for (const [hash, buf] of t.blobs) {
+            blobs.set(hash, buf);
+        }
+    }
+
+    // ── Phase 2: Single register → upload → finish ─────────────────────
+
     const client = createDocsLedgerClient({ baseUrl: fdrOrigin, token, headers });
 
-    // Step 1: Register — server computes deployment hash, returns presigned
-    // S3 URLs for any blobs it doesn't already have in CAS.
+    // Register — server computes deployment hash, returns presigned S3
+    // URLs for any blobs it doesn't already have in CAS.
     context.logger.debug("[ledger] Registering deployment...");
     const registerStart = performance.now();
     const registerResult = await client.register(input);
@@ -249,12 +285,12 @@ export async function publishDocsViaLedger({
         `[ledger] Registered in ${registerTime.toFixed(0)}ms — hash=${registerResult.deploymentHash}, missing=${registerResult.missingContent.length} blobs`
     );
 
-    // Step 2: Upload any blobs the server doesn't have yet.
-    // In-memory blobs (pages, config, apiManifest) are checked first;
-    // file blobs are read lazily from disk via filePaths.
+    // Upload all blobs the server doesn't have yet (base + translations
+    // combined). In-memory blobs are checked first; file blobs are read
+    // lazily from disk via filePaths.
     await uploadMissingBlobs(registerResult.missingContent, blobs, context, filePaths);
 
-    // Step 3: Finish — server persists the deployment.
+    // Finish — server persists the base deployment.
     context.logger.debug("[ledger] Finishing deployment...");
     const finishStart = performance.now();
     const finishResult = await client.finish(input);
@@ -263,23 +299,42 @@ export async function publishDocsViaLedger({
         `[ledger] Finished in ${finishTime.toFixed(0)}ms — deploymentId=${finishResult.deploymentId}, reused=${finishResult.reusedDeployment}`
     );
 
-    // Step 4: Publish translations if the resolver has them.
-    if (resolver != null) {
-        await publishTranslationsViaLedger({
-            docsDefinition,
-            deploymentId: finishResult.deploymentId,
-            organization,
-            domain,
-            basepath,
-            git,
-            apiDefinitions,
-            fileManifest,
-            fileIdToPath,
-            filePaths,
-            client,
-            context,
-            resolver
-        });
+    // ── Phase 3: Attach translations to the deployment ─────────────────
+    // Translation blobs are already uploaded. Each finishTranslation call
+    // registers the locale's content hashes, uploads any remaining blobs
+    // the base register didn't cover, and attaches locale-specific
+    // segments to the existing deployment.
+
+    if (builtTranslations.length > 0) {
+        context.logger.info(`[ledger] Attaching translations for ${builtTranslations.length} locale(s)...`);
+
+        for (const t of builtTranslations) {
+            // Register translation to discover any blobs not covered by
+            // the base register (translation pages have different hashes).
+            const localeRegister = await client.register(t.input);
+            await uploadMissingBlobs(localeRegister.missingContent, t.blobs, context, filePaths);
+
+            const finishInput: FinishTranslationInput = {
+                orgId: organization,
+                domain,
+                basepath: basepath ?? "",
+                deploymentId: finishResult.deploymentId,
+                locale: t.locale,
+                root: t.translatedDefinition.config.root ?? t.translatedDefinition.config.navigation,
+                pages: t.input.pages,
+                apiManifest: t.input.apiManifest,
+                config: t.input.config,
+                fileManifest: t.input.fileManifest,
+                jsFiles: t.input.jsFiles,
+                redirects: t.input.redirects,
+                git: t.input.git
+            };
+
+            const result = await client.finishTranslation(finishInput);
+            context.logger.info(
+                `[ledger] Locale "${t.locale}": ${Object.keys(t.localePages).length} page(s), ${result.segmentsAdded} segment(s) added`
+            );
+        }
     }
 
     return finishResult;
@@ -396,25 +451,25 @@ async function uploadBlobWithRetry(
     throw new Error(`[ledger] Upload exhausted retries for ${hash}`);
 }
 
-// ── Translation publishing ─────────────────────────────────────────────
+// ── Translation build helpers ──────────────────────────────────────────
 
-type DocsLedgerClient = ReturnType<typeof createDocsLedgerClient>;
+interface BuiltTranslation {
+    locale: string;
+    localePages: Record<string, string>;
+    translatedDefinition: DocsDefinition;
+    input: DocsPublishInput;
+    blobs: Map<string, Buffer>;
+}
 
 /**
- * After a base deployment finishes, publish translated content for each
- * locale the resolver discovered under `translations/<lang>/`.
+ * Build ledger inputs for every translation locale the resolver discovered.
  *
- * For each locale:
- *  1. Build a translated DocsDefinition (overlay translated pages + nav).
- *  2. Convert to a ledger input via {@link buildLedgerInput} with the locale.
- *  3. Call `register` to dedup blobs and get presigned upload URLs.
- *  4. Upload any missing blobs (translated page content).
- *  5. Call `finishTranslation` to attach locale-specific segments to the
- *     existing deployment.
+ * All locales are built in parallel. If ANY locale fails, the returned
+ * promise rejects — callers should let the error propagate to abort the
+ * entire publish.
  */
-async function publishTranslationsViaLedger({
+async function buildAllTranslationInputs({
     docsDefinition,
-    deploymentId,
     organization,
     domain,
     basepath,
@@ -422,13 +477,10 @@ async function publishTranslationsViaLedger({
     apiDefinitions,
     fileManifest,
     fileIdToPath,
-    filePaths,
-    client,
-    context,
-    resolver
+    resolver,
+    context
 }: {
     docsDefinition: DocsDefinition;
-    deploymentId: string;
     organization: string;
     domain: string;
     basepath: string | undefined;
@@ -436,87 +488,48 @@ async function publishTranslationsViaLedger({
     apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
     fileManifest?: Record<string, FileManifestEntry>;
     fileIdToPath?: Map<string, string>;
-    filePaths?: Map<string, AbsoluteFilePath>;
-    client: DocsLedgerClient;
+    resolver?: DocsDefinitionResolver;
     context: TaskContext;
-    resolver: DocsDefinitionResolver;
-}): Promise<void> {
+}): Promise<BuiltTranslation[]> {
+    if (resolver == null) {
+        return [];
+    }
+
     const translationPages = resolver.getTranslationPages();
     const translationNavigationOverlays = resolver.getTranslationNavigationOverlays();
 
     if (translationPages == null || Object.keys(translationPages).length === 0) {
-        return;
+        return [];
     }
 
     const localeEntries = Object.entries(translationPages);
-    context.logger.info(`[ledger] Publishing translations for ${localeEntries.length} locale(s)...`);
+    context.logger.info(`[ledger] Building ${localeEntries.length} translation locale(s)...`);
 
-    const localeResults = await Promise.all(
-        localeEntries.map(async ([locale, localePages]) => {
-            try {
-                const translatedDefinition = await buildTranslatedDocsDefinition({
-                    docsDefinition,
-                    locale,
-                    localePages,
-                    translationNavigationOverlays,
-                    resolver,
-                    context
-                });
+    return Promise.all(
+        localeEntries.map(async ([locale, localePages]): Promise<BuiltTranslation> => {
+            const translatedDefinition = await buildTranslatedDocsDefinition({
+                docsDefinition,
+                locale,
+                localePages,
+                translationNavigationOverlays,
+                resolver,
+                context
+            });
 
-                const { input: translationInput, blobs: translationBlobs } = buildLedgerInput({
-                    docsDefinition: translatedDefinition,
-                    organization,
-                    domain,
-                    basepath,
-                    previewId: undefined,
-                    git,
-                    apiDefinitions,
-                    fileManifest,
-                    fileIdToPath,
-                    locale
-                });
+            const { input, blobs } = buildLedgerInput({
+                docsDefinition: translatedDefinition,
+                organization,
+                domain,
+                basepath,
+                previewId: undefined,
+                git,
+                apiDefinitions,
+                fileManifest,
+                fileIdToPath,
+                locale
+            });
 
-                // Register to get presigned URLs for any new blobs (translated page content).
-                const registerResult = await client.register(translationInput);
-
-                // Upload missing blobs (translated pages will have different content hashes).
-                await uploadMissingBlobs(registerResult.missingContent, translationBlobs, context, filePaths);
-
-                // Finish translation — attaches locale-specific segments to the existing deployment.
-                const finishInput: FinishTranslationInput = {
-                    orgId: organization,
-                    domain,
-                    basepath: basepath ?? "",
-                    deploymentId,
-                    locale,
-                    root: translatedDefinition.config.root ?? translatedDefinition.config.navigation,
-                    pages: translationInput.pages,
-                    apiManifest: translationInput.apiManifest,
-                    config: translationInput.config,
-                    fileManifest: translationInput.fileManifest,
-                    jsFiles: translationInput.jsFiles,
-                    redirects: translationInput.redirects,
-                    git: translationInput.git
-                };
-
-                const result = await client.finishTranslation(finishInput);
-
-                const pageCount = Object.keys(localePages).length;
-                context.logger.info(
-                    `[ledger] Locale "${locale}": ${pageCount} page(s), ${result.segmentsAdded} segment(s) added`
-                );
-            } catch (error) {
-                context.logger.warn(`[ledger] Failed to publish translations for locale "${locale}": ${String(error)}`);
-                return locale;
-            }
-            return undefined;
+            return { locale, localePages, translatedDefinition, input, blobs };
         })
     );
-
-    const failedLocales = localeResults.filter((l): l is string => l != null);
-    if (failedLocales.length > 0) {
-        context.logger.warn(
-            `[ledger] ${failedLocales.length}/${localeEntries.length} locale(s) failed: ${failedLocales.join(", ")}`
-        );
-    }
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -3,9 +3,21 @@ import {
     createDocsLedgerClient,
     type DocsPublishGitInput,
     type DocsPublishInput,
-    type FileManifestEntry
+    type FileManifestEntry,
+    type FinishTranslationInput
 } from "@fern-api/fdr-sdk/orpc-client";
-import type { AbsoluteFilePath } from "@fern-api/fs-utils";
+import {
+    applyTranslatedFrontmatterToNavTree,
+    applyTranslatedNavigationOverlays,
+    type DocsDefinitionResolver,
+    getTranslatedAnnouncement,
+    replaceImagePathsAndUrls,
+    replaceReferencedCode,
+    replaceReferencedMarkdown,
+    stripMdxComments,
+    transformAtPrefixImports
+} from "@fern-api/docs-resolver";
+import { AbsoluteFilePath, doesPathExist, RelativeFilePath, relative, resolve } from "@fern-api/fs-utils";
 import type { TaskContext } from "@fern-api/task-context";
 import { createHash } from "crypto";
 import { readFile } from "fs/promises";
@@ -81,7 +93,8 @@ export function buildLedgerInput({
     git,
     apiDefinitions,
     fileManifest,
-    fileIdToPath
+    fileIdToPath,
+    locale = "en"
 }: {
     docsDefinition: DocsDefinition;
     organization: string;
@@ -100,6 +113,8 @@ export function buildLedgerInput({
      * path-based references (e.g. `ImageRef { path, width, height }`).
      */
     fileIdToPath?: Map<string, string>;
+    /** Locale to stamp on segments. Defaults to "en". */
+    locale?: string;
 }): { input: DocsPublishInput; blobs: Map<string, Buffer> } {
     const blobs = new Map<string, Buffer>();
 
@@ -161,7 +176,7 @@ export function buildLedgerInput({
         apiManifest: apiManifestRef,
         fileManifest,
         redirects: null,
-        locale: "en",
+        locale,
         git
     };
 
@@ -196,7 +211,8 @@ export async function publishDocsViaLedger({
     apiDefinitions,
     fileManifest,
     filePaths,
-    fileIdToPath
+    fileIdToPath,
+    resolver
 }: {
     docsDefinition: DocsDefinition;
     organization: string;
@@ -214,6 +230,8 @@ export async function publishDocsViaLedger({
     /** Hash → absolute file path for lazy on-demand reads during upload. */
     filePaths?: Map<string, AbsoluteFilePath>;
     fileIdToPath?: Map<string, string>;
+    /** Resolver instance for accessing translation pages/overlays. Optional. */
+    resolver?: DocsDefinitionResolver;
 }): Promise<LedgerPublishResult> {
     const { input, blobs } = buildLedgerInput({
         docsDefinition,
@@ -253,6 +271,25 @@ export async function publishDocsViaLedger({
     context.logger.debug(
         `[ledger] Finished in ${finishTime.toFixed(0)}ms — deploymentId=${finishResult.deploymentId}, reused=${finishResult.reusedDeployment}`
     );
+
+    // Step 4: Publish translations if the resolver has them.
+    if (resolver != null) {
+        await publishTranslationsViaLedger({
+            docsDefinition,
+            deploymentId: finishResult.deploymentId,
+            organization,
+            domain,
+            basepath,
+            git,
+            apiDefinitions,
+            fileManifest,
+            fileIdToPath,
+            filePaths,
+            client,
+            context,
+            resolver
+        });
+    }
 
     return finishResult;
 }
@@ -366,4 +403,274 @@ async function uploadBlobWithRetry(
     }
 
     throw new Error(`[ledger] Upload exhausted retries for ${hash}`);
+}
+
+// ── Translation publishing ─────────────────────────────────────────────
+
+type DocsLedgerClient = ReturnType<typeof createDocsLedgerClient>;
+
+/**
+ * After a base deployment finishes, publish translated content for each
+ * locale the resolver discovered under `translations/<lang>/`.
+ *
+ * For each locale:
+ *  1. Build a translated DocsDefinition (overlay translated pages + nav).
+ *  2. Convert to a ledger input via {@link buildLedgerInput} with the locale.
+ *  3. Call `register` to dedup blobs and get presigned upload URLs.
+ *  4. Upload any missing blobs (translated page content).
+ *  5. Call `finishTranslation` to attach locale-specific segments to the
+ *     existing deployment.
+ */
+async function publishTranslationsViaLedger({
+    docsDefinition,
+    deploymentId,
+    organization,
+    domain,
+    basepath,
+    git,
+    apiDefinitions,
+    fileManifest,
+    fileIdToPath,
+    filePaths,
+    client,
+    context,
+    resolver
+}: {
+    docsDefinition: DocsDefinition;
+    deploymentId: string;
+    organization: string;
+    domain: string;
+    basepath: string | undefined;
+    git?: DocsPublishGitInput;
+    apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
+    fileManifest?: Record<string, FileManifestEntry>;
+    fileIdToPath?: Map<string, string>;
+    filePaths?: Map<string, AbsoluteFilePath>;
+    client: DocsLedgerClient;
+    context: TaskContext;
+    resolver: DocsDefinitionResolver;
+}): Promise<void> {
+    const translationPages = resolver.getTranslationPages();
+    const translationNavigationOverlays = resolver.getTranslationNavigationOverlays();
+
+    if (translationPages == null || Object.keys(translationPages).length === 0) {
+        return;
+    }
+
+    context.logger.info(`[ledger] Publishing translations for ${Object.keys(translationPages).length} locale(s)...`);
+
+    for (const [locale, localePages] of Object.entries(translationPages)) {
+        try {
+            const translatedDefinition = await buildTranslatedDocsDefinition({
+                docsDefinition,
+                locale,
+                localePages,
+                translationNavigationOverlays,
+                resolver,
+                context
+            });
+
+            const { input: translationInput, blobs: translationBlobs } = buildLedgerInput({
+                docsDefinition: translatedDefinition,
+                organization,
+                domain,
+                basepath,
+                previewId: undefined,
+                git,
+                apiDefinitions,
+                fileManifest,
+                fileIdToPath,
+                locale
+            });
+
+            // Register to get presigned URLs for any new blobs (translated page content).
+            const registerResult = await client.register(translationInput);
+
+            // Upload missing blobs (translated pages will have different content hashes).
+            await uploadMissingBlobs(registerResult.missingContent, translationBlobs, context, filePaths);
+
+            // Finish translation — attaches locale-specific segments to the existing deployment.
+            const finishInput: FinishTranslationInput = {
+                orgId: organization,
+                domain,
+                basepath: basepath ?? "",
+                deploymentId,
+                locale,
+                root: translatedDefinition.config.root ?? translatedDefinition.config.navigation,
+                pages: translationInput.pages,
+                apiManifest: translationInput.apiManifest,
+                config: translationInput.config,
+                fileManifest: translationInput.fileManifest,
+                jsFiles: translationInput.jsFiles,
+                redirects: translationInput.redirects,
+                git: translationInput.git
+            };
+
+            const result = await client.finishTranslation(finishInput);
+
+            const pageCount = Object.keys(localePages).length;
+            context.logger.info(
+                `[ledger] Locale "${locale}": ${pageCount} page(s), ${result.segmentsAdded} segment(s) added`
+            );
+        } catch (error) {
+            context.logger.warn(`[ledger] Failed to publish translations for locale "${locale}": ${String(error)}`);
+        }
+    }
+}
+
+/**
+ * Build a translated DocsDefinition by overlaying translated pages and
+ * navigation on top of the base definition. Applies the same MDX processing
+ * pipeline as the V2 translation path:
+ *
+ *  1. Locale-aware snippet resolution (prefers translated snippets)
+ *  2. `<Code src="..."/>` reference resolution
+ *  3. `@/` import transforms
+ *  4. MDX comment stripping
+ *  5. Image path rewrites (using base page location)
+ *  6. `editThisPageUrl` rewriting to point to the translated file
+ *  7. Nav tree overlay (translated sidebar titles from frontmatter + docs.yml)
+ *  8. Translated announcement and navbar links
+ */
+async function buildTranslatedDocsDefinition({
+    docsDefinition,
+    locale,
+    localePages,
+    translationNavigationOverlays,
+    resolver,
+    context
+}: {
+    docsDefinition: DocsDefinition;
+    locale: string;
+    localePages: Record<string, string>;
+    translationNavigationOverlays:
+        | Record<string, import("@fern-api/configuration").docsYml.TranslationNavigationOverlay>
+        | undefined;
+    resolver: DocsDefinitionResolver;
+    context: TaskContext;
+}): Promise<DocsDefinition> {
+    const collectedFileIds = resolver.getCollectedFileIds();
+    const docsWorkspacePath = resolver.getDocsWorkspacePath();
+
+    const resolveLocalePath = async (filepath: AbsoluteFilePath): Promise<AbsoluteFilePath> => {
+        const relPath = relative(docsWorkspacePath, filepath);
+        const translatedPath = resolve(docsWorkspacePath, RelativeFilePath.of(`translations/${locale}/${relPath}`));
+        return (await doesPathExist(translatedPath)) ? translatedPath : filepath;
+    };
+
+    const localeAwareMarkdownLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
+        const pathToRead = await resolveLocalePath(filepath);
+        const raw = await readFile(pathToRead, "utf-8");
+        const fmMatch = raw.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+        return fmMatch != null ? raw.slice(fmMatch[0].length) : raw;
+    };
+
+    const localeAwareFileLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
+        const pathToRead = await resolveLocalePath(filepath);
+        return readFile(pathToRead, "utf-8");
+    };
+
+    const translatedPageEntries = await Promise.all(
+        Object.entries(localePages).map(async ([path, rawMarkdown]) => {
+            try {
+                const basePage = docsDefinition.pages[path as DocsV1Write.PageId];
+                const absolutePathToMarkdownFile = resolve(docsWorkspacePath, RelativeFilePath.of(path));
+
+                const { markdown: markdownResolved } = await replaceReferencedMarkdown({
+                    markdown: rawMarkdown,
+                    absolutePathToFernFolder: docsWorkspacePath,
+                    absolutePathToMarkdownFile,
+                    context,
+                    markdownLoader: localeAwareMarkdownLoader
+                });
+
+                const codeResolved = await replaceReferencedCode({
+                    markdown: markdownResolved,
+                    absolutePathToFernFolder: docsWorkspacePath,
+                    absolutePathToMarkdownFile,
+                    context,
+                    fileLoader: localeAwareFileLoader
+                });
+
+                const importsResolved = transformAtPrefixImports({
+                    markdown: codeResolved,
+                    absolutePathToFernFolder: docsWorkspacePath,
+                    absolutePathToMarkdownFile
+                });
+
+                let processedMarkdown = stripMdxComments(importsResolved);
+
+                processedMarkdown = replaceImagePathsAndUrls(
+                    processedMarkdown,
+                    collectedFileIds,
+                    {},
+                    {
+                        absolutePathToMarkdownFile,
+                        absolutePathToFernFolder: docsWorkspacePath
+                    },
+                    context
+                );
+
+                let editThisPageUrl = basePage?.editThisPageUrl;
+                if (editThisPageUrl != null) {
+                    const fernPathPattern = `/fern/${path}`;
+                    const translatedPathStr = `/fern/translations/${locale}/${path}`;
+                    editThisPageUrl = editThisPageUrl.replace(
+                        fernPathPattern,
+                        translatedPathStr
+                    ) as typeof editThisPageUrl;
+                }
+
+                return [
+                    path,
+                    {
+                        markdown: processedMarkdown,
+                        rawMarkdown: processedMarkdown,
+                        editThisPageUrl,
+                        editThisPageLaunch: basePage?.editThisPageLaunch
+                    }
+                ];
+            } catch (pageError) {
+                context.logger.warn(
+                    `[ledger] Failed to process translated page "${path}" for locale "${locale}": ${String(pageError)}. Falling back to base page.`
+                );
+                return undefined;
+            }
+        })
+    );
+
+    const translatedPages = {
+        ...docsDefinition.pages,
+        ...Object.fromEntries(
+            translatedPageEntries.filter((entry): entry is NonNullable<typeof entry> => entry != null)
+        )
+    };
+
+    let updatedRoot = applyTranslatedFrontmatterToNavTree(
+        docsDefinition.config.root,
+        localePages as Record<string, string>,
+        context
+    );
+
+    const localeNavOverlay = translationNavigationOverlays?.[locale];
+    let translatedAnnouncement = docsDefinition.config.announcement;
+    let translatedNavbarLinks = docsDefinition.config.navbarLinks;
+    if (localeNavOverlay != null) {
+        updatedRoot = applyTranslatedNavigationOverlays(updatedRoot, localeNavOverlay);
+        translatedAnnouncement = getTranslatedAnnouncement(localeNavOverlay) ?? translatedAnnouncement;
+        if (localeNavOverlay.navbarLinks != null) {
+            translatedNavbarLinks = localeNavOverlay.navbarLinks;
+        }
+    }
+
+    return {
+        ...docsDefinition,
+        pages: translatedPages,
+        config: {
+            ...docsDefinition.config,
+            root: updatedRoot,
+            announcement: translatedAnnouncement,
+            navbarLinks: translatedNavbarLinks
+        }
+    };
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -1,14 +1,4 @@
-import {
-    applyTranslatedFrontmatterToNavTree,
-    applyTranslatedNavigationOverlays,
-    type DocsDefinitionResolver,
-    getTranslatedAnnouncement,
-    replaceImagePathsAndUrls,
-    replaceReferencedCode,
-    replaceReferencedMarkdown,
-    stripMdxComments,
-    transformAtPrefixImports
-} from "@fern-api/docs-resolver";
+import { type DocsDefinitionResolver } from "@fern-api/docs-resolver";
 import type { APIV1Write, DocsV1Write } from "@fern-api/fdr-sdk";
 import {
     createDocsLedgerClient,
@@ -17,11 +7,12 @@ import {
     type FileManifestEntry,
     type FinishTranslationInput
 } from "@fern-api/fdr-sdk/orpc-client";
-import { AbsoluteFilePath, doesPathExist, RelativeFilePath, relative, resolve } from "@fern-api/fs-utils";
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { TaskContext } from "@fern-api/task-context";
 import { createHash } from "crypto";
 import { readFile } from "fs/promises";
 
+import { buildTranslatedDocsDefinition } from "./buildTranslatedDocsDefinition.js";
 import { mapDocsConfigToLedgerConfig } from "./mapDocsConfigToLedgerConfig.js";
 import { asyncPool } from "./utils/asyncPool.js";
 
@@ -457,220 +448,66 @@ async function publishTranslationsViaLedger({
         return;
     }
 
-    context.logger.info(`[ledger] Publishing translations for ${Object.keys(translationPages).length} locale(s)...`);
+    const localeEntries = Object.entries(translationPages);
+    context.logger.info(`[ledger] Publishing translations for ${localeEntries.length} locale(s)...`);
 
-    for (const [locale, localePages] of Object.entries(translationPages)) {
-        try {
-            const translatedDefinition = await buildTranslatedDocsDefinition({
-                docsDefinition,
-                locale,
-                localePages,
-                translationNavigationOverlays,
-                resolver,
-                context
-            });
-
-            const { input: translationInput, blobs: translationBlobs } = buildLedgerInput({
-                docsDefinition: translatedDefinition,
-                organization,
-                domain,
-                basepath,
-                previewId: undefined,
-                git,
-                apiDefinitions,
-                fileManifest,
-                fileIdToPath,
-                locale
-            });
-
-            // Register to get presigned URLs for any new blobs (translated page content).
-            const registerResult = await client.register(translationInput);
-
-            // Upload missing blobs (translated pages will have different content hashes).
-            await uploadMissingBlobs(registerResult.missingContent, translationBlobs, context, filePaths);
-
-            // Finish translation — attaches locale-specific segments to the existing deployment.
-            const finishInput: FinishTranslationInput = {
-                orgId: organization,
-                domain,
-                basepath: basepath ?? "",
-                deploymentId,
-                locale,
-                root: translatedDefinition.config.root ?? translatedDefinition.config.navigation,
-                pages: translationInput.pages,
-                apiManifest: translationInput.apiManifest,
-                config: translationInput.config,
-                fileManifest: translationInput.fileManifest,
-                jsFiles: translationInput.jsFiles,
-                redirects: translationInput.redirects,
-                git: translationInput.git
-            };
-
-            const result = await client.finishTranslation(finishInput);
-
-            const pageCount = Object.keys(localePages).length;
-            context.logger.info(
-                `[ledger] Locale "${locale}": ${pageCount} page(s), ${result.segmentsAdded} segment(s) added`
-            );
-        } catch (error) {
-            context.logger.warn(`[ledger] Failed to publish translations for locale "${locale}": ${String(error)}`);
-        }
-    }
-}
-
-/**
- * Build a translated DocsDefinition by overlaying translated pages and
- * navigation on top of the base definition. Applies the same MDX processing
- * pipeline as the V2 translation path:
- *
- *  1. Locale-aware snippet resolution (prefers translated snippets)
- *  2. `<Code src="..."/>` reference resolution
- *  3. `@/` import transforms
- *  4. MDX comment stripping
- *  5. Image path rewrites (using base page location)
- *  6. `editThisPageUrl` rewriting to point to the translated file
- *  7. Nav tree overlay (translated sidebar titles from frontmatter + docs.yml)
- *  8. Translated announcement and navbar links
- */
-async function buildTranslatedDocsDefinition({
-    docsDefinition,
-    locale,
-    localePages,
-    translationNavigationOverlays,
-    resolver,
-    context
-}: {
-    docsDefinition: DocsDefinition;
-    locale: string;
-    localePages: Record<string, string>;
-    translationNavigationOverlays:
-        | Record<string, import("@fern-api/configuration").docsYml.TranslationNavigationOverlay>
-        | undefined;
-    resolver: DocsDefinitionResolver;
-    context: TaskContext;
-}): Promise<DocsDefinition> {
-    const collectedFileIds = resolver.getCollectedFileIds();
-    const docsWorkspacePath = resolver.getDocsWorkspacePath();
-
-    const resolveLocalePath = async (filepath: AbsoluteFilePath): Promise<AbsoluteFilePath> => {
-        const relPath = relative(docsWorkspacePath, filepath);
-        const translatedPath = resolve(docsWorkspacePath, RelativeFilePath.of(`translations/${locale}/${relPath}`));
-        return (await doesPathExist(translatedPath)) ? translatedPath : filepath;
-    };
-
-    const localeAwareMarkdownLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
-        const pathToRead = await resolveLocalePath(filepath);
-        const raw = await readFile(pathToRead, "utf-8");
-        const fmMatch = raw.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
-        return fmMatch != null ? raw.slice(fmMatch[0].length) : raw;
-    };
-
-    const localeAwareFileLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
-        const pathToRead = await resolveLocalePath(filepath);
-        return readFile(pathToRead, "utf-8");
-    };
-
-    const translatedPageEntries = await Promise.all(
-        Object.entries(localePages).map(async ([path, rawMarkdown]) => {
+    await Promise.all(
+        localeEntries.map(async ([locale, localePages]) => {
             try {
-                const basePage = docsDefinition.pages[path as DocsV1Write.PageId];
-                const absolutePathToMarkdownFile = resolve(docsWorkspacePath, RelativeFilePath.of(path));
-
-                const { markdown: markdownResolved } = await replaceReferencedMarkdown({
-                    markdown: rawMarkdown,
-                    absolutePathToFernFolder: docsWorkspacePath,
-                    absolutePathToMarkdownFile,
-                    context,
-                    markdownLoader: localeAwareMarkdownLoader
-                });
-
-                const codeResolved = await replaceReferencedCode({
-                    markdown: markdownResolved,
-                    absolutePathToFernFolder: docsWorkspacePath,
-                    absolutePathToMarkdownFile,
-                    context,
-                    fileLoader: localeAwareFileLoader
-                });
-
-                const importsResolved = transformAtPrefixImports({
-                    markdown: codeResolved,
-                    absolutePathToFernFolder: docsWorkspacePath,
-                    absolutePathToMarkdownFile
-                });
-
-                let processedMarkdown = stripMdxComments(importsResolved);
-
-                processedMarkdown = replaceImagePathsAndUrls(
-                    processedMarkdown,
-                    collectedFileIds,
-                    {},
-                    {
-                        absolutePathToMarkdownFile,
-                        absolutePathToFernFolder: docsWorkspacePath
-                    },
+                const translatedDefinition = await buildTranslatedDocsDefinition({
+                    docsDefinition,
+                    locale,
+                    localePages,
+                    translationNavigationOverlays,
+                    resolver,
                     context
-                );
+                });
 
-                let editThisPageUrl = basePage?.editThisPageUrl;
-                if (editThisPageUrl != null) {
-                    const fernPathPattern = `/fern/${path}`;
-                    const translatedPathStr = `/fern/translations/${locale}/${path}`;
-                    editThisPageUrl = editThisPageUrl.replace(
-                        fernPathPattern,
-                        translatedPathStr
-                    ) as typeof editThisPageUrl;
-                }
+                const { input: translationInput, blobs: translationBlobs } = buildLedgerInput({
+                    docsDefinition: translatedDefinition,
+                    organization,
+                    domain,
+                    basepath,
+                    previewId: undefined,
+                    git,
+                    apiDefinitions,
+                    fileManifest,
+                    fileIdToPath,
+                    locale
+                });
 
-                return [
-                    path,
-                    {
-                        markdown: processedMarkdown,
-                        rawMarkdown: processedMarkdown,
-                        editThisPageUrl,
-                        editThisPageLaunch: basePage?.editThisPageLaunch
-                    }
-                ];
-            } catch (pageError) {
-                context.logger.warn(
-                    `[ledger] Failed to process translated page "${path}" for locale "${locale}": ${String(pageError)}. Falling back to base page.`
+                // Register to get presigned URLs for any new blobs (translated page content).
+                const registerResult = await client.register(translationInput);
+
+                // Upload missing blobs (translated pages will have different content hashes).
+                await uploadMissingBlobs(registerResult.missingContent, translationBlobs, context, filePaths);
+
+                // Finish translation — attaches locale-specific segments to the existing deployment.
+                const finishInput: FinishTranslationInput = {
+                    orgId: organization,
+                    domain,
+                    basepath: basepath ?? "",
+                    deploymentId,
+                    locale,
+                    root: translatedDefinition.config.root ?? translatedDefinition.config.navigation,
+                    pages: translationInput.pages,
+                    apiManifest: translationInput.apiManifest,
+                    config: translationInput.config,
+                    fileManifest: translationInput.fileManifest,
+                    jsFiles: translationInput.jsFiles,
+                    redirects: translationInput.redirects,
+                    git: translationInput.git
+                };
+
+                const result = await client.finishTranslation(finishInput);
+
+                const pageCount = Object.keys(localePages).length;
+                context.logger.info(
+                    `[ledger] Locale "${locale}": ${pageCount} page(s), ${result.segmentsAdded} segment(s) added`
                 );
-                return undefined;
+            } catch (error) {
+                context.logger.warn(`[ledger] Failed to publish translations for locale "${locale}": ${String(error)}`);
             }
         })
     );
-
-    const translatedPages = {
-        ...docsDefinition.pages,
-        ...Object.fromEntries(
-            translatedPageEntries.filter((entry): entry is NonNullable<typeof entry> => entry != null)
-        )
-    };
-
-    let updatedRoot = applyTranslatedFrontmatterToNavTree(
-        docsDefinition.config.root,
-        localePages as Record<string, string>,
-        context
-    );
-
-    const localeNavOverlay = translationNavigationOverlays?.[locale];
-    let translatedAnnouncement = docsDefinition.config.announcement;
-    let translatedNavbarLinks = docsDefinition.config.navbarLinks;
-    if (localeNavOverlay != null) {
-        updatedRoot = applyTranslatedNavigationOverlays(updatedRoot, localeNavOverlay);
-        translatedAnnouncement = getTranslatedAnnouncement(localeNavOverlay) ?? translatedAnnouncement;
-        if (localeNavOverlay.navbarLinks != null) {
-            translatedNavbarLinks = localeNavOverlay.navbarLinks;
-        }
-    }
-
-    return {
-        ...docsDefinition,
-        pages: translatedPages,
-        config: {
-            ...docsDefinition.config,
-            root: updatedRoot,
-            announcement: translatedAnnouncement,
-            navbarLinks: translatedNavbarLinks
-        }
-    };
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
@@ -4,7 +4,7 @@ import {
     createDocsLedgerClient,
     type DocsPublishGitInput,
     type FileManifestEntry,
-    type FinishTranslationInput
+    type TranslationEntry
 } from "@fern-api/fdr-sdk/orpc-client";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { TaskContext } from "@fern-api/task-context";
@@ -145,6 +145,23 @@ export async function publishDocsViaLedgerPreview({
 
     await uploadMissingBlobs(registerResult.missingContent, blobs, context, filePaths);
 
+    // Build the translations array for the finish call.
+    const translations: TranslationEntry[] = translationInputs.map((t) => ({
+        locale: t.locale,
+        root: t.input.root,
+        pages: t.input.pages,
+        apiManifest: t.input.apiManifest,
+        config: t.input.config,
+        fileManifest: t.input.fileManifest,
+        jsFiles: t.input.jsFiles,
+        redirects: t.input.redirects,
+        version: t.input.version,
+        repo: t.input.repo,
+        git: t.input.git
+    }));
+
+    // Finish — server persists the preview deployment + all translations
+    // in a single call.
     context.logger.debug("[ledger-preview] Finishing preview deployment...");
     const finishStart = performance.now();
     const finishResult = await client.finish({
@@ -152,7 +169,8 @@ export async function publishDocsViaLedgerPreview({
         domain: registerResult.domain,
         basepath: registerResult.basepath,
         customDomains: [],
-        previewId: registerResult.previewId
+        previewId: registerResult.previewId,
+        translations: translations.length > 0 ? translations : undefined
     });
     const finishTime = performance.now() - finishStart;
     context.logger.debug(
@@ -160,35 +178,10 @@ export async function publishDocsViaLedgerPreview({
             `reused=${finishResult.reusedDeployment}`
     );
 
-    // ── Phase 3: Attach translations to the deployment ─────────────────
-
-    if (translationInputs.length > 0) {
-        context.logger.info(`[ledger-preview] Attaching translations for ${translationInputs.length} locale(s)...`);
-
-        for (const t of translationInputs) {
-            const localeRegister = await client.register(t.input);
-            await uploadMissingBlobs(localeRegister.missingContent, t.blobs, context, filePaths);
-
-            const finishInput: FinishTranslationInput = {
-                orgId: organization,
-                domain: registerResult.domain,
-                basepath: registerResult.basepath ?? "",
-                deploymentId: finishResult.deploymentId,
-                locale: t.locale,
-                root: t.translatedDefinition.config.root ?? t.translatedDefinition.config.navigation,
-                pages: t.input.pages,
-                apiManifest: t.input.apiManifest,
-                config: t.input.config,
-                fileManifest: t.input.fileManifest,
-                jsFiles: t.input.jsFiles,
-                redirects: t.input.redirects,
-                git: t.input.git
-            };
-
-            const result = await client.finishTranslation(finishInput);
-            context.logger.info(
-                `[ledger-preview] Locale "${t.locale}": ${Object.keys(t.localePages).length} page(s), ${result.segmentsAdded} segment(s) added`
-            );
+    // Log translation results if any were processed.
+    if (finishResult.translationsProcessed != null) {
+        for (const tp of finishResult.translationsProcessed) {
+            context.logger.info(`[ledger-preview] Locale "${tp.locale}": ${tp.segmentsAdded} segment(s) added`);
         }
     }
 

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
@@ -23,6 +23,9 @@ export interface LedgerPreviewResult {
  * Publish a docs preview via the dedicated ledger preview endpoint
  * (POST /preview/init) followed by the standard finish call.
  *
+ * All translation locales are built upfront before any network calls.
+ * If any locale fails to build, the entire preview publish aborts.
+ *
  * Unlike the production {@link publishDocsViaLedger}, this flow:
  *   - Sends `LedgerPreviewRegisterInput` (no `domain` / `customDomains`).
  *   - Receives a server-generated preview URL and domain.
@@ -62,10 +65,12 @@ export async function publishDocsViaLedgerPreview({
     /** Resolver instance for accessing translation pages/overlays. Optional. */
     resolver?: DocsDefinitionResolver;
 }): Promise<LedgerPreviewResult> {
-    // Build the input and blob map using the shared helper.  We pass a
-    // throwaway `domain` — it's required by buildLedgerInput's type but will
-    // not be sent to the preview endpoint (LedgerPreviewRegisterInput has no
-    // domain field).
+    // ── Phase 1: Build all locales upfront ──────────────────────────────
+    // Translated DocsDefinitions are built before any network calls so a
+    // single locale failure aborts the entire preview publish. The cheap
+    // sync buildLedgerInput for translations is deferred until after
+    // previewRegister because we need the server-assigned domain.
+
     const { input, blobs } = buildLedgerInput({
         docsDefinition,
         organization,
@@ -79,10 +84,16 @@ export async function publishDocsViaLedgerPreview({
         fileIdToPath
     });
 
+    const builtTranslationDefs = await buildAllTranslationDefinitions({
+        docsDefinition,
+        resolver,
+        context
+    });
+
+    // ── Phase 2: Single register → upload → finish ─────────────────────
+
     const client = createDocsLedgerClient({ baseUrl: fdrOrigin, token, headers });
 
-    // Step 1: Preview register — server picks the preview host and returns
-    // presigned upload URLs for missing blobs.
     context.logger.debug("[ledger-preview] Registering preview deployment...");
     const registerStart = performance.now();
     const registerResult = await client.previewRegister({
@@ -107,11 +118,33 @@ export async function publishDocsViaLedgerPreview({
             `preview=${registerResult.previewUrl}, missing=${registerResult.missingContent.length} blobs`
     );
 
-    // Step 2: Upload missing blobs.
+    // Build translation ledger inputs now that we have the server domain.
+    // This is a cheap sync operation (serialization only).
+    const translationInputs = builtTranslationDefs.map((t) => {
+        const { input: translationInput, blobs: translationBlobs } = buildLedgerInput({
+            docsDefinition: t.translatedDefinition,
+            organization,
+            domain: registerResult.domain,
+            basepath: registerResult.basepath,
+            previewId: registerResult.previewId,
+            git,
+            apiDefinitions,
+            fileManifest,
+            fileIdToPath,
+            locale: t.locale
+        });
+        return { ...t, input: translationInput, blobs: translationBlobs };
+    });
+
+    // Merge all translation blobs into the base pool for the upload phase.
+    for (const t of translationInputs) {
+        for (const [hash, buf] of t.blobs) {
+            blobs.set(hash, buf);
+        }
+    }
+
     await uploadMissingBlobs(registerResult.missingContent, blobs, context, filePaths);
 
-    // Step 3: Finish — use the server-assigned domain and previewId so the
-    // deployment is keyed to the preview branch.
     context.logger.debug("[ledger-preview] Finishing preview deployment...");
     const finishStart = performance.now();
     const finishResult = await client.finish({
@@ -127,79 +160,35 @@ export async function publishDocsViaLedgerPreview({
             `reused=${finishResult.reusedDeployment}`
     );
 
-    // Step 4: Publish translations if the resolver has them.
-    if (resolver != null) {
-        const translationPages = resolver.getTranslationPages();
-        const translationNavigationOverlays = resolver.getTranslationNavigationOverlays();
+    // ── Phase 3: Attach translations to the deployment ─────────────────
 
-        if (translationPages != null && Object.keys(translationPages).length > 0) {
-            const localeEntries = Object.entries(translationPages);
-            context.logger.info(`[ledger-preview] Publishing translations for ${localeEntries.length} locale(s)...`);
+    if (translationInputs.length > 0) {
+        context.logger.info(`[ledger-preview] Attaching translations for ${translationInputs.length} locale(s)...`);
 
-            const localeResults = await Promise.all(
-                localeEntries.map(async ([locale, localePages]) => {
-                    try {
-                        const translatedDefinition = await buildTranslatedDocsDefinition({
-                            docsDefinition,
-                            locale,
-                            localePages,
-                            translationNavigationOverlays,
-                            resolver,
-                            context
-                        });
+        for (const t of translationInputs) {
+            const localeRegister = await client.register(t.input);
+            await uploadMissingBlobs(localeRegister.missingContent, t.blobs, context, filePaths);
 
-                        const { input: translationInput, blobs: translationBlobs } = buildLedgerInput({
-                            docsDefinition: translatedDefinition,
-                            organization,
-                            domain: registerResult.domain,
-                            basepath: registerResult.basepath,
-                            previewId: registerResult.previewId,
-                            git,
-                            apiDefinitions,
-                            fileManifest,
-                            fileIdToPath,
-                            locale
-                        });
+            const finishInput: FinishTranslationInput = {
+                orgId: organization,
+                domain: registerResult.domain,
+                basepath: registerResult.basepath ?? "",
+                deploymentId: finishResult.deploymentId,
+                locale: t.locale,
+                root: t.translatedDefinition.config.root ?? t.translatedDefinition.config.navigation,
+                pages: t.input.pages,
+                apiManifest: t.input.apiManifest,
+                config: t.input.config,
+                fileManifest: t.input.fileManifest,
+                jsFiles: t.input.jsFiles,
+                redirects: t.input.redirects,
+                git: t.input.git
+            };
 
-                        const localeRegister = await client.register(translationInput);
-                        await uploadMissingBlobs(localeRegister.missingContent, translationBlobs, context, filePaths);
-
-                        const finishInput: FinishTranslationInput = {
-                            orgId: organization,
-                            domain: registerResult.domain,
-                            basepath: registerResult.basepath ?? "",
-                            deploymentId: finishResult.deploymentId,
-                            locale,
-                            root: translatedDefinition.config.root ?? translatedDefinition.config.navigation,
-                            pages: translationInput.pages,
-                            apiManifest: translationInput.apiManifest,
-                            config: translationInput.config,
-                            fileManifest: translationInput.fileManifest,
-                            jsFiles: translationInput.jsFiles,
-                            redirects: translationInput.redirects,
-                            git: translationInput.git
-                        };
-
-                        const result = await client.finishTranslation(finishInput);
-                        context.logger.info(
-                            `[ledger-preview] Locale "${locale}": ${Object.keys(localePages).length} page(s), ${result.segmentsAdded} segment(s) added`
-                        );
-                    } catch (error) {
-                        context.logger.warn(
-                            `[ledger-preview] Failed to publish translations for locale "${locale}": ${String(error)}`
-                        );
-                        return locale;
-                    }
-                    return undefined;
-                })
+            const result = await client.finishTranslation(finishInput);
+            context.logger.info(
+                `[ledger-preview] Locale "${t.locale}": ${Object.keys(t.localePages).length} page(s), ${result.segmentsAdded} segment(s) added`
             );
-
-            const failedLocales = localeResults.filter((l): l is string => l != null);
-            if (failedLocales.length > 0) {
-                context.logger.warn(
-                    `[ledger-preview] ${failedLocales.length}/${localeEntries.length} locale(s) failed: ${failedLocales.join(", ")}`
-                );
-            }
         }
     }
 
@@ -207,4 +196,61 @@ export async function publishDocsViaLedgerPreview({
         previewUrl: registerResult.previewUrl,
         deploymentId: finishResult.deploymentId
     };
+}
+
+// ── Translation build helpers ──────────────────────────────────────────
+
+interface BuiltTranslationDef {
+    locale: string;
+    localePages: Record<string, string>;
+    translatedDefinition: DocsDefinition;
+}
+
+/**
+ * Build translated DocsDefinitions for every locale the resolver discovered.
+ *
+ * All locales are built in parallel. If ANY locale fails, the returned
+ * promise rejects — callers should let the error propagate to abort the
+ * entire publish.
+ *
+ * This only builds the DocsDefinitions (the expensive async part). The
+ * cheap sync `buildLedgerInput` is deferred by the caller because the
+ * preview flow needs the server-assigned domain first.
+ */
+async function buildAllTranslationDefinitions({
+    docsDefinition,
+    resolver,
+    context
+}: {
+    docsDefinition: DocsDefinition;
+    resolver?: DocsDefinitionResolver;
+    context: TaskContext;
+}): Promise<BuiltTranslationDef[]> {
+    if (resolver == null) {
+        return [];
+    }
+
+    const translationPages = resolver.getTranslationPages();
+    const translationNavigationOverlays = resolver.getTranslationNavigationOverlays();
+
+    if (translationPages == null || Object.keys(translationPages).length === 0) {
+        return [];
+    }
+
+    const localeEntries = Object.entries(translationPages);
+    context.logger.info(`[ledger-preview] Building ${localeEntries.length} translation locale(s)...`);
+
+    return Promise.all(
+        localeEntries.map(async ([locale, localePages]): Promise<BuiltTranslationDef> => {
+            const translatedDefinition = await buildTranslatedDocsDefinition({
+                docsDefinition,
+                locale,
+                localePages,
+                translationNavigationOverlays,
+                resolver,
+                context
+            });
+            return { locale, localePages, translatedDefinition };
+        })
+    );
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
@@ -1,12 +1,15 @@
+import type { DocsDefinitionResolver } from "@fern-api/docs-resolver";
 import type { APIV1Write, DocsV1Write } from "@fern-api/fdr-sdk";
 import {
     createDocsLedgerClient,
     type DocsPublishGitInput,
-    type FileManifestEntry
+    type FileManifestEntry,
+    type FinishTranslationInput
 } from "@fern-api/fdr-sdk/orpc-client";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { TaskContext } from "@fern-api/task-context";
 
+import { buildTranslatedDocsDefinition } from "./buildTranslatedDocsDefinition.js";
 import { buildLedgerInput, uploadMissingBlobs } from "./publishDocsLedger.js";
 
 type DocsDefinition = DocsV1Write.DocsDefinition;
@@ -39,7 +42,8 @@ export async function publishDocsViaLedgerPreview({
     apiDefinitions,
     fileManifest,
     filePaths,
-    fileIdToPath
+    fileIdToPath,
+    resolver
 }: {
     docsDefinition: DocsDefinition;
     organization: string;
@@ -55,6 +59,8 @@ export async function publishDocsViaLedgerPreview({
     /** Hash → absolute file path for lazy on-demand reads during upload. */
     filePaths?: Map<string, AbsoluteFilePath>;
     fileIdToPath?: Map<string, string>;
+    /** Resolver instance for accessing translation pages/overlays. Optional. */
+    resolver?: DocsDefinitionResolver;
 }): Promise<LedgerPreviewResult> {
     // Build the input and blob map using the shared helper.  We pass a
     // throwaway `domain` — it's required by buildLedgerInput's type but will
@@ -120,6 +126,74 @@ export async function publishDocsViaLedgerPreview({
         `[ledger-preview] Finished in ${finishTime.toFixed(0)}ms — deploymentId=${finishResult.deploymentId}, ` +
             `reused=${finishResult.reusedDeployment}`
     );
+
+    // Step 4: Publish translations if the resolver has them.
+    if (resolver != null) {
+        const translationPages = resolver.getTranslationPages();
+        const translationNavigationOverlays = resolver.getTranslationNavigationOverlays();
+
+        if (translationPages != null && Object.keys(translationPages).length > 0) {
+            const client2 = createDocsLedgerClient({ baseUrl: fdrOrigin, token, headers });
+            const localeEntries = Object.entries(translationPages);
+            context.logger.info(`[ledger-preview] Publishing translations for ${localeEntries.length} locale(s)...`);
+
+            await Promise.all(
+                localeEntries.map(async ([locale, localePages]) => {
+                    try {
+                        const translatedDefinition = await buildTranslatedDocsDefinition({
+                            docsDefinition,
+                            locale,
+                            localePages,
+                            translationNavigationOverlays,
+                            resolver,
+                            context
+                        });
+
+                        const { input: translationInput, blobs: translationBlobs } = buildLedgerInput({
+                            docsDefinition: translatedDefinition,
+                            organization,
+                            domain: registerResult.domain,
+                            basepath: registerResult.basepath,
+                            previewId: registerResult.previewId,
+                            git,
+                            apiDefinitions,
+                            fileManifest,
+                            fileIdToPath,
+                            locale
+                        });
+
+                        const localeRegister = await client2.register(translationInput);
+                        await uploadMissingBlobs(localeRegister.missingContent, translationBlobs, context, filePaths);
+
+                        const finishInput: FinishTranslationInput = {
+                            orgId: organization,
+                            domain: registerResult.domain,
+                            basepath: registerResult.basepath ?? "",
+                            deploymentId: finishResult.deploymentId,
+                            locale,
+                            root: translatedDefinition.config.root ?? translatedDefinition.config.navigation,
+                            pages: translationInput.pages,
+                            apiManifest: translationInput.apiManifest,
+                            config: translationInput.config,
+                            fileManifest: translationInput.fileManifest,
+                            jsFiles: translationInput.jsFiles,
+                            redirects: translationInput.redirects,
+                            git: translationInput.git
+                        };
+
+                        const result = await client2.finishTranslation(finishInput);
+                        context.logger.info(
+                            `[ledger-preview] Locale "${locale}": ${Object.keys(localePages).length} page(s), ${result.segmentsAdded} segment(s) added`
+                        );
+                    } catch (error) {
+                        context.logger.warn(
+                            `[ledger-preview] Failed to publish translations for locale "${locale}": ${String(error)}`
+                        );
+                    }
+                })
+            );
+        }
+    }
 
     return {
         previewUrl: registerResult.previewUrl,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
@@ -133,11 +133,10 @@ export async function publishDocsViaLedgerPreview({
         const translationNavigationOverlays = resolver.getTranslationNavigationOverlays();
 
         if (translationPages != null && Object.keys(translationPages).length > 0) {
-            const client2 = createDocsLedgerClient({ baseUrl: fdrOrigin, token, headers });
             const localeEntries = Object.entries(translationPages);
             context.logger.info(`[ledger-preview] Publishing translations for ${localeEntries.length} locale(s)...`);
 
-            await Promise.all(
+            const localeResults = await Promise.all(
                 localeEntries.map(async ([locale, localePages]) => {
                     try {
                         const translatedDefinition = await buildTranslatedDocsDefinition({
@@ -162,7 +161,7 @@ export async function publishDocsViaLedgerPreview({
                             locale
                         });
 
-                        const localeRegister = await client2.register(translationInput);
+                        const localeRegister = await client.register(translationInput);
                         await uploadMissingBlobs(localeRegister.missingContent, translationBlobs, context, filePaths);
 
                         const finishInput: FinishTranslationInput = {
@@ -181,7 +180,7 @@ export async function publishDocsViaLedgerPreview({
                             git: translationInput.git
                         };
 
-                        const result = await client2.finishTranslation(finishInput);
+                        const result = await client.finishTranslation(finishInput);
                         context.logger.info(
                             `[ledger-preview] Locale "${locale}": ${Object.keys(localePages).length} page(s), ${result.segmentsAdded} segment(s) added`
                         );
@@ -189,9 +188,18 @@ export async function publishDocsViaLedgerPreview({
                         context.logger.warn(
                             `[ledger-preview] Failed to publish translations for locale "${locale}": ${String(error)}`
                         );
+                        return locale;
                     }
+                    return undefined;
                 })
             );
+
+            const failedLocales = localeResults.filter((l): l is string => l != null);
+            if (failedLocales.length > 0) {
+                context.logger.warn(
+                    `[ledger-preview] ${failedLocales.length}/${localeEntries.length} locale(s) failed: ${failedLocales.join(", ")}`
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Ports the V2 multi-locale translation publishing pipeline into the docs-ledger CLI path. Works with the FDR-side localization support added in fern-platform#11146.

## Architecture: Two-Phase Pipeline

Both production and preview paths follow a two-phase pipeline:

### Phase 1: Build all locales upfront
- Build the base locale's `DocsPublishInput` + blob map
- Build **all** translation locales in parallel via `Promise.all` — each locale goes through `buildTranslatedDocsDefinition` (snippet resolution, image rewrites, nav overlays) then `buildLedgerInput`
- **Fail-fast**: if any locale fails to build, the entire publish aborts before any network calls are made

### Phase 2: Single register → upload → finish (with translations)
- Merge all translation blobs into the base blob pool
- Single `register` call for the base locale
- Single `uploadMissingBlobs` with the combined blob pool (base + all translations)
- Single `finish` call with `translations[]` array — server persists base + all locale segments in one request
- No per-locale `finishTranslation` round-trips

### Preview path variation
The preview flow builds translated `DocsDefinition`s (the expensive async part) upfront, and defers the cheap sync `buildLedgerInput` until after `previewRegister` returns the server-assigned domain. Translations are still passed inline to the single `finish` call.

## Changes Made
- **`publishDocsLedger.ts`**: Removed Phase 3 per-locale `finishTranslation` loop. Translations are now mapped to `TranslationEntry[]` and passed inline to the `finish` call. Logs `translationsProcessed` results from the server response.
- **`publishDocsLedgerPreview.ts`**: Same restructure — translations passed inline to `finish` instead of per-locale `finishTranslation` calls.
- **`buildTranslatedDocsDefinition.ts`**: Shared extraction (from prior commit) used by both V2 and ledger paths
- **Dual-mode**: In `dual` deploy mode, translations are intentionally published via both ledger and V2 for migration parity

## Testing
- [x] Biome lint passes (zero errors)
- [x] Compile/test failures are pre-existing on `feat/docs_ledger` base branch (TS errors from unpublished `@fern-api/fdr-sdk/orpc-client` types — verified identical on base)

Link to Devin session: https://app.devin.ai/sessions/47a39f0fd5894d988a5dadffd94f5e4e
Requested by: @emjoseph