### PR TITLE
chore(python): bump generator-cli to 0.9.31

### DIFF
--- a/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.31.yml
+++ b/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.31.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.31, which includes @fern-api/replay
+    0.16.0 with squash-merge and force-push recovery delegated to the replay
+    engine.
+  type: chore


### PR DESCRIPTION
## Description
Refs https://github.com/fern-api/fern/pull/15969

Bumps the Python SDK generator to pick up `@fern-api/generator-cli` 0.9.31 (which includes `@fern-api/replay` 0.16.0).

## Changes Made
- Added unreleased changelog entry for Python SDK generator (`generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.31.yml`)

This triggers a new Docker image build that will bundle the latest catalog-pinned generator-cli (0.9.31).

Key changes in this chain:
- **replay 0.16.0**: Squash-merge and force-push recovery delegated to the replay engine; divergent-merge gauntlet removed from generator-cli.

## Testing
- [x] No code changes — changelog entry only to trigger Docker rebuild
- [x] Generator will pick up generator-cli 0.9.31 via catalog pin

Link to Devin session: https://app.devin.ai/sessions/d3544d0689dd4c8583ce9eac22cb7cbf
Requested by: @tstanmay13