### PR TITLE
fix(generator-cli): restore web-flow signing on cloud-generated commits

### DIFF
--- a/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
+++ b/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
@@ -97,8 +97,7 @@ describe("pushSignedCommit", () => {
             "local-sha",
             expect.stringMatching(/^refs\/temp\/fern-/)
         );
-        // Default path: `author` is always sent (stable attribution), but `committer` is
-        // omitted so GitHub fills it in from the App installation and signs the commit.
+        // `author` always sent; `committer` omitted so GitHub fills it in and signs.
         expect(octokit.git.createCommit).toHaveBeenCalledWith({
             owner: "acme",
             repo: "acme-sdk",

--- a/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
+++ b/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
@@ -97,15 +97,18 @@ describe("pushSignedCommit", () => {
             "local-sha",
             expect.stringMatching(/^refs\/temp\/fern-/)
         );
+        // Default path: `author` is always sent (stable attribution), but `committer` is
+        // omitted so GitHub fills it in from the App installation and signs the commit.
         expect(octokit.git.createCommit).toHaveBeenCalledWith({
             owner: "acme",
             repo: "acme-sdk",
             message: "SDK Generation",
             tree: "tree-sha",
             parents: ["parent-sha"],
-            author: { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" },
-            committer: { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" }
+            author: { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" }
         });
+        const defaultCall = octokit.git.createCommit.mock.calls[0]?.[0] as Record<string, unknown>;
+        expect(defaultCall).not.toHaveProperty("committer");
         expect(octokit.git.updateRef).toHaveBeenCalledWith({
             owner: "acme",
             repo: "acme-sdk",
@@ -229,9 +232,10 @@ describe("pushSignedCommit", () => {
             message: "SDK Generation",
             tree: "tree-sha-2",
             parents: ["parent-sha-2"],
-            author: { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" },
-            committer: { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" }
+            author: { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" }
         });
+        const retryCall = octokit.git.createCommit.mock.calls[1]?.[0] as Record<string, unknown>;
+        expect(retryCall).not.toHaveProperty("committer");
         // Temp ref re-push on the rebase retry must force, because the rebased commit
         // is not a descendant of the original tempRef tip.
         expect(repository.pushObjectToRef).toHaveBeenCalledTimes(2);
@@ -246,6 +250,68 @@ describe("pushSignedCommit", () => {
             expect.stringMatching(/^refs\/temp\/fern-/),
             { force: true }
         );
+    });
+
+    it("forwards explicit author as both author and committer when the caller provides one", async () => {
+        const repository = buildRepository();
+        const octokit = buildOctokit();
+        const customAuthor = { name: "auth0-bot", email: "auth0-bot@example.com" };
+
+        await makeCaller(
+            repository,
+            octokit
+        )({
+            ...baseArgs,
+            author: customAuthor,
+            repository: repository as never,
+            octokit: octokit as never
+        });
+
+        expect(octokit.git.createCommit).toHaveBeenCalledWith({
+            owner: "acme",
+            repo: "acme-sdk",
+            message: "SDK Generation",
+            tree: "tree-sha",
+            parents: ["parent-sha"],
+            author: customAuthor,
+            committer: customAuthor
+        });
+    });
+
+    it("preserves the explicit author/committer pair across the rebase-on-conflict retry", async () => {
+        const nonFF = Object.assign(new Error("Update is not a fast forward"), { status: 422 });
+        const customAuthor = { name: "auth0-bot", email: "auth0-bot@example.com" };
+        const repository = buildRepository({
+            getHeadSha: vi.fn().mockResolvedValueOnce("local-sha-1").mockResolvedValue("local-sha-2"),
+            getHeadTreeHash: vi.fn().mockResolvedValueOnce("tree-sha-1").mockResolvedValue("tree-sha-2"),
+            getHeadParents: vi.fn().mockResolvedValueOnce(["parent-sha-1"]).mockResolvedValue(["parent-sha-2"])
+        });
+        const octokit = buildOctokit({
+            createCommit: vi
+                .fn()
+                .mockResolvedValueOnce({ data: { sha: "signed-sha-1" } })
+                .mockResolvedValueOnce({ data: { sha: "signed-sha-2" } }),
+            updateRef: vi.fn().mockRejectedValueOnce(nonFF).mockResolvedValueOnce({ data: {} })
+        });
+
+        await makeCaller(
+            repository,
+            octokit
+        )({
+            ...baseArgs,
+            force: false,
+            rebaseOnConflict: true,
+            author: customAuthor,
+            repository: repository as never,
+            octokit: octokit as never
+        });
+
+        for (const attempt of [1, 2]) {
+            expect(octokit.git.createCommit).toHaveBeenNthCalledWith(
+                attempt,
+                expect.objectContaining({ author: customAuthor, committer: customAuthor })
+            );
+        }
     });
 
     it("propagates errors from the post-update local sync (does not swallow stale-HEAD risk)", async () => {

--- a/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
+++ b/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
@@ -35,12 +35,10 @@ export interface PushSignedCommitOptions {
     /**
      * Override the commit author and committer identity.
      *
-     * When omitted, `author` defaults to the Fern bot identity (so attribution stays stable
-     * even on GHE/PAT auth) and `committer` is *not* sent — letting GitHub fill it in from
-     * the authenticated installation and sign the commit with the web-flow GPG key.
-     * When set, both `author` and `committer` are forced to the provided identity; this
-     * suppresses GitHub's auto-signing but is the only way to get a stable committer name
-     * for downstream tooling that reads `git log --format=%cn`.
+     * Omitted: `author` defaults to the Fern bot identity; `committer` is not sent, so
+     * GitHub fills it in from the authenticated installation and signs the commit.
+     * Set: forces both `author` and `committer` to the provided identity — suppresses
+     * auto-signing, but pins the committer for tooling that reads `git log --format=%cn`.
      */
     author?: CommitAuthor;
     logger: PipelineLogger;
@@ -83,14 +81,10 @@ export async function pushSignedCommit({
         tempRefPushed = true;
 
         for (let attempt = 0; attempt < MAX_CONCURRENT_PUSH_RETRIES; attempt++) {
-            // GitHub's web-flow signer keys off the `committer` field, not `author`:
-            //   - committer omitted -> GitHub fills it in from the authenticated installation
-            //     and signs the commit (the "Verified" badge path).
-            //   - committer set     -> GitHub uses it verbatim and skips signing unless the
-            //     email matches a verified email on the App's bot user.
-            // We always send `author` (stable attribution on PRs and `git log`), but only send
-            // `committer` when the caller explicitly demands it. Cloud generations get signed;
-            // GHE/PAT callers that need a deterministic committer can opt in via `author`.
+            // GitHub's web-flow signer keys off `committer`, not `author`. Omitting `committer`
+            // lets GitHub fill it in from the authenticated signing-capable principal (App
+            // installation, OAuth — never a PAT) and stamp the "Verified" signature. Always
+            // sending `author` keeps PR/`git log` attribution stable across every auth flavour.
             const resolvedAuthor = author ?? { name: FERN_BOT_NAME, email: FERN_BOT_EMAIL };
             const committerField = author != null ? { committer: author } : {};
             const { data: signedCommit } = await octokit.git.createCommit({

--- a/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
+++ b/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
@@ -34,7 +34,13 @@ export interface PushSignedCommitOptions {
     rebaseOnConflict?: boolean;
     /**
      * Override the commit author and committer identity.
-     * Defaults to the Fern bot identity (fern-api / fern-api[bot] noreply email).
+     *
+     * When omitted, `author` defaults to the Fern bot identity (so attribution stays stable
+     * even on GHE/PAT auth) and `committer` is *not* sent — letting GitHub fill it in from
+     * the authenticated installation and sign the commit with the web-flow GPG key.
+     * When set, both `author` and `committer` are forced to the provided identity; this
+     * suppresses GitHub's auto-signing but is the only way to get a stable committer name
+     * for downstream tooling that reads `git log --format=%cn`.
      */
     author?: CommitAuthor;
     logger: PipelineLogger;
@@ -77,18 +83,24 @@ export async function pushSignedCommit({
         tempRefPushed = true;
 
         for (let attempt = 0; attempt < MAX_CONCURRENT_PUSH_RETRIES; attempt++) {
-            const commitAuthor = {
-                name: author?.name ?? FERN_BOT_NAME,
-                email: author?.email ?? FERN_BOT_EMAIL
-            };
+            // GitHub's web-flow signer keys off the `committer` field, not `author`:
+            //   - committer omitted -> GitHub fills it in from the authenticated installation
+            //     and signs the commit (the "Verified" badge path).
+            //   - committer set     -> GitHub uses it verbatim and skips signing unless the
+            //     email matches a verified email on the App's bot user.
+            // We always send `author` (stable attribution on PRs and `git log`), but only send
+            // `committer` when the caller explicitly demands it. Cloud generations get signed;
+            // GHE/PAT callers that need a deterministic committer can opt in via `author`.
+            const resolvedAuthor = author ?? { name: FERN_BOT_NAME, email: FERN_BOT_EMAIL };
+            const committerField = author != null ? { committer: author } : {};
             const { data: signedCommit } = await octokit.git.createCommit({
                 owner,
                 repo,
                 message,
                 tree: treeSha,
                 parents,
-                author: commitAuthor,
-                committer: commitAuthor
+                author: resolvedAuthor,
+                ...committerField
             });
             const signedSha = signedCommit.sha;
 

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,20 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Restore GitHub commit signing on cloud-generated PRs while keeping the
+        stable Fern bot attribution introduced in 0.9.28. `pushSignedCommit` now
+        always sends `author` (defaulting to the Fern bot identity) but only
+        sends `committer` when the caller explicitly passes one. GitHub's
+        web-flow signer keys off `committer`, so omitting it lets the
+        installation's bot identity be filled in and the commit signed — the
+        previous unconditional `committer` override silently suppressed the
+        "Verified" badge on every cloud generation after 0.9.28.
+      type: fix
+  createdAt: "2026-05-19"
+  version: 0.9.32
+
+- changelogEntry:
+    - summary: |
         Bump @fern-api/replay to 0.16.0 and remove the consumer-side divergent-merge
         gauntlet. Squash-merge and force-push recovery are now handled inside the
         replay engine via the derived scan boundary (`findPreviousGenerationFromHistory`

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,14 +1,12 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
-        Restore GitHub commit signing on cloud-generated PRs while keeping the
-        stable Fern bot attribution introduced in 0.9.28. `pushSignedCommit` now
-        always sends `author` (defaulting to the Fern bot identity) but only
-        sends `committer` when the caller explicitly passes one. GitHub's
-        web-flow signer keys off `committer`, so omitting it lets the
-        installation's bot identity be filled in and the commit signed — the
-        previous unconditional `committer` override silently suppressed the
-        "Verified" badge on every cloud generation after 0.9.28.
+        Restore GitHub web-flow signing on cloud-generated PRs. `pushSignedCommit`
+        still sends `author` (Fern bot attribution from 0.9.28) but no longer
+        sends `committer` by default — the signer keys off `committer`, so the
+        unconditional override added in 0.9.28 silently suppressed the "Verified"
+        badge on every cloud generation. Callers that need a pinned committer
+        can still opt in via `GithubStepConfig.author`.
       type: fix
   createdAt: "2026-05-19"
   version: 0.9.32


### PR DESCRIPTION
## Summary

- `pushSignedCommit` was sending a hardcoded `committer` to `octokit.git.createCommit` on every API-created commit, which silently suppressed GitHub's web-flow GPG signature. Cloud-generated PRs have shipped without the "Verified" badge since 0.9.28 (2026-05-06).
- Fix: always send `author` (preserves the stable Fern-bot attribution that 0.9.28 was after) but only send `committer` when a caller passes an explicit `author`. The signer keys off `committer` — omitting it lets GitHub fill it in from the installation and stamp the signature.
- Bumps `@fern-api/generator-cli` to 0.9.32. Catalog pin and CLI changelog will follow in a separate PR after the publish, matching the recent #15971 / #15961 / #15927 pattern.

| Scenario | Author | Committer | Signed |
|---|---|---|---|
| Cloud / App auth, default | `fern-api` bot | omitted → GitHub fills in App identity | ✅ |
| GHE / PAT, default | `fern-api` bot | omitted → PAT owner | ❌ (PATs can't be signed) — attribution still stable |
| Explicit `author: { ... }` | caller-provided | caller-provided (=author) | ❌ (caller opts out for deterministic committer) |

## Why both halves matter

- 0.9.28 (#15893) added explicit `author` + `committer` to fix GHE/PAT attribution showing the PAT-owning service account as the committer. The fix worked for attribution but broke signing for every cloud user.
- A naive revert would re-break GHE attribution. This change keeps the attribution goal by always sending `author` and only suppresses signing when the caller explicitly needs a deterministic committer — defaulting both behaviours to "do the right thing for cloud."

## Test plan

- [x] `pnpm turbo run test --filter @fern-api/generator-cli` — 412/413 passing (1 pre-existing skip), including the two new opt-in tests
- [x] Existing default-path test updated to assert `committer` is *not* sent (with `.not.toHaveProperty` belt-and-suspenders against vitest's loose object equality)
- [x] Rebase-on-conflict retry test updated to assert the same invariant on the second attempt
- [x] New test covers the explicit-author opt-in path (single attempt + rebase retry)
- [ ] After merge: verify a fresh cloud-generated PR ships with the green "Verified" badge

## Reviewer follow-ups (deferred)

- `findExistingUpdatablePR.ts:88-101` uses commit author email as one half of an "is this a Fern-authored commit" check. Pre-existing fragility — surfaces here because the committer email is no longer pinned. Branch-name + commit-message prefix are the resilient legs of that check.
- `PostGenerationPipeline.ts:118-119` still sets `git config user.name/user.email` for the local working copy. Cosmetic since the API commit is what gets pushed; cleanup ticket.