### PR TITLE
chore(deps): bump @fern-api/generator-cli to 0.9.35 (catalog pin + Python/TS/CLI changelogs)

### DIFF
--- a/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.35.yml
+++ b/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.35.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.35, which disables minimatch negation
+    on `.fernignore` patterns so a stray `!pattern` no longer silently inverts
+    the match and discards generator output.
+  type: fix

--- a/generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.35.yml
+++ b/generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.35.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.35, which disables minimatch negation
+    on `.fernignore` patterns so a stray `!pattern` no longer silently inverts
+    the match and discards generator output.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/bump-generator-cli-0.9.35.yml
+++ b/packages/cli/cli/changes/unreleased/bump-generator-cli-0.9.35.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.35, which disables minimatch negation
+    on `.fernignore` patterns so a stray `!pattern` no longer silently inverts
+    the match and discards generator output.
+  type: fix

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.34
-      version: 0.9.34
+      specifier: 0.9.35
+      version: 0.9.35
     '@fern-api/venus-api-sdk':
       specifier: 0.22.34
       version: 0.22.34
@@ -630,7 +630,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.34
+        version: 0.9.35
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0
@@ -699,7 +699,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.34
+        version: 0.9.35
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2466,7 +2466,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.34
+        version: 0.9.35
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9489,8 +9489,8 @@ packages:
   '@fern-api/fdr-sdk@1.2.4-f661387fb2':
     resolution: {integrity: sha512-wlk1lTCIZ7biND4vQf8jvhUw9P/rBQ5pXASCrumv8R96up0B3DY6yiY1C4VmFyHmp/kPhcjzc5T9TvHZZxFdrA==}
 
-  '@fern-api/generator-cli@0.9.34':
-    resolution: {integrity: sha512-TaxOiakFHZPjP7zGSS7OK9eW3w5pTJ56W8yx7nJCUlTVGv4PiS5ORLBMb6OGBEXwpoKJiFv3oZ5dMTx9tAqkDw==}
+  '@fern-api/generator-cli@0.9.35':
+    resolution: {integrity: sha512-84+K5K4jquuqpMo3p2NDk/OJuiyZtRcQW5tlEYH3R9y7G5wX71qwAWM21qWqu6+vYfN1oZ+4fUcqgqp6tOhxVA==}
     hasBin: true
 
   '@fern-api/replay@0.16.2':
@@ -16426,7 +16426,7 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.34':
+  '@fern-api/generator-cli@0.9.35':
     dependencies:
       '@boundaryml/baml': 0.219.0
       '@fern-api/replay': 0.16.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.33
-      version: 0.9.33
+      specifier: 0.9.34
+      version: 0.9.34
     '@fern-api/venus-api-sdk':
       specifier: 0.22.34
       version: 0.22.34
@@ -630,7 +630,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.33
+        version: 0.9.34
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0
@@ -699,7 +699,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.33
+        version: 0.9.34
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2466,7 +2466,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.33
+        version: 0.9.34
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9489,13 +9489,8 @@ packages:
   '@fern-api/fdr-sdk@1.2.4-f661387fb2':
     resolution: {integrity: sha512-wlk1lTCIZ7biND4vQf8jvhUw9P/rBQ5pXASCrumv8R96up0B3DY6yiY1C4VmFyHmp/kPhcjzc5T9TvHZZxFdrA==}
 
-  '@fern-api/generator-cli@0.9.33':
-    resolution: {integrity: sha512-KG5lQEbJr5x2Z7Ggbzyv/2/JGCSJ5IYBMFFYVhzx2MCf+XJPhw+G4X1l199M7PCrIoNXKD7WBiqCmQkgiKSjQQ==}
-    hasBin: true
-
-  '@fern-api/replay@0.16.1':
-    resolution: {integrity: sha512-860fIHdRORH4Xg908oxBC6pduiujRdgsb8NguvHt+cQE2lHcEOqsHwUIjiWtmBW09h8Hpi9xf8nGdk6vtBpe+g==}
-    engines: {node: '>=18'}
+  '@fern-api/generator-cli@0.9.34':
+    resolution: {integrity: sha512-TaxOiakFHZPjP7zGSS7OK9eW3w5pTJ56W8yx7nJCUlTVGv4PiS5ORLBMb6OGBEXwpoKJiFv3oZ5dMTx9tAqkDw==}
     hasBin: true
 
   '@fern-api/replay@0.16.2':
@@ -16431,23 +16426,14 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.33':
+  '@fern-api/generator-cli@0.9.34':
     dependencies:
       '@boundaryml/baml': 0.219.0
-      '@fern-api/replay': 0.16.1
+      '@fern-api/replay': 0.16.2
       '@octokit/rest': 22.0.1
       es-toolkit: 1.45.1
       semver: 7.7.4
       tmp-promise: 3.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@fern-api/replay@0.16.1':
-    dependencies:
-      minimatch: 10.2.5
-      node-diff3: 3.2.0
-      simple-git: 3.36.0
-      yaml: 2.8.3
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.2.4-f661387fb2
-  "@fern-api/generator-cli": 0.9.33
+  "@fern-api/generator-cli": 0.9.34
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.2.4-f661387fb2
-  "@fern-api/generator-cli": 0.9.34
+  "@fern-api/generator-cli": 0.9.35
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description\nRefs https://github.com/fern-api/fern/pull/16032\n\nBumps `@fern-api/generator-cli` to 0.9.35 across the monorepo:\n- Catalog pin in `pnpm-workspace.yaml`\n- Unreleased changelog entries for Python SDK, TypeScript SDK, and CLI so automation cuts new versions with the updated generator-cli\n\nGenerator-cli 0.9.35 includes:\n- fix: pass `nonegate: true` to minimatch on `.fernignore` (prevents `!pattern` inversion)\n- fix: expand .fernignore glob patterns before the wipe\n- chore: bump @fern-api/replay to 0.16.2\n\n## Changes Made\n- Updated `pnpm-workspace.yaml` catalog: `@fern-api/generator-cli` 0.9.34 → 0.9.35\n- Updated `pnpm-lock.yaml` accordingly\n- Added `generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.35.yml`\n- Added `generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.35.yml`\n- Added `packages/cli/cli/changes/unreleased/bump-generator-cli-0.9.35.yml`\n\n## Testing\n- [x] No code changes — dependency pin bump + changelog entries only\n- [x] Lock file regenerated cleanly

Link to Devin session: https://app.devin.ai/sessions/c20ea16296234011b65ac875e8c8803f
Requested by: @tstanmay13