### PR TITLE
fix(generator-cli): pass nonegate:true to minimatch on .fernignore

### DIFF
--- a/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
+++ b/packages/commons/github/src/__test__/expandFernignorePatterns.test.ts
@@ -65,4 +65,13 @@ describe("expandFernignorePatterns", () => {
 
         expect([...preserved].sort()).toEqual(["src/bar/b.py", "src/foo/a.py"].sort());
     });
+
+    it("treats a leading `!` as literal so minimatch does not silently invert the result", () => {
+        const fernignore = "!src/bar";
+        const tracked = ["src/foo/a.py", "src/bar/b.py"];
+
+        const preserved = expandFernignorePatterns(fernignore, tracked);
+
+        expect(preserved).toEqual([]);
+    });
 });

--- a/packages/commons/github/src/expandFernignorePatterns.ts
+++ b/packages/commons/github/src/expandFernignorePatterns.ts
@@ -13,7 +13,10 @@ export function expandFernignorePatterns(fernignoreContent: string, candidatePat
 
 function matches(candidate: string, pattern: string): boolean {
     const normalized = pattern.endsWith("/") ? pattern.slice(0, -1) : pattern;
-    if (minimatch(candidate, normalized, { dot: true })) {
+    // `nonegate` makes `!` a literal character. Without it, minimatch would
+    // invert the result and a stray `!pattern` would silently preserve nearly
+    // every file — discarding generator output instead of customer code.
+    if (minimatch(candidate, normalized, { dot: true, nonegate: true })) {
         return true;
     }
     return candidate === normalized || candidate.startsWith(normalized + "/");

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Disable minimatch negation on `.fernignore` patterns so a stray `!pattern` doesn't silently invert the match and discard generator output.
+      type: fix
+  createdAt: "2026-05-21"
+  version: 0.9.35
+
+- changelogEntry:
+    - summary: |
         Expand `.fernignore` glob patterns before the generator wipe.
         `getFernignoreFiles` previously matched each line literally via
         `fileExists`, so a pattern like `src/foo/**` was checked as a file


### PR DESCRIPTION
## Summary

Follow-up to #16030. Closes a silent-failure mode an external reviewer flagged on that PR.

`expandFernignorePatterns` calls `minimatch(candidate, pattern, { dot: true })`. With default settings, a pattern that starts with `!` is treated as **logical negation** — the predicate is inverted. So `!src/bar` returns "every file that isn't literally `src/bar`," which is essentially the entire tracked list.

That list flows into `GitHub.getFernignoreFiles` → `restoreFiles` → `git restore <every-file> --source=HEAD`. The generator's fresh output is silently discarded and the customer's SDK regen produces a PR with **no API changes**.

A customer trips this trivially by copy-pasting `!path` from a `.gitignore` (where `!` legitimately means re-include). The regen "succeeds," the PR opens, and the customer's API changes never reach their SDK.

## Fix

One line: pass `{ dot: true, nonegate: true }` so `!` is a literal character in patterns. The existing comment in this file already claimed negation was disabled — this enforces it.

Cuts `@fern-api/generator-cli` **0.9.35**. Also trims the 0.9.34 changelog entry that just shipped to match the rest of `versions.yml`.

## Test plan

- [x] `pnpm turbo run test --filter @fern-api/github` — RED→GREEN regression test that runs `!src/bar` against a known tracked list and asserts the predicate doesn't invert. All other tests in the suite pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->