### PR TITLE
fix(go): only emit .Ptr() on enum path params when arg type is a pointer

### DIFF
--- a/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -660,7 +660,9 @@ export class EndpointSnippetGenerator {
         const pathParameters = [...(this.context.ir.pathParameters ?? []), ...(request.pathParameters ?? [])];
         if (pathParameters.length > 0) {
             otherArgs.push(
-                ...this.getPathParameters({ namedParameters: pathParameters, snippet }).map((field) => field.value)
+                ...this.getPathParameters({ namedParameters: pathParameters, snippet, asPointer: true }).map(
+                    (field) => field.value
+                )
             );
         }
         this.context.errors.unscope();
@@ -723,6 +725,11 @@ export class EndpointSnippetGenerator {
             inlineFileProperties: this.context.customConfig?.inlineFileProperties ?? true
         };
 
+        const includePathParamsInRequest = this.context.includePathParametersInWrappedRequest({
+            request,
+            inlinePathParameters
+        });
+
         this.context.errors.scope(Scope.PathParameters);
         const pathParameterFields: go.StructField[] = [];
         const pathParameters = [...(this.context.ir.pathParameters ?? []), ...(request.pathParameters ?? [])];
@@ -730,7 +737,8 @@ export class EndpointSnippetGenerator {
             pathParameterFields.push(
                 ...this.getPathParameters({
                     namedParameters: pathParameters,
-                    snippet
+                    snippet,
+                    asPointer: !includePathParamsInRequest
                 })
             );
         }
@@ -740,7 +748,7 @@ export class EndpointSnippetGenerator {
         const filePropertyInfo = this.getFilePropertyInfo({ request, snippet });
         this.context.errors.unscope();
 
-        if (!this.context.includePathParametersInWrappedRequest({ request, inlinePathParameters })) {
+        if (!includePathParamsInRequest) {
             otherArgs.push(...pathParameterFields.map((field) => field.value));
         }
 
@@ -756,12 +764,7 @@ export class EndpointSnippetGenerator {
             ? this.getInlinedRequestArg({
                   request,
                   snippet,
-                  pathParameterFields: this.context.includePathParametersInWrappedRequest({
-                      request,
-                      inlinePathParameters
-                  })
-                      ? pathParameterFields
-                      : [],
+                  pathParameterFields: includePathParamsInRequest ? pathParameterFields : [],
                   filePropertyInfo
               })
             : undefined;
@@ -928,10 +931,12 @@ export class EndpointSnippetGenerator {
 
     private getPathParameters({
         namedParameters,
-        snippet
+        snippet,
+        asPointer
     }: {
         namedParameters: FernIr.dynamic.NamedParameter[];
         snippet: FernIr.dynamic.EndpointSnippetRequest;
+        asPointer: boolean;
     }): go.StructField[] {
         const args: go.StructField[] = [];
 
@@ -942,7 +947,9 @@ export class EndpointSnippetGenerator {
         for (const parameter of pathParameters) {
             args.push({
                 name: this.context.getTypeName(parameter.name.name),
-                value: this.context.dynamicTypeInstantiationMapper.convertToPointerIfPossible(parameter)
+                value: asPointer
+                    ? this.context.dynamicTypeInstantiationMapper.convertToPointerIfPossible(parameter)
+                    : this.context.dynamicTypeInstantiationMapper.convert(parameter)
             });
         }
 

--- a/generators/go/sdk/changes/unreleased/fix-enum-path-param-ptr-in-snippets.yml
+++ b/generators/go/sdk/changes/unreleased/fix-enum-path-param-ptr-in-snippets.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Fix dynamic snippet generation for enum path parameters. Path parameters inlined as
+    struct fields on a wrapped request now use the enum value directly (e.g.
+    `Action: prelude.ActionAllow`) instead of `.Ptr()`, which produced a typecheck error
+    when the struct field is a non-pointer required enum. Path parameters passed as
+    positional function arguments continue to use `.Ptr()` when the SDK signature takes
+    a pointer.
+  type: fix


### PR DESCRIPTION
Closes FER-10695

## Summary

- Generated Go dynamic snippets were calling `.Ptr()` on enum path parameters that get inlined as struct fields on a wrapped request. Those struct fields are non-pointer (path params are required), so the snippet failed to typecheck.
- Branched `getPathParameters` on whether the path param is going into a positional function arg vs. an inlined struct field. `.Ptr()` is now emitted only in the former case.

## Background

This is a regression from #9527, which correctly added `.Ptr()` for endpoints like `enum/pathparam` where `Send(ctx, operand *fern.Operand, ...)` takes a pointer — but applied it unconditionally to all path params, breaking the inlined-struct-field case.

A simpler one-line revert was attempted in #16018, but it re-regresses the original case: the `enum` seed fixture's snippet then passes `fern.OperandGreaterThan` (value) where `*fern.Operand` is required, which fails to compile.

## Example

Surfaced by [prelude-go-sdk CI](https://github.com/fern-demo/prelude-go-sdk/actions/runs/26181457585/job/77025413251):

```
verification_management_test.go:140:11: cannot use prelude.ListPhoneNumbersVerificationManagementRequestActionAllow.Ptr()
  (value of type *prelude.ListPhoneNumbersVerificationManagementRequestAction)
  as prelude.ListPhoneNumbersVerificationManagementRequestAction value in struct literal
```

**Before** (Prelude — inlined struct field, broken):
```go
request := &prelude.ListPhoneNumbersVerificationManagementRequest{
    Action: prelude.ListPhoneNumbersVerificationManagementRequestActionAllow.Ptr(),
}
```

**After** (Prelude — plain value, compiles):
```go
request := &prelude.ListPhoneNumbersVerificationManagementRequest{
    Action: prelude.ListPhoneNumbersVerificationManagementRequestActionAllow,
}
```

**Preserved** (`enum/pathparam` — positional arg, signature takes `*fern.Operand`):
```go
client.PathParam.Send(
    context.TODO(),
    fern.OperandGreaterThan.Ptr(),
    ...
)
```

## Test plan

- [x] Local regen of Prelude SDK: all 9 affected snippets in `dynamic-snippets/example4{1..9}/snippet.go` now emit `Action: ...Allow` (no `.Ptr()`).
- [x] `pnpm seed test --generator go-sdk --fixture enum --skip-scripts` passes; `seed/go-sdk/enum/dynamic-snippets/example3/snippet.go` still emits `fern.OperandGreaterThan.Ptr()`.
- [x] `pnpm seed test --generator go-sdk --fixture nullable-optional --skip-scripts` passes; optional-body-field `.Ptr()` snippets unchanged.
- [x] Final diff touches only `EndpointSnippetGenerator.ts` and the changelog entry — no seed snapshots changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)