### PR TITLE
feat(cli): add gzip compression to v2 docs publish requests

### DIFF
--- a/packages/cli/cli/changes/unreleased/feat-v2-gzip-compression.yml
+++ b/packages/cli/cli/changes/unreleased/feat-v2-gzip-compression.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Gzip-compress v2 docs publish request bodies (register, finish, API
+    registration, translation registration) to reduce transfer time for
+    large deployments.
+  type: feat

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/compressedFetch.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/compressedFetch.ts
@@ -1,0 +1,48 @@
+/**
+ * Returns a `fetch` function that gzip-compresses request bodies using the
+ * Web Streams `CompressionStream` API.
+ *
+ * Designed to be captured by oRPC's `LinkFetchClient` at construction time
+ * so all subsequent requests through the client are transparently compressed.
+ *
+ * The FDR server registers `@fastify/compress` which transparently
+ * decompresses incoming `Content-Encoding: gzip` request bodies.
+ */
+export function createGzipFetch(): typeof globalThis.fetch {
+    return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        if (input instanceof Request && input.body != null) {
+            const headers = new Headers(input.headers);
+            headers.set("Content-Encoding", "gzip");
+            headers.delete("Content-Length");
+
+            const compressedBody = input.body.pipeThrough(new CompressionStream("gzip"));
+
+            const compressedRequest = new Request(input.url, {
+                method: input.method,
+                headers,
+                body: compressedBody,
+                // @ts-expect-error duplex required for streaming request bodies in Node.js
+                duplex: "half"
+            });
+            return globalThis.fetch(compressedRequest, init);
+        }
+
+        return globalThis.fetch(input, init);
+    };
+}
+
+/**
+ * Gzip-compresses a JSON body and returns a `RequestInit` suitable for
+ * `fetch()`, with the correct `Content-Encoding` and `Content-Type` headers.
+ */
+export async function gzipJsonBody(body: unknown): Promise<{ body: ReadableStream; headers: Record<string, string> }> {
+    const json = JSON.stringify(body);
+    const stream = new Blob([json]).stream().pipeThrough(new CompressionStream("gzip"));
+    return {
+        body: stream,
+        headers: {
+            "Content-Encoding": "gzip",
+            "Content-Type": "application/json"
+        }
+    };
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -45,6 +45,7 @@ import { readFile } from "fs/promises";
 import { chunk } from "lodash-es";
 import * as mime from "mime-types";
 import terminalLink from "terminal-link";
+import { createGzipFetch, gzipJsonBody } from "./compressedFetch.js";
 import { getDynamicGeneratorConfig } from "./getDynamicGeneratorConfig.js";
 import { measureImageSizes } from "./measureImageSizes.js";
 import { asyncPool } from "./utils/asyncPool.js";
@@ -205,10 +206,17 @@ export async function publishDocs({
     if (deployerAuthor?.email != null) {
         headers["X-Deployer-Author-Email"] = deployerAuthor.email;
     }
+    // Capture a gzip-compressing fetch into the oRPC client so all FDR
+    // requests with a body are transparently compressed.  LinkFetchClient
+    // snapshots globalThis.fetch at construction time, so we swap it in
+    // before building the client and restore immediately after.
+    const savedFetch = globalThis.fetch;
+    globalThis.fetch = createGzipFetch();
     const fdr = createFdrService({
         token: token.value,
         ...(Object.keys(headers).length > 0 && { headers })
     });
+    globalThis.fetch = savedFetch;
     const authConfig = { type: "public" as const };
 
     if (excludeApis) {
@@ -821,24 +829,28 @@ export async function publishDocs({
                         );
                         // Use a raw fetch instead of the oRPC client to send `docsDefinition`
                         // (the live server expects that field; the published fdr-sdk still uses `content`).
+                        const translationPayload = {
+                            domain: translationDomain,
+                            // Send customDomains in production so FDR fans the translation
+                            // S3 write out across every URL the docs are published to.
+                            // Skipped in preview because preview deploys to a single
+                            // ephemeral URL with no custom-domain mirrors.
+                            customDomains: preview ? [] : customDomains,
+                            orgId: organization,
+                            locale,
+                            docsDefinition: translatedDefinition
+                        };
+                        const compressed = await gzipJsonBody(translationPayload);
                         const translationResponse = await fetch(`${fdrOrigin}/v2/registry/docs/translations/register`, {
                             method: "POST",
                             headers: {
-                                "Content-Type": "application/json",
+                                ...compressed.headers,
                                 Authorization: `Bearer ${token.value}`,
                                 ...headers // Include telemetry headers (X-CLI-Version, X-CI-Source, etc.)
                             },
-                            body: JSON.stringify({
-                                domain: translationDomain,
-                                // Send customDomains in production so FDR fans the translation
-                                // S3 write out across every URL the docs are published to.
-                                // Skipped in preview because preview deploys to a single
-                                // ephemeral URL with no custom-domain mirrors.
-                                customDomains: preview ? [] : customDomains,
-                                orgId: organization,
-                                locale,
-                                docsDefinition: translatedDefinition
-                            })
+                            body: compressed.body,
+                            // @ts-expect-error duplex required for streaming request bodies in Node.js
+                            duplex: "half"
                         });
                         if (!translationResponse.ok) {
                             const body = await translationResponse.text();


### PR DESCRIPTION
## Description
Refs FER-10484

Adds transparent gzip compression to the v2 (current default) docs publish request bodies. This is the companion to https://github.com/fern-api/fern/pull/16033 which does the same for the docs-ledger write path.

## Changes Made
- New `compressedFetch.ts`: `createGzipFetch()` returns a `fetch` wrapper that pipes request bodies through `CompressionStream("gzip")` and sets `Content-Encoding: gzip`. Also exports `gzipJsonBody()` for raw fetch calls.
- `publishDocs.ts`: The `FdrClient` is constructed while `globalThis.fetch` is temporarily replaced with the gzip fetch, so oRPC's `LinkFetchClient` captures it for all subsequent calls (register, finish, API registration).
- `publishDocs.ts`: The raw `fetch` translation registration call now uses `gzipJsonBody()` to compress its JSON body.
- Changelog entry added.

## How it works
1. oRPC's `LinkFetchClient` snapshots `globalThis.fetch` at construction time
2. We temporarily swap in a gzip-compressing fetch before building the `FdrClient`, then restore immediately after
3. All subsequent requests through the oRPC client use the captured gzip fetch — bodies are piped through `CompressionStream("gzip")` with `Content-Encoding: gzip` header
4. FDR's `@fastify/compress` transparently decompresses on the server side
5. File uploads to S3 (via axios) and dynamic IR uploads are unaffected

## Testing
- [x] Biome lint, format, and check all pass
- [ ] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/08fa84ed296b46629c0316c86ee1aca1
Requested by: @broady