### PR TITLE
fix: unify docs-ledger publish client to use locales[] wire format

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-ledger-translation-register.yml
+++ b/packages/cli/cli/changes/unreleased/fix-ledger-translation-register.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Include translations in docs-ledger register call so the server issues
+    presigned upload URLs for translation-unique blobs. Previously only base
+    locale content was sent to register, causing locale-specific pages with
+    different hashes to get no upload URL.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/fix-ledger-translation-register.yml
+++ b/packages/cli/cli/changes/unreleased/fix-ledger-translation-register.yml
@@ -1,6 +1,6 @@
 - summary: |
-    Include translations in docs-ledger register call so the server issues
-    presigned upload URLs for translation-unique blobs. Previously only base
-    locale content was sent to register, causing locale-specific pages with
-    different hashes to get no upload URL.
+    Refactor docs-ledger publish client to use unified locales[] wire format.
+    Base locale and translations are now sent as a single locales array where
+    all entries go through the same register/finish pipeline, eliminating the
+    separate translation bolt-on codepath.
   type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
@@ -36,17 +36,13 @@ function makeDocsDefinition({
 describe("buildLedgerInput", () => {
     it("hashes page content and creates blob refs", () => {
         const markdown = "# Hello World";
-        const { input, blobs } = buildLedgerInput({
+        const { localeEntry, blobs } = buildLedgerInput({
             docsDefinition: makeDocsDefinition({ pages: { "page-1": { markdown } } }),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: new Map()
         });
 
         const expectedHash = sha256(markdown);
-        expect(input.pages["page-1"]).toEqual({
+        expect(localeEntry.pages["page-1"]).toEqual({
             hash: expectedHash,
             contentType: "text/markdown",
             contentLength: Buffer.byteLength(markdown, "utf-8")
@@ -56,36 +52,28 @@ describe("buildLedgerInput", () => {
 
     it("skips null/undefined pages", () => {
         const pages = { "page-1": null } as unknown as Record<string, { markdown: string }>;
-        const { input } = buildLedgerInput({
+        const { localeEntry } = buildLedgerInput({
             docsDefinition: makeDocsDefinition({ pages }),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: new Map()
         });
 
-        expect(Object.keys(input.pages)).toHaveLength(0);
+        expect(Object.keys(localeEntry.pages)).toHaveLength(0);
     });
 
     it("maps a minimal DocsConfig to a LedgerConfig shape (mostly empty fields)", () => {
-        const { input } = buildLedgerInput({
+        const { localeEntry } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: new Map()
         });
 
         // With only `root` set on the source DocsConfig every LedgerConfig
-        // field is `undefined` — but `input.config` itself is the populated
+        // field is `undefined` — but `localeEntry.config` itself is the populated
         // ledger object (not `undefined`), unlike the prior workaround.
-        expect(input.config).toBeDefined();
-        expect(input.config?.title).toBeUndefined();
-        expect(input.config?.colorsV3).toBeUndefined();
-        expect(input.config?.metadata).toBeUndefined();
-        expect(input.config?.redirects).toBeUndefined();
+        expect(localeEntry.config).toBeDefined();
+        expect(localeEntry.config?.title).toBeUndefined();
+        expect(localeEntry.config?.colorsV3).toBeUndefined();
+        expect(localeEntry.config?.metadata).toBeUndefined();
+        expect(localeEntry.config?.redirects).toBeUndefined();
     });
 
     it("translates a DocsConfig logo FileId into a LedgerConfig ImageRef using fileManifest dimensions", () => {
@@ -114,19 +102,15 @@ describe("buildLedgerInput", () => {
             }
         };
 
-        const { input } = buildLedgerInput({
+        const { localeEntry } = buildLedgerInput({
             docsDefinition,
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: new Map(),
             fileManifest,
             // Identity map: fileId === sanitizedPath in the current FDR flow.
             fileIdToPath: new Map([["assets/logo.png", "assets/logo.png"]])
         });
 
-        expect(input.config?.colorsV3).toEqual({
+        expect(localeEntry.config?.colorsV3).toEqual({
             type: "dark",
             accentPrimary: { r: 1, g: 2, b: 3 },
             logo: { path: "assets/logo.png", width: 320, height: 160 }
@@ -156,19 +140,15 @@ describe("buildLedgerInput", () => {
             }
         };
 
-        const { input } = buildLedgerInput({
+        const { localeEntry } = buildLedgerInput({
             docsDefinition,
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: new Map(),
             fileManifest,
             fileIdToPath: new Map([["assets/unmeasured.svg", "assets/unmeasured.svg"]])
         });
 
         // Logo absent rather than emitted with placeholder dimensions.
-        expect(input.config?.colorsV3).toEqual({
+        expect(localeEntry.config?.colorsV3).toEqual({
             type: "light",
             accentPrimary: { r: 4, g: 5, b: 6 },
             logo: undefined,
@@ -181,48 +161,22 @@ describe("buildLedgerInput", () => {
         });
     });
 
-    it("passes through org, domain, basepath, previewId", () => {
-        const { input } = buildLedgerInput({
+    it("defaults locale to en", () => {
+        const { localeEntry } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: "/v2",
-            previewId: "pr-42",
             apiDefinitions: new Map()
         });
 
-        expect(input.orgId).toBe("acme");
-        expect(input.domain).toBe("docs.acme.com");
-        expect(input.basepath).toBe("/v2");
-        expect(input.previewId).toBe("pr-42");
-    });
-
-    it("defaults basepath to empty string, previewId to null, and locale to en", () => {
-        const { input } = buildLedgerInput({
-            docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
-            apiDefinitions: new Map()
-        });
-
-        expect(input.basepath).toBe("");
-        expect(input.previewId).toBeNull();
-        expect(input.locale).toBe("en");
+        expect(localeEntry.locale).toBe("en");
     });
 
     it("uses config.root for the root field", () => {
-        const { input } = buildLedgerInput({
+        const { localeEntry } = buildLedgerInput({
             docsDefinition: makeDocsDefinition({ root: MINIMAL_ROOT }),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: new Map()
         });
 
-        expect(input.root).toEqual(MINIMAL_ROOT);
+        expect(localeEntry.root).toEqual(MINIMAL_ROOT);
     });
 
     it("deduplicates pages with identical content", () => {
@@ -234,10 +188,6 @@ describe("buildLedgerInput", () => {
                     "page-b": { markdown }
                 }
             }),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: new Map()
         });
 
@@ -253,16 +203,12 @@ describe("buildLedgerInput", () => {
     });
 
     it("sets apiManifest to null when apiDefinitions is empty", () => {
-        const { input } = buildLedgerInput({
+        const { localeEntry } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: new Map()
         });
 
-        expect(input.apiManifest).toBeNull();
+        expect(localeEntry.apiManifest).toBeNull();
     });
 
     it("apiManifest blob hash is stable across Map insertion order (determinism guard)", () => {
@@ -296,20 +242,12 @@ describe("buildLedgerInput", () => {
         reverse.set("api-def-b", minimalApiDefinition);
         reverse.set("api-def-a", minimalApiDefinition);
 
-        const { input: inForward } = buildLedgerInput({
+        const { localeEntry: inForward } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: forward
         });
-        const { input: inReverse } = buildLedgerInput({
+        const { localeEntry: inReverse } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: reverse
         });
 
@@ -336,21 +274,17 @@ describe("buildLedgerInput", () => {
         const apiDefinitions = new Map<string, APIV1Write.ApiDefinition>();
         apiDefinitions.set("api-def-1", minimalApiDefinition);
 
-        const { input, blobs } = buildLedgerInput({
+        const { localeEntry, blobs } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions
         });
 
-        expect(input.apiManifest).not.toBeNull();
-        expect(input.apiManifest?.contentType).toBe("application/json");
-        expect(input.apiManifest?.contentLength).toBeGreaterThan(0);
+        expect(localeEntry.apiManifest).not.toBeNull();
+        expect(localeEntry.apiManifest?.contentType).toBe("application/json");
+        expect(localeEntry.apiManifest?.contentLength).toBeGreaterThan(0);
 
         // The blob should exist in the blob map.
-        const manifestBuf = blobs.get(input.apiManifest?.hash ?? "");
+        const manifestBuf = blobs.get(localeEntry.apiManifest?.hash ?? "");
         expect(manifestBuf).toBeDefined();
 
         // Round-trip: the blob content should deserialize to match the input map.
@@ -386,18 +320,14 @@ describe("buildLedgerInput", () => {
             "docs/notes.txt": docEntry
         };
 
-        const { input, blobs } = buildLedgerInput({
+        const { localeEntry, blobs } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: new Map(),
             fileManifest
         });
 
         // fileManifest round-trips unchanged.
-        expect(input.fileManifest).toEqual(fileManifest);
+        expect(localeEntry.fileManifest).toEqual(fileManifest);
 
         // File blobs are NOT in the blob map — they are loaded lazily during
         // the upload step via filePaths (hash → absolute path).
@@ -406,16 +336,12 @@ describe("buildLedgerInput", () => {
     });
 
     it("legacy behaviour: omitting fileManifest still works", () => {
-        const { input, blobs } = buildLedgerInput({
+        const { localeEntry, blobs } = buildLedgerInput({
             docsDefinition: makeDocsDefinition({ pages: { "page-1": { markdown: "# hi" } } }),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: new Map()
         });
 
-        expect(input.fileManifest).toBeUndefined();
+        expect(localeEntry.fileManifest).toBeUndefined();
         // Blob map still contains the page + config blobs.
         expect(blobs.size).toBeGreaterThan(0);
     });
@@ -428,30 +354,22 @@ describe("buildLedgerInput", () => {
             branch: "main",
             commitSha: "abc123"
         };
-        const { input } = buildLedgerInput({
+        const { localeEntry } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             git,
             apiDefinitions: new Map()
         });
 
-        expect(input.git).toEqual(git);
+        expect(localeEntry.git).toEqual(git);
     });
 
     it("omits git from DocsPublishInput when not provided", () => {
-        const { input } = buildLedgerInput({
+        const { localeEntry } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             apiDefinitions: new Map()
         });
 
-        expect(input.git).toBeUndefined();
+        expect(localeEntry.git).toBeUndefined();
     });
 
     it("forwards git without commitSha when commitSha is omitted", () => {
@@ -459,47 +377,13 @@ describe("buildLedgerInput", () => {
             repoUrl: "https://gitlab.com/acme/docs",
             branch: "feature/x"
         };
-        const { input } = buildLedgerInput({
+        const { localeEntry } = buildLedgerInput({
             docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
             git,
             apiDefinitions: new Map()
         });
 
-        expect(input.git).toEqual(git);
-        expect(input.git?.commitSha).toBeUndefined();
-    });
-
-    // ── ADR 0009: customDomains ───────────────────────────────────────
-
-    it("forwards customDomains into DocsPublishInput", () => {
-        const customDomains = ["docs.acme.com", "alt.acme.com/v2"];
-        const { input } = buildLedgerInput({
-            docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "acme.docs.buildwithfern.com",
-            basepath: undefined,
-            previewId: undefined,
-            customDomains,
-            apiDefinitions: new Map()
-        });
-
-        expect(input.customDomains).toEqual(customDomains);
-    });
-
-    it("defaults customDomains to [] when omitted", () => {
-        const { input } = buildLedgerInput({
-            docsDefinition: makeDocsDefinition(),
-            organization: "acme",
-            domain: "docs.acme.com",
-            basepath: undefined,
-            previewId: undefined,
-            apiDefinitions: new Map()
-        });
-
-        expect(input.customDomains).toEqual([]);
+        expect(localeEntry.git).toEqual(git);
+        expect(localeEntry.git?.commitSha).toBeUndefined();
     });
 });

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -5,7 +5,7 @@ import {
     type DocsPublishGitInput,
     type DocsPublishInput,
     type FileManifestEntry,
-    type TranslationEntry
+    type LocaleEntry
 } from "@fern-api/fdr-sdk/orpc-client";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { TaskContext } from "@fern-api/task-context";
@@ -76,11 +76,6 @@ function jsonBlobRef(value: unknown): { ref: BlobRef; hash: string; buf: Buffer 
  */
 export function buildLedgerInput({
     docsDefinition,
-    organization,
-    domain,
-    basepath,
-    previewId,
-    customDomains,
     git,
     apiDefinitions,
     fileManifest,
@@ -88,11 +83,6 @@ export function buildLedgerInput({
     locale = "en"
 }: {
     docsDefinition: DocsDefinition;
-    organization: string;
-    domain: string;
-    basepath: string | undefined;
-    previewId: string | undefined;
-    customDomains?: string[];
     git?: DocsPublishGitInput;
     apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
     fileManifest?: Record<string, FileManifestEntry>;
@@ -106,11 +96,11 @@ export function buildLedgerInput({
     fileIdToPath?: Map<string, string>;
     /** Locale to stamp on segments. Defaults to "en". */
     locale?: string;
-}): { input: DocsPublishInput; blobs: Map<string, Buffer> } {
+}): { localeEntry: LocaleEntry; blobs: Map<string, Buffer> } {
     const blobs = new Map<string, Buffer>();
 
     // Pages: hash each page's markdown content.
-    const pages: DocsPublishInput["pages"] = {};
+    const pages: LocaleEntry["pages"] = {};
     for (const [pageId, page] of Object.entries(docsDefinition.pages)) {
         if (page == null) {
             continue;
@@ -164,12 +154,7 @@ export function buildLedgerInput({
         jsFilesRef = jsFilesBlob.ref;
     }
 
-    const input: DocsPublishInput = {
-        orgId: organization,
-        domain,
-        basepath: basepath ?? "",
-        customDomains: customDomains ?? [],
-        previewId: previewId ?? null,
+    const localeEntry: LocaleEntry = {
         root: docsDefinition.config.root ?? docsDefinition.config.navigation,
         pages,
         config: ledgerConfig,
@@ -181,7 +166,7 @@ export function buildLedgerInput({
         git
     };
 
-    return { input, blobs };
+    return { localeEntry, blobs };
 }
 
 export interface LedgerPublishResult {
@@ -244,24 +229,16 @@ export async function publishDocsViaLedger({
     // If any locale fails to build, the entire publish aborts before any
     // network calls are made.
 
-    const { input, blobs } = buildLedgerInput({
+    const { localeEntry: baseLocale, blobs } = buildLedgerInput({
         docsDefinition,
-        organization,
-        domain,
-        basepath,
-        previewId,
-        customDomains,
         git,
         apiDefinitions,
         fileManifest,
         fileIdToPath
     });
 
-    const translationInputs = buildAllTranslationInputs({
+    const builtTranslations = await buildAllTranslationInputs({
         docsDefinition,
-        organization,
-        domain,
-        basepath,
         git,
         apiDefinitions,
         fileManifest,
@@ -269,9 +246,6 @@ export async function publishDocsViaLedger({
         resolver,
         context
     });
-
-    // Wait for all translation builds to complete (fail-fast).
-    const builtTranslations = await translationInputs;
 
     // Merge all translation blobs into the base blob pool so the single
     // upload phase covers everything.
@@ -282,56 +256,41 @@ export async function publishDocsViaLedger({
     }
 
     // ── Phase 2: Single register → upload → finish ─────────────────────
-    // Translations are passed inline to both register and finish so the
-    // server can issue presigned URLs for translation-unique blobs during
-    // register, and persist base + all locale segments during finish.
+    // Build a unified locales[] array where the base locale is the first
+    // entry and translations follow. The server processes all locales
+    // through the same pipeline.
 
     const client = createDocsLedgerClient({ baseUrl: fdrOrigin, token, headers });
 
-    // Build the translations array before register so the server sees
-    // translation content refs and can issue presigned upload URLs for
-    // locale-specific blobs that don't share a hash with the base.
-    const translations: TranslationEntry[] = builtTranslations.map((t) => ({
-        locale: t.locale,
-        root: t.input.root,
-        pages: t.input.pages,
-        apiManifest: t.input.apiManifest,
-        config: t.input.config,
-        fileManifest: t.input.fileManifest,
-        jsFiles: t.input.jsFiles,
-        redirects: t.input.redirects,
-        version: t.input.version,
-        repo: t.input.repo,
-        git: t.input.git
-    }));
+    const locales: LocaleEntry[] = [baseLocale, ...builtTranslations.map((t) => t.localeEntry)];
 
-    const registerInput: DocsPublishInput = {
-        ...input,
-        translations: translations.length > 0 ? translations : undefined
+    const publishInput: DocsPublishInput = {
+        orgId: organization,
+        domain,
+        basepath: basepath ?? "",
+        customDomains: customDomains ?? [],
+        previewId: previewId ?? null,
+        locales
     };
 
     // Register — server computes deployment hash, returns presigned S3
-    // URLs for any blobs it doesn't already have in CAS (base +
-    // translations combined).
+    // URLs for any blobs it doesn't already have in CAS (all locales).
     context.logger.debug("[ledger] Registering deployment...");
     const registerStart = performance.now();
-    const registerResult = await client.register(registerInput);
+    const registerResult = await client.register(publishInput);
     const registerTime = performance.now() - registerStart;
     context.logger.debug(
         `[ledger] Registered in ${registerTime.toFixed(0)}ms — hash=${registerResult.deploymentHash}, missing=${registerResult.missingContent.length} blobs`
     );
 
-    // Upload all blobs the server doesn't have yet (base + translations
-    // combined). In-memory blobs are checked first; file blobs are read
-    // lazily from disk via filePaths.
+    // Upload all blobs the server doesn't have yet (all locales combined).
     await uploadMissingBlobs(registerResult.missingContent, blobs, context, filePaths);
 
-    // Finish — server persists the base deployment + all translations
-    // in a single call. Uses the same input shape as register.
-    const finishInput: DocsPublishInput = registerInput;
+    // Finish — server persists the deployment + all locale segments in
+    // a single atomic transaction. Same input shape as register.
     context.logger.debug("[ledger] Finishing deployment...");
     const finishStart = performance.now();
-    const finishResult = await client.finish(finishInput);
+    const finishResult = await client.finish(publishInput);
     const finishTime = performance.now() - finishStart;
     context.logger.debug(
         `[ledger] Finished in ${finishTime.toFixed(0)}ms — deploymentId=${finishResult.deploymentId}, reused=${finishResult.reusedDeployment}`
@@ -464,7 +423,7 @@ interface BuiltTranslation {
     locale: string;
     localePages: Record<string, string>;
     translatedDefinition: DocsDefinition;
-    input: DocsPublishInput;
+    localeEntry: LocaleEntry;
     blobs: Map<string, Buffer>;
 }
 
@@ -477,9 +436,6 @@ interface BuiltTranslation {
  */
 async function buildAllTranslationInputs({
     docsDefinition,
-    organization,
-    domain,
-    basepath,
     git,
     apiDefinitions,
     fileManifest,
@@ -488,9 +444,6 @@ async function buildAllTranslationInputs({
     context
 }: {
     docsDefinition: DocsDefinition;
-    organization: string;
-    domain: string;
-    basepath: string | undefined;
     git?: DocsPublishGitInput;
     apiDefinitions: Map<string, APIV1Write.ApiDefinition>;
     fileManifest?: Record<string, FileManifestEntry>;
@@ -523,12 +476,8 @@ async function buildAllTranslationInputs({
                 context
             });
 
-            const { input, blobs } = buildLedgerInput({
+            const { localeEntry, blobs } = buildLedgerInput({
                 docsDefinition: translatedDefinition,
-                organization,
-                domain,
-                basepath,
-                previewId: undefined,
                 git,
                 apiDefinitions,
                 fileManifest,
@@ -536,7 +485,7 @@ async function buildAllTranslationInputs({
                 locale
             });
 
-            return { locale, localePages, translatedDefinition, input, blobs };
+            return { locale, localePages, translatedDefinition, localeEntry, blobs };
         })
     );
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -282,29 +282,15 @@ export async function publishDocsViaLedger({
     }
 
     // ── Phase 2: Single register → upload → finish ─────────────────────
-    // Translations are passed inline to the finish call so the server
-    // persists base + all locale segments in a single request.
+    // Translations are passed inline to both register and finish so the
+    // server can issue presigned URLs for translation-unique blobs during
+    // register, and persist base + all locale segments during finish.
 
     const client = createDocsLedgerClient({ baseUrl: fdrOrigin, token, headers });
 
-    // Register — server computes deployment hash, returns presigned S3
-    // URLs for any blobs it doesn't already have in CAS.
-    context.logger.debug("[ledger] Registering deployment...");
-    const registerStart = performance.now();
-    const registerResult = await client.register(input);
-    const registerTime = performance.now() - registerStart;
-    context.logger.debug(
-        `[ledger] Registered in ${registerTime.toFixed(0)}ms — hash=${registerResult.deploymentHash}, missing=${registerResult.missingContent.length} blobs`
-    );
-
-    // Upload all blobs the server doesn't have yet (base + translations
-    // combined). In-memory blobs are checked first; file blobs are read
-    // lazily from disk via filePaths.
-    await uploadMissingBlobs(registerResult.missingContent, blobs, context, filePaths);
-
-    // Build the translations array for the finish call. Each entry
-    // carries only the content fields + locale — orgId/domain/basepath
-    // are inherited from the base input on the server side.
+    // Build the translations array before register so the server sees
+    // translation content refs and can issue presigned upload URLs for
+    // locale-specific blobs that don't share a hash with the base.
     const translations: TranslationEntry[] = builtTranslations.map((t) => ({
         locale: t.locale,
         root: t.input.root,
@@ -319,12 +305,30 @@ export async function publishDocsViaLedger({
         git: t.input.git
     }));
 
-    // Finish — server persists the base deployment + all translations
-    // in a single call.
-    const finishInput: DocsPublishInput = {
+    const registerInput: DocsPublishInput = {
         ...input,
         translations: translations.length > 0 ? translations : undefined
     };
+
+    // Register — server computes deployment hash, returns presigned S3
+    // URLs for any blobs it doesn't already have in CAS (base +
+    // translations combined).
+    context.logger.debug("[ledger] Registering deployment...");
+    const registerStart = performance.now();
+    const registerResult = await client.register(registerInput);
+    const registerTime = performance.now() - registerStart;
+    context.logger.debug(
+        `[ledger] Registered in ${registerTime.toFixed(0)}ms — hash=${registerResult.deploymentHash}, missing=${registerResult.missingContent.length} blobs`
+    );
+
+    // Upload all blobs the server doesn't have yet (base + translations
+    // combined). In-memory blobs are checked first; file blobs are read
+    // lazily from disk via filePaths.
+    await uploadMissingBlobs(registerResult.missingContent, blobs, context, filePaths);
+
+    // Finish — server persists the base deployment + all translations
+    // in a single call. Uses the same input shape as register.
+    const finishInput: DocsPublishInput = registerInput;
     context.logger.debug("[ledger] Finishing deployment...");
     const finishStart = performance.now();
     const finishResult = await client.finish(finishInput);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedgerPreview.ts
@@ -4,7 +4,7 @@ import {
     createDocsLedgerClient,
     type DocsPublishGitInput,
     type FileManifestEntry,
-    type TranslationEntry
+    type LocaleEntry
 } from "@fern-api/fdr-sdk/orpc-client";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { TaskContext } from "@fern-api/task-context";
@@ -71,13 +71,8 @@ export async function publishDocsViaLedgerPreview({
     // sync buildLedgerInput for translations is deferred until after
     // previewRegister because we need the server-assigned domain.
 
-    const { input, blobs } = buildLedgerInput({
+    const { localeEntry: baseLocale, blobs } = buildLedgerInput({
         docsDefinition,
-        organization,
-        domain: "",
-        basepath: basePath,
-        previewId,
-        customDomains: [],
         git,
         apiDefinitions,
         fileManifest,
@@ -100,16 +95,16 @@ export async function publishDocsViaLedgerPreview({
         orgId: organization,
         previewId: previewId ?? null,
         basePath: basePath ?? "",
-        root: input.root,
-        pages: input.pages,
-        apiManifest: input.apiManifest,
-        config: input.config,
-        fileManifest: input.fileManifest,
-        jsFiles: input.jsFiles,
-        redirects: input.redirects,
-        locale: input.locale,
-        version: input.version,
-        repo: input.repo,
+        root: baseLocale.root,
+        pages: baseLocale.pages,
+        apiManifest: baseLocale.apiManifest,
+        config: baseLocale.config,
+        fileManifest: baseLocale.fileManifest,
+        jsFiles: baseLocale.jsFiles,
+        redirects: baseLocale.redirects,
+        locale: baseLocale.locale,
+        version: baseLocale.version,
+        repo: baseLocale.repo,
         git
     });
     const registerTime = performance.now() - registerStart;
@@ -121,19 +116,15 @@ export async function publishDocsViaLedgerPreview({
     // Build translation ledger inputs now that we have the server domain.
     // This is a cheap sync operation (serialization only).
     const translationInputs = builtTranslationDefs.map((t) => {
-        const { input: translationInput, blobs: translationBlobs } = buildLedgerInput({
+        const { localeEntry, blobs: translationBlobs } = buildLedgerInput({
             docsDefinition: t.translatedDefinition,
-            organization,
-            domain: registerResult.domain,
-            basepath: registerResult.basepath,
-            previewId: registerResult.previewId,
             git,
             apiDefinitions,
             fileManifest,
             fileIdToPath,
             locale: t.locale
         });
-        return { ...t, input: translationInput, blobs: translationBlobs };
+        return { ...t, localeEntry, blobs: translationBlobs };
     });
 
     // Merge all translation blobs into the base pool for the upload phase.
@@ -145,32 +136,20 @@ export async function publishDocsViaLedgerPreview({
 
     await uploadMissingBlobs(registerResult.missingContent, blobs, context, filePaths);
 
-    // Build the translations array for the finish call.
-    const translations: TranslationEntry[] = translationInputs.map((t) => ({
-        locale: t.locale,
-        root: t.input.root,
-        pages: t.input.pages,
-        apiManifest: t.input.apiManifest,
-        config: t.input.config,
-        fileManifest: t.input.fileManifest,
-        jsFiles: t.input.jsFiles,
-        redirects: t.input.redirects,
-        version: t.input.version,
-        repo: t.input.repo,
-        git: t.input.git
-    }));
+    // Build the unified locales array for the finish call.
+    const locales: LocaleEntry[] = [baseLocale, ...translationInputs.map((t) => t.localeEntry)];
 
-    // Finish — server persists the preview deployment + all translations
+    // Finish — server persists the preview deployment + all locale segments
     // in a single call.
     context.logger.debug("[ledger-preview] Finishing preview deployment...");
     const finishStart = performance.now();
     const finishResult = await client.finish({
-        ...input,
+        orgId: organization,
         domain: registerResult.domain,
         basepath: registerResult.basepath,
         customDomains: [],
         previewId: registerResult.previewId,
-        translations: translations.length > 0 ? translations : undefined
+        locales
     });
     const finishTime = performance.now() - finishStart;
     context.logger.debug(


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-10484

Updates the CLI docs-ledger publish client to use the unified `locales[]` wire format instead of the bolt-on `translations[]` array. The base locale becomes `locales[0]` with `locale: defaultLocale`, and all translations are additional entries in the same array.

**Stacked on**: https://github.com/fern-api/fern-platform/pull/11312 (server-side changes)

## Changes Made
- **`publishDocsLedger.ts`**: Refactored `buildLedgerInput` to return `{ localeEntry, blobs }` instead of `{ input, blobs }`. Deployment-level params (`orgId`, `domain`, `basepath`, `previewId`, `customDomains`) are now assembled in `publishDocsViaLedger` when constructing the final `DocsPublishInput` with unified `locales[]` array.
- **`publishDocsLedgerPreview.ts`**: Updated to use `locales[]` format for preview publishing. Calls `buildLedgerInput` with only content fields.
- **`buildLedgerInput.test.ts`**: Updated all test cases to use new `buildLedgerInput` signature and destructure `{ localeEntry, blobs }` instead of `{ input, blobs }`.
- Added changelog entry for the wire format change.

## Testing
- [x] Unit tests updated and passing locally
- [x] Manual testing: verified `buildLedgerInput` returns correct `localeEntry` shape
- Note: compile/lint failures in CI are **pre-existing on `feat/docs_ledger`** — all errors are from `@fern-api/fdr-sdk/orpc-client` missing exports that don't exist in the published SDK yet. Verified by checking out `feat/docs_ledger` and running compile locally (identical errors).

Link to Devin session: https://app.devin.ai/sessions/39280dca1e9e4499ab649331c7809231
Requested by: @broady