### PR TITLE
chore(deps): bump brace-expansion to 5.0.6 in Docker images (GHSA-jxxr-4gwj-5jf2)

### DIFF
--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -43,17 +43,22 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Upgrade bundled npm to 11.14.1 to pick up patched transitive dependencies
-# (picomatch 4.0.4, brace-expansion 5.0.5, minimatch 10.2.5, tar 7.5.13).
+# (picomatch 4.0.4, minimatch 10.2.5, tar 7.5.13).
 # node:24.15.0 ships npm 11.12.1 which still vendors picomatch 4.0.3 and
 # brace-expansion 5.0.4. Replace ip-address with 10.1.1 to fix
 # GHSA-v2v4-37r5-5v8g (still bundled at 10.1.0 even in npm 11.14.1).
+# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; npm 11.14.1 vendors 5.0.5).
 RUN npm install -g npm@11.14.1 --force && \
     cd /usr/local/lib/node_modules/npm/node_modules && \
     npm pack ip-address@10.1.1 && \
     rm -rf ip-address && \
     mkdir ip-address && \
     tar -xzf ip-address-10.1.1.tgz --strip-components=1 -C ip-address/ && \
-    rm ip-address-10.1.1.tgz
+    rm ip-address-10.1.1.tgz && \
+    rm -rf brace-expansion && \
+    mkdir brace-expansion && \
+    curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz | \
+    tar -xz --strip-components=1 -C brace-expansion/
 
 RUN npm install -g pnpm@10.33.3 --force
 RUN corepack prepare pnpm@10.33.3

--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -55,10 +55,11 @@ RUN npm install -g npm@11.14.1 --force && \
     mkdir ip-address && \
     tar -xzf ip-address-10.1.1.tgz --strip-components=1 -C ip-address/ && \
     rm ip-address-10.1.1.tgz && \
+    npm pack brace-expansion@5.0.6 && \
     rm -rf brace-expansion && \
     mkdir brace-expansion && \
-    curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz | \
-    tar -xz --strip-components=1 -C brace-expansion/
+    tar -xzf brace-expansion-5.0.6.tgz --strip-components=1 -C brace-expansion/ && \
+    rm brace-expansion-5.0.6.tgz
 
 RUN npm install -g pnpm@10.33.3 --force
 RUN corepack prepare pnpm@10.33.3

--- a/generators/csharp/model/Dockerfile
+++ b/generators/csharp/model/Dockerfile
@@ -24,6 +24,19 @@ COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
+# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.15 vendors 5.0.5).
+RUN for dir in \
+      /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
+      if [ -d "$dir" ]; then \
+        rm -rf "$dir" && \
+        cd "$(dirname "$dir")" && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
+        mv package brace-expansion && \
+        rm brace-expansion-5.0.6.tgz; \
+      fi; \
+    done
+
 RUN dotnet tool install -g csharpier --version "1.2.6"
 
 COPY generators/csharp/model/dist /dist

--- a/generators/csharp/model/Dockerfile
+++ b/generators/csharp/model/Dockerfile
@@ -25,17 +25,12 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.15 vendors 5.0.5).
-RUN for dir in \
-      /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
-      if [ -d "$dir" ]; then \
-        rm -rf "$dir" && \
-        cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
-        tar -xzf brace-expansion-5.0.6.tgz && \
-        mv package brace-expansion && \
-        rm brace-expansion-5.0.6.tgz; \
-      fi; \
-    done
+RUN cd /usr/local/lib/node_modules/npm/node_modules && \
+    npm pack brace-expansion@5.0.6 && \
+    rm -rf brace-expansion && \
+    mkdir brace-expansion && \
+    tar -xzf brace-expansion-5.0.6.tgz --strip-components=1 -C brace-expansion/ && \
+    rm brace-expansion-5.0.6.tgz
 
 RUN dotnet tool install -g csharpier --version "1.2.6"
 

--- a/generators/csharp/sdk/Dockerfile
+++ b/generators/csharp/sdk/Dockerfile
@@ -69,17 +69,17 @@ RUN for dir in \
       fi; \
     done
 
-# Patch brace-expansion to 5.0.5 to fix GHSA-f886-m6hf-6m8v
+# Patch brace-expansion to 5.0.6 to fix GHSA-jxxr-4gwj-5jf2
 # (zero-step sequence hangs).
 RUN for dir in \
       /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
       if [ -d "$dir" ]; then \
         rm -rf "$dir" && \
         cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz -o brace-expansion-5.0.5.tgz && \
-        tar -xzf brace-expansion-5.0.5.tgz && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
         mv package brace-expansion && \
-        rm brace-expansion-5.0.5.tgz; \
+        rm brace-expansion-5.0.6.tgz; \
       fi; \
     done
 

--- a/generators/go/model/Dockerfile
+++ b/generators/go/model/Dockerfile
@@ -28,8 +28,8 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # Patch npm's bundled picomatch@4.0.3 -> 4.0.4 (GHSA-c2c7-rcm5-vvqj,
-# GHSA-3v7f-55p6-f55p) and brace-expansion@5.0.4 -> 5.0.5
-# (GHSA-f886-m6hf-6m8v) copied from the node stage.
+# GHSA-3v7f-55p6-f55p) and brace-expansion@5.0.4 -> 5.0.6
+# (GHSA-jxxr-4gwj-5jf2) copied from the node stage.
 RUN for dir in \
       /usr/local/lib/node_modules/npm/node_modules/picomatch \
       /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch; do \
@@ -47,10 +47,10 @@ RUN for dir in \
       if [ -d "$dir" ]; then \
         rm -rf "$dir" && \
         cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz -o brace-expansion-5.0.5.tgz && \
-        tar -xzf brace-expansion-5.0.5.tgz && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
         mv package brace-expansion && \
-        rm brace-expansion-5.0.5.tgz; \
+        rm brace-expansion-5.0.6.tgz; \
       fi; \
     done
 

--- a/generators/go/sdk/Dockerfile
+++ b/generators/go/sdk/Dockerfile
@@ -7,7 +7,7 @@ RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github
 
 # Patch vulnerable packages bundled inside npm's node_modules that lag behind
 # upstream advisories (ip-address GHSA-v2v4-37r5-5v8g, brace-expansion
-# GHSA-f886-m6hf-6m8v, picomatch GHSA-3v7f-55p6-f55p / GHSA-c2c7-rcm5-vvqj).
+# GHSA-jxxr-4gwj-5jf2, picomatch GHSA-3v7f-55p6-f55p / GHSA-c2c7-rcm5-vvqj).
 # We replace them with the latest patched releases via `npm pack` so the
 # resulting layer does not ship known-vulnerable copies.
 RUN set -eux; \

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -136,17 +136,17 @@ RUN for dir in \
       fi; \
     done
 
-# Patch brace-expansion to 5.0.5 to fix GHSA-f886-m6hf-6m8v
+# Patch brace-expansion to 5.0.6 to fix GHSA-jxxr-4gwj-5jf2
 # (zero-step sequence DoS; bundled by npm 11.12.1 at 5.0.4).
 RUN for dir in \
       /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
       if [ -d "$dir" ]; then \
         rm -rf "$dir" && \
         cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz -o brace-expansion-5.0.5.tgz && \
-        tar -xzf brace-expansion-5.0.5.tgz && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
         mv package brace-expansion && \
-        rm brace-expansion-5.0.5.tgz; \
+        rm brace-expansion-5.0.6.tgz; \
       fi; \
     done
 

--- a/generators/php/model/Dockerfile
+++ b/generators/php/model/Dockerfile
@@ -21,8 +21,8 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # Patch npm's bundled picomatch@4.0.3 -> 4.0.4 (GHSA-c2c7-rcm5-vvqj,
-# GHSA-3v7f-55p6-f55p) and brace-expansion@5.0.4 -> 5.0.5
-# (GHSA-f886-m6hf-6m8v) in the node_modules copied from the node stage.
+# GHSA-3v7f-55p6-f55p) and brace-expansion@5.0.4 -> 5.0.6
+# (GHSA-jxxr-4gwj-5jf2) in the node_modules copied from the node stage.
 RUN for dir in \
       /usr/local/lib/node_modules/npm/node_modules/picomatch \
       /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch; do \
@@ -40,10 +40,10 @@ RUN for dir in \
       if [ -d "$dir" ]; then \
         rm -rf "$dir" && \
         cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz -o brace-expansion-5.0.5.tgz && \
-        tar -xzf brace-expansion-5.0.5.tgz && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
         mv package brace-expansion && \
-        rm brace-expansion-5.0.5.tgz; \
+        rm brace-expansion-5.0.6.tgz; \
       fi; \
     done
 

--- a/generators/php/sdk/Dockerfile
+++ b/generators/php/sdk/Dockerfile
@@ -21,8 +21,8 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # Patch npm's bundled picomatch@4.0.3 -> 4.0.4 (GHSA-c2c7-rcm5-vvqj,
-# GHSA-3v7f-55p6-f55p) and brace-expansion@5.0.4 -> 5.0.5
-# (GHSA-f886-m6hf-6m8v) in the node_modules copied from the node stage.
+# GHSA-3v7f-55p6-f55p) and brace-expansion@5.0.4 -> 5.0.6
+# (GHSA-jxxr-4gwj-5jf2) in the node_modules copied from the node stage.
 RUN for dir in \
       /usr/local/lib/node_modules/npm/node_modules/picomatch \
       /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch; do \
@@ -40,10 +40,10 @@ RUN for dir in \
       if [ -d "$dir" ]; then \
         rm -rf "$dir" && \
         cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz -o brace-expansion-5.0.5.tgz && \
-        tar -xzf brace-expansion-5.0.5.tgz && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
         mv package brace-expansion && \
-        rm brace-expansion-5.0.5.tgz; \
+        rm brace-expansion-5.0.6.tgz; \
       fi; \
     done
 

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -20,6 +20,19 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
        curl libcurl4t64 libgnutls30t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
+# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.15 vendors 5.0.5).
+RUN for dir in \
+      /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
+      if [ -d "$dir" ]; then \
+        rm -rf "$dir" && \
+        cd "$(dirname "$dir")" && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
+        mv package brace-expansion && \
+        rm brace-expansion-5.0.6.tgz; \
+      fi; \
+    done
+
 RUN curl -LsSf https://astral.sh/ruff/0.15.7/install.sh | sh
 ENV PATH="/root/.local/bin:${PATH}"
 RUN ruff --version

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -21,17 +21,12 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 # Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.15 vendors 5.0.5).
-RUN for dir in \
-      /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
-      if [ -d "$dir" ]; then \
-        rm -rf "$dir" && \
-        cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
-        tar -xzf brace-expansion-5.0.6.tgz && \
-        mv package brace-expansion && \
-        rm brace-expansion-5.0.6.tgz; \
-      fi; \
-    done
+RUN cd /usr/local/lib/node_modules/npm/node_modules && \
+    npm pack brace-expansion@5.0.6 && \
+    rm -rf brace-expansion && \
+    mkdir brace-expansion && \
+    tar -xzf brace-expansion-5.0.6.tgz --strip-components=1 -C brace-expansion/ && \
+    rm brace-expansion-5.0.6.tgz
 
 RUN curl -LsSf https://astral.sh/ruff/0.15.7/install.sh | sh
 ENV PATH="/root/.local/bin:${PATH}"

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -37,8 +37,8 @@ RUN node --version
 RUN npm --version
 
 # Patch npm's bundled picomatch@4.0.3 -> 4.0.4 (GHSA-c2c7-rcm5-vvqj,
-# GHSA-3v7f-55p6-f55p) and brace-expansion@5.0.4 -> 5.0.5
-# (GHSA-f886-m6hf-6m8v) copied from the node stage.
+# GHSA-3v7f-55p6-f55p) and brace-expansion@5.0.4 -> 5.0.6
+# (GHSA-jxxr-4gwj-5jf2) copied from the node stage.
 RUN for dir in \
       /usr/local/lib/node_modules/npm/node_modules/picomatch \
       /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch; do \
@@ -56,10 +56,10 @@ RUN for dir in \
       if [ -d "$dir" ]; then \
         rm -rf "$dir" && \
         cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz -o brace-expansion-5.0.5.tgz && \
-        tar -xzf brace-expansion-5.0.5.tgz && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
         mv package brace-expansion && \
-        rm brace-expansion-5.0.5.tgz; \
+        rm brace-expansion-5.0.6.tgz; \
       fi; \
     done
 

--- a/generators/ruby-v2/sdk/Dockerfile
+++ b/generators/ruby-v2/sdk/Dockerfile
@@ -135,16 +135,16 @@ RUN for dir in \
       fi; \
     done
 
-# - brace-expansion 5.0.3 -> 5.0.5 (GHSA-f886-m6hf-6m8v: zero-step sequence hangs).
+# - brace-expansion 5.0.3 -> 5.0.6 (GHSA-jxxr-4gwj-5jf2: zero-step sequence hangs).
 RUN for dir in \
       /usr/lib/node_modules/npm/node_modules/brace-expansion; do \
       if [ -d "$dir" ]; then \
         rm -rf "$dir" && \
         cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz -o brace-expansion-5.0.5.tgz && \
-        tar -xzf brace-expansion-5.0.5.tgz && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
         mv package brace-expansion && \
-        rm brace-expansion-5.0.5.tgz; \
+        rm brace-expansion-5.0.6.tgz; \
       fi; \
     done
 

--- a/generators/rust/model/Dockerfile
+++ b/generators/rust/model/Dockerfile
@@ -25,17 +25,12 @@ ENV PATH=/usr/local/lib/rustfmt:$PATH \
 RUN rustfmt --version
 
 # Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.15 vendors 5.0.5).
-RUN for dir in \
-      /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
-      if [ -d "$dir" ]; then \
-        rm -rf "$dir" && \
-        cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
-        tar -xzf brace-expansion-5.0.6.tgz && \
-        mv package brace-expansion && \
-        rm brace-expansion-5.0.6.tgz; \
-      fi; \
-    done
+RUN cd /usr/local/lib/node_modules/npm/node_modules && \
+    npm pack brace-expansion@5.0.6 && \
+    rm -rf brace-expansion && \
+    mkdir brace-expansion && \
+    tar -xzf brace-expansion-5.0.6.tgz --strip-components=1 -C brace-expansion/ && \
+    rm brace-expansion-5.0.6.tgz
 
 COPY generators/rust/model/dist /dist
 

--- a/generators/rust/model/Dockerfile
+++ b/generators/rust/model/Dockerfile
@@ -24,6 +24,19 @@ ENV PATH=/usr/local/lib/rustfmt:$PATH \
     LD_LIBRARY_PATH=/usr/local/lib/rustfmt/lib
 RUN rustfmt --version
 
+# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.15 vendors 5.0.5).
+RUN for dir in \
+      /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
+      if [ -d "$dir" ]; then \
+        rm -rf "$dir" && \
+        cd "$(dirname "$dir")" && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
+        mv package brace-expansion && \
+        rm brace-expansion-5.0.6.tgz; \
+      fi; \
+    done
+
 COPY generators/rust/model/dist /dist
 
 ENTRYPOINT ["node", "--enable-source-maps", "/dist/cli.cjs", "rust-model"]

--- a/generators/rust/sdk/Dockerfile
+++ b/generators/rust/sdk/Dockerfile
@@ -35,17 +35,12 @@ RUN mkdir -p /tmp/ip-address-upgrade \
     && rm -rf /tmp/ip-address-upgrade
 
 # Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; npm 11.13.0 vendors 5.0.5).
-RUN for dir in \
-      /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
-      if [ -d "$dir" ]; then \
-        rm -rf "$dir" && \
-        cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
-        tar -xzf brace-expansion-5.0.6.tgz && \
-        mv package brace-expansion && \
-        rm brace-expansion-5.0.6.tgz; \
-      fi; \
-    done
+RUN cd /usr/local/lib/node_modules/npm/node_modules && \
+    npm pack brace-expansion@5.0.6 && \
+    rm -rf brace-expansion && \
+    mkdir brace-expansion && \
+    tar -xzf brace-expansion-5.0.6.tgz --strip-components=1 -C brace-expansion/ && \
+    rm brace-expansion-5.0.6.tgz
 
 ARG SENTRY_DSN
 ARG SENTRY_ENVIRONMENT=production

--- a/generators/rust/sdk/Dockerfile
+++ b/generators/rust/sdk/Dockerfile
@@ -34,6 +34,19 @@ RUN mkdir -p /tmp/ip-address-upgrade \
     && mv package /usr/local/lib/node_modules/npm/node_modules/ip-address \
     && rm -rf /tmp/ip-address-upgrade
 
+# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; npm 11.13.0 vendors 5.0.5).
+RUN for dir in \
+      /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
+      if [ -d "$dir" ]; then \
+        rm -rf "$dir" && \
+        cd "$(dirname "$dir")" && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
+        mv package brace-expansion && \
+        rm brace-expansion-5.0.6.tgz; \
+      fi; \
+    done
+
 ARG SENTRY_DSN
 ARG SENTRY_ENVIRONMENT=production
 ARG SENTRY_RELEASE

--- a/generators/swift/model/Dockerfile
+++ b/generators/swift/model/Dockerfile
@@ -3,8 +3,8 @@ FROM node:24.15-alpine3.23
 RUN apk update && apk upgrade --no-cache && apk --no-cache add curl
 
 # Patch npm's bundled picomatch@4.0.3 -> 4.0.4 (GHSA-c2c7-rcm5-vvqj,
-# GHSA-3v7f-55p6-f55p) and brace-expansion@5.0.4 -> 5.0.5
-# (GHSA-f886-m6hf-6m8v) in node:24.15's bundled npm 11.12.1.
+# GHSA-3v7f-55p6-f55p) and brace-expansion@5.0.4 -> 5.0.6
+# (GHSA-jxxr-4gwj-5jf2) in node:24.15's bundled npm 11.12.1.
 RUN for dir in \
       /usr/local/lib/node_modules/npm/node_modules/picomatch \
       /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch; do \
@@ -22,10 +22,10 @@ RUN for dir in \
       if [ -d "$dir" ]; then \
         rm -rf "$dir" && \
         cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz -o brace-expansion-5.0.5.tgz && \
-        tar -xzf brace-expansion-5.0.5.tgz && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
         mv package brace-expansion && \
-        rm brace-expansion-5.0.5.tgz; \
+        rm brace-expansion-5.0.6.tgz; \
       fi; \
     done
 

--- a/generators/swift/sdk/Dockerfile
+++ b/generators/swift/sdk/Dockerfile
@@ -7,7 +7,7 @@ RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github
 
 # Patch picomatch to 4.0.4 (GHSA-c2c7-rcm5-vvqj ReDoS via extglob quantifiers,
 # GHSA-3v7f-55p6-f55p method injection in POSIX character classes) and
-# brace-expansion to 5.0.5 (GHSA-f886-m6hf-6m8v zero-step sequence hangs)
+# brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2 zero-step sequence hangs)
 # in npm's bundled node_modules. node:24.15 ships npm 11.12.1 with
 # picomatch@4.0.3 and brace-expansion@5.0.4.
 RUN for dir in \
@@ -27,10 +27,10 @@ RUN for dir in \
       if [ -d "$dir" ]; then \
         rm -rf "$dir" && \
         cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz -o brace-expansion-5.0.5.tgz && \
-        tar -xzf brace-expansion-5.0.5.tgz && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
         mv package brace-expansion && \
-        rm brace-expansion-5.0.5.tgz; \
+        rm brace-expansion-5.0.6.tgz; \
       fi; \
     done
 

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -84,10 +84,11 @@ RUN npm install -g npm@11.13.0 --force && \
     mkdir ip-address && \
     tar -xzf ip-address-10.1.1.tgz --strip-components=1 -C ip-address/ && \
     rm ip-address-10.1.1.tgz && \
+    npm pack brace-expansion@5.0.6 && \
     rm -rf brace-expansion && \
     mkdir brace-expansion && \
-    curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz | \
-    tar -xz --strip-components=1 -C brace-expansion/
+    tar -xzf brace-expansion-5.0.6.tgz --strip-components=1 -C brace-expansion/ && \
+    rm brace-expansion-5.0.6.tgz
 
 # pnpm 10.33.3 bundles patched picomatch, brace-expansion, tar, and ip-address.
 RUN npm install -g pnpm@10.33.3 --force

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -73,16 +73,21 @@ ENV SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT
 ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
 # Upgrade the bundled npm to pick up patched transitive dependencies
-# (minimatch, picomatch, tar, brace-expansion). npm at this version still
-# vendors ip-address@10.1.0, so swap in the patched 10.1.1 release that
-# fixes GHSA-v2v4-37r5-5v8g (XSS in Address6 HTML-emitting methods).
+# (minimatch, picomatch, tar). npm at this version still vendors
+# ip-address@10.1.0, so swap in the patched 10.1.1 release that fixes
+# GHSA-v2v4-37r5-5v8g (XSS in Address6 HTML-emitting methods).
+# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; npm 11.13.0 vendors 5.0.5).
 RUN npm install -g npm@11.13.0 --force && \
     cd /usr/local/lib/node_modules/npm/node_modules && \
     npm pack ip-address@10.1.1 && \
     rm -rf ip-address && \
     mkdir ip-address && \
     tar -xzf ip-address-10.1.1.tgz --strip-components=1 -C ip-address/ && \
-    rm ip-address-10.1.1.tgz
+    rm ip-address-10.1.1.tgz && \
+    rm -rf brace-expansion && \
+    mkdir brace-expansion && \
+    curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz | \
+    tar -xz --strip-components=1 -C brace-expansion/
 
 # pnpm 10.33.3 bundles patched picomatch, brace-expansion, tar, and ip-address.
 RUN npm install -g pnpm@10.33.3 --force

--- a/generators/typescript/sdk/validator/Dockerfile
+++ b/generators/typescript/sdk/validator/Dockerfile
@@ -35,4 +35,17 @@ RUN cd /tmp/warm-cache \
     && pnpm install --ignore-scripts --prefer-offline \
     && rm -rf /tmp/warm-cache/node_modules
 
+# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.15 vendors 5.0.5).
+RUN for dir in \
+      /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
+      if [ -d "$dir" ]; then \
+        rm -rf "$dir" && \
+        cd "$(dirname "$dir")" && \
+        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
+        tar -xzf brace-expansion-5.0.6.tgz && \
+        mv package brace-expansion && \
+        rm brace-expansion-5.0.6.tgz; \
+      fi; \
+    done
+
 WORKDIR /workspace

--- a/generators/typescript/sdk/validator/Dockerfile
+++ b/generators/typescript/sdk/validator/Dockerfile
@@ -36,16 +36,11 @@ RUN cd /tmp/warm-cache \
     && rm -rf /tmp/warm-cache/node_modules
 
 # Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.15 vendors 5.0.5).
-RUN for dir in \
-      /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
-      if [ -d "$dir" ]; then \
-        rm -rf "$dir" && \
-        cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz -o brace-expansion-5.0.6.tgz && \
-        tar -xzf brace-expansion-5.0.6.tgz && \
-        mv package brace-expansion && \
-        rm brace-expansion-5.0.6.tgz; \
-      fi; \
-    done
+RUN cd /usr/local/lib/node_modules/npm/node_modules && \
+    npm pack brace-expansion@5.0.6 && \
+    rm -rf brace-expansion && \
+    mkdir brace-expansion && \
+    tar -xzf brace-expansion-5.0.6.tgz --strip-components=1 -C brace-expansion/ && \
+    rm brace-expansion-5.0.6.tgz
 
 WORKDIR /workspace


### PR DESCRIPTION
## Description

Fixes the persistent brace-expansion CVE alerts (GHSA-jxxr-4gwj-5jf2 / CVE-2026-45149) that appear in AWS ECR image scanning (Grype) for generator Docker images (`dev/typescript-sdk-generator`, `dev/ts-seed`, `dev/swift-sdk-generator`, `dev/rust-sdk-generator`, `dev/python-sdk-generator`, `dev/php-sdk-generator`, `dev/csharp-sdk-generator`, `dev/java-sdk-generator`).

**Root cause:** npm@11.12.1–11.14.1 bundles brace-expansion 5.0.5 as a transitive dependency. Most Dockerfiles explicitly patched to 5.0.5 for the older CVE (GHSA-f886-m6hf-6m8v), but the new CVE (GHSA-jxxr-4gwj-5jf2) requires ≥5.0.6. Several Dockerfiles had npm in the final image with no brace-expansion patch at all.

The earlier fern-platform PR (#11177) and fern PR (#15976) fixed Dependabot-tracked `pnpm-lock.yaml` references, but the Docker image alerts come from Grype scanning the vendored npm `node_modules` inside built containers — a separate code path.

## Changes Made

**Updated existing patches (5.0.5 → 5.0.6) in 9 Dockerfiles:**
- `generators/csharp/sdk/Dockerfile`
- `generators/go/model/Dockerfile`
- `generators/java/sdk/Dockerfile`
- `generators/php/model/Dockerfile`
- `generators/php/sdk/Dockerfile`
- `generators/python/sdk/Dockerfile`
- `generators/ruby-v2/sdk/Dockerfile`
- `generators/swift/model/Dockerfile`
- `generators/swift/sdk/Dockerfile`

**Added new brace-expansion 5.0.6 patch to 7 Dockerfiles** (had npm in final image with no patch):
- `docker/seed/Dockerfile.ts`
- `generators/csharp/model/Dockerfile`
- `generators/python-v2/sdk/Dockerfile`
- `generators/rust/model/Dockerfile`
- `generators/rust/sdk/Dockerfile`
- `generators/typescript/sdk/cli/Dockerfile`
- `generators/typescript/sdk/validator/Dockerfile`

**Updated GHSA comment reference in 1 Dockerfile** (uses `@latest`, already resolves to 5.0.6):
- `generators/go/sdk/Dockerfile`

New patches use `npm pack` instead of `curl` to avoid missing `curl` in slim/alpine base images.

## Testing

- [x] All 17 Grype container scans pass (brace-expansion CVE no longer flagged)
- [x] All required CI checks pass
- [x] Docker builds succeed for all affected images
- [x] Verified no Dockerfiles reference brace-expansion 5.0.5 after changes

Link to Devin session: https://app.devin.ai/sessions/a86a3e8d5e634519a88ebba7480d646a
Requested by: @davidkonigsberg