### PR TITLE
fix(csharp,php): fix parameter ordering when path params have defaults

### DIFF
--- a/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -567,9 +567,13 @@ export class EndpointSnippetGenerator extends WithGeneration {
 
         this.context.errors.scope(Scope.PathParameters);
         const pathParameterFields: ast.ConstructorField[] = [];
+        const optionalPathParameterFields: ast.ConstructorField[] = [];
         const pathParameters = [...(this.context.ir.pathParameters ?? []), ...(request.pathParameters ?? [])];
         if (pathParameters.length > 0) {
-            pathParameterFields.push(...this.getPathParameters({ namedParameters: pathParameters, snippet }));
+            const requiredParams = pathParameters.filter((p) => p.typeReference.type !== "optional");
+            const optionalParams = pathParameters.filter((p) => p.typeReference.type === "optional");
+            pathParameterFields.push(...this.getPathParameters({ namedParameters: requiredParams, snippet }));
+            optionalPathParameterFields.push(...this.getPathParameters({ namedParameters: optionalParams, snippet }));
         }
         this.context.errors.unscope();
 
@@ -578,28 +582,29 @@ export class EndpointSnippetGenerator extends WithGeneration {
         const filePropertyInfo = this.getFilePropertyInfo({ request, snippet });
         this.context.errors.unscope();
 
-        if (
-            !this.context.includePathParametersInWrappedRequest({
-                request,
-                inlinePathParameters: this.settings.shouldInlinePathParameters
-            })
-        ) {
+        const includeInWrapped = this.context.includePathParametersInWrappedRequest({
+            request,
+            inlinePathParameters: this.settings.shouldInlinePathParameters
+        });
+
+        if (!includeInWrapped) {
             args.push(...pathParameterFields.map((field) => field.value));
         }
         // For now, the C# SDK always requires the inlined request parameter.
+        const allPathFieldsForWrapped = includeInWrapped
+            ? [...pathParameterFields, ...optionalPathParameterFields]
+            : [];
         args.push(
             this.getInlinedRequestArg({
                 request,
                 snippet,
-                pathParameterFields: this.context.includePathParametersInWrappedRequest({
-                    request,
-                    inlinePathParameters: this.settings.shouldInlinePathParameters
-                })
-                    ? pathParameterFields
-                    : [],
+                pathParameterFields: allPathFieldsForWrapped,
                 filePropertyInfo
             })
         );
+        if (!includeInWrapped) {
+            args.push(...optionalPathParameterFields.map((field) => field.value));
+        }
         return args;
     }
 
@@ -791,9 +796,11 @@ export class EndpointSnippetGenerator extends WithGeneration {
         const args: ast.Literal[] = [];
         this.context.errors.scope(Scope.PathParameters);
         const pathParameters = [...(this.context.ir.pathParameters ?? []), ...(request.pathParameters ?? [])];
-        if (pathParameters.length > 0) {
+        const requiredPathParams = pathParameters.filter((p) => p.typeReference.type !== "optional");
+        const optionalPathParams = pathParameters.filter((p) => p.typeReference.type === "optional");
+        if (requiredPathParams.length > 0) {
             args.push(
-                ...this.getPathParameters({ namedParameters: pathParameters, snippet }).map((field) => field.value)
+                ...this.getPathParameters({ namedParameters: requiredPathParams, snippet }).map((field) => field.value)
             );
         }
         this.context.errors.unscope();
@@ -803,6 +810,14 @@ export class EndpointSnippetGenerator extends WithGeneration {
             args.push(this.getBodyRequestArg({ body: request.body, value: snippet.requestBody }));
         }
         this.context.errors.unscope();
+
+        if (optionalPathParams.length > 0) {
+            this.context.errors.scope(Scope.PathParameters);
+            args.push(
+                ...this.getPathParameters({ namedParameters: optionalPathParams, snippet }).map((field) => field.value)
+            );
+            this.context.errors.unscope();
+        }
 
         return args;
     }

--- a/generators/csharp/sdk/changes/unreleased/fix-base-path-param-ordering.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-base-path-param-ordering.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix argument ordering in generated test snippets when path parameters have default values.
+    Required path parameters now correctly appear before the request body, with optional
+    (defaulted) path parameters after it.
+  type: fix

--- a/generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts
@@ -407,8 +407,12 @@ export abstract class AbstractEndpointGenerator extends WithGeneration {
         const required: (ast.CodeBlock | ast.ClassInstantiation)[] = [];
         const optional: (ast.CodeBlock | ast.ClassInstantiation)[] = [];
         for (let i = 0; i < examplePathParameters.length; i++) {
+            const exampleParam = examplePathParameters[i];
+            if (exampleParam == null) {
+                continue;
+            }
             const snippet = this.exampleGenerator.getSnippetForTypeReference({
-                exampleTypeReference: examplePathParameters[i]!.value,
+                exampleTypeReference: exampleParam.value,
                 parseDatetimes
             });
             const irParam = irPathParameters[i];

--- a/generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts
@@ -293,15 +293,17 @@ export abstract class AbstractEndpointGenerator extends WithGeneration {
         }
         const serviceFilePath = service.name.fernFilepath;
 
-        const args = this.getNonEndpointArguments({
+        const { required: requiredArgs, optional: optionalArgs } = this.getNonEndpointArguments({
             endpoint,
             example,
             parseDatetimes
         });
         const endpointRequestSnippet = this.getEndpointRequestSnippet(example, endpoint, serviceId, parseDatetimes);
+        const args: (ast.CodeBlock | ast.ClassInstantiation)[] = [...requiredArgs];
         if (endpointRequestSnippet != null) {
             args.push(endpointRequestSnippet);
         }
+        args.push(...optionalArgs);
         const on = this.csharp.codeblock((writer) => {
             writer.write(`${clientVariableName}`);
             for (const path of serviceFilePath.allParts) {
@@ -392,21 +394,31 @@ export abstract class AbstractEndpointGenerator extends WithGeneration {
         endpoint: HttpEndpoint;
         example: ExampleEndpointCall;
         parseDatetimes: boolean;
-    }): (ast.CodeBlock | ast.ClassInstantiation)[] {
+    }): { required: (ast.CodeBlock | ast.ClassInstantiation)[]; optional: (ast.CodeBlock | ast.ClassInstantiation)[] } {
         if (!this.includePathParametersInEndpointSignature({ endpoint })) {
-            return [];
+            return { required: [], optional: [] };
         }
-        const pathParameters = [
+        const examplePathParameters = [
             ...example.rootPathParameters,
             ...example.servicePathParameters,
             ...example.endpointPathParameters
         ];
-        return pathParameters.map((pathParameter) =>
-            this.exampleGenerator.getSnippetForTypeReference({
-                exampleTypeReference: pathParameter.value,
+        const irPathParameters = endpoint.allPathParameters;
+        const required: (ast.CodeBlock | ast.ClassInstantiation)[] = [];
+        const optional: (ast.CodeBlock | ast.ClassInstantiation)[] = [];
+        for (let i = 0; i < examplePathParameters.length; i++) {
+            const snippet = this.exampleGenerator.getSnippetForTypeReference({
+                exampleTypeReference: examplePathParameters[i]!.value,
                 parseDatetimes
-            })
-        );
+            });
+            const irParam = irPathParameters[i];
+            if (irParam?.clientDefault != null) {
+                optional.push(snippet);
+            } else {
+                required.push(snippet);
+            }
+        }
+        return { required, optional };
     }
 
     private getJustRequestBodySnippet(

--- a/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -1741,15 +1741,17 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
     }): ast.MethodInvocation | undefined {
         const service = this.context.getHttpService(serviceId) ?? fail(`Service with id ${serviceId} not found`);
         const serviceFilePath = service.name.fernFilepath;
-        const args = this.getNonEndpointArguments({
+        const { required: requiredArgs, optional: optionalArgs } = this.getNonEndpointArguments({
             endpoint,
             example,
             parseDatetimes
         });
         const endpointRequestSnippet = this.getEndpointRequestSnippet(example, endpoint, serviceId, parseDatetimes);
+        const args: (ast.CodeBlock | ast.ClassInstantiation)[] = [...requiredArgs];
         if (endpointRequestSnippet != null) {
             args.push(endpointRequestSnippet);
         }
+        args.push(...optionalArgs);
         const on = this.csharp.codeblock((writer) => {
             writer.write(`${clientVariableName}`);
             for (const path of serviceFilePath.allParts) {

--- a/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -819,9 +819,11 @@ export class EndpointSnippetGenerator {
 
         this.context.errors.scope(Scope.PathParameters);
         const pathParameters = [...(this.context.ir.pathParameters ?? []), ...(request.pathParameters ?? [])];
-        if (pathParameters.length > 0) {
+        const requiredPathParams = pathParameters.filter((p) => p.typeReference.type !== "optional");
+        const optionalPathParams = pathParameters.filter((p) => p.typeReference.type === "optional");
+        if (requiredPathParams.length > 0) {
             args.push(
-                ...this.getPathParameters({ namedParameters: pathParameters, snippet }).map((field) => field.value)
+                ...this.getPathParameters({ namedParameters: requiredPathParams, snippet }).map((field) => field.value)
             );
         }
         this.context.errors.unscope();
@@ -831,6 +833,14 @@ export class EndpointSnippetGenerator {
             args.push(this.getBodyRequestArg({ body: request.body, value: snippet.requestBody }));
         }
         this.context.errors.unscope();
+
+        if (optionalPathParams.length > 0) {
+            this.context.errors.scope(Scope.PathParameters);
+            args.push(
+                ...this.getPathParameters({ namedParameters: optionalPathParams, snippet }).map((field) => field.value)
+            );
+            this.context.errors.unscope();
+        }
 
         return args;
     }
@@ -874,9 +884,13 @@ export class EndpointSnippetGenerator {
 
         this.context.errors.scope(Scope.PathParameters);
         const pathParameterFields: php.ConstructorField[] = [];
+        const optionalPathParameterFields: php.ConstructorField[] = [];
         const pathParameters = [...(this.context.ir.pathParameters ?? []), ...(request.pathParameters ?? [])];
         if (pathParameters.length > 0) {
-            pathParameterFields.push(...this.getPathParameters({ namedParameters: pathParameters, snippet }));
+            const requiredParams = pathParameters.filter((p) => p.typeReference.type !== "optional");
+            const optionalParams = pathParameters.filter((p) => p.typeReference.type === "optional");
+            pathParameterFields.push(...this.getPathParameters({ namedParameters: requiredParams, snippet }));
+            optionalPathParameterFields.push(...this.getPathParameters({ namedParameters: optionalParams, snippet }));
         }
         this.context.errors.unscope();
 
@@ -884,7 +898,12 @@ export class EndpointSnippetGenerator {
         const filePropertyInfo = this.getFilePropertyInfo({ request, snippet });
         this.context.errors.unscope();
 
-        if (!this.context.includePathParametersInWrappedRequest({ request, inlinePathParameters })) {
+        const includeInWrapped = this.context.includePathParametersInWrappedRequest({
+            request,
+            inlinePathParameters
+        });
+
+        if (!includeInWrapped) {
             args.push(...pathParameterFields.map((field) => field.value));
         }
 
@@ -895,19 +914,20 @@ export class EndpointSnippetGenerator {
                 inlineFileProperties: true // The PHP SDK requires inlineFileProperties.
             })
         ) {
+            const allPathFieldsForWrapped = includeInWrapped
+                ? [...pathParameterFields, ...optionalPathParameterFields]
+                : [];
             args.push(
                 this.getInlinedRequestArg({
                     request,
                     snippet,
-                    pathParameterFields: this.context.includePathParametersInWrappedRequest({
-                        request,
-                        inlinePathParameters
-                    })
-                        ? pathParameterFields
-                        : [],
+                    pathParameterFields: allPathFieldsForWrapped,
                     filePropertyInfo
                 })
             );
+        }
+        if (!includeInWrapped) {
+            args.push(...optionalPathParameterFields.map((field) => field.value));
         }
         return args;
     }

--- a/generators/php/sdk/changes/unreleased/fix-base-path-param-ordering.yml
+++ b/generators/php/sdk/changes/unreleased/fix-base-path-param-ordering.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix parameter ordering in generated SDK methods when path parameters have default values.
+    Required parameters now correctly appear before optional parameters, resolving a PHP 8.0+
+    deprecation error.
+  type: fix

--- a/generators/php/sdk/src/endpoint/AbstractEndpointGenerator.ts
+++ b/generators/php/sdk/src/endpoint/AbstractEndpointGenerator.ts
@@ -29,8 +29,12 @@ export abstract class AbstractEndpointGenerator {
         const { pathParameters, pathParameterReferences } = this.getAllPathParameters({ serviceId, endpoint });
         const request = getEndpointRequest({ context: this.context, endpoint, serviceId, service });
         const requestParameter = request != null ? this.getRequestParameter({ request }) : undefined;
+        const requiredPathParameters = pathParameters.filter((p) => p.initializer == null);
+        const optionalPathParameters = pathParameters.filter((p) => p.initializer != null);
         return {
-            baseParameters: [...pathParameters, requestParameter].filter((p): p is php.Parameter => p != null),
+            baseParameters: [...requiredPathParameters, requestParameter, ...optionalPathParameters].filter(
+                (p): p is php.Parameter => p != null
+            ),
             pathParameters,
             pathParameterReferences,
             request,

--- a/generators/php/sdk/src/reference/buildReference.ts
+++ b/generators/php/sdk/src/reference/buildReference.ts
@@ -131,15 +131,8 @@ function getReferenceEndpointInvocationParameters({
 }): string {
     const parameters: string[] = [];
 
-    for (const param of endpointSignatureInfo.pathParameters) {
+    for (const param of endpointSignatureInfo.baseParameters) {
         const paramName = param.name.startsWith("$") ? param.name : `$${param.name}`;
-        parameters.push(paramName);
-    }
-
-    if (endpointSignatureInfo.requestParameter != null) {
-        const paramName = endpointSignatureInfo.requestParameter.name.startsWith("$")
-            ? endpointSignatureInfo.requestParameter.name
-            : `$${endpointSignatureInfo.requestParameter.name}`;
         parameters.push(paramName);
     }
 
@@ -285,15 +278,8 @@ function getEndpointSnippet({
 
     const params: string[] = [];
 
-    for (const param of endpointSignatureInfo.pathParameters) {
+    for (const param of endpointSignatureInfo.baseParameters) {
         const paramName = param.name.startsWith("$") ? param.name : `$${param.name}`;
-        params.push(paramName);
-    }
-
-    if (endpointSignatureInfo.requestParameter != null) {
-        const paramName = endpointSignatureInfo.requestParameter.name.startsWith("$")
-            ? endpointSignatureInfo.requestParameter.name
-            : `$${endpointSignatureInfo.requestParameter.name}`;
         params.push(paramName);
     }
 

--- a/packages/cli/generation/ir-generator/src/dynamic-snippets/DynamicSnippetsConverter.ts
+++ b/packages/cli/generation/ir-generator/src/dynamic-snippets/DynamicSnippetsConverter.ts
@@ -394,15 +394,21 @@ export class DynamicSnippetsConverter {
     }: {
         pathParameters: PathParameter[];
     }): DynamicSnippets.NamedParameter[] {
-        return pathParameters.map((pathParameter) => ({
-            name: {
-                name: this.inflateName(pathParameter.name),
-                wireValue: getOriginalName(pathParameter.name)
-            },
-            typeReference: this.convertTypeReference(pathParameter.valueType),
-            propertyAccess: undefined,
-            variable: pathParameter.variable
-        }));
+        return pathParameters.map((pathParameter) => {
+            let typeReference = this.convertTypeReference(pathParameter.valueType);
+            if (pathParameter.clientDefault != null) {
+                typeReference = DynamicSnippets.TypeReference.optional(typeReference);
+            }
+            return {
+                name: {
+                    name: this.inflateName(pathParameter.name),
+                    wireValue: getOriginalName(pathParameter.name)
+                },
+                typeReference,
+                propertyAccess: undefined,
+                variable: pathParameter.variable
+            };
+        });
     }
 
     private convertBodyPropertiesToParameters({

--- a/seed/csharp-sdk/api-wide-base-path-with-default/.fern/metadata.json
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/api-wide-base-path-with-default/README.md
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/README.md
@@ -42,7 +42,7 @@ Instantiate and use the client with the following:
 using SeedApi;
 
 var client = new SeedApiClient();
-await client.Widgets.CreateAsync("v1beta", new Widget { Name = "name" });
+await client.Widgets.CreateAsync(new Widget { Name = "name" }, "v1beta");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/api-wide-base-path-with-default/Snippets/Example0.cs
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/Snippets/Example0.cs
@@ -10,10 +10,10 @@ public partial class Examples
         );
 
         await client.Widgets.CreateAsync(
-            "v1beta",
             new Widget {
                 Name = "name"
-            }
+            },
+            "v1beta"
         );
     }
 

--- a/seed/csharp-sdk/api-wide-base-path-with-default/Snippets/Example1.cs
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/Snippets/Example1.cs
@@ -10,10 +10,10 @@ public partial class Examples
         );
 
         await client.Widgets.CreateAsync(
-            "apiVersion",
             new Widget {
                 Name = "name"
-            }
+            },
+            "apiVersion"
         );
     }
 

--- a/seed/csharp-sdk/api-wide-base-path-with-default/reference.md
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/reference.md
@@ -13,7 +13,7 @@
 <dd>
 
 ```csharp
-await client.Widgets.CreateAsync("v1beta", new Widget { Name = "name" });
+await client.Widgets.CreateAsync(new Widget { Name = "name" }, "v1beta");
 ```
 </dd>
 </dl>

--- a/seed/csharp-sdk/api-wide-base-path-with-default/snippet.json
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/snippet.json
@@ -10,7 +10,7 @@
             },
             "snippet": {
                 "type": "csharp",
-                "client": "using SeedApi;\n\nvar client = new SeedApiClient();\nawait client.Widgets.CreateAsync(\"v1beta\", new Widget { Name = \"name\" });\n"
+                "client": "using SeedApi;\n\nvar client = new SeedApiClient();\nawait client.Widgets.CreateAsync(new Widget { Name = \"name\" }, \"v1beta\");\n"
             }
         }
     ]

--- a/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi.Test/Unit/MockServer/Widgets/CreateTest.cs
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi.Test/Unit/MockServer/Widgets/CreateTest.cs
@@ -39,7 +39,7 @@ public class CreateTest : BaseMockServerTest
                     .WithBody(mockResponse)
             );
 
-        var response = await Client.Widgets.CreateAsync("apiVersion", new Widget { Name = "name" });
+        var response = await Client.Widgets.CreateAsync(new Widget { Name = "name" }, "apiVersion");
         JsonAssert.AreEqual(response, mockResponse);
     }
 
@@ -73,7 +73,7 @@ public class CreateTest : BaseMockServerTest
                     .WithBody(mockResponse)
             );
 
-        var response = await Client.Widgets.CreateAsync("v1beta", new Widget { Name = "name" });
+        var response = await Client.Widgets.CreateAsync(new Widget { Name = "name" }, "v1beta");
         JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi/Widgets/WidgetsClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi/Widgets/WidgetsClient.cs
@@ -83,7 +83,7 @@ public partial class WidgetsClient : IWidgetsClient
     }
 
     /// <example><code>
-    /// await client.Widgets.CreateAsync("v1beta", new Widget { Name = "name" });
+    /// await client.Widgets.CreateAsync(new Widget { Name = "name" }, "v1beta");
     /// </code></example>
     public WithRawResponseTask<Widget> CreateAsync(
         Widget request,

--- a/seed/php-sdk/api-wide-base-path-with-default/.fern/metadata.json
+++ b/seed/php-sdk/api-wide-base-path-with-default/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/api-wide-base-path-with-default/README.md
+++ b/seed/php-sdk/api-wide-base-path-with-default/README.md
@@ -41,10 +41,10 @@ use Seed\Types\Widget;
 
 $client = new SeedClient();
 $client->widgets->create(
-    'v1beta',
     new Widget([
         'name' => 'name',
     ]),
+    'v1beta',
 );
 
 ```

--- a/seed/php-sdk/api-wide-base-path-with-default/reference.md
+++ b/seed/php-sdk/api-wide-base-path-with-default/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Widgets
-<details><summary><code>$client-&gt;widgets-&gt;create($apiVersion, $request) -> ?Widget</code></summary>
+<details><summary><code>$client-&gt;widgets-&gt;create($request, $apiVersion) -> ?Widget</code></summary>
 <dl>
 <dd>
 

--- a/seed/php-sdk/api-wide-base-path-with-default/reference.md
+++ b/seed/php-sdk/api-wide-base-path-with-default/reference.md
@@ -14,10 +14,10 @@
 
 ```php
 $client->widgets->create(
-    'v1beta',
     new Widget([
         'name' => 'name',
     ]),
+    'v1beta',
 );
 ```
 </dd>

--- a/seed/php-sdk/api-wide-base-path-with-default/src/Widgets/WidgetsClient.php
+++ b/seed/php-sdk/api-wide-base-path-with-default/src/Widgets/WidgetsClient.php
@@ -49,8 +49,8 @@ class WidgetsClient
     }
 
     /**
-     * @param string $apiVersion
      * @param Widget $request
+     * @param string $apiVersion
      * @param ?array{
      *   baseUrl?: string,
      *   maxRetries?: int,
@@ -63,7 +63,7 @@ class WidgetsClient
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function create(string $apiVersion = 'v1beta', Widget $request, ?array $options = null): ?Widget
+    public function create(Widget $request, string $apiVersion = 'v1beta', ?array $options = null): ?Widget
     {
         $options = array_merge($this->options, $options ?? []);
         try {

--- a/seed/php-sdk/api-wide-base-path-with-default/src/dynamic-snippets/example0/snippet.php
+++ b/seed/php-sdk/api-wide-base-path-with-default/src/dynamic-snippets/example0/snippet.php
@@ -11,8 +11,8 @@ $client = new SeedClient(
     ],
 );
 $client->widgets->create(
-    'v1beta',
     new Widget([
         'name' => 'name',
     ]),
+    'v1beta',
 );

--- a/seed/php-sdk/api-wide-base-path-with-default/src/dynamic-snippets/example1/snippet.php
+++ b/seed/php-sdk/api-wide-base-path-with-default/src/dynamic-snippets/example1/snippet.php
@@ -11,8 +11,8 @@ $client = new SeedClient(
     ],
 );
 $client->widgets->create(
-    'apiVersion',
     new Widget([
         'name' => 'name',
     ]),
+    'apiVersion',
 );

--- a/seed/php-sdk/x-fern-default/README.md
+++ b/seed/php-sdk/x-fern-default/README.md
@@ -41,8 +41,8 @@ use Seed\Requests\TestGetRequest;
 
 $client = new SeedClient();
 $client->testGet(
-    'region',
     new TestGetRequest([]),
+    'region',
 );
 
 ```

--- a/seed/php-sdk/x-fern-default/reference.md
+++ b/seed/php-sdk/x-fern-default/reference.md
@@ -1,5 +1,5 @@
 # Reference
-<details><summary><code>$client-&gt;testGet($region, $request) -> ?TestGetResponse</code></summary>
+<details><summary><code>$client-&gt;testGet($request, $region) -> ?TestGetResponse</code></summary>
 <dl>
 <dd>
 
@@ -13,8 +13,8 @@
 
 ```php
 $client->testGet(
-    'region',
     new TestGetRequest([]),
+    'region',
 );
 ```
 </dd>

--- a/seed/php-sdk/x-fern-default/src/SeedClient.php
+++ b/seed/php-sdk/x-fern-default/src/SeedClient.php
@@ -69,8 +69,8 @@ class SeedClient
     }
 
     /**
-     * @param string $region
      * @param TestGetRequest $request
+     * @param string $region
      * @param ?array{
      *   baseUrl?: string,
      *   maxRetries?: int,
@@ -83,7 +83,7 @@ class SeedClient
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function testGet(string $region = 'us-east-1', TestGetRequest $request = new TestGetRequest(), ?array $options = null): ?TestGetResponse
+    public function testGet(TestGetRequest $request = new TestGetRequest(), string $region = 'us-east-1', ?array $options = null): ?TestGetResponse
     {
         $options = array_merge($this->options, $options ?? []);
         $query = [];

--- a/seed/php-sdk/x-fern-default/src/dynamic-snippets/example0/snippet.php
+++ b/seed/php-sdk/x-fern-default/src/dynamic-snippets/example0/snippet.php
@@ -11,6 +11,6 @@ $client = new SeedClient(
     ],
 );
 $client->testGet(
-    'region',
     new TestGetRequest([]),
+    'region',
 );

--- a/seed/php-sdk/x-fern-default/src/dynamic-snippets/example1/snippet.php
+++ b/seed/php-sdk/x-fern-default/src/dynamic-snippets/example1/snippet.php
@@ -11,8 +11,8 @@ $client = new SeedClient(
     ],
 );
 $client->testGet(
-    'region',
     new TestGetRequest([
         'limit' => 'limit',
     ]),
+    'region',
 );


### PR DESCRIPTION
## Description
Fix parameter ordering when path parameters have `clientDefault` values (e.g., `x-fern-default`). These parameters should be treated as optional and placed after required parameters and the request body in generated method signatures and snippets.

## Changes Made
- **Main SDK generators (C#, PHP)**: Reorder method signature parameters so required path params come before the request body, and optional path params (those with `clientDefault`) come after
- **Dynamic snippets generators (C#, PHP)**: Apply the same ordering fix to the dynamic snippet generation code path (`getMethodArgsForBodyRequest` and `getMethodArgsForInlinedRequest`)
- **DynamicSnippetsConverter**: Wrap path parameter type references in `optional` when `clientDefault` is present, so downstream generators can distinguish required vs optional path params
- **Biome lint fix**: Replace non-null assertion (`!`) with null-safe variable extraction
- Regenerated seed outputs for affected fixtures: `api-wide-base-path-with-default` (C# + PHP), `x-fern-default` (PHP)

## Testing
- [x] `pnpm seed test --generator csharp-sdk --fixture api-wide-base-path-with-default --skip-scripts` ✅
- [x] `pnpm seed test --generator php-sdk --fixture api-wide-base-path-with-default --skip-scripts` ✅
- [x] `pnpm seed test --generator php-sdk --fixture x-fern-default --skip-scripts` ✅
- [x] `pnpm seed test --generator php-sdk --fixture oauth-client-credentials-with-variables --skip-scripts` ✅ (previously in allowedFailures, now passes)

Link to Devin session: https://app.devin.ai/sessions/fc7e67254cf84d9e8fcc7fc42e817b45
Requested by: @iamnamananand996