### PR TITLE
fix(cli): validate basepaths for custom domain cutovers

### DIFF
--- a/packages/cli/cli/changes/unreleased/validate-custom-domain-basepath.yml
+++ b/packages/cli/cli/changes/unreleased/validate-custom-domain-basepath.yml
@@ -1,0 +1,11 @@
+- summary: |
+    Validate that the Fern instance `url` and every `custom-domain` share the same basepath when
+    basepath-aware mode is enabled (`multi-source: true` or the deprecated
+    `experimental.basepath-aware: true`). Previously the check was skipped when the custom domain
+    was at the root, allowing publishes that would 404 after DNS cutover.
+  type: fix
+- summary: |
+    Strip any `https://` or `http://` prefix from `custom-domain` entries in `docs.yml` before
+    they're sent to FDR or used for basepath comparisons. Including the protocol in the configured
+    value could interfere with basepath resolution during DNS cutover.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/customDomainValidation.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/customDomainValidation.test.ts
@@ -1,0 +1,114 @@
+import { CliError, TaskContext } from "@fern-api/task-context";
+import { describe, expect, it, vi } from "vitest";
+
+import { getBasepath, stripCustomDomainProtocol, validateBasepathAlignment } from "../customDomainValidation.js";
+
+interface FakeContext {
+    context: TaskContext;
+    failAndThrow: ReturnType<typeof vi.fn>;
+}
+
+function createFakeContext(): FakeContext {
+    const failAndThrow = vi.fn((message?: string) => {
+        throw new Error(message ?? "failAndThrow");
+    });
+    // Test helper: TaskContext has a wide surface; this validation only touches `failAndThrow`.
+    // The cast is the CLAUDE.md-documented test mock exception.
+    const context = {
+        failAndThrow
+    } as unknown as TaskContext;
+    return { context, failAndThrow };
+}
+
+describe("stripCustomDomainProtocol", () => {
+    it("strips https:// prefix", () => {
+        expect(stripCustomDomainProtocol("https://docs.example.com")).toBe("docs.example.com");
+    });
+
+    it("strips http:// prefix", () => {
+        expect(stripCustomDomainProtocol("http://docs.example.com/path")).toBe("docs.example.com/path");
+    });
+
+    it("leaves bare hostnames untouched", () => {
+        expect(stripCustomDomainProtocol("docs.example.com")).toBe("docs.example.com");
+    });
+
+    it("does not strip protocol-like substrings that are not prefixes", () => {
+        expect(stripCustomDomainProtocol("docs.example.com/https://x")).toBe("docs.example.com/https://x");
+    });
+});
+
+describe("getBasepath", () => {
+    it("returns / for a bare hostname", () => {
+        expect(getBasepath("docs.example.com")).toBe("/");
+    });
+
+    it("returns the basepath for a hostname with a path", () => {
+        expect(getBasepath("docs.example.com/docs")).toBe("/docs");
+    });
+
+    it("normalizes trailing slashes", () => {
+        expect(getBasepath("docs.example.com/docs/")).toBe("/docs");
+    });
+
+    it("preserves the root basepath as /", () => {
+        expect(getBasepath("docs.example.com/")).toBe("/");
+    });
+
+    it("handles inputs that already include a protocol", () => {
+        expect(getBasepath("https://docs.example.com/api")).toBe("/api");
+    });
+
+    it("falls back to / for unparseable inputs", () => {
+        expect(getBasepath("")).toBe("/");
+    });
+});
+
+describe("validateBasepathAlignment", () => {
+    it("passes when the instance url and custom domains share a root basepath", () => {
+        const { context, failAndThrow } = createFakeContext();
+        validateBasepathAlignment("acme.docs.buildwithfern.com", ["docs.acme.com"], context);
+        expect(failAndThrow).not.toHaveBeenCalled();
+    });
+
+    it("passes when the instance url and custom domains share a non-root basepath", () => {
+        const { context, failAndThrow } = createFakeContext();
+        validateBasepathAlignment("acme.docs.buildwithfern.com/docs", ["docs.acme.com/docs", "acme.com/docs"], context);
+        expect(failAndThrow).not.toHaveBeenCalled();
+    });
+
+    it("fails when the Fern url has a basepath but the custom domain is at the root", () => {
+        const { context, failAndThrow } = createFakeContext();
+        expect(() =>
+            validateBasepathAlignment("acme.docs.buildwithfern.com/docs", ["docs.acme.com"], context)
+        ).toThrow();
+        expect(failAndThrow).toHaveBeenCalledTimes(1);
+        const [message, , options] = failAndThrow.mock.calls[0] ?? [];
+        expect(message).toContain("DNS cutover");
+        expect(message).toContain("'/docs'");
+        expect(message).toContain("'/'");
+        expect(options).toEqual({ code: CliError.Code.ConfigError });
+    });
+
+    it("fails when the custom domain has a basepath but the Fern url is at the root", () => {
+        const { context, failAndThrow } = createFakeContext();
+        expect(() =>
+            validateBasepathAlignment("acme.docs.buildwithfern.com", ["docs.acme.com/docs"], context)
+        ).toThrow();
+        expect(failAndThrow).toHaveBeenCalledTimes(1);
+    });
+
+    it("fails when the basepaths differ", () => {
+        const { context, failAndThrow } = createFakeContext();
+        expect(() =>
+            validateBasepathAlignment("acme.docs.buildwithfern.com/docs", ["docs.acme.com/api"], context)
+        ).toThrow();
+        expect(failAndThrow).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats trailing-slash differences as equivalent", () => {
+        const { context, failAndThrow } = createFakeContext();
+        validateBasepathAlignment("acme.docs.buildwithfern.com/docs/", ["docs.acme.com/docs"], context);
+        expect(failAndThrow).not.toHaveBeenCalled();
+    });
+});

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/customDomainValidation.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/customDomainValidation.ts
@@ -1,0 +1,69 @@
+import { CliError, TaskContext } from "@fern-api/task-context";
+
+const HTTPS_PREFIX = "https://";
+const HTTP_PREFIX = "http://";
+
+/**
+ * Strips a leading `https://` or `http://` from a custom domain string.
+ */
+export function stripCustomDomainProtocol(customDomain: string): string {
+    if (customDomain.startsWith(HTTPS_PREFIX)) {
+        return customDomain.slice(HTTPS_PREFIX.length);
+    }
+    if (customDomain.startsWith(HTTP_PREFIX)) {
+        return customDomain.slice(HTTP_PREFIX.length);
+    }
+    return customDomain;
+}
+
+/**
+ * Extracts the basepath (URL pathname) from a domain string. Trailing slashes
+ * are stripped (except for the root) so `/docs` and `/docs/` compare equal.
+ */
+export function getBasepath(domain: string): string {
+    try {
+        const url =
+            domain.startsWith(HTTPS_PREFIX) || domain.startsWith(HTTP_PREFIX) ? domain : `${HTTPS_PREFIX}${domain}`;
+        return normalizeBasepath(new URL(url).pathname);
+    } catch {
+        return "/";
+    }
+}
+
+function normalizeBasepath(pathname: string): string {
+    if (pathname === "" || pathname === "/") {
+        return "/";
+    }
+    return pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
+/**
+ * Validates that the Fern instance URL and every custom domain share the same
+ * basepath when basepath-aware mode is enabled (via `multi-source: true` or
+ * the deprecated `experimental.basepath-aware: true`).
+ *
+ * Without this check, docs published under a Fern URL with one basepath but
+ * fronted by a custom domain with a different basepath will 404 after the
+ * customer's DNS cutover, since the basepath-aware S3 keys won't line up.
+ */
+export function validateBasepathAlignment(
+    instanceUrl: string,
+    customDomains: readonly string[],
+    context: TaskContext
+): void {
+    const urlBasepath = getBasepath(instanceUrl);
+    for (const customDomain of customDomains) {
+        const customDomainBasepath = getBasepath(customDomain);
+        if (urlBasepath !== customDomainBasepath) {
+            context.failAndThrow(
+                `Basepath mismatch between Fern url and custom-domain. When basepath-aware mode is enabled ` +
+                    `(via 'multi-source: true' or the deprecated 'experimental.basepath-aware: true'), the ` +
+                    `instance 'url' and 'custom-domain' must share the same basepath, otherwise docs will ` +
+                    `fail to resolve after DNS cutover. Instance url '${instanceUrl}' has basepath ` +
+                    `'${urlBasepath}' but custom-domain '${customDomain}' has basepath '${customDomainBasepath}'.`,
+                undefined,
+                { code: CliError.Code.ConfigError }
+            );
+        }
+    }
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -3,6 +3,7 @@ import { replaceEnvVariables } from "@fern-api/core-utils";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { CliError, TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace, DocsWorkspace } from "@fern-api/workspace-loader";
+import { stripCustomDomainProtocol, validateBasepathAlignment } from "./customDomainValidation.js";
 import { DocsPublishConflictError, publishDocs } from "./publishDocs.js";
 
 const PUBLISH_CONFLICT_RETRY_DELAYS_MS = [
@@ -105,19 +106,19 @@ export async function runRemoteGenerationForDocsWorkspace({
         return;
     }
 
-    // TODO: validate custom domains
-    const customDomains: string[] = [];
+    const customDomains = (
+        typeof maybeInstance.customDomain === "string"
+            ? [maybeInstance.customDomain]
+            : (maybeInstance.customDomain ?? [])
+    ).map(stripCustomDomainProtocol);
 
-    if (maybeInstance.customDomain != null) {
-        if (typeof maybeInstance.customDomain === "string") {
-            customDomains.push(maybeInstance.customDomain);
-        } else if (Array.isArray(maybeInstance.customDomain)) {
-            customDomains.push(...maybeInstance.customDomain);
-        }
-    }
+    // Basepath-aware mode requires the Fern instance url and every custom domain to share the
+    // same basepath, otherwise docs won't resolve once the customer cuts their DNS over to Fern.
+    const isBasepathAware =
+        maybeInstance.multiSource === true || docsWorkspace.config.experimental?.basepathAware === true;
 
-    if (maybeInstance.multiSource === true) {
-        validateMultiSourceBasepaths(maybeInstance.url, customDomains, context);
+    if (isBasepathAware) {
+        validateBasepathAlignment(maybeInstance.url, customDomains, context);
     }
 
     context.logger.info(`Starting docs publishing for ${preview ? "preview" : "production"}: ${maybeInstance.url}`);
@@ -193,28 +194,4 @@ export async function runRemoteGenerationForDocsWorkspace({
         context.logger.debug(`Docs publishing completed in ${publishTime.toFixed(0)}ms`);
     });
     return publishedUrl;
-}
-
-function getBasepath(domain: string): string {
-    try {
-        const url = domain.startsWith("https://") || domain.startsWith("http://") ? domain : `https://${domain}`;
-        return new URL(url).pathname;
-    } catch {
-        return "/";
-    }
-}
-
-function validateMultiSourceBasepaths(instanceUrl: string, customDomains: string[], context: TaskContext): void {
-    const urlBasepath = getBasepath(instanceUrl);
-    for (const customDomain of customDomains) {
-        const customDomainBasepath = getBasepath(customDomain);
-        if (customDomainBasepath !== "/" && urlBasepath !== customDomainBasepath) {
-            context.failAndThrow(
-                `When multi-source is enabled, the url and custom-domain must share the same basepath. ` +
-                    `Instance url '${instanceUrl}' has basepath '${urlBasepath}' but custom-domain '${customDomain}' has basepath '${customDomainBasepath}'.`,
-                undefined,
-                { code: CliError.Code.ConfigError }
-            );
-        }
-    }
 }


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-10155

Adds stricter validation for basepath-aware docs publishes so the Fern instance URL and configured custom domains must resolve under the same basepath before a customer cuts DNS over to Fern.

## Changes Made
- Validate that `instances[].url` and every `custom-domain` share the same basepath when basepath-aware mode is enabled via `multi-source: true` or deprecated `experimental.basepath-aware: true`.
- Strip `https://` and `http://` prefixes from `custom-domain` values before passing them to FDR or using them for basepath comparisons.
- Add focused unit tests for custom domain protocol normalization and basepath alignment validation.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

Ran:
- `pnpm --filter @fern-api/remote-workspace-runner test -- customDomainValidation`
- `pnpm turbo run compile --filter @fern-api/remote-workspace-runner`
- `pnpm lint:biome`