### PR TITLE
fix(csharp): emit millisecond precision for nullable datetime params in mock tests

### DIFF
--- a/generators/csharp/sdk/changes/unreleased/fix-mock-test-nullable-datetime-millis.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-mock-test-nullable-datetime-millis.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Mock-server tests now serialize nullable date-time query and header parameters with millisecond precision so they match what the runtime sends. Previously, when a date-time field was wrapped in a nullable container (e.g. with `respect-nullable-schemas: true` and `coerce-optional-schemas-to-nullable: false`), the generated `WithParam("since", "2024-01-15T09:30:00Z")` omitted milliseconds while the SDK actually sent `2024-01-15T09:30:00.000Z`, causing WireMock to return 404.
+  type: fix

--- a/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
@@ -196,14 +196,16 @@ export class MockEndpointGenerator extends WithGeneration {
 
     private getDateTime(exampleTypeReference: ExampleTypeReference): Date | undefined {
         switch (exampleTypeReference.shape.type) {
-            case "container":
-                if (exampleTypeReference.shape.container.type !== "optional") {
-                    return undefined;
+            case "container": {
+                const container = exampleTypeReference.shape.container;
+                if (container.type === "optional") {
+                    return container.optional == null ? undefined : this.getDateTime(container.optional);
                 }
-                if (exampleTypeReference.shape.container.optional == null) {
-                    return undefined;
+                if (container.type === "nullable") {
+                    return container.nullable == null ? undefined : this.getDateTime(container.nullable);
                 }
-                return this.getDateTime(exampleTypeReference.shape.container.optional);
+                return undefined;
+            }
             case "named":
                 if (exampleTypeReference.shape.shape.type !== "alias") {
                     return undefined;


### PR DESCRIPTION
Closes FER-10694

## Summary

Generated C# mock-server tests for nullable date-time query/header parameters were producing `WithParam("since", "2024-01-15T09:30:00Z")` (no millis) while the SDK runtime serializes `DateTime` with `yyyy-MM-ddTHH:mm:ss.fffK` and actually sends `2024-01-15T09:30:00.000Z`. WireMock requires exact match → 404.

Root cause: `getDateTime` in `MockEndpointGenerator.ts` only unwrapped `container.optional`. When the IR wraps a date-time in `container.nullable` (common with `respect-nullable-schemas: true` + `coerce-optional-schemas-to-nullable: false`), it returned `undefined` and the test fell back to the raw `value.jsonExample` string, which omits millis.

## Example

Found while debugging `auth0-teams-csharp-sdk` CI: `Activity.ListTest` failed with `Auth0.TeamsApiException : Error with status code 404`. The IR for the `since` parameter walked as `container.optional → container.nullable → named.alias → primitive.datetime`. The `nullable` step short-circuited the recursion.

Before/after for that generated test:

```csharp
// Before
.WithParam("since", "2024-01-15T09:30:00Z")
.WithParam("until", "2024-01-15T09:30:00Z")

// After
.WithParam("since", "2024-01-15T09:30:00.000Z")
.WithParam("until", "2024-01-15T09:30:00.000Z")
```

Fix:

```ts
case "container": {
    const container = exampleTypeReference.shape.container;
    if (container.type === "optional") {
        return container.optional == null ? undefined : this.getDateTime(container.optional);
    }
    if (container.type === "nullable") {
        return container.nullable == null ? undefined : this.getDateTime(container.nullable);
    }
    return undefined;
}
```

## Test plan

- [x] `pnpm turbo run compile --filter @fern-api/fern-csharp-sdk` — clean
- [x] `pnpm turbo run test --filter @fern-api/fern-csharp-sdk` — 41/41 pass
- [x] Re-ran seed on auth0-teams-csharp config; `dotnet test --filter FullyQualifiedName~Activity.ListTest` now passes 2/2 (was 0/2)
- [x] No existing csharp-sdk seed snapshots use the bare `Z` form, so no fixture churn expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)