### PR TITLE
chore(seed): add api-wide-base-path-with-default to allowedFailures for csharp-sdk

### DIFF
--- a/seed/csharp-sdk/seed.yml
+++ b/seed/csharp-sdk/seed.yml
@@ -418,6 +418,7 @@ fixtures:
         redact-response-body-on-error: true
       outputFolder: redact-response-body-on-error
 allowedFailures:
+  - api-wide-base-path-with-default
   - allof
   - allof-inline
   - enum:forward-compatible-enums


### PR DESCRIPTION
## Description

The new `api-wide-base-path-with-default` fixture introduced in #15998 causes seed test failures for `csharp-sdk`. This adds the fixture to `allowedFailures` until the generator supports the new feature.

Note: `php-sdk` was already fixed on main via #16006.

## Changes Made
- Added `api-wide-base-path-with-default` to `allowedFailures` in `seed/csharp-sdk/seed.yml`

## Testing
- Verified the fixture is the cause of failure by inspecting CI logs from PR #15998 (job ID 76884683824 for csharp-sdk)
- CI shows `❌ THERE WERE UNEXPECTED TEST CASE FAILURES: ... api-wide-base-path-with-default`


Link to Devin session: https://app.devin.ai/sessions/eae9060efee04cb49d8451238ffd1ce9
Requested by: @Swimburger