### PR TITLE
chore(ci): migrate dynamic-ir-sdk publishing from NPM_TOKEN to OIDC

### DIFF
--- a/.github/workflows/ir-release.yml
+++ b/.github/workflows/ir-release.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Release SDKs
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-          NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
         run: |
           cd packages/ir-sdk
           version=$(cat fern/apis/ir-types-latest/VERSION)

--- a/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
@@ -24,7 +24,7 @@ groups:
         output:
           location: npm
           package-name: "@fern-api/dynamic-ir-sdk"
-          token: ${NPM_TOKEN}
+          token: OIDC
         config:
           noOptionalProperties: false
         smart-casing: false


### PR DESCRIPTION
## Description

Migrates `@fern-api/dynamic-ir-sdk` publishing from using `NPM_TOKEN` secret to OIDC trusted publishing via Fern's generation system.

## Changes Made

- Changed `token: ${NPM_TOKEN}` to `token: OIDC` in `packages/ir-sdk/fern/apis/ir-types-latest/generators.yml` for the `dynamic-ir` group
- Removed `NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}` env var from the `dynamic-ir` job in `.github/workflows/ir-release.yml`

This mirrors the approach already used by `@fern-api/venus-api-sdk` which uses `token: OIDC` in its generators.yml.

## Testing

- [ ] Manual testing completed — no code changes, only CI config
- **Pre-merge requirement:** Configure npm trusted publisher for `@fern-api/dynamic-ir-sdk` at https://www.npmjs.com/package/@fern-api/dynamic-ir-sdk/access → Add trusted publisher for the Fern generation infrastructure (same OIDC config used by venus-api-sdk)

Link to Devin session: https://app.devin.ai/sessions/82f5751c688442aba14fc2fbb515c352
Requested by: @davidkonigsberg