### PR TITLE
chore(deps): bump @fern-api/venus-api-sdk to 4.0.0

### DIFF
--- a/packages/cli/auth/src/orgs/checkOrganizationMembership.ts
+++ b/packages/cli/auth/src/orgs/checkOrganizationMembership.ts
@@ -17,14 +17,14 @@ export async function checkOrganizationMembership({
     const venus = createVenusService({ token: token.value });
 
     // First check if the user is a member of the organization.
-    const isMemberResponse = await venus.organization.isMember(organization);
+    const isMemberResponse = await venus.organization.isMember({ organizationId: organization });
     if (isMemberResponse.ok && isMemberResponse.body) {
         return { type: "member" };
     }
 
     // Either the isMember call failed or the user is not a member.
     // Check whether the org exists at all.
-    const getResponse = await venus.organization.get(organization);
+    const getResponse = await venus.organization.get({ orgId: organization });
     if (getResponse.ok) {
         // Org exists but user is not a member.
         return { type: "no-access" };
@@ -33,8 +33,8 @@ export async function checkOrganizationMembership({
     // Org doesn't exist (or we got an auth error checking it).
     let result: OrganizationCheckResult = { type: "unknown-error" };
     getResponse.error._visit({
-        unauthorizedError: () => {
-            result = { type: "no-access" };
+        unprocessableEntityError: () => {
+            result = { type: "not-found" };
         },
         _other: () => {
             // TODO: We should actually send a 404 to more clearly communicate a not-found error.

--- a/packages/cli/auth/src/orgs/createOrganizationIfDoesNotExist.ts
+++ b/packages/cli/auth/src/orgs/createOrganizationIfDoesNotExist.ts
@@ -13,7 +13,7 @@ export async function createOrganizationIfDoesNotExist({
     context: TaskContext;
 }): Promise<boolean> {
     const venus = createVenusService({ token: token.value });
-    const getOrganizationResponse = await venus.organization.get(organization);
+    const getOrganizationResponse = await venus.organization.get({ orgId: organization });
 
     if (getOrganizationResponse.ok) {
         return false;

--- a/packages/cli/cli-v2/src/commands/auth/token/command.ts
+++ b/packages/cli/cli-v2/src/commands/auth/token/command.ts
@@ -39,24 +39,10 @@ export class TokenCommand {
         }
 
         response.error._visit({
-            organizationNotFoundError: () => {
+            unprocessableEntityError: () => {
                 process.stderr.write(`${Icons.error} Organization "${orgId}" was not found.\n`);
                 throw new CliError({
                     code: CliError.Code.ConfigError
-                });
-            },
-            unauthorizedError: () => {
-                process.stderr.write(`${Icons.error} You do not have access to organization "${orgId}".\n`);
-                throw new CliError({
-                    code: CliError.Code.AuthError
-                });
-            },
-            missingOrgPermissionsError: () => {
-                process.stderr.write(
-                    `${Icons.error} You do not have the required permissions in organization "${orgId}".\n`
-                );
-                throw new CliError({
-                    code: CliError.Code.AuthError
                 });
             },
             _other: () => {

--- a/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
@@ -116,9 +116,7 @@ describe("InviteMemberCommand", () => {
             cmd.handle(context, { email: "user@example.com", org: "acme" } as InviteMemberCommand.Args)
         ).rejects.toThrow(CliError);
 
-        expect(context.stderr.error).toHaveBeenCalledWith(
-            expect.stringContaining("do not have access to organization")
-        );
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
     });
 
     it("should handle UnprocessableEntityError from inviteUser", async () => {

--- a/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
@@ -58,7 +58,7 @@ describe("InviteMemberCommand", () => {
         const context = createMockContext();
         await cmd.handle(context, { email: "user@example.com", org: "acme" } as InviteMemberCommand.Args);
 
-        expect(mockGet).toHaveBeenCalledWith("acme");
+        expect(mockGet).toHaveBeenCalledWith({ orgId: "acme" });
         expect(mockInviteUser).toHaveBeenCalledWith({
             emailAddress: "user@example.com",
             auth0OrgId: "org_abc123"
@@ -104,7 +104,7 @@ describe("InviteMemberCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
+                _visit: (visitor: { unprocessableEntityError: () => void }) => visitor.unprocessableEntityError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -121,34 +121,13 @@ describe("InviteMemberCommand", () => {
         );
     });
 
-    it("should handle UnauthorizedError from inviteUser", async () => {
+    it("should handle UnprocessableEntityError from inviteUser", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockGet = mockOrgLookupSuccess();
         const mockInviteUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
-            }
-        });
-        vi.mocked(createVenusService).mockReturnValue({
-            organization: { get: mockGet, inviteUser: mockInviteUser }
-        } as unknown as ReturnType<typeof createVenusService>);
-
-        const context = createMockContext();
-        await expect(
-            cmd.handle(context, { email: "user@example.com", org: "acme" } as InviteMemberCommand.Args)
-        ).rejects.toThrow(CliError);
-
-        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("do not have permission to invite"));
-    });
-
-    it("should handle UserIdDoesNotExistError", async () => {
-        const { createVenusService } = await import("@fern-api/core");
-        const mockGet = mockOrgLookupSuccess();
-        const mockInviteUser = vi.fn().mockResolvedValue({
-            ok: false,
-            error: {
-                _visit: (visitor: { userIdDoesNotExistError: () => void }) => visitor.userIdDoesNotExistError()
+                _visit: (visitor: { unprocessableEntityError: () => void }) => visitor.unprocessableEntityError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -161,6 +140,27 @@ describe("InviteMemberCommand", () => {
         ).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("No user found with email"));
+    });
+
+    it("should handle unknown error from inviteUser", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
+        const mockInviteUser = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: { _other: () => void }) => visitor._other()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet, inviteUser: mockInviteUser }
+        } as unknown as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(
+            cmd.handle(context, { email: "user@example.com", org: "acme" } as InviteMemberCommand.Args)
+        ).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to invite member"));
     });
 
     it("should handle unknown errors", async () => {

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -28,10 +28,10 @@ export class InviteMemberCommand {
 
         const venus = createVenusService({ token: token.value });
 
-        const orgLookup = await venus.organization.get(args.org);
+        const orgLookup = await venus.organization.get({ orgId: args.org });
         if (!orgLookup.ok) {
             orgLookup.error._visit({
-                unauthorizedError: () => {
+                unprocessableEntityError: () => {
                     context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
                     throw new CliError({ code: CliError.Code.AuthError });
                 },
@@ -63,13 +63,7 @@ export class InviteMemberCommand {
         }
 
         response.error._visit({
-            unauthorizedError: () => {
-                context.stderr.error(
-                    `${Icons.error} You do not have permission to invite members to organization "${args.org}".`
-                );
-                throw new CliError({ code: CliError.Code.AuthError });
-            },
-            userIdDoesNotExistError: () => {
+            unprocessableEntityError: () => {
                 context.stderr.error(`${Icons.error} No user found with email "${args.email}".`);
                 throw CliError.notFound();
             },

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -32,11 +32,11 @@ export class InviteMemberCommand {
         if (!orgLookup.ok) {
             orgLookup.error._visit({
                 unprocessableEntityError: () => {
-                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                    throw new CliError({ code: CliError.Code.AuthError });
+                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    throw CliError.notFound();
                 },
                 _other: () => {
-                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    context.stderr.error(`${Icons.error} Failed to look up organization "${args.org}".`);
                     throw CliError.notFound();
                 }
             });

--- a/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
@@ -58,7 +58,7 @@ describe("ListMembersCommand", () => {
         const context = createMockContext();
         await cmd.handle(context, { org: "acme" } as ListMembersCommand.Args);
 
-        expect(mockGet).toHaveBeenCalledWith("acme");
+        expect(mockGet).toHaveBeenCalledWith({ orgId: "acme" });
         expect(context.stdout.info).toHaveBeenCalledTimes(2);
     });
 
@@ -118,12 +118,12 @@ describe("ListMembersCommand", () => {
         );
     });
 
-    it("should handle UnauthorizedError", async () => {
+    it("should handle UnprocessableEntityError", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
+                _visit: (visitor: { unprocessableEntityError: () => void }) => visitor.unprocessableEntityError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({

--- a/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
@@ -133,9 +133,7 @@ describe("ListMembersCommand", () => {
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as ListMembersCommand.Args)).rejects.toThrow(CliError);
 
-        expect(context.stderr.error).toHaveBeenCalledWith(
-            expect.stringContaining("do not have access to organization")
-        );
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
     });
 
     it("should handle unknown errors", async () => {

--- a/packages/cli/cli-v2/src/commands/org/member/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/command.ts
@@ -29,12 +29,12 @@ export class ListMembersCommand {
 
         const response = await withSpinner({
             message: `Fetching members of organization "${args.org}"`,
-            operation: () => venus.organization.get(args.org)
+            operation: () => venus.organization.get({ orgId: args.org })
         });
 
         if (!response.ok) {
             response.error._visit({
-                unauthorizedError: () => {
+                unprocessableEntityError: () => {
                     context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
                     throw new CliError({ code: CliError.Code.AuthError });
                 },

--- a/packages/cli/cli-v2/src/commands/org/member/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/command.ts
@@ -35,8 +35,8 @@ export class ListMembersCommand {
         if (!response.ok) {
             response.error._visit({
                 unprocessableEntityError: () => {
-                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                    throw new CliError({ code: CliError.Code.AuthError });
+                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    throw CliError.notFound();
                 },
                 _other: () => {
                     context.stderr.error(

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -112,7 +112,7 @@ describe("RemoveMemberCommand", () => {
             cmd.handle(context, { userId: "user123", org: "acme" } as RemoveMemberCommand.Args)
         ).rejects.toThrow(CliError);
 
-        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to look up organization"));
     });
 
     it("should handle UnprocessableEntityError from removeUser", async () => {

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -133,9 +133,7 @@ describe("RemoveMemberCommand", () => {
             cmd.handle(context, { userId: "user123", org: "acme" } as RemoveMemberCommand.Args)
         ).rejects.toThrow(CliError);
 
-        expect(context.stderr.error).toHaveBeenCalledWith(
-            expect.stringContaining("was not found")
-        );
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
     });
 
     it("should handle unknown error from removeUser", async () => {

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -58,7 +58,7 @@ describe("RemoveMemberCommand", () => {
         const context = createMockContext();
         await cmd.handle(context, { userId: "user123", org: "acme" } as RemoveMemberCommand.Args);
 
-        expect(mockGet).toHaveBeenCalledWith("acme");
+        expect(mockGet).toHaveBeenCalledWith({ orgId: "acme" });
         expect(mockRemoveUser).toHaveBeenCalledWith({
             userId: "user123",
             auth0OrgId: "org_abc123"
@@ -115,13 +115,13 @@ describe("RemoveMemberCommand", () => {
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
     });
 
-    it("should handle UnauthorizedError from removeUser", async () => {
+    it("should handle UnprocessableEntityError from removeUser", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockGet = mockOrgLookupSuccess();
         const mockRemoveUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
+                _visit: (visitor: { unprocessableEntityError: () => void }) => visitor.unprocessableEntityError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -134,17 +134,17 @@ describe("RemoveMemberCommand", () => {
         ).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(
-            expect.stringContaining("do not have permission to remove members")
+            expect.stringContaining("was not found")
         );
     });
 
-    it("should handle UserIdDoesNotExistError", async () => {
+    it("should handle unknown error from removeUser", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockGet = mockOrgLookupSuccess();
         const mockRemoveUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: { userIdDoesNotExistError: () => void }) => visitor.userIdDoesNotExistError()
+                _visit: (visitor: { _other: () => void }) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -156,7 +156,7 @@ describe("RemoveMemberCommand", () => {
             cmd.handle(context, { userId: "user123", org: "acme" } as RemoveMemberCommand.Args)
         ).rejects.toThrow(CliError);
 
-        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to remove member"));
     });
 
     it("should handle unknown errors", async () => {

--- a/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
@@ -32,11 +32,11 @@ export class RemoveMemberCommand {
         if (!orgLookup.ok) {
             orgLookup.error._visit({
                 unprocessableEntityError: () => {
-                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                    throw new CliError({ code: CliError.Code.AuthError });
+                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    throw CliError.notFound();
                 },
                 _other: () => {
-                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    context.stderr.error(`${Icons.error} Failed to look up organization "${args.org}".`);
                     throw CliError.notFound();
                 }
             });

--- a/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
@@ -28,10 +28,10 @@ export class RemoveMemberCommand {
 
         const venus = createVenusService({ token: token.value });
 
-        const orgLookup = await venus.organization.get(args.org);
+        const orgLookup = await venus.organization.get({ orgId: args.org });
         if (!orgLookup.ok) {
             orgLookup.error._visit({
-                unauthorizedError: () => {
+                unprocessableEntityError: () => {
                     context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
                     throw new CliError({ code: CliError.Code.AuthError });
                 },
@@ -64,13 +64,7 @@ export class RemoveMemberCommand {
         }
 
         response.error._visit({
-            unauthorizedError: () => {
-                context.stderr.error(
-                    `${Icons.error} You do not have permission to remove members from organization "${args.org}".`
-                );
-                throw new CliError({ code: CliError.Code.AuthError });
-            },
-            userIdDoesNotExistError: () => {
+            unprocessableEntityError: () => {
                 context.stderr.error(`${Icons.error} User "${userId}" was not found.`);
                 throw CliError.notFound();
             },

--- a/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
@@ -118,7 +118,7 @@ describe("CreateTokenCommand", () => {
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as CreateTokenCommand.Args)).rejects.toThrow(CliError);
 
-        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to look up organization"));
     });
 
     it("should handle UnprocessableEntityError from apiKeys.create", async () => {

--- a/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
@@ -62,7 +62,7 @@ describe("CreateTokenCommand", () => {
         const context = createMockContext();
         await cmd.handle(context, { org: "acme", description: "CI token" } as CreateTokenCommand.Args);
 
-        expect(mockGet).toHaveBeenCalledWith("acme");
+        expect(mockGet).toHaveBeenCalledWith({ orgId: "acme" });
         expect(mockCreate).toHaveBeenCalledWith({
             organizationId: "org_abc123",
             description: "CI token"
@@ -121,35 +121,13 @@ describe("CreateTokenCommand", () => {
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
     });
 
-    it("should handle UnauthorizedError from apiKeys.create", async () => {
+    it("should handle UnprocessableEntityError from apiKeys.create", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockGet = mockOrgLookupSuccess();
         const mockCreate = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
-            }
-        });
-        vi.mocked(createVenusService).mockReturnValue({
-            organization: { get: mockGet },
-            apiKeys: { create: mockCreate }
-        } as unknown as ReturnType<typeof createVenusService>);
-
-        const context = createMockContext();
-        await expect(cmd.handle(context, { org: "acme" } as CreateTokenCommand.Args)).rejects.toThrow(CliError);
-
-        expect(context.stderr.error).toHaveBeenCalledWith(
-            expect.stringContaining("do not have access to organization")
-        );
-    });
-
-    it("should handle OrganizationNotFoundError", async () => {
-        const { createVenusService } = await import("@fern-api/core");
-        const mockGet = mockOrgLookupSuccess();
-        const mockCreate = vi.fn().mockResolvedValue({
-            ok: false,
-            error: {
-                _visit: (visitor: { organizationNotFoundError: () => void }) => visitor.organizationNotFoundError()
+                _visit: (visitor: { unprocessableEntityError: () => void }) => visitor.unprocessableEntityError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({

--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -32,11 +32,11 @@ export class CreateTokenCommand {
         if (!orgLookup.ok) {
             orgLookup.error._visit({
                 unprocessableEntityError: () => {
-                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                    throw new CliError({ code: CliError.Code.AuthError });
+                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    throw CliError.notFound();
                 },
                 _other: () => {
-                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    context.stderr.error(`${Icons.error} Failed to look up organization "${args.org}".`);
                     throw CliError.notFound();
                 }
             });

--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -28,10 +28,10 @@ export class CreateTokenCommand {
 
         const venus = createVenusService({ token: token.value });
 
-        const orgLookup = await venus.organization.get(args.org);
+        const orgLookup = await venus.organization.get({ orgId: args.org });
         if (!orgLookup.ok) {
             orgLookup.error._visit({
-                unauthorizedError: () => {
+                unprocessableEntityError: () => {
                     context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
                     throw new CliError({ code: CliError.Code.AuthError });
                 },
@@ -70,11 +70,7 @@ export class CreateTokenCommand {
         }
 
         response.error._visit({
-            unauthorizedError: () => {
-                context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                throw new CliError({ code: CliError.Code.AuthError });
-            },
-            organizationNotFoundError: () => {
+            unprocessableEntityError: () => {
                 context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
                 throw CliError.notFound();
             },

--- a/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
@@ -183,9 +183,7 @@ describe("ListTokensCommand", () => {
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);
 
-        expect(context.stderr.error).toHaveBeenCalledWith(
-            expect.stringContaining("was not found")
-        );
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
     });
 
     it("should handle unknown errors", async () => {

--- a/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
@@ -75,8 +75,8 @@ describe("ListTokensCommand", () => {
         const context = createMockContext();
         await cmd.handle(context, { org: "acme" } as ListTokensCommand.Args);
 
-        expect(mockGet).toHaveBeenCalledWith("acme");
-        expect(mockGetTokens).toHaveBeenCalledWith("org_abc123");
+        expect(mockGet).toHaveBeenCalledWith({ orgId: "acme" });
+        expect(mockGetTokens).toHaveBeenCalledWith({ organizationId: "org_abc123" });
         expect(context.stdout.info).toHaveBeenCalledTimes(2);
     });
 
@@ -151,7 +151,7 @@ describe("ListTokensCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
+                _visit: (visitor: { unprocessableEntityError: () => void }) => visitor.unprocessableEntityError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -166,13 +166,13 @@ describe("ListTokensCommand", () => {
         );
     });
 
-    it("should handle UnauthorizedError from getTokensForOrganization", async () => {
+    it("should handle UnprocessableEntityError from getTokensForOrganization", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockGet = mockOrgLookupSuccess();
         const mockGetTokens = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
+                _visit: (visitor: { unprocessableEntityError: () => void }) => visitor.unprocessableEntityError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -184,28 +184,8 @@ describe("ListTokensCommand", () => {
         await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(
-            expect.stringContaining("do not have access to organization")
+            expect.stringContaining("was not found")
         );
-    });
-
-    it("should handle OrganizationNotFoundError", async () => {
-        const { createVenusService } = await import("@fern-api/core");
-        const mockGet = mockOrgLookupSuccess();
-        const mockGetTokens = vi.fn().mockResolvedValue({
-            ok: false,
-            error: {
-                _visit: (visitor: { organizationNotFoundError: () => void }) => visitor.organizationNotFoundError()
-            }
-        });
-        vi.mocked(createVenusService).mockReturnValue({
-            organization: { get: mockGet },
-            apiKeys: { getTokensForOrganization: mockGetTokens }
-        } as unknown as ReturnType<typeof createVenusService>);
-
-        const context = createMockContext();
-        await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);
-
-        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
     });
 
     it("should handle unknown errors", async () => {

--- a/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
@@ -161,9 +161,7 @@ describe("ListTokensCommand", () => {
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);
 
-        expect(context.stderr.error).toHaveBeenCalledWith(
-            expect.stringContaining("do not have access to organization")
-        );
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
     });
 
     it("should handle UnprocessableEntityError from getTokensForOrganization", async () => {

--- a/packages/cli/cli-v2/src/commands/org/token/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/command.ts
@@ -28,10 +28,10 @@ export class ListTokensCommand {
 
         const venus = createVenusService({ token: token.value });
 
-        const orgLookup = await venus.organization.get(args.org);
+        const orgLookup = await venus.organization.get({ orgId: args.org });
         if (!orgLookup.ok) {
             orgLookup.error._visit({
-                unauthorizedError: () => {
+                unprocessableEntityError: () => {
                     context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
                     throw new CliError({ code: CliError.Code.AuthError });
                 },
@@ -46,16 +46,12 @@ export class ListTokensCommand {
 
         const response = await withSpinner({
             message: `Fetching tokens for organization "${args.org}"`,
-            operation: () => venus.apiKeys.getTokensForOrganization(auth0OrgId)
+            operation: () => venus.apiKeys.getTokensForOrganization({ organizationId: auth0OrgId })
         });
 
         if (!response.ok) {
             response.error._visit({
-                unauthorizedError: () => {
-                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                    throw new CliError({ code: CliError.Code.AuthError });
-                },
-                organizationNotFoundError: () => {
+                unprocessableEntityError: () => {
                     context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
                     throw CliError.notFound();
                 },

--- a/packages/cli/cli-v2/src/commands/org/token/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/command.ts
@@ -32,11 +32,11 @@ export class ListTokensCommand {
         if (!orgLookup.ok) {
             orgLookup.error._visit({
                 unprocessableEntityError: () => {
-                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                    throw new CliError({ code: CliError.Code.AuthError });
+                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    throw CliError.notFound();
                 },
                 _other: () => {
-                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    context.stderr.error(`${Icons.error} Failed to look up organization "${args.org}".`);
                     throw CliError.notFound();
                 }
             });

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
@@ -50,7 +50,7 @@ describe("RevokeTokenCommand", () => {
         const context = createMockContext();
         await cmd.handle(context, { tokenId: "tok_123" } as RevokeTokenCommand.Args);
 
-        expect(mockRevoke).toHaveBeenCalledWith("tok_123");
+        expect(mockRevoke).toHaveBeenCalledWith({ tokenId: "tok_123" });
         expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("has been revoked"));
     });
 
@@ -80,30 +80,12 @@ describe("RevokeTokenCommand", () => {
         );
     });
 
-    it("should handle UnauthorizedError", async () => {
+    it("should handle UnprocessableEntityError", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockRevoke = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
-            }
-        });
-        vi.mocked(createVenusService).mockReturnValue({
-            apiKeys: { revokeTokenById: mockRevoke }
-        } as unknown as ReturnType<typeof createVenusService>);
-
-        const context = createMockContext();
-        await expect(cmd.handle(context, { tokenId: "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(CliError);
-
-        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("not authorized to revoke"));
-    });
-
-    it("should handle TokenNotFoundError", async () => {
-        const { createVenusService } = await import("@fern-api/core");
-        const mockRevoke = vi.fn().mockResolvedValue({
-            ok: false,
-            error: {
-                _visit: (visitor: { tokenNotFoundError: () => void }) => visitor.tokenNotFoundError()
+                _visit: (visitor: { unprocessableEntityError: () => void }) => visitor.unprocessableEntityError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
@@ -31,7 +31,7 @@ export class RevokeTokenCommand {
 
         const response = await withSpinner({
             message: `Revoking token "${tokenId}"`,
-            operation: () => venus.apiKeys.revokeTokenById(tokenId)
+            operation: () => venus.apiKeys.revokeTokenById({ tokenId })
         });
 
         if (response.ok) {
@@ -44,11 +44,7 @@ export class RevokeTokenCommand {
         }
 
         response.error._visit({
-            unauthorizedError: () => {
-                context.stderr.error(`${Icons.error} You are not authorized to revoke this token.`);
-                throw new CliError({ code: CliError.Code.AuthError });
-            },
-            tokenNotFoundError: () => {
+            unprocessableEntityError: () => {
                 context.stderr.error(`${Icons.error} Token "${tokenId}" was not found.`);
                 throw CliError.notFound();
             },

--- a/packages/cli/cli/changes/unreleased/bump-venus-sdk-4.yml
+++ b/packages/cli/cli/changes/unreleased/bump-venus-sdk-4.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump @fern-api/venus-api-sdk from 0.22.34 to 4.0.0, fixing a bug where
+    Authorization headers were silently dropped on org GET endpoints.
+  type: chore

--- a/packages/cli/cli/src/commands/token/token.ts
+++ b/packages/cli/cli/src/commands/token/token.ts
@@ -24,21 +24,9 @@ export async function generateToken({
         return;
     }
     response.error._visit({
-        organizationNotFoundError: () =>
+        unprocessableEntityError: () =>
             taskContext.failAndThrow(
                 `Failed to create token because the organization ${orgId} was not found. Please reach out to support@buildwithfern.com`,
-                undefined,
-                { code: CliError.Code.AuthError }
-            ),
-        unauthorizedError: () =>
-            taskContext.failAndThrow(
-                `Failed to create token because you are not in the ${orgId} organization. Please reach out to support@buildwithfern.com`,
-                undefined,
-                { code: CliError.Code.AuthError }
-            ),
-        missingOrgPermissionsError: () =>
-            taskContext.failAndThrow(
-                `Failed to create token because you do not have the required permissions in the ${orgId} organization. Please reach out to support@buildwithfern.com`,
                 undefined,
                 { code: CliError.Code.AuthError }
             ),

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -201,7 +201,7 @@ export async function runLocalGenerationForWorkspace({
                     }
                 }
 
-                const organization = await venus.organization.get(projectConfig.organization);
+                const organization = await venus.organization.get({ orgId: projectConfig.organization });
 
                 if (generatorInvocation.absolutePathToLocalOutput == null && !organization.ok) {
                     interactiveTaskContext.failWithoutThrowing(

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -192,7 +192,7 @@ export async function runRemoteGenerationForGenerator({
 
     const venus = createVenusService({ token: token.value });
     if (!isAirGapped) {
-        const orgResponse = await venus.organization.get(projectConfig.organization);
+        const orgResponse = await venus.organization.get({ orgId: projectConfig.organization });
 
         if (orgResponse.ok) {
             if (orgResponse.body.isWhitelabled) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 0.9.32
       version: 0.9.32
     '@fern-api/venus-api-sdk':
-      specifier: 0.22.34
-      version: 0.22.34
+      specifier: 4.0.0
+      version: 4.0.0
     '@fern-fern/docs-config':
       specifier: 0.0.80
       version: 0.0.80
@@ -4289,7 +4289,7 @@ importers:
         version: link:../task-context
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
-        version: 0.22.34
+        version: 4.0.0
       jsonwebtoken:
         specifier: 'catalog:'
         version: 9.0.3
@@ -4473,7 +4473,7 @@ importers:
         version: link:../task-context
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
-        version: 0.22.34
+        version: 4.0.0
       '@fern-api/workspace-loader':
         specifier: workspace:*
         version: link:../workspace/loader
@@ -4889,7 +4889,7 @@ importers:
         version: link:../task-context
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
-        version: 0.22.34
+        version: 4.0.0
       '@fern-api/workspace-loader':
         specifier: workspace:*
         version: link:../workspace/loader
@@ -6166,7 +6166,7 @@ importers:
         version: link:../../../../../generators/typescript-v2/dynamic-snippets
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
-        version: 0.22.34
+        version: 4.0.0
       '@fern-api/workspace-loader':
         specifier: workspace:*
         version: link:../../../workspace/loader
@@ -6326,7 +6326,7 @@ importers:
         version: link:../../../task-context
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
-        version: 0.22.34
+        version: 4.0.0
       '@fern-api/workspace-loader':
         specifier: workspace:*
         version: link:../../../workspace/loader
@@ -7918,7 +7918,7 @@ importers:
         version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
-        version: 0.22.34
+        version: 4.0.0
       '@fern-fern/fdr-test-sdk':
         specifier: 'catalog:'
         version: 0.0.5297
@@ -9486,8 +9486,8 @@ packages:
   '@fern-api/ui-core-utils@0.145.12-b50d999d1':
     resolution: {integrity: sha512-S1sE+Fs6kc/7F1Gzwsz7sZlAhMLIsaMeVDQ68038YXfzsLhrsg3DEVPvil5T3KxH/qV80Uso25q1D1W/LwXo6Q==}
 
-  '@fern-api/venus-api-sdk@0.22.34':
-    resolution: {integrity: sha512-21J/+zvL/v2LlCsVcBu7uM6k0Ej7Tz+2Tg6qZkUNH5TS0wmU6CyQ3lURE9jwiDRnw/bpNNkVXGuu9R7Vmvyi6Q==}
+  '@fern-api/venus-api-sdk@4.0.0':
+    resolution: {integrity: sha512-cyy0be2/dA15UZOVfU6/xFsgRjXB9cq0WPERjCH5z9alPlWWUDK3NGPU7ayQK6rShO7K8DYORoFoAFME20W0BA==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/docs-config@0.0.80':
@@ -16439,7 +16439,7 @@ snapshots:
       title: 3.5.3
       ua-parser-js: 1.0.41
 
-  '@fern-api/venus-api-sdk@0.22.34': {}
+  '@fern-api/venus-api-sdk@4.0.0': {}
 
   '@fern-fern/docs-config@0.0.80': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,7 +70,7 @@ catalog:
   "@fern-api/fdr-sdk": 1.2.4-f661387fb2
   "@fern-api/generator-cli": 0.9.32
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
-  "@fern-api/venus-api-sdk": 0.22.34
+  "@fern-api/venus-api-sdk": 4.0.0
   "@fern-fern/docs-config": 0.0.80
   "@fern-fern/fdr-test-sdk": ^0.0.5297
   "@fern-fern/fiddle-sdk": 1.1.0


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-10501
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->

Bumps `@fern-api/venus-api-sdk` from `0.22.34` to `4.0.0` in `pnpm-workspace.yaml`. The old SDK had a bug where `Authorization` headers were silently dropped on org GET endpoints. SDK 4.0.0 fixes this and preserves the public API surface (`FernVenusApiClient`, `FernVenusApi` namespace).

## Changes Made

- Bumped `@fern-api/venus-api-sdk` catalog pin from `0.22.34` → `4.0.0`
- Wrapped `venus.organization.get()` calls with `{ orgId: ... }` request objects
- Wrapped `venus.organization.isMember()` with `{ organizationId: ... }`
- Wrapped `venus.apiKeys.getTokensForOrganization()` with `{ organizationId: ... }`
- Wrapped `venus.apiKeys.revokeTokenById()` with `{ tokenId: ... }`
- Replaced removed error visitor cases (`unauthorizedError`, `organizationNotFoundError`, `tokenNotFoundError`, `userIdDoesNotExistError`, `missingOrgPermissionsError`) with new SDK error types (`unprocessableEntityError` + `_other`)
- Updated test mocks and assertions to match new request/error shapes
- Added CLI changelog entry

## Testing
- [x] Unit tests added/updated (all 692 tests pass across 60 test files in cli-v2)
- [x] Local compile passing (94/94 tasks)
- [x] Biome lint passing
- [x] CI checks passing: compile, lint, biome, test, test-ete, get-all-test-matrices

Link to Devin session: https://app.devin.ai/sessions/3ddbcc0782834039a5d9875b69980e11
Requested by: @jsklan