### PR TITLE
fix(cli): check broken links in folder-referenced pages

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-folder-broken-link-check.yml
+++ b/packages/cli/cli/changes/unreleased/fix-folder-broken-link-check.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix broken link checker to validate links in pages referenced via folder entries in docs.yml navigation.
+  type: fix

--- a/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
+++ b/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
@@ -75,6 +75,17 @@ describe("fern docs broken-links", () => {
         expect(stripAnsi(stdout)).toContain("All checks passed");
     }, 20_000);
 
+    it("broken links in folder-referenced pages should be detected", async ({ signal }) => {
+        const { stdout } = await runFernCli(["docs", "broken-links"], {
+            cwd: join(fixturesDir, RelativeFilePath.of("folder-navigation")),
+            reject: false,
+            signal
+        });
+        // This fixture tests that markdown files referenced via folder entries
+        // in docs.yml are validated for broken links
+        expect(stripAnsi(stdout)).toContain("Found 2 errors");
+    }, 20_000);
+
     it("broken links in sections with path property should be detected", async ({ signal }) => {
         const { stdout } = await runFernCli(["docs", "broken-links"], {
             cwd: join(fixturesDir, RelativeFilePath.of("section-with-path")),

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/folder-navigation/fern/docs.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/folder-navigation/fern/docs.yml
@@ -1,0 +1,8 @@
+instances:
+  - url: ferndevtest.docs.dev.buildwithfern.com
+
+navigation:
+  - page: Overview
+    path: overview.mdx
+  - title: Resources
+    folder: ./pages/resources

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/folder-navigation/fern/fern.config.json
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/folder-navigation/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/folder-navigation/fern/overview.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/folder-navigation/fern/overview.mdx
@@ -1,0 +1,3 @@
+# Overview
+
+Welcome to the plant store documentation.

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/folder-navigation/fern/pages/resources/cloud-sql.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/folder-navigation/fern/pages/resources/cloud-sql.mdx
@@ -1,0 +1,7 @@
+# Cloud SQL
+
+For supported database engines and versions, see [Database Engine Support Policy].
+
+[Database Engine Support Policy]: /nonexistent-page
+
+This page also has a [broken inline link](/another-missing-page).

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/folder-navigation/fern/pages/resources/overview.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/folder-navigation/fern/pages/resources/overview.mdx
@@ -1,0 +1,3 @@
+# Resources Overview
+
+This page has a valid link to [Cloud SQL](/resources/cloud-sql).

--- a/packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts
+++ b/packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts
@@ -270,10 +270,8 @@ async function visitNavigationItem({
             await visitFolderMarkdownFiles({
                 directoryPath: folderDir,
                 absolutePathToFernFolder,
-                absoluteFilepathToConfiguration,
                 visitor,
                 nodePath: [...nodePath, "folder"],
-                apiWorkspaces,
                 context
             });
         }
@@ -324,18 +322,14 @@ function navigationItemIsFolder(
 async function visitFolderMarkdownFiles({
     directoryPath,
     absolutePathToFernFolder,
-    absoluteFilepathToConfiguration,
     visitor,
     nodePath,
-    apiWorkspaces,
     context
 }: {
     directoryPath: AbsoluteFilePath;
     absolutePathToFernFolder: AbsoluteFilePath;
-    absoluteFilepathToConfiguration: AbsoluteFilePath;
     visitor: Partial<DocsConfigFileAstVisitor>;
     nodePath: NodePath;
-    apiWorkspaces: AbstractAPIWorkspace<unknown>[];
     context: TaskContext;
 }): Promise<void> {
     const entries = await readdir(directoryPath, { withFileTypes: true });
@@ -351,9 +345,6 @@ async function visitFolderMarkdownFiles({
 
     await asyncPool(VALIDATION_CONCURRENCY, markdownFiles, async (file) => {
         const absoluteFilepath = join(directoryPath, RelativeFilePath.of(file.name));
-        if (!(await doesPathExist(absoluteFilepath))) {
-            return;
-        }
 
         const fileStats = await stat(absoluteFilepath);
         const fileSizeMB = fileStats.size / (1024 * 1024);
@@ -401,10 +392,8 @@ async function visitFolderMarkdownFiles({
         await visitFolderMarkdownFiles({
             directoryPath: subdirPath,
             absolutePathToFernFolder,
-            absoluteFilepathToConfiguration,
             visitor,
             nodePath: [...nodePath, subdir.name],
-            apiWorkspaces,
             context
         });
     });

--- a/packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts
+++ b/packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts
@@ -13,8 +13,8 @@ import {
 } from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
-import path from "path";
 import { readdir, readFile, stat } from "fs/promises";
+import path from "path";
 import { asyncPool } from "../utils/asyncPool.js";
 import { DocsConfigFileAstVisitor } from "./DocsConfigFileAstVisitor.js";
 import { visitFilepath } from "./visitFilepath.js";

--- a/packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts
+++ b/packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts
@@ -2,9 +2,18 @@ import { docsYml } from "@fern-api/configuration-loader";
 import { noop, visitObjectAsync } from "@fern-api/core-utils";
 import { parseImagePaths } from "@fern-api/docs-markdown-utils";
 import { NodePath } from "@fern-api/fern-definition-schema";
-import { AbsoluteFilePath, dirname, doesPathExist, relative, resolve } from "@fern-api/fs-utils";
+import {
+    AbsoluteFilePath,
+    dirname,
+    doesPathExist,
+    join,
+    RelativeFilePath,
+    relative,
+    resolve
+} from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
+import path from "path";
 import { readdir, readFile, stat } from "fs/promises";
 import { asyncPool } from "../utils/asyncPool.js";
 import { DocsConfigFileAstVisitor } from "./DocsConfigFileAstVisitor.js";
@@ -110,6 +119,10 @@ async function visitNavigationItem({
         api: noop,
         apiName: noop,
         audiences: noop,
+        folder: noop,
+        titleSource: noop,
+        collapsible: noop,
+        collapsedByDefault: noop,
         openrpc: async (path: string | undefined): Promise<void> => {
             if (path == null) {
                 return;
@@ -251,6 +264,21 @@ async function visitNavigationItem({
         }
     }
 
+    if (navigationItemIsFolder(navigationItem)) {
+        const folderDir = resolve(dirname(absoluteFilepathToConfiguration), navigationItem.folder);
+        if (await doesPathExist(folderDir)) {
+            await visitFolderMarkdownFiles({
+                directoryPath: folderDir,
+                absolutePathToFernFolder,
+                absoluteFilepathToConfiguration,
+                visitor,
+                nodePath: [...nodePath, "folder"],
+                apiWorkspaces,
+                context
+            });
+        }
+    }
+
     if (navigationItemIsChangelog(navigationItem)) {
         const changelogDir = resolve(dirname(absoluteFilepathToConfiguration), navigationItem.changelog);
         context.logger.trace(`Starting changelog processing for directory: ${changelogDir}`);
@@ -284,6 +312,102 @@ async function visitNavigationItem({
             context.logger.trace(`Changelog directory does not exist: ${changelogDir}`);
         }
     }
+}
+
+function navigationItemIsFolder(
+    item: docsYml.RawSchemas.NavigationItem
+): item is docsYml.RawSchemas.FolderConfiguration {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    return (item as docsYml.RawSchemas.FolderConfiguration)?.folder != null;
+}
+
+async function visitFolderMarkdownFiles({
+    directoryPath,
+    absolutePathToFernFolder,
+    absoluteFilepathToConfiguration,
+    visitor,
+    nodePath,
+    apiWorkspaces,
+    context
+}: {
+    directoryPath: AbsoluteFilePath;
+    absolutePathToFernFolder: AbsoluteFilePath;
+    absoluteFilepathToConfiguration: AbsoluteFilePath;
+    visitor: Partial<DocsConfigFileAstVisitor>;
+    nodePath: NodePath;
+    apiWorkspaces: AbstractAPIWorkspace<unknown>[];
+    context: TaskContext;
+}): Promise<void> {
+    const entries = await readdir(directoryPath, { withFileTypes: true });
+
+    const markdownFiles = entries.filter(
+        (entry) =>
+            entry.isFile() &&
+            !entry.name.startsWith("_") &&
+            (entry.name.toLowerCase().endsWith(".md") || entry.name.toLowerCase().endsWith(".mdx"))
+    );
+
+    const subdirectories = entries.filter((entry) => entry.isDirectory() && !entry.name.startsWith("_"));
+
+    await asyncPool(VALIDATION_CONCURRENCY, markdownFiles, async (file) => {
+        const absoluteFilepath = join(directoryPath, RelativeFilePath.of(file.name));
+        if (!(await doesPathExist(absoluteFilepath))) {
+            return;
+        }
+
+        const fileStats = await stat(absoluteFilepath);
+        const fileSizeMB = fileStats.size / (1024 * 1024);
+        if (fileSizeMB > 1) {
+            context.logger.trace(
+                `Processing large markdown file in folder: ${file.name} (${fileSizeMB.toFixed(2)} MB)`
+            );
+        }
+
+        const content = (await readFile(absoluteFilepath, "utf8")).toString();
+        const title = path.basename(file.name, path.extname(file.name));
+
+        await visitor.markdownPage?.(
+            {
+                title,
+                content,
+                absoluteFilepath
+            },
+            [...nodePath, file.name]
+        );
+
+        try {
+            const { filepaths } = parseImagePaths(content, {
+                absolutePathToFernFolder,
+                absolutePathToMarkdownFile: absoluteFilepath
+            });
+
+            for (const filepath of filepaths) {
+                await visitor.filepath?.(
+                    {
+                        absoluteFilepath: filepath,
+                        value: relative(absolutePathToFernFolder, filepath),
+                        willBeUploaded: true
+                    },
+                    [...nodePath, file.name]
+                );
+            }
+        } catch (err) {
+            context.logger.trace(`Failed to parse image paths in folder file ${file.name}: ${err}`);
+        }
+    });
+
+    await asyncPool(VALIDATION_CONCURRENCY, subdirectories, async (subdir) => {
+        const subdirPath = join(directoryPath, RelativeFilePath.of(subdir.name));
+        await visitFolderMarkdownFiles({
+            directoryPath: subdirPath,
+            absolutePathToFernFolder,
+            absoluteFilepathToConfiguration,
+            visitor,
+            nodePath: [...nodePath, subdir.name],
+            apiWorkspaces,
+            context
+        });
+    });
 }
 
 function navigationItemIsChangelog(


### PR DESCRIPTION
## Description

Fixes an issue where `fern check` (and `fern docs broken-links`) did not validate links inside markdown files referenced via `folder` entries in `docs.yml` navigation. Only pages explicitly listed with `page`/`path` entries were checked, so broken links in folder-referenced pages went undetected.

## Changes Made

- **`packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts`**: 
  - Added `navigationItemIsFolder` type guard to detect folder navigation items
  - Added `visitFolderMarkdownFiles` function that recursively reads all markdown files from a folder directory (and subdirectories), visiting each as a `markdownPage` so broken link rules apply
  - Added `folder`, `titleSource`, `collapsible`, `collapsedByDefault` property handlers to `visitObjectAsync` to handle `FolderConfiguration` properties
  - Folder expansion follows the same conventions as `expandFolderConfiguration` in the config loader: skips files starting with `_`, handles `.md`/`.mdx`, recurses into subdirectories
- **Added ETE test fixture** (`folder-navigation`) with a `docs.yml` that uses a folder entry containing a markdown file with broken links
- **Added changelog entry** for the fix

## Testing

- [x] ETE test added (`broken links in folder-referenced pages should be detected`)
- [x] Biome lint passing
- [x] Biome format passing
- [x] TypeScript compilation passing
<img width="2856" height="1486" alt="CleanShot 2026-05-19 at 15 48 40@2x" src="https://github.com/user-attachments/assets/babe6aa4-2e26-4635-a25a-613c59edd47b" />


Link to Devin session: https://app.devin.ai/sessions/1a2cb678dfc543d88fe978f462c710d7
Requested by: @Ryan-Amirthan