### PR TITLE
chore(deps): bump moby to v29.5.1 to fix 3 docker cp CVEs in seed containers

### DIFF
--- a/docker/seed/Dockerfile.go
+++ b/docker/seed/Dockerfile.go
@@ -16,10 +16,11 @@ RUN apk add --no-cache curl && \
 FROM golang:1.26.3-alpine3.23 AS overlay-binaries
 ARG CONTAINERD_VERSION=2.3.0
 ARG RUNC_VERSION=1.3.5
-# moby v2.0.0-beta.12 (docker v29.5.0-rc.1) is past the v2.0.0-beta.8
-# upstream fix for CVE-2026-33997 / CVE-2026-34040.
-ARG MOBY_VERSION=29.5.0-rc.1
-ARG DOCKER_CLI_VERSION=29.5.0-rc.1
+# moby v29.5.1 fixes CVE-2026-41567, CVE-2026-41568, CVE-2026-42306
+# (GHSA-x86f-5xw2-fm2r, GHSA-vp62-88p7-qqf5, GHSA-rg2x-37c3-w2rh)
+# and includes the earlier CVE-2026-33997 / CVE-2026-34040 fixes.
+ARG MOBY_VERSION=29.5.1
+ARG DOCKER_CLI_VERSION=29.5.1
 ARG XNET_VERSION=0.53.0
 ARG OTEL_SDK_VERSION=1.43.0
 ARG IN_TOTO_VERSION=0.11.0

--- a/docker/seed/Dockerfile.php
+++ b/docker/seed/Dockerfile.php
@@ -16,10 +16,11 @@ RUN apk add --no-cache curl && \
 FROM golang:1.26.3-alpine3.23 AS overlay-binaries
 ARG CONTAINERD_VERSION=2.3.0
 ARG RUNC_VERSION=1.3.5
-# moby v2.0.0-beta.12 (docker v29.5.0-rc.1) is past the v2.0.0-beta.8
-# upstream fix for CVE-2026-33997 / CVE-2026-34040.
-ARG MOBY_VERSION=29.5.0-rc.1
-ARG DOCKER_CLI_VERSION=29.5.0-rc.1
+# moby v29.5.1 fixes CVE-2026-41567, CVE-2026-41568, CVE-2026-42306
+# (GHSA-x86f-5xw2-fm2r, GHSA-vp62-88p7-qqf5, GHSA-rg2x-37c3-w2rh)
+# and includes the earlier CVE-2026-33997 / CVE-2026-34040 fixes.
+ARG MOBY_VERSION=29.5.1
+ARG DOCKER_CLI_VERSION=29.5.1
 ARG COMPOSE_VERSION=5.1.3
 ARG XNET_VERSION=0.53.0
 ARG OTEL_SDK_VERSION=1.43.0

--- a/docker/seed/Dockerfile.python
+++ b/docker/seed/Dockerfile.python
@@ -16,10 +16,11 @@ RUN apk add --no-cache curl && \
 FROM golang:1.26.3-alpine3.23 AS overlay-binaries
 ARG CONTAINERD_VERSION=2.3.0
 ARG RUNC_VERSION=1.3.5
-# moby v2.0.0-beta.12 (docker v29.5.0-rc.1) is past the v2.0.0-beta.8
-# upstream fix for CVE-2026-33997 / CVE-2026-34040.
-ARG MOBY_VERSION=29.5.0-rc.1
-ARG DOCKER_CLI_VERSION=29.5.0-rc.1
+# moby v29.5.1 fixes CVE-2026-41567, CVE-2026-41568, CVE-2026-42306
+# (GHSA-x86f-5xw2-fm2r, GHSA-vp62-88p7-qqf5, GHSA-rg2x-37c3-w2rh)
+# and includes the earlier CVE-2026-33997 / CVE-2026-34040 fixes.
+ARG MOBY_VERSION=29.5.1
+ARG DOCKER_CLI_VERSION=29.5.1
 ARG COMPOSE_VERSION=5.1.3
 ARG XNET_VERSION=0.53.0
 ARG OTEL_SDK_VERSION=1.43.0


### PR DESCRIPTION
## Description

Address 6 AWS ECR container vulnerabilities (across 3 containers) flagged by Vanta by bumping moby/moby from v29.5.0-rc.1 to v29.5.1 and docker/cli from v29.5.0-rc.1 to v29.5.1 in the seed container Dockerfiles.

## Changes Made

- Bumped `MOBY_VERSION` from `29.5.0-rc.1` to `29.5.1` in `docker/seed/Dockerfile.python`, `docker/seed/Dockerfile.go`, and `docker/seed/Dockerfile.php`
- Bumped `DOCKER_CLI_VERSION` from `29.5.0-rc.1` to `29.5.1` in the same three Dockerfiles
- Updated version comments to reference the new CVEs being fixed

### CVEs addressed

| CVE | GHSA | Description |
|-----|------|-------------|
| CVE-2026-41567 | GHSA-x86f-5xw2-fm2r | `docker cp` arbitrary binary execution via PATH inside container |
| CVE-2026-41568 | GHSA-vp62-88p7-qqf5 | `docker cp` TOCTOU allowing arbitrary file creation on host |
| CVE-2026-42306 | GHSA-rg2x-37c3-w2rh | `docker cp` TOCTOU allowing bind mount redirect on host |

### Affected containers

- `dev/python-seed`
- `dev/go-seed`
- `dev/php-seed`

## Testing

- [x] Verified `docker-v29.5.1` tag exists on moby/moby via `git ls-remote`
- [x] Verified `v29.5.1` tag exists on docker/cli via `git ls-remote`
- [ ] CI builds will validate the Dockerfiles can be built successfully

Link to Devin session: https://app.devin.ai/sessions/a0ffafac70f34982ba48341ec9792492
Requested by: @davidkonigsberg