### PR TITLE
chore(deps): bump @fern-api/generator-cli catalog pin to 0.9.32

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.31
-      version: 0.9.31
+      specifier: 0.9.32
+      version: 0.9.32
     '@fern-api/venus-api-sdk':
       specifier: 0.22.34
       version: 0.22.34
@@ -630,7 +630,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.31
+        version: 0.9.32
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0
@@ -699,7 +699,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.31
+        version: 0.9.32
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2466,7 +2466,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.31
+        version: 0.9.32
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9474,8 +9474,8 @@ packages:
   '@fern-api/fdr-sdk@1.2.4-f661387fb2':
     resolution: {integrity: sha512-wlk1lTCIZ7biND4vQf8jvhUw9P/rBQ5pXASCrumv8R96up0B3DY6yiY1C4VmFyHmp/kPhcjzc5T9TvHZZxFdrA==}
 
-  '@fern-api/generator-cli@0.9.31':
-    resolution: {integrity: sha512-ZvqBLwd0J39miiSjU1P9ZJb903VyDN82lSDVnA+xG4i+4/cy+Z7MUCo1AGRQzYydyJQsSAo/PYD/6jJ3qFU9lg==}
+  '@fern-api/generator-cli@0.9.32':
+    resolution: {integrity: sha512-i51Wp7iGPOj0xUIPFQg1SCzzojV/5jWgkq4Pp+VnPG8x2xmHUE65ZgdRWdpu3em6pqFNLCHfW/so2VKrxal4ag==}
     hasBin: true
 
   '@fern-api/replay@0.16.0':
@@ -16411,7 +16411,7 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.31':
+  '@fern-api/generator-cli@0.9.32':
     dependencies:
       '@boundaryml/baml': 0.219.0
       '@fern-api/replay': 0.16.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.2.4-f661387fb2
-  "@fern-api/generator-cli": 0.9.31
+  "@fern-api/generator-cli": 0.9.32
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description
Refs https://github.com/fern-api/fern/pull/15983

Bumps the `pnpm-workspace.yaml` catalog pin for `@fern-api/generator-cli` from 0.9.31 → 0.9.32, picking up the web-flow signing fix.

## Changes Made
- Updated `pnpm-workspace.yaml` catalog: `@fern-api/generator-cli` 0.9.31 → 0.9.32
- Updated `pnpm-lock.yaml` accordingly

Generator-cli 0.9.32 includes:
- fix(generator-cli): restore web-flow signing on cloud-generated commits

## Testing
- [x] No code changes — dependency pin bump only
- [x] Lock file regenerated cleanly

Link to Devin session: https://app.devin.ai/sessions/a9a213b097a74243b3b966c79d64486b
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->