### PR TITLE
fix(generator-cli): expand .fernignore glob patterns before the wipe

### DIFF
--- a/packages/commons/github/package.json
+++ b/packages/commons/github/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
+    "minimatch": "catalog:",
     "octokit": "^4.1.4",
     "semver": "^7.7.3",
     "simple-git": "catalog:",

--- a/packages/commons/github/src/ClonedRepository.ts
+++ b/packages/commons/github/src/ClonedRepository.ts
@@ -75,6 +75,12 @@ export class ClonedRepository {
         await this.git.raw([...args, ...(Array.isArray(files) ? files : [files])]);
     }
 
+    public async listTrackedFiles(): Promise<string[]> {
+        await this.git.cwd(this.clonePath);
+        const result = await this.git.raw(["ls-tree", "-r", "HEAD", "--name-only"]);
+        return result.split("\n").filter((line) => line.length > 0);
+    }
+
     public async restoreFilesFromCommit(commitSha: string, files: string | string[]): Promise<void> {
         await this.git.cwd(this.clonePath);
         const fileList = Array.isArray(files) ? files : [files];

--- a/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
+++ b/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
@@ -38,4 +38,13 @@ describe("expandFernignorePatterns", () => {
 
         expect(preserved).toEqual(["src/foo/a.py"]);
     });
+
+    it("matches dotfiles when expanded by a glob", () => {
+        const fernignore = "src/**";
+        const tracked = ["src/.hidden.py", "src/visible.py"];
+
+        const preserved = expandFernignorePatterns(fernignore, tracked);
+
+        expect(preserved).toEqual(["src/.hidden.py", "src/visible.py"]);
+    });
 });

--- a/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
+++ b/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
@@ -27,7 +27,7 @@ describe("expandFernignorePatterns", () => {
 
         const preserved = expandFernignorePatterns(fernignore, tracked);
 
-        expect(preserved).toEqual(["src/foo/a.py", "src/foo/nested/b.py"]);
+        expect([...preserved].sort()).toEqual(["src/foo/a.py", "src/foo/nested/b.py"].sort());
     });
 
     it("treats a trailing-slash directory path the same as a bare directory", () => {

--- a/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
+++ b/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
@@ -11,4 +11,13 @@ describe("expandFernignorePatterns", () => {
 
         expect(preserved).toEqual(["src/foo/keep.py", "src/foo/nested/also.py"]);
     });
+
+    it("matches a literal file path", () => {
+        const fernignore = "LICENSE";
+        const tracked = ["LICENSE", "README.md", "src/index.ts"];
+
+        const preserved = expandFernignorePatterns(fernignore, tracked);
+
+        expect(preserved).toEqual(["LICENSE"]);
+    });
 });

--- a/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
+++ b/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
@@ -20,4 +20,13 @@ describe("expandFernignorePatterns", () => {
 
         expect(preserved).toEqual(["LICENSE"]);
     });
+
+    it("treats a bare directory path as a prefix so its contents are preserved", () => {
+        const fernignore = "src/foo";
+        const tracked = ["src/foo/a.py", "src/foo/nested/b.py", "src/bar/c.py"];
+
+        const preserved = expandFernignorePatterns(fernignore, tracked);
+
+        expect(preserved).toEqual(["src/foo/a.py", "src/foo/nested/b.py"]);
+    });
 });

--- a/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
+++ b/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
@@ -29,4 +29,13 @@ describe("expandFernignorePatterns", () => {
 
         expect(preserved).toEqual(["src/foo/a.py", "src/foo/nested/b.py"]);
     });
+
+    it("trims whitespace and ignores comments and blank lines", () => {
+        const fernignore = ["# leading comment", "", "  src/foo/**  ", "   ", "# trailing comment"].join("\n");
+        const tracked = ["src/foo/a.py", "src/bar/b.py"];
+
+        const preserved = expandFernignorePatterns(fernignore, tracked);
+
+        expect(preserved).toEqual(["src/foo/a.py"]);
+    });
 });

--- a/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
+++ b/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
@@ -30,6 +30,15 @@ describe("expandFernignorePatterns", () => {
         expect(preserved).toEqual(["src/foo/a.py", "src/foo/nested/b.py"]);
     });
 
+    it("treats a trailing-slash directory path the same as a bare directory", () => {
+        const fernignore = "src/foo/";
+        const tracked = ["src/foo/a.py", "src/foo/nested/b.py", "src/bar/c.py"];
+
+        const preserved = expandFernignorePatterns(fernignore, tracked);
+
+        expect([...preserved].sort()).toEqual(["src/foo/a.py", "src/foo/nested/b.py"].sort());
+    });
+
     it("trims whitespace and ignores comments and blank lines", () => {
         const fernignore = ["# leading comment", "", "  src/foo/**  ", "   ", "# trailing comment"].join("\n");
         const tracked = ["src/foo/a.py", "src/bar/b.py"];

--- a/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
+++ b/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
@@ -56,4 +56,13 @@ describe("expandFernignorePatterns", () => {
 
         expect(preserved).toEqual(["src/.hidden.py", "src/visible.py"]);
     });
+
+    it("expands extglob patterns through minimatch", () => {
+        const fernignore = "src/+(foo|bar)/**";
+        const tracked = ["src/foo/a.py", "src/bar/b.py", "src/baz/c.py"];
+
+        const preserved = expandFernignorePatterns(fernignore, tracked);
+
+        expect([...preserved].sort()).toEqual(["src/bar/b.py", "src/foo/a.py"].sort());
+    });
 });

--- a/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
+++ b/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { expandFernignorePatterns } from "../expandFernignorePatterns.js";
+
+describe("expandFernignorePatterns", () => {
+    it("expands ** glob across nested files", () => {
+        const fernignore = "src/foo/**";
+        const tracked = ["src/foo/keep.py", "src/foo/nested/also.py", "src/bar/del.py"];
+
+        const preserved = expandFernignorePatterns(fernignore, tracked);
+
+        expect(preserved).toEqual(["src/foo/keep.py", "src/foo/nested/also.py"]);
+    });
+});

--- a/packages/commons/github/src/__test__/listTrackedFiles.test.ts
+++ b/packages/commons/github/src/__test__/listTrackedFiles.test.ts
@@ -1,0 +1,42 @@
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { simpleGit } from "simple-git";
+import tmp from "tmp-promise";
+import { describe, expect, it } from "vitest";
+
+import { ClonedRepository } from "../ClonedRepository.js";
+
+async function makeRepoWith(files: Record<string, string>): Promise<string> {
+    const dir = (await tmp.dir({ unsafeCleanup: true })).path;
+    const git = simpleGit(dir);
+    await git.init();
+    await git.addConfig("user.name", "test");
+    await git.addConfig("user.email", "test@example.com");
+    for (const [relPath, contents] of Object.entries(files)) {
+        const absPath = path.join(dir, relPath);
+        await mkdir(path.dirname(absPath), { recursive: true });
+        await writeFile(absPath, contents);
+    }
+    await git.add(".");
+    await git.commit("initial");
+    return dir;
+}
+
+describe("ClonedRepository.listTrackedFiles", () => {
+    it("returns every file path tracked at HEAD", async () => {
+        const dir = await makeRepoWith({
+            ".fernignore": "src/keep/**\n",
+            "README.md": "# hi",
+            "src/keep/a.py": "a",
+            "src/keep/nested/b.py": "b",
+            "src/drop/c.py": "c"
+        });
+        const repo = ClonedRepository.createAtPath(dir);
+
+        const tracked = await repo.listTrackedFiles();
+
+        expect([...tracked].sort()).toEqual(
+            [".fernignore", "README.md", "src/drop/c.py", "src/keep/a.py", "src/keep/nested/b.py"].sort()
+        );
+    });
+});

--- a/packages/commons/github/src/__test__/publishSequence.integration.test.ts
+++ b/packages/commons/github/src/__test__/publishSequence.integration.test.ts
@@ -1,0 +1,74 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+import { simpleGit } from "simple-git";
+import tmp from "tmp-promise";
+import { describe, expect, it } from "vitest";
+
+import { ClonedRepository } from "../ClonedRepository.js";
+import { expandFernignorePatterns } from "../expandFernignorePatterns.js";
+
+async function makeRepoWith(files: Record<string, string>): Promise<string> {
+    const dir = (await tmp.dir({ unsafeCleanup: true })).path;
+    const git = simpleGit(dir);
+    await git.init();
+    await git.addConfig("user.name", "test");
+    await git.addConfig("user.email", "test@example.com");
+    for (const [relPath, contents] of Object.entries(files)) {
+        const absPath = path.join(dir, relPath);
+        await mkdir(path.dirname(absPath), { recursive: true });
+        await writeFile(absPath, contents);
+    }
+    await git.add(".");
+    await git.commit("initial");
+    return dir;
+}
+
+async function makeSourceDirWith(files: Record<string, string>): Promise<string> {
+    const dir = (await tmp.dir({ unsafeCleanup: true })).path;
+    for (const [relPath, contents] of Object.entries(files)) {
+        const absPath = path.join(dir, relPath);
+        await mkdir(path.dirname(absPath), { recursive: true });
+        await writeFile(absPath, contents);
+    }
+    return dir;
+}
+
+async function readIfExists(absPath: string): Promise<string | undefined> {
+    try {
+        return await readFile(absPath, "utf-8");
+    } catch {
+        return undefined;
+    }
+}
+
+describe(".fernignore preservation through the publish sequence", () => {
+    it("preserves files matching a glob and lets the generator replace the rest", async () => {
+        const repoDir = await makeRepoWith({
+            ".fernignore": "src/keep/**\n",
+            "src/keep/a.py": "customer-a",
+            "src/keep/nested/b.py": "customer-b",
+            "src/replace/c.py": "old-generator-c"
+        });
+        const sourceDir = await makeSourceDirWith({
+            "src/replace/c.py": "new-generator-c",
+            "src/new/d.py": "new-generator-d"
+        });
+        const repo = ClonedRepository.createAtPath(repoDir);
+
+        const fernignore = await repo.getFernignore();
+        const tracked = await repo.listTrackedFiles();
+        const preserved = fernignore !== undefined ? expandFernignorePatterns(fernignore, tracked) : [];
+
+        await repo.overwriteLocalContents(sourceDir);
+        await repo.add(".");
+        if (preserved.length > 0) {
+            await repo.restoreFiles({ files: preserved, staged: true });
+            await repo.restoreFiles({ files: preserved });
+        }
+
+        expect(await readIfExists(path.join(repoDir, "src/keep/a.py"))).toBe("customer-a");
+        expect(await readIfExists(path.join(repoDir, "src/keep/nested/b.py"))).toBe("customer-b");
+        expect(await readIfExists(path.join(repoDir, "src/replace/c.py"))).toBe("new-generator-c");
+        expect(await readIfExists(path.join(repoDir, "src/new/d.py"))).toBe("new-generator-d");
+    });
+});

--- a/packages/commons/github/src/expandFernignorePatterns.ts
+++ b/packages/commons/github/src/expandFernignorePatterns.ts
@@ -1,7 +1,8 @@
 import { minimatch } from "minimatch";
 
-const GLOB_CHARS = /[*?[\]{}!]/;
-
+// Negation (`!pattern`) is NOT honored — every entry is treated as include-only.
+// `.fernignore` is a flat list of paths to protect; gitignore-style re-inclusion
+// isn't part of the contract.
 export function expandFernignorePatterns(fernignoreContent: string, candidatePaths: string[]): string[] {
     const patterns = fernignoreContent
         .split("\n")
@@ -11,8 +12,9 @@ export function expandFernignorePatterns(fernignoreContent: string, candidatePat
 }
 
 function matches(candidate: string, pattern: string): boolean {
-    if (!GLOB_CHARS.test(pattern)) {
-        return candidate === pattern || candidate.startsWith(pattern + "/");
+    const normalized = pattern.endsWith("/") ? pattern.slice(0, -1) : pattern;
+    if (minimatch(candidate, normalized, { dot: true })) {
+        return true;
     }
-    return minimatch(candidate, pattern, { dot: true });
+    return candidate === normalized || candidate.startsWith(normalized + "/");
 }

--- a/packages/commons/github/src/expandFernignorePatterns.ts
+++ b/packages/commons/github/src/expandFernignorePatterns.ts
@@ -3,7 +3,10 @@ import { minimatch } from "minimatch";
 const GLOB_CHARS = /[*?[\]{}!]/;
 
 export function expandFernignorePatterns(fernignoreContent: string, candidatePaths: string[]): string[] {
-    const patterns = fernignoreContent.split("\n");
+    const patterns = fernignoreContent
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0 && !line.startsWith("#"));
     return candidatePaths.filter((candidate) => patterns.some((pattern) => matches(candidate, pattern)));
 }
 

--- a/packages/commons/github/src/expandFernignorePatterns.ts
+++ b/packages/commons/github/src/expandFernignorePatterns.ts
@@ -1,0 +1,8 @@
+import { minimatch } from "minimatch";
+
+export function expandFernignorePatterns(fernignoreContent: string, candidatePaths: string[]): string[] {
+    const patterns = fernignoreContent.split("\n");
+    return candidatePaths.filter((candidate) =>
+        patterns.some((pattern) => minimatch(candidate, pattern, { dot: true }))
+    );
+}

--- a/packages/commons/github/src/expandFernignorePatterns.ts
+++ b/packages/commons/github/src/expandFernignorePatterns.ts
@@ -1,8 +1,15 @@
 import { minimatch } from "minimatch";
 
+const GLOB_CHARS = /[*?[\]{}!]/;
+
 export function expandFernignorePatterns(fernignoreContent: string, candidatePaths: string[]): string[] {
     const patterns = fernignoreContent.split("\n");
-    return candidatePaths.filter((candidate) =>
-        patterns.some((pattern) => minimatch(candidate, pattern, { dot: true }))
-    );
+    return candidatePaths.filter((candidate) => patterns.some((pattern) => matches(candidate, pattern)));
+}
+
+function matches(candidate: string, pattern: string): boolean {
+    if (!GLOB_CHARS.test(pattern)) {
+        return candidate === pattern || candidate.startsWith(pattern + "/");
+    }
+    return minimatch(candidate, pattern, { dot: true });
 }

--- a/packages/commons/github/src/index.ts
+++ b/packages/commons/github/src/index.ts
@@ -2,6 +2,7 @@ export { ClonedRepository } from "./ClonedRepository.js";
 export { cloneRepository } from "./cloneRepository.js";
 export { createOrUpdatePullRequest } from "./createOrUpdatePullRequest.js";
 export { deleteBranch } from "./deleteBranch.js";
+export { expandFernignorePatterns } from "./expandFernignorePatterns.js";
 export { getFileContent } from "./getFileContent.js";
 export { getGithubApiBaseUrl } from "./getGithubApiBaseUrl.js";
 export { getLatestRelease } from "./getLatestRelease.js";

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -41,7 +41,7 @@
     "@fern-api/docker-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-api/replay": "0.16.1",
+    "@fern-api/replay": "0.16.2",
     "@fern-api/task-context": "workspace:*",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",

--- a/packages/generator-cli/src/github/GitHub.ts
+++ b/packages/generator-cli/src/github/GitHub.ts
@@ -1,5 +1,11 @@
 import { cwd, resolve } from "@fern-api/fs-utils";
-import { ClonedRepository, cloneRepository, getGithubApiBaseUrl, parseRepository } from "@fern-api/github";
+import {
+    ClonedRepository,
+    cloneRepository,
+    expandFernignorePatterns,
+    getGithubApiBaseUrl,
+    parseRepository
+} from "@fern-api/github";
 import { Octokit } from "@octokit/rest";
 
 import type { FernGeneratorCli } from "../configuration/sdk/index.js";
@@ -136,19 +142,8 @@ export class GitHub {
         if (fernignore === undefined) {
             return [];
         }
-        const fernignoreLines = fernignore.split("\n");
-        const fernignoreFiles: string[] = [];
-        for (const line of fernignoreLines) {
-            const trimmedLine = line.trim();
-            if (
-                !trimmedLine.startsWith("#") &&
-                trimmedLine.length > 0 &&
-                (await repository.fileExists({ relativeFilePath: trimmedLine }))
-            ) {
-                fernignoreFiles.push(trimmedLine);
-            }
-        }
-        return fernignoreFiles;
+        const tracked = await repository.listTrackedFiles();
+        return expandFernignorePatterns(fernignore, tracked);
     }
 
     private async restoreFiles(repository: ClonedRepository, files: string[]): Promise<void> {

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,25 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Expand `.fernignore` glob patterns before the generator wipe.
+        `getFernignoreFiles` previously matched each line literally via
+        `fileExists`, so a pattern like `src/foo/**` was checked as a file
+        literally named `**` and silently produced no matches — the wipe
+        then deleted the customer's files. Now patterns are run through
+        the same `minimatch` (with `dot: true`) that `@fern-api/replay`
+        uses, expanded against the HEAD-tracked file list, and passed
+        concrete paths to the existing `restoreFiles` step. Trailing-slash
+        (`src/foo/`), bare-directory (`src/foo`), extglob (`+(a|b)`), and
+        dotfile (`.github/**`) patterns are all honored.
+      type: fix
+    - summary: |
+        Bump @fern-api/replay to 0.16.2.
+      type: chore
+  createdAt: "2026-05-21"
+  version: 0.9.34
+
+- changelogEntry:
+    - summary: |
         Bump @fern-api/replay to 0.16.1.
       type: chore
   createdAt: "2026-05-20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7713,6 +7713,9 @@ importers:
       '@fern-api/core-utils':
         specifier: workspace:*
         version: link:../core-utils
+      minimatch:
+        specifier: '>=10.2.3'
+        version: 10.2.5
       octokit:
         specifier: ^4.1.4
         version: 4.1.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7978,8 +7978,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/logging-execa
       '@fern-api/replay':
-        specifier: 0.16.1
-        version: 0.16.1
+        specifier: 0.16.2
+        version: 0.16.2
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../cli/task-context
@@ -9495,6 +9495,11 @@ packages:
 
   '@fern-api/replay@0.16.1':
     resolution: {integrity: sha512-860fIHdRORH4Xg908oxBC6pduiujRdgsb8NguvHt+cQE2lHcEOqsHwUIjiWtmBW09h8Hpi9xf8nGdk6vtBpe+g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@fern-api/replay@0.16.2':
+    resolution: {integrity: sha512-eUg5d5qay8C+3nin5dWCOLGji/HcmWsA9hQL1cISO+eH58dJjufGd92hxjsD02sw5eX0CuDzzq6LMuYVW2Swzg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16438,6 +16443,15 @@ snapshots:
       - supports-color
 
   '@fern-api/replay@0.16.1':
+    dependencies:
+      minimatch: 10.2.5
+      node-diff3: 3.2.0
+      simple-git: 3.36.0
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fern-api/replay@0.16.2':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Summary

Customer-reported data loss: the fern-bot regen PR on the smallest-ai Python SDK ([fern-demo/smallest-ai-python-sdk#64](https://github.com/fern-demo/smallest-ai-python-sdk/pull/64)) deleted files matching the customer's `.fernignore` (`src/smallestai/atoms/helpers/**`, `src/smallestai/cli/**`).

### Root cause

`GitHub.getFernignoreFiles` (`packages/generator-cli/src/github/GitHub.ts`) called `repository.fileExists({ relativeFilePath: trimmedLine })` for each line in `.fernignore` — literal-only matching. A pattern like `src/foo/**` was checked as a file literally named `**`, returned false, and never reached the preserve list. `overwriteLocalContents()` then wiped the customer's files and `restoreFiles` ran with an empty list.

### Fix

A new pure helper `expandFernignorePatterns(content, candidatePaths)` in `@fern-api/github` runs each pattern through `minimatch` (the matcher `@fern-api/replay` already uses, with `dot: true`) against the HEAD-tracked file list returned by the new `ClonedRepository.listTrackedFiles()`. The existing `restoreFiles` mechanism is unchanged — it now receives concrete file paths instead of un-expanded patterns.

Supported pattern shapes (regression-tested):
- `src/foo/**` — globs
- `src/foo` — bare directory (preserves contents)
- `src/foo/` — trailing-slash directory (gitignore-style)
- `LICENSE` — literal file
- `.github/**` — dotfile expansion (`dot: true`)
- `src/+(foo|bar)/**` — extglob

Per [ADR 0002](https://github.com/fern-api/fern-replay/blob/main/docs/adr/0002-fernignore-hands-off-contract.md) in `@fern-api/replay`, `.fernignore`-matched files are protected at the generator-wipe layer. Replay stays entirely out of this loop; this PR makes the implementation match that contract.

### Bundled release

- Bumps `@fern-api/replay` to **0.16.2** (the matching release that ships the lockfile-cleanse half of the customer story).
- Cuts `@fern-api/generator-cli` **0.9.34**.

### Out of scope (separate follow-ups)

- `LocalTaskHandler` / `RemoteTaskHandler` in `packages/cli/generation/` pass raw `.fernignore` strings as git pathspecs to `git reset` / `git clean` — parallel data-loss bug on the local-generate path.
- Fiddle's Java `GithubFiddleTask.java` legacy path (literal `trackedFiles.contains(pattern)`).

## Test plan

- [x] `pnpm turbo run test --filter @fern-api/github` — 28/28 pass, includes the customer-shaped integration test that walks through the full publish sequence on a real tmp git repo
- [x] `pnpm turbo run test --filter @fern-api/generator-cli` — 412/412 pass
- [x] `pnpm turbo run compile --filter @fern-api/github --filter @fern-api/generator-cli --filter "...@fern-api/generator-cli"` — 95/95 packages compile clean
- [ ] Manual: regenerate against the smallest-ai customer repo on a side branch and confirm `helpers/**` files survive the wipe
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->