### PR TITLE
feat(cli-v2): add --json global flag with structured error envelope

### DIFF
--- a/packages/cli/cli-v2/src/__test__/renderError.test.ts
+++ b/packages/cli/cli-v2/src/__test__/renderError.test.ts
@@ -143,3 +143,144 @@ describe("renderError", () => {
         expect(out).toContain("caused by: Error: inner");
     });
 });
+
+describe("renderError --json mode", () => {
+    function renderJson(error: unknown, options: { debug?: boolean; logFile?: string } = {}): Record<string, unknown> {
+        const out = renderError(error, { json: true, ...options });
+        if (out == null) {
+            throw new Error("renderError returned null in JSON mode");
+        }
+        return JSON.parse(out) as Record<string, unknown>;
+    }
+
+    it("returns null for TaskAbortSignal even in JSON mode", () => {
+        expect(renderError(new TaskAbortSignal(), { json: true })).toBeNull();
+    });
+
+    it("emits an envelope with code, message, hint and docsLink for a CliError", () => {
+        const error = new CliError({
+            code: CliError.Code.AuthError,
+            message: "You are not logged in.",
+            hint: "Run `fern auth login`.",
+            docsLink: "https://buildwithfern.com/learn/cli/auth"
+        });
+
+        const envelope = renderJson(error);
+
+        expect(envelope).toMatchObject({
+            ok: false,
+            code: "AUTH_ERROR",
+            message: "You are not logged in.",
+            hint: "Run `fern auth login`.",
+            docsLink: "https://buildwithfern.com/learn/cli/auth"
+        });
+        expect(envelope).not.toHaveProperty("debug");
+        expect(envelope).not.toHaveProperty("logFile");
+    });
+
+    it("falls back to a per-code title when the CliError has no message", () => {
+        const envelope = renderJson(new CliError({ code: CliError.Code.ValidationError }));
+        expect(envelope.code).toBe("VALIDATION_ERROR");
+        expect(envelope.message).toBe("Validation failed");
+    });
+
+    it("serializes ValidationError violations", () => {
+        const error = new ValidationError([
+            {
+                severity: "error",
+                relativeFilepath: "fern.yml",
+                message: "org is required",
+                nodePath: ["fern", "config"]
+            }
+        ]);
+
+        const envelope = renderJson(error);
+
+        expect(envelope.code).toBe("VALIDATION_ERROR");
+        expect(envelope.violations).toEqual([
+            {
+                severity: "error",
+                message: "org is required",
+                file: "fern.yml",
+                nodePath: "fern.config"
+            }
+        ]);
+    });
+
+    it("serializes SourcedValidationError issues with file/line/column", () => {
+        const location = new SourceLocation({
+            absoluteFilePath: AbsoluteFilePath.of("/tmp/fern.yml"),
+            relativeFilePath: RelativeFilePath.of("fern.yml"),
+            line: 7,
+            column: 13
+        });
+        const issue = new ValidationIssue({
+            location,
+            message: "sdks.targets.node.lang must be one of: csharp, go, java"
+        });
+
+        const envelope = renderJson(new SourcedValidationError([issue]));
+
+        expect(envelope.code).toBe("VALIDATION_ERROR");
+        expect(envelope.violations).toEqual([
+            {
+                severity: "error",
+                message: "sdks.targets.node.lang must be one of: csharp, go, java",
+                file: "fern.yml",
+                line: 7,
+                column: 13
+            }
+        ]);
+    });
+
+    it("sets code=null for unknown thrown values", () => {
+        const envelope = renderJson("oops, a string was thrown");
+        expect(envelope.code).toBeNull();
+        expect(envelope.message).toBe("oops, a string was thrown");
+    });
+
+    it("sets code=null for plain Error instances", () => {
+        const envelope = renderJson(new Error("boom"));
+        expect(envelope.code).toBeNull();
+        expect(envelope.message).toBe("boom");
+    });
+
+    it("includes logFile when supplied", () => {
+        const envelope = renderJson(new CliError({ code: CliError.Code.InternalError, message: "boom" }), {
+            logFile: "/tmp/fern/logs/2026-05-20T18-58-00.log"
+        });
+        expect(envelope.logFile).toBe("/tmp/fern/logs/2026-05-20T18-58-00.log");
+    });
+
+    it("includes a debug block with stack and causes when debug=true", () => {
+        const cause = new Error("inner");
+        const outer = new CliError({ code: CliError.Code.InternalError, message: "outer" });
+        (outer as { cause?: unknown }).cause = cause;
+
+        const envelope = renderJson(outer, { debug: true });
+
+        expect(envelope.debug).toBeDefined();
+        const debugInfo = envelope.debug as { stack?: string; causes?: string[] };
+        expect(debugInfo.stack).toContain("outer");
+        expect(debugInfo.causes).toEqual(["Error: inner"]);
+    });
+
+    it("omits the debug block when debug=false", () => {
+        const envelope = renderJson(new CliError({ code: CliError.Code.InternalError, message: "boom" }));
+        expect(envelope).not.toHaveProperty("debug");
+    });
+
+    it("produces parseable JSON with no ANSI escape codes", () => {
+        const out = renderError(
+            new CliError({
+                code: CliError.Code.AuthError,
+                message: "Unauthorized.",
+                hint: "Run `fern auth login`."
+            }),
+            { json: true }
+        );
+        // biome-ignore lint/suspicious/noControlCharactersInRegex: assertion that no ANSI escape (ESC=0x1b) leaks into the JSON envelope.
+        expect(out).not.toMatch(/\u001b\[/);
+        expect(() => JSON.parse(out ?? "")).not.toThrow();
+    });
+});

--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -120,6 +120,12 @@ function createCliV2(argv?: string[]): Argv<GlobalArgs> {
             description: "Show full stack traces and error cause chains (also: FERN_DEBUG=1)",
             default: false
         })
+        .option("json", {
+            type: "boolean",
+            description:
+                "Render errors as JSON on stderr (for CI/agents). Commands that support --json for success output already accept this flag.",
+            default: false
+        })
         .option("env", {
             type: "string",
             description: "Path to a .env file to load environment variables from"

--- a/packages/cli/cli-v2/src/commands/_internal/yargsFailHandler.ts
+++ b/packages/cli/cli-v2/src/commands/_internal/yargsFailHandler.ts
@@ -22,11 +22,14 @@ export function makeYargsFailHandler({
 }): (msg: string | null, err: Error | null, y: Argv<GlobalArgs>) => void {
     return (msg, err, y) => {
         const error = err ?? new CliError({ code: CliError.Code.UserError, message: msg ?? "Invalid usage." });
-        const rendered = renderError(error);
+        const json = isJsonFlagInArgv();
+        const rendered = renderError(error, { json });
         if (rendered != null) {
             process.stderr.write(`${rendered}\n`);
         }
-        if (showHelp) {
+        // In JSON mode we suppress the human help block so the envelope on
+        // stderr is the only thing a caller has to parse.
+        if (showHelp && !json) {
             process.stderr.write("\n");
             y.showHelp("error");
         }
@@ -36,4 +39,25 @@ export function makeYargsFailHandler({
         // mapping ships separately.
         process.exit(1);
     };
+}
+
+/**
+ * Inspects `process.argv` for a `--json` (or `--json=true`) flag. We can't
+ * rely on yargs-parsed args here because `.fail` is called for usage errors
+ * that happen during parsing.
+ */
+function isJsonFlagInArgv(): boolean {
+    for (const arg of process.argv.slice(2)) {
+        if (arg === "--json") {
+            return true;
+        }
+        if (arg === "--no-json") {
+            return false;
+        }
+        if (arg.startsWith("--json=")) {
+            const value = arg.slice("--json=".length).toLowerCase();
+            return value === "true" || value === "1" || value === "yes";
+        }
+    }
+    return false;
 }

--- a/packages/cli/cli-v2/src/context/GlobalArgs.ts
+++ b/packages/cli/cli-v2/src/context/GlobalArgs.ts
@@ -6,4 +6,14 @@ export interface GlobalArgs {
      * failure. Mirrors `FERN_DEBUG=1`. Implies `--log-level debug`.
      */
     debug?: boolean;
+    /**
+     * When true, render errors as a JSON envelope on stderr so CI pipelines
+     * and agents can parse failure details without scraping human output.
+     *
+     * Commands that produce structured success output (e.g. `auth whoami`,
+     * `sdk list`) also declare this locally for their stdout path; the
+     * global flag guarantees the *error* path is JSON-serializable
+     * regardless of which command ran.
+     */
+    json?: boolean;
 }

--- a/packages/cli/cli-v2/src/context/withContext.ts
+++ b/packages/cli/cli-v2/src/context/withContext.ts
@@ -39,7 +39,7 @@ export function withContext<T extends GlobalArgs>(
         } catch (error) {
             reportError(context, error);
             await context.telemetry.flush();
-            handleError(context, error);
+            handleError(context, error, { json: args.json === true });
             context.finish();
             await exitGracefully(1);
         }
@@ -79,16 +79,21 @@ function isFernDebugEnv(): boolean {
  * on the most common failure path (we previously only did this on
  * SIGINT and `TaskGroup` failures).
  */
-function handleError(context: Context, error: unknown): void {
+function handleError(context: Context, error: unknown, options: { json: boolean }): void {
     if (error instanceof TaskAbortSignal) {
         return;
     }
     const debug = context.logLevel === LogLevel.Debug;
-    const rendered = renderError(error, { debug });
+    const logFile = options.json && !context.logs.empty() ? context.logs.absoluteFilePath : undefined;
+    const rendered = renderError(error, { debug, json: options.json, logFile });
     if (rendered != null) {
         process.stderr.write(`${rendered}\n`);
     }
-    context.printLogFilePath(process.stderr);
+    // Skip the dim log-file hint in JSON mode — it would corrupt the
+    // JSON envelope. The path is embedded inside the envelope as `logFile`.
+    if (!options.json) {
+        context.printLogFilePath(process.stderr);
+    }
 }
 
 /**

--- a/packages/cli/cli-v2/src/errors/renderError.ts
+++ b/packages/cli/cli-v2/src/errors/renderError.ts
@@ -12,6 +12,51 @@ export interface RenderErrorOptions {
      * Enables stack/cause-chain rendering for all error classes.
      */
     debug?: boolean;
+    /**
+     * When true, return a JSON envelope string instead of the human-readable
+     * Rust-style block. The envelope shape is {@link ErrorEnvelope}.
+     */
+    json?: boolean;
+    /**
+     * Absolute path to the debug log file for the current run. Surfaced in
+     * the JSON envelope as `logFile` so CI/agents can attach it to issue
+     * reports. Ignored in human mode (the log path is printed separately by
+     * `Context.printLogFilePath`).
+     */
+    logFile?: string;
+}
+
+/**
+ * Structured error envelope for `--json` mode.
+ *
+ * This is the public contract for CI/agents. Every field is optional except
+ * `ok` (always `false`) and `message`. Callers should **not** assume new
+ * fields won't be added — forward-compatible consumers should ignore unknown
+ * keys.
+ */
+export interface ErrorEnvelope {
+    ok: false;
+    code: CliError.Code | null;
+    message: string;
+    hint?: string;
+    docsLink?: string;
+    violations?: ErrorEnvelopeViolation[];
+    logFile?: string;
+    debug?: ErrorEnvelopeDebug;
+}
+
+export interface ErrorEnvelopeViolation {
+    severity: string;
+    message: string;
+    file?: string;
+    line?: number;
+    column?: number;
+    nodePath?: string;
+}
+
+export interface ErrorEnvelopeDebug {
+    stack?: string;
+    causes?: string[];
 }
 
 /**
@@ -35,6 +80,10 @@ export interface RenderErrorOptions {
 export function renderError(error: unknown, options: RenderErrorOptions = {}): string | null {
     if (error instanceof TaskAbortSignal) {
         return null;
+    }
+
+    if (options.json === true) {
+        return JSON.stringify(buildErrorEnvelope(error, options), null, 2);
     }
 
     if (error instanceof SourcedValidationError) {
@@ -251,4 +300,104 @@ function collectDebugLines(error: Error): string[] {
         depth += 1;
     }
     return out;
+}
+
+// ---------------------------------------------------------------------------
+// JSON envelope builder (--json mode)
+// ---------------------------------------------------------------------------
+
+function buildErrorEnvelope(error: unknown, options: RenderErrorOptions): ErrorEnvelope {
+    const base: ErrorEnvelope = {
+        ok: false,
+        code: null,
+        message: "An unknown error occurred"
+    };
+
+    if (error instanceof SourcedValidationError) {
+        base.code = error.code;
+        base.message = error.message || titleForCode(error.code, "Validation failed");
+        if (error.hint != null) {
+            base.hint = error.hint;
+        }
+        if (error.docsLink != null) {
+            base.docsLink = error.docsLink;
+        }
+        base.violations = error.issues.map((issue) => {
+            const v: ErrorEnvelopeViolation = {
+                severity: "error",
+                message: issue.message,
+                file: String(issue.location.relativeFilePath),
+                line: issue.location.line,
+                column: issue.location.column
+            };
+            return v;
+        });
+    } else if (error instanceof ValidationError) {
+        base.code = error.code;
+        base.message = error.message || titleForCode(error.code, "Validation failed");
+        if (error.hint != null) {
+            base.hint = error.hint;
+        }
+        if (error.docsLink != null) {
+            base.docsLink = error.docsLink;
+        }
+        base.violations = error.violations.map((violation) => {
+            const v: ErrorEnvelopeViolation = {
+                severity: violation.severity,
+                message: violation.message,
+                file: violation.relativeFilepath
+            };
+            if (violation.nodePath.length > 0) {
+                v.nodePath = violation.nodePath
+                    .map((seg) => (typeof seg === "string" ? seg : `${seg.key}[${seg.arrayIndex ?? ""}]`))
+                    .join(".");
+            }
+            return v;
+        });
+    } else if (error instanceof CliError) {
+        base.code = error.code;
+        base.message = error.message || titleForCode(error.code, "Command failed");
+        if (error.hint != null) {
+            base.hint = error.hint;
+        }
+        if (error.docsLink != null) {
+            base.docsLink = error.docsLink;
+        }
+    } else if (error instanceof Error) {
+        base.message = error.message || "An unexpected error occurred";
+    } else {
+        base.message = stringifyUnknown(error);
+    }
+
+    if (options.logFile != null) {
+        base.logFile = options.logFile;
+    }
+
+    if (options.debug === true && error instanceof Error) {
+        const debugInfo: ErrorEnvelopeDebug = {};
+        if (error.stack != null) {
+            debugInfo.stack = error.stack;
+        }
+        const causes: string[] = [];
+        let cause: unknown = (error as { cause?: unknown }).cause;
+        let depth = 0;
+        while (cause != null && depth < 5) {
+            if (cause instanceof Error) {
+                causes.push(`${cause.name}: ${cause.message}`);
+                cause = (cause as { cause?: unknown }).cause;
+            } else {
+                causes.push(stringifyUnknown(cause));
+                cause = undefined;
+            }
+            depth += 1;
+        }
+        if (causes.length > 0) {
+            debugInfo.causes = causes;
+        }
+        if (debugInfo.stack != null || debugInfo.causes != null) {
+            base.debug = debugInfo;
+        }
+    }
+
+    return base;
 }

--- a/packages/cli/cli-v2/src/errors/renderError.ts
+++ b/packages/cli/cli-v2/src/errors/renderError.ts
@@ -1,3 +1,4 @@
+import { assertNever } from "@fern-api/core-utils";
 import { CliError, TaskAbortSignal } from "@fern-api/task-context";
 import chalk from "chalk";
 
@@ -89,7 +90,7 @@ export function renderError(error: unknown, options: RenderErrorOptions = {}): s
     if (error instanceof SourcedValidationError) {
         return renderEnvelope({
             code: error.code,
-            title: titleForCode(error.code, "Validation failed"),
+            title: titleForCode(error.code),
             detail: formatIssues(error.issues),
             hint: error.hint,
             docsLink: error.docsLink,
@@ -101,7 +102,7 @@ export function renderError(error: unknown, options: RenderErrorOptions = {}): s
     if (error instanceof ValidationError) {
         return renderEnvelope({
             code: error.code,
-            title: titleForCode(error.code, "Validation failed"),
+            title: titleForCode(error.code),
             detail: formatViolations(error.violations.map(toFormattableViolation)),
             hint: error.hint,
             docsLink: error.docsLink,
@@ -125,7 +126,7 @@ export function renderError(error: unknown, options: RenderErrorOptions = {}): s
     if (error instanceof CliError) {
         return renderEnvelope({
             code: error.code,
-            title: firstLine(error.message) ?? titleForCode(error.code, "Command failed"),
+            title: firstLine(error.message) ?? titleForCode(error.code),
             detail: restAfterFirstLine(error.message),
             hint: error.hint,
             docsLink: error.docsLink,
@@ -227,7 +228,7 @@ function restAfterFirstLine(text: string | undefined): string | undefined {
     return rest.length > 0 ? rest : undefined;
 }
 
-function titleForCode(code: CliError.Code, fallback: string): string {
+function titleForCode(code: CliError.Code): string {
     switch (code) {
         case "VALIDATION_ERROR":
             return "Validation failed";
@@ -253,8 +254,10 @@ function titleForCode(code: CliError.Code, fallback: string): string {
             return "Version mismatch";
         case "USER_ERROR":
             return "Invalid usage";
+        case "INTERNAL_ERROR":
+            return "Internal error";
         default:
-            return fallback;
+            assertNever(code);
     }
 }
 
@@ -315,7 +318,7 @@ function buildErrorEnvelope(error: unknown, options: RenderErrorOptions): ErrorE
 
     if (error instanceof SourcedValidationError) {
         base.code = error.code;
-        base.message = error.message || titleForCode(error.code, "Validation failed");
+        base.message = error.message || titleForCode(error.code);
         if (error.hint != null) {
             base.hint = error.hint;
         }
@@ -334,7 +337,7 @@ function buildErrorEnvelope(error: unknown, options: RenderErrorOptions): ErrorE
         });
     } else if (error instanceof ValidationError) {
         base.code = error.code;
-        base.message = error.message || titleForCode(error.code, "Validation failed");
+        base.message = error.message || titleForCode(error.code);
         if (error.hint != null) {
             base.hint = error.hint;
         }
@@ -356,7 +359,7 @@ function buildErrorEnvelope(error: unknown, options: RenderErrorOptions): ErrorE
         });
     } else if (error instanceof CliError) {
         base.code = error.code;
-        base.message = error.message || titleForCode(error.code, "Command failed");
+        base.message = error.message || titleForCode(error.code);
         if (error.hint != null) {
             base.hint = error.hint;
         }

--- a/packages/cli/cli/changes/unreleased/cli-v2-json-error-envelope.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-json-error-envelope.yml
@@ -1,0 +1,10 @@
+- summary: |
+    Add `--json` global flag to cli-v2 that renders errors as a structured JSON
+    envelope on stderr for CI pipelines and agents. The envelope contains
+    `{ ok: false, code, message, hint, docsLink, violations, logFile, debug }`,
+    where violations include `file`/`line`/`column` for sourced YAML errors.
+    `--debug --json` adds a `debug.stack` and `debug.causes` block.
+    Commands that already declared a local `--json` flag for success output
+    continue to work; the global flag guarantees the error path is
+    JSON-parseable regardless of which command failed.
+  type: feat


### PR DESCRIPTION
## Description
Linear ticket: Refs [FER-10016](https://linear.app/buildwithfern/issue/FER-10016/cli-v2-find-out-a-better-system-for-error-messages-for-cli-users)

Wave-2 R13 of the cli-v2 error UX/DX cleanup: a `--json` global flag that renders failures as a structured JSON envelope on stderr, so CI pipelines and agents can parse error details without scraping human output.

**Stacked on** #16040 (wave-1 renderer + `--debug`). Re-target to `main` after #16040 merges.

### Envelope shape
```json
{
  "ok": false,
  "code": "AUTH_ERROR",
  "message": "You are not logged in.",
  "hint": "Run `fern auth login`.",
  "docsLink": "https://buildwithfern.com/learn/cli/auth",
  "violations": [
    { "severity": "error", "message": "...", "file": "fern.yml", "line": 7, "column": 13 }
  ],
  "logFile": "~/.fern/v1/logs/2026-05-20T18-58-00.log",
  "debug": { "stack": "...", "causes": ["..."] }
}
```

- `code` is `null` for non-`CliError` failures (plain `Error`, unknown throwables).
- `violations` is populated for `ValidationError` and `SourcedValidationError`; the latter includes `file`/`line`/`column` from the YAML source.
- `logFile` is only set when there's something written to the per-run debug log.
- `debug` only appears when `--debug` (or `FERN_DEBUG=1`) is also on.
- `TaskAbortSignal` (Ctrl+C) still returns `null` — no envelope is emitted on clean shutdowns.

## Changes Made
- New `ErrorEnvelope` / `ErrorEnvelopeViolation` / `ErrorEnvelopeDebug` types and `buildErrorEnvelope()` in `packages/cli/cli-v2/src/errors/renderError.ts`. `renderError(error, { json: true })` short-circuits to the JSON path.
- `packages/cli/cli-v2/src/context/GlobalArgs.ts`: added `json?: boolean`.
- `packages/cli/cli-v2/src/cli.ts`: registers `--json` as a global yargs option (commands that already declared a local `--json` for success output continue to work — yargs merges the definitions).
- `packages/cli/cli-v2/src/context/withContext.ts`: threads `args.json` through to `handleError`, passes the log-file absolute path into the envelope, and suppresses the dim "Logs written to:" hint in JSON mode so the envelope is the only thing on stderr.
- `packages/cli/cli-v2/src/commands/_internal/yargsFailHandler.ts`: yargs `.fail` runs before parsing finishes, so it inspects `process.argv` for `--json`/`--no-json`/`--json=true` and routes through the same renderer. Help block is suppressed in JSON mode.
- Unreleased changelog entry: `packages/cli/cli/changes/unreleased/cli-v2-json-error-envelope.yml` (`feat`).

## Testing
- [x] Unit tests added/updated — 13 new `renderError --json mode` cases covering `TaskAbortSignal`, `CliError`, `ValidationError`, `SourcedValidationError`, plain `Error`, non-`Error` throwables, `logFile`, `debug=true`, `debug=false`, and ANSI-free output. All 22 `renderError.test.ts` tests pass; the full cli-v2 suite (725 tests) is green.
- [x] Manual testing completed — `pnpm format`, `pnpm lint:biome`, `pnpm check`, `pnpm turbo run compile --filter @fern-api/cli-v2` all clean.
- [ ] Updated README.md generator (N/A — public CLI surface; will land alongside R15's user-facing errors README)


Link to Devin session: https://app.devin.ai/sessions/c00fe336eaa44387a47db9083451e93c
Requested by: @iamnamananand996