### PR TITLE
chore(deps): bump @fern-api/replay to 0.16.1 in generator-cli

### DIFF
--- a/packages/cli/cli/changes/unreleased/bump-generator-cli-0.9.33.yml
+++ b/packages/cli/cli/changes/unreleased/bump-generator-cli-0.9.33.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.33 (picks up @fern-api/replay 0.16.1).
+  type: chore

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -41,7 +41,7 @@
     "@fern-api/docker-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-api/replay": "0.16.0",
+    "@fern-api/replay": "0.16.1",
     "@fern-api/task-context": "workspace:*",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Bump @fern-api/replay to 0.16.1.
+      type: chore
+  createdAt: "2026-05-20"
+  version: 0.9.33
+
+- changelogEntry:
+    - summary: |
         Restore GitHub web-flow signing on cloud-generated PRs. `pushSignedCommit`
         still sends `author` (Fern bot attribution from 0.9.28) but no longer
         sends `committer` by default — the signer keys off `committer`, so the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7963,8 +7963,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/logging-execa
       '@fern-api/replay':
-        specifier: 0.16.0
-        version: 0.16.0
+        specifier: 0.16.1
+        version: 0.16.1
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../cli/task-context
@@ -9480,6 +9480,11 @@ packages:
 
   '@fern-api/replay@0.16.0':
     resolution: {integrity: sha512-i4TC4/UJtju9hX9aDWMlHXMPJ07lM0XD8cQLawYcDInY3LDOmnzqExoByWJb/m4AvhfxY2VFlITtCr0mVPethg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@fern-api/replay@0.16.1':
+    resolution: {integrity: sha512-860fIHdRORH4Xg908oxBC6pduiujRdgsb8NguvHt+cQE2lHcEOqsHwUIjiWtmBW09h8Hpi9xf8nGdk6vtBpe+g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16423,6 +16428,15 @@ snapshots:
       - supports-color
 
   '@fern-api/replay@0.16.0':
+    dependencies:
+      minimatch: 10.2.5
+      node-diff3: 3.2.0
+      simple-git: 3.36.0
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fern-api/replay@0.16.1':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description
Refs https://github.com/fern-api/fern-replay/releases/tag/0.16.1

Bumps `@fern-api/replay` from 0.16.0 to 0.16.1 in generator-cli, releasing as generator-cli 0.9.33.

## Changes Made
- `packages/generator-cli/package.json`: `@fern-api/replay` 0.16.0 → 0.16.1
- `packages/generator-cli/versions.yml`: new 0.9.33 entry
- `packages/cli/cli/changes/unreleased/bump-generator-cli-0.9.33.yml`: CLI changelog entry

Replay 0.16.1 includes:
- fix(PatchRegionDiff): preserve customer additions when workingTree shape diverges from patch (#90)

## Follow-up
After this merges and 0.9.33 publishes to npm:
1. Bump `pnpm-workspace.yaml` catalog pin to 0.9.33

## Testing
- [x] No code changes — dependency bump only
- [x] Lock file regenerated cleanly

Link to Devin session: https://app.devin.ai/sessions/3021f2b98cfb42e6a2a2776b6b7ca387
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->