### PR TITLE
fix(cli): include jsFiles in ledger publish payload

### DIFF
--- a/packages/cli/cli/changes/unreleased/ledger-jsfiles.yml
+++ b/packages/cli/cli/changes/unreleased/ledger-jsfiles.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Include jsFiles (custom React components, referenced markdown snippets, and
+    custom header/footer components) in the ledger publish payload so they are
+    stored in CAS and available on the ledger read path.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -149,6 +149,15 @@ export function buildLedgerInput({
         apiManifestRef = manifestBlob.ref;
     }
 
+    // jsFiles: custom React components, referenced markdown snippets, and
+    // custom header/footer components resolved by DocsDefinitionResolver.
+    let jsFilesRef: BlobRef | null = null;
+    if (docsDefinition.jsFiles != null && Object.keys(docsDefinition.jsFiles).length > 0) {
+        const jsFilesBlob = jsonBlobRef(docsDefinition.jsFiles);
+        blobs.set(jsFilesBlob.hash, jsFilesBlob.buf);
+        jsFilesRef = jsFilesBlob.ref;
+    }
+
     const input: DocsPublishInput = {
         orgId: organization,
         domain,
@@ -159,6 +168,7 @@ export function buildLedgerInput({
         pages,
         config: ledgerConfig,
         apiManifest: apiManifestRef,
+        jsFiles: jsFilesRef,
         fileManifest,
         redirects: null,
         locale: "en",


### PR DESCRIPTION
## Description

The CLI's ledger publish path (`buildLedgerInput`) was not including `jsFiles` in the `DocsPublishInput` payload. This meant that custom React components, referenced markdown snippets, and custom header/footer components resolved by `DocsDefinitionResolver` were never uploaded to CAS during ledger publishes, leaving `docs_ledger_deployments.js_files_id` as null.

The ledger docs loader then fell back to the legacy V2 path for `getMdxBundlerFiles`, which correctly has the data. This was visible as a `fern:loader-fallbacks` meta tag containing `getMdxBundlerFiles` on every page rendered via the ledger path.

Confirmed locally: Square docs has 226 jsFiles (2 React components + 224 MDX snippets) in the V2 blob but `js_files_id = null` in the ledger deployment row.

## Changes Made

- Serialize `docsDefinition.jsFiles` as a JSON blob via `jsonBlobRef` (same pattern as `apiManifest`) and include the `BlobRef` in the ledger publish input
- The FDR server-side already handles `jsFiles` correctly (`docsPublishTransform.ts` tracks it in `contentRefs`, `DocsLedgerDao` writes `js_files_id`) — only the CLI was missing the field

## Testing

- Verified the `DocsPublishInputSchema` already defines `jsFiles: BlobRefSchema.nullish()` — the field is accepted by the contract
- Lint passes (`pnpm lint:biome`)
- Format passes (`pnpm format`)
- [ ] Re-publish Square docs locally with this fix and verify `js_files_id` is populated
- [ ] Confirm `getMdxBundlerFiles` fallback no longer appears in `fern:loader-fallbacks` meta tag

Link to Devin session: https://app.devin.ai/sessions/bb6f1707df774511a340e09f2153c02c
Requested by: @emjoseph