### PR TITLE
fix(cli): guard streaming-extension parse when only resumable is set

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/getFernStreamingExtension.test.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/getFernStreamingExtension.test.ts
@@ -91,6 +91,22 @@ describe("getFernStreamingExtension - resumable inheritance (Option A: silent fa
         expect(result?.type).toBe("streamCondition");
         expect(result?.resumable).toBe(true);
     });
+
+    it("returns undefined (no crash) when only resumable is set, with no format or stream-condition", () => {
+        const document = makeDocument();
+        const operation = makeOperation({ resumable: true });
+
+        expect(() => getFernStreamingExtension(document, operation)).not.toThrow();
+        expect(getFernStreamingExtension(document, operation)).toBeUndefined();
+    });
+
+    it("returns undefined (no crash) when stream-condition is missing and format is missing", () => {
+        const document = makeDocument();
+        const operation = makeOperation({ terminator: "[DONE]" });
+
+        expect(() => getFernStreamingExtension(document, operation)).not.toThrow();
+        expect(getFernStreamingExtension(document, operation)).toBeUndefined();
+    });
 });
 
 describe("getDocumentLevelResumable", () => {

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/extensions/getFernStreamingExtension.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/extensions/getFernStreamingExtension.ts
@@ -75,6 +75,10 @@ export function getFernStreamingExtension(
         };
     }
 
+    if (streaming["stream-condition"] == null) {
+        return undefined;
+    }
+
     return {
         type: "streamCondition",
         format: streaming.format ?? "json",

--- a/packages/cli/cli/changes/unreleased/fix-streaming-resumable-without-format.yml
+++ b/packages/cli/cli/changes/unreleased/fix-streaming-resumable-without-format.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix a `TypeError: Cannot read properties of undefined (reading 'startsWith')`
+    crash in the OpenAPI parser when an operation's `x-fern-streaming` extension
+    sets only `resumable: true` (or otherwise omits both `format` and
+    `stream-condition`). The parser now returns `undefined` for that operation
+    instead of crashing.
+  type: fix

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -454,6 +454,9 @@ scripts:
         - export NPM_CONFIG_CACHE="$(pwd)/.cache"
         - export HOME="$(pwd)/"
         - poetry run pytest -rP .
+        # yarl 1.24.0/1.24.1 (2026-05-19) ship only cp310 wheels; constrain to <1.24 so the
+        # cp313 test container can resolve a compatible build. Drop once 1.24.2+ lands.
+        - poetry add 'yarl@<1.24'
         - poetry install --extras aiohttp
         - poetry run pytest -rP -n auto -m aiohttp .
   # Test Pydantic V1
@@ -472,6 +475,9 @@ scripts:
         - export NPM_CONFIG_CACHE="$(pwd)/.cache"
         - export HOME="$(pwd)/"
         - poetry run pytest -rP .
+        # yarl 1.24.0/1.24.1 (2026-05-19) ship only cp310 wheels; constrain to <1.24 so the
+        # cp313 test container can resolve a compatible build. Drop once 1.24.2+ lands.
+        - poetry add 'yarl@<1.24'
         - poetry install --extras aiohttp
         - poetry run pytest -rP -n auto -m aiohttp .
 allowedFailures:

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -454,9 +454,6 @@ scripts:
         - export NPM_CONFIG_CACHE="$(pwd)/.cache"
         - export HOME="$(pwd)/"
         - poetry run pytest -rP .
-        # yarl 1.24.0/1.24.1 (2026-05-19) ship only cp310 wheels; constrain to <1.24 so the
-        # cp313 test container can resolve a compatible build. Drop once 1.24.2+ lands.
-        - poetry add 'yarl@<1.24'
         - poetry install --extras aiohttp
         - poetry run pytest -rP -n auto -m aiohttp .
   # Test Pydantic V1
@@ -475,9 +472,6 @@ scripts:
         - export NPM_CONFIG_CACHE="$(pwd)/.cache"
         - export HOME="$(pwd)/"
         - poetry run pytest -rP .
-        # yarl 1.24.0/1.24.1 (2026-05-19) ship only cp310 wheels; constrain to <1.24 so the
-        # cp313 test container can resolve a compatible build. Drop once 1.24.2+ lands.
-        - poetry add 'yarl@<1.24'
         - poetry install --extras aiohttp
         - poetry run pytest -rP -n auto -m aiohttp .
 allowedFailures:


### PR DESCRIPTION
Closes FER-10651

## Summary

- The legacy `openapi-ir-parser` crashes with `TypeError: Cannot read properties of undefined (reading 'startsWith')` when an operation's `x-fern-streaming` is set to an object with `resumable: true` but no `format` and no `stream-condition`.
- `getFernStreamingExtension` now returns `undefined` in that case instead of falling through to `maybeTrimRequestPrefix(undefined)`.

## Example

Triggering config (operation-level override):

```yaml
paths:
  /sse-thing:
    post:
      x-fern-streaming:
        resumable: true   # no format, no stream-condition
```

Before this PR, parsing the document fails outright. After, the operation is treated as not opted into streaming (no-op).

## Code change

`packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/extensions/getFernStreamingExtension.ts`:

```ts
if (streaming["stream-condition"] == null && streaming.format != null) {
    return { type: "stream", ... };
}

+ if (streaming["stream-condition"] == null) {
+     return undefined;
+ }

return {
    type: "streamCondition",
    ...
    streamConditionProperty: maybeTrimRequestPrefix(streaming["stream-condition"]),
    ...
};
```

The newer `openapi-to-ir` parser already has the equivalent guard.

## Test plan

- [x] New vitest cases in `getFernStreamingExtension.test.ts` reproduce the exact `TypeError` pre-fix and pass post-fix
- [x] All existing tests in `getFernStreamingExtension.test.ts` still pass (13/13)
- [ ] Auth0 (Kunal Dawar) regenerates with `x-fern-streaming.resumable` on their SSE endpoint and confirms the parser no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)