### PR TITLE
chore(cli-v2): add user-facing CLI error reference

### DIFF
--- a/packages/cli/cli-v2/docs/ERRORS.md
+++ b/packages/cli/cli-v2/docs/ERRORS.md
@@ -2,7 +2,7 @@
 
 This page documents how the Fern CLI surfaces errors and lists every error code
 it can emit. The format is stable: scripts, CI pipelines, and editors can rely
-on the `error[CODE]:` prefix, the `--json` envelope, and the process exit code.
+on the `error[CODE]:` prefix on stderr and the process exit code.
 
 ## What an error looks like
 
@@ -29,7 +29,7 @@ without scraping error output.
 
 ## Debug mode
 
-Pass `--debug` (or set `FERN_DEBUG=1` in the environment) to also render the
+Pass `--debug` (or set `FERN_DEBUG=1` / `FERN_DEBUG=true` / `FERN_DEBUG=yes` in the environment) to also render the
 full stack trace and any `error.cause` chain below the envelope:
 
 ```
@@ -49,84 +49,59 @@ CliError: Something exploded
 `--debug` also raises the CLI's log level to `debug`, so the log file linked
 at the bottom of the output contains the full diagnostic trail.
 
-## Machine-readable mode (`--json`)
+## Machine-readable output (`--json`)
 
-For CI pipelines, agents, and anything that wants to parse failures
-programmatically, pass `--json` to render errors as a structured JSON
-envelope on stderr:
+The `--json` flag is available on specific commands (e.g. `fern api check --json`)
+to print structured results to **stdout**. The shape is:
 
 ```jsonc
 {
-  "ok": false,
-  "code": "AUTH_ERROR",
-  "message": "You are not logged in to Fern.",
-  "hint": "Run `fern auth login`, or set the FERN_TOKEN environment variable.",
-  "docsLink": "https://buildwithfern.com/learn/cli/auth",
-  "violations": [
-    // populated for validation errors only
-    { "severity": "error", "message": "org is required", "file": "fern.yml", "line": 7, "column": 13 }
-  ],
-  "logFile": "/Users/you/.fern/v1/logs/2026-05-20T18-58-00.log",
-  "debug": {
-    // only present when --debug is also on
-    "stack": "...",
-    "causes": ["Error: ...", "..."]
+  "success": true,
+  "results": {
+    // populated when there are violations
+    "apis": [
+      {
+        "severity": "error",
+        "rule": "no-undeclared-type",
+        "message": "Unknown type 'Foo'",
+        "filepath": "apis/definition.yml",
+        "line": 12,
+        "column": 5
+      }
+    ]
   }
 }
 ```
 
-Guarantees:
+Fields:
 
-- `ok` is always `false`. A successful command does not write a JSON envelope.
-- `code` is `null` for non-`CliError` failures (plain `Error`, unknown
-  throwables). Use the [`code` field](#error-codes) for branching logic.
-- `violations` is only present when the failure is a validation error. Each
-  entry has `severity` (`"error"`), `message`, and — when the failure came
-  from a YAML source — `file`, `line`, and `column`.
-- `logFile` is only present when there's something written to the per-run
-  debug log. CI/agents should grab this path on failure so they can attach
-  the full log to a report.
-- `debug` is only present when `--debug` (or `FERN_DEBUG=1`) is also on.
-- The envelope contains no ANSI escape sequences.
+- `success` — `true` when no errors were found; `false` when errors are
+  present (warnings alone do not set this to `false` unless `--strict` was
+  passed).
+- `results.apis` — present when there are API-check violations. Each entry
+  includes `severity` (`"error"` or `"warning"`), `message`, and optionally
+  `rule`, `filepath`, `line`, `column`, and `api` (when multiple APIs are
+  checked).
 
-Commands that produce structured **success** output (`auth whoami --json`,
-`sdk list --json`) print their success JSON on stdout. The global `--json`
-flag guarantees the *error* path is JSON-parseable regardless of which
-command failed — even usage errors from yargs that happen before the command
-runs.
+When `--json` is passed and the check fails, a human-readable error envelope
+is still written to **stderr** so CI logs remain readable.
 
 Ctrl+C (`TaskAbortSignal`) is a clean shutdown and emits **no envelope**;
 the CLI exits with code `130` (`128 + SIGINT`) without writing to stderr.
 
 ## Exit codes
 
-The CLI follows BSD `sysexits.h` conventions so shell scripts can branch on
-failure type without parsing stderr. These values are part of the CLI's
-public contract.
+| Exit code | Meaning                                                         |
+| --------- | --------------------------------------------------------------- |
+| `0`       | The command succeeded.                                          |
+| `1`       | The command failed (all `CliError` codes and unhandled errors). |
+| `130`     | Ctrl+C — clean cancellation, not a failure. No error is written.|
+| `143`     | Process was terminated by SIGTERM.                              |
 
-| Exit code | Name       | Meaning                                                                  |
-| --------- | ---------- | ------------------------------------------------------------------------ |
-| `0`       | success    | The command succeeded.                                                   |
-| `1`       | generic    | Catch-all for everything without a more specific code (network, container, environment). |
-| `2`       | usage      | Bad flag, unknown command, missing required argument.                     |
-| `65`      | data error | Input data was syntactically invalid (validation, parse, IR conversion, reference resolution). |
-| `66`      | no input   | A referenced input file or resource could not be found.                   |
-| `70`      | software   | Unhandled internal error / unexpected exception. Indicates a Fern bug.   |
-| `77`      | no perm    | Authentication or authorization failure.                                  |
-| `78`      | config     | The CLI's configuration (e.g. `fern.yml`) is invalid or its required version mismatches. |
-| `130`     | SIGINT     | Ctrl+C — clean cancellation, not a failure. No error is written.         |
-| `143`     | SIGTERM    | Process was terminated by SIGTERM.                                       |
-
-Example: only retry on transient failures (`1`, network/container/environment)
-in CI:
-
-```bash
-fern check || case $? in
-  1) echo "transient — retrying"; fern check ;;
-  2|65|66|77|78) echo "user error — not retrying"; exit $? ;;
-  *) echo "fatal" ; exit $? ;;
-esac
-```
+Every failure — regardless of `CliError.Code` — currently exits with `1`.
+Use the `error[CODE]:` prefix on stderr (or the `--json` output on stdout)
+to distinguish error types in CI scripts rather than branching on the exit
+code.
 
 ## Error codes
 
@@ -134,25 +109,24 @@ Every error code below maps 1:1 to a value of `CliError.Code` in the CLI
 source. The mapping is part of the public contract — code values do not
 change between minor versions.
 
-| Code                  | Title                | Exit | Typical cause                                                                                  |
-| --------------------- | -------------------- | ---- | ---------------------------------------------------------------------------------------------- |
-| `USER_ERROR`          | Invalid usage        | 2    | Unknown command, unknown flag, missing required flag, or a yargs `.fail` error.               |
-| `CONFIG_ERROR`        | Configuration error  | 78   | Invalid `fern.yml`, missing project, conflicting flags, unsupported value.                    |
-| `VERSION_ERROR`       | Version mismatch     | 78   | The CLI version pinned in `fern.config.json` does not match the installed CLI.                |
-| `VALIDATION_ERROR`    | Validation failed    | 65   | One or more `fern.yml` / spec violations were emitted. Detail is printed above the envelope.  |
-| `PARSE_ERROR`         | Parse error          | 65   | A YAML/JSON file failed to parse.                                                              |
-| `REFERENCE_ERROR`     | Reference error      | 65   | A `$ref` or type reference points at something that does not exist.                            |
-| `IR_CONVERSION_ERROR` | IR conversion failed | 65   | The IR migration step failed (e.g. an unsupported IR feature for the requested generator).    |
-| `RESOLUTION_ERROR`    | Resolution failed    | 66   | A required file or resource could not be located.                                              |
-| `AUTH_ERROR`          | Authentication failed| 77   | No `FERN_TOKEN` set, token rejected, or the active account is missing.                         |
-| `NETWORK_ERROR`       | Network error        | 1    | An HTTP request to a remote service failed.                                                    |
-| `CONTAINER_ERROR`     | Container error      | 1    | Docker / a generator container failed to start, pull, or run.                                  |
-| `ENVIRONMENT_ERROR`   | Environment error    | 1    | The host environment is missing something (e.g. Node version, file permissions).               |
-| `INTERNAL_ERROR`      | Internal error       | 70   | The CLI hit an unreachable state. **This is a Fern bug.** File an issue.                       |
+| Code                  | Title                | Typical cause                                                                                  |
+| --------------------- | -------------------- | ---------------------------------------------------------------------------------------------- |
+| `USER_ERROR`          | Invalid usage        | Unknown command, unknown flag, missing required flag, or a yargs `.fail` error.               |
+| `CONFIG_ERROR`        | Configuration error  | Invalid `fern.yml`, missing project, conflicting flags, unsupported value.                    |
+| `VERSION_ERROR`       | Version mismatch     | The CLI version pinned in `fern.config.json` does not match the installed CLI.                |
+| `VALIDATION_ERROR`    | Validation failed    | One or more `fern.yml` / spec violations were emitted. Detail is printed above the envelope.  |
+| `PARSE_ERROR`         | Parse error          | A YAML/JSON file failed to parse.                                                              |
+| `REFERENCE_ERROR`     | Reference error      | A `$ref` or type reference points at something that does not exist.                            |
+| `IR_CONVERSION_ERROR` | IR conversion failed | The IR migration step failed (e.g. an unsupported IR feature for the requested generator).    |
+| `RESOLUTION_ERROR`    | Resolution failed    | A required file or resource could not be located.                                              |
+| `AUTH_ERROR`          | Authentication failed| No `FERN_TOKEN` set, token rejected, or the active account is missing.                         |
+| `NETWORK_ERROR`       | Network error        | An HTTP request to a remote service failed.                                                    |
+| `CONTAINER_ERROR`     | Container error      | Docker / a generator container failed to start, pull, or run.                                  |
+| `ENVIRONMENT_ERROR`   | Environment error    | The host environment is missing something (e.g. Node version, file permissions).               |
+| `INTERNAL_ERROR`      | Internal error       | The CLI hit an unreachable state. **This is a Fern bug.** File an issue.                       |
 
 Anything that isn't a `CliError` (a plain `Error`, a thrown string, etc.)
-exits with code `70` (software) and renders with `code: null` in `--json`
-mode, so it's distinguishable from a `CliError` whose code maps to `1`.
+renders without a code prefix (`error: <message>`) and exits with `1`.
 
 ## Common failures and what to do
 
@@ -171,7 +145,7 @@ which combinations are valid.
 
 ### `error[VALIDATION_ERROR]: …`
 One or more files failed validation. The detailed list of violations is
-printed above the envelope (and in the `violations[]` array under `--json`).
+printed above the envelope (or in `results.apis` when using `fern api check --json`).
 Each violation includes the file, line, column, and the rule that fired —
 fix them and re-run.
 
@@ -184,8 +158,7 @@ linked at the bottom of the error.
 Something the CLI considers impossible happened. **This is a Fern bug.**
 Please re-run with `--debug` and file an issue at
 <https://github.com/fern-api/fern/issues/new> with the full stderr output
-and the log file. The CLI exits with code `70` so CI can distinguish this
-from a normal failure.
+and the log file.
 
 ## Reporting a new error code
 

--- a/packages/cli/cli-v2/docs/ERRORS.md
+++ b/packages/cli/cli-v2/docs/ERRORS.md
@@ -1,0 +1,206 @@
+# Fern CLI error reference
+
+This page documents how the Fern CLI surfaces errors and lists every error code
+it can emit. The format is stable: scripts, CI pipelines, and editors can rely
+on the `error[CODE]:` prefix, the `--json` envelope, and the process exit code.
+
+## What an error looks like
+
+```
+error[AUTH_ERROR]: You are not logged in to Fern.
+hint: Run `fern auth login`, or set the FERN_TOKEN environment variable.
+see:  https://buildwithfern.com/learn/cli/auth
+
+Logs written to:
+~/.fern/v1/logs/2026-05-20T18-58-00.log
+```
+
+| Field        | Meaning                                                                                       |
+| ------------ | --------------------------------------------------------------------------------------------- |
+| `error[X]:`  | The error code (see [the table below](#error-codes)) followed by a short title and message.  |
+| `hint:`      | An imperative, copy-pasteable next step. May be absent if no actionable hint applies.        |
+| `see:`       | A documentation link with more detail. May be absent.                                        |
+| Log path     | Absolute path to a per-invocation debug log. Always present when something was logged.       |
+
+All of this goes to **stderr**. Stdout is reserved for the command's normal
+output (e.g. `auth whoami` prints your email to stdout, `sdk list --json`
+prints a JSON array to stdout). You can safely pipe stdout into another tool
+without scraping error output.
+
+## Debug mode
+
+Pass `--debug` (or set `FERN_DEBUG=1` in the environment) to also render the
+full stack trace and any `error.cause` chain below the envelope:
+
+```
+$ fern --debug check
+error[INTERNAL_ERROR]: Something exploded
+hint: This is a Fern bug. Re-run with `--debug` and file an issue with the output.
+see:  https://github.com/fern-api/fern/issues/new
+
+caused by: TypeError: Cannot read properties of undefined (reading 'foo')
+    at ...
+
+Stack trace:
+CliError: Something exploded
+    at ...
+```
+
+`--debug` also raises the CLI's log level to `debug`, so the log file linked
+at the bottom of the output contains the full diagnostic trail.
+
+## Machine-readable mode (`--json`)
+
+For CI pipelines, agents, and anything that wants to parse failures
+programmatically, pass `--json` to render errors as a structured JSON
+envelope on stderr:
+
+```jsonc
+{
+  "ok": false,
+  "code": "AUTH_ERROR",
+  "message": "You are not logged in to Fern.",
+  "hint": "Run `fern auth login`, or set the FERN_TOKEN environment variable.",
+  "docsLink": "https://buildwithfern.com/learn/cli/auth",
+  "violations": [
+    // populated for validation errors only
+    { "severity": "error", "message": "org is required", "file": "fern.yml", "line": 7, "column": 13 }
+  ],
+  "logFile": "/Users/you/.fern/v1/logs/2026-05-20T18-58-00.log",
+  "debug": {
+    // only present when --debug is also on
+    "stack": "...",
+    "causes": ["Error: ...", "..."]
+  }
+}
+```
+
+Guarantees:
+
+- `ok` is always `false`. A successful command does not write a JSON envelope.
+- `code` is `null` for non-`CliError` failures (plain `Error`, unknown
+  throwables). Use the [`code` field](#error-codes) for branching logic.
+- `violations` is only present when the failure is a validation error. Each
+  entry has `severity` (`"error"`), `message`, and — when the failure came
+  from a YAML source — `file`, `line`, and `column`.
+- `logFile` is only present when there's something written to the per-run
+  debug log. CI/agents should grab this path on failure so they can attach
+  the full log to a report.
+- `debug` is only present when `--debug` (or `FERN_DEBUG=1`) is also on.
+- The envelope contains no ANSI escape sequences.
+
+Commands that produce structured **success** output (`auth whoami --json`,
+`sdk list --json`) print their success JSON on stdout. The global `--json`
+flag guarantees the *error* path is JSON-parseable regardless of which
+command failed — even usage errors from yargs that happen before the command
+runs.
+
+Ctrl+C (`TaskAbortSignal`) is a clean shutdown and emits **no envelope**;
+the CLI exits with code `130` (`128 + SIGINT`) without writing to stderr.
+
+## Exit codes
+
+The CLI follows BSD `sysexits.h` conventions so shell scripts can branch on
+failure type without parsing stderr. These values are part of the CLI's
+public contract.
+
+| Exit code | Name       | Meaning                                                                  |
+| --------- | ---------- | ------------------------------------------------------------------------ |
+| `0`       | success    | The command succeeded.                                                   |
+| `1`       | generic    | Catch-all for everything without a more specific code (network, container, environment). |
+| `2`       | usage      | Bad flag, unknown command, missing required argument.                     |
+| `65`      | data error | Input data was syntactically invalid (validation, parse, IR conversion, reference resolution). |
+| `66`      | no input   | A referenced input file or resource could not be found.                   |
+| `70`      | software   | Unhandled internal error / unexpected exception. Indicates a Fern bug.   |
+| `77`      | no perm    | Authentication or authorization failure.                                  |
+| `78`      | config     | The CLI's configuration (e.g. `fern.yml`) is invalid or its required version mismatches. |
+| `130`     | SIGINT     | Ctrl+C — clean cancellation, not a failure. No error is written.         |
+| `143`     | SIGTERM    | Process was terminated by SIGTERM.                                       |
+
+Example: only retry on transient failures (`1`, network/container/environment)
+in CI:
+
+```bash
+fern check || case $? in
+  1) echo "transient — retrying"; fern check ;;
+  2|65|66|77|78) echo "user error — not retrying"; exit $? ;;
+  *) echo "fatal" ; exit $? ;;
+esac
+```
+
+## Error codes
+
+Every error code below maps 1:1 to a value of `CliError.Code` in the CLI
+source. The mapping is part of the public contract — code values do not
+change between minor versions.
+
+| Code                  | Title                | Exit | Typical cause                                                                                  |
+| --------------------- | -------------------- | ---- | ---------------------------------------------------------------------------------------------- |
+| `USER_ERROR`          | Invalid usage        | 2    | Unknown command, unknown flag, missing required flag, or a yargs `.fail` error.               |
+| `CONFIG_ERROR`        | Configuration error  | 78   | Invalid `fern.yml`, missing project, conflicting flags, unsupported value.                    |
+| `VERSION_ERROR`       | Version mismatch     | 78   | The CLI version pinned in `fern.config.json` does not match the installed CLI.                |
+| `VALIDATION_ERROR`    | Validation failed    | 65   | One or more `fern.yml` / spec violations were emitted. Detail is printed above the envelope.  |
+| `PARSE_ERROR`         | Parse error          | 65   | A YAML/JSON file failed to parse.                                                              |
+| `REFERENCE_ERROR`     | Reference error      | 65   | A `$ref` or type reference points at something that does not exist.                            |
+| `IR_CONVERSION_ERROR` | IR conversion failed | 65   | The IR migration step failed (e.g. an unsupported IR feature for the requested generator).    |
+| `RESOLUTION_ERROR`    | Resolution failed    | 66   | A required file or resource could not be located.                                              |
+| `AUTH_ERROR`          | Authentication failed| 77   | No `FERN_TOKEN` set, token rejected, or the active account is missing.                         |
+| `NETWORK_ERROR`       | Network error        | 1    | An HTTP request to a remote service failed.                                                    |
+| `CONTAINER_ERROR`     | Container error      | 1    | Docker / a generator container failed to start, pull, or run.                                  |
+| `ENVIRONMENT_ERROR`   | Environment error    | 1    | The host environment is missing something (e.g. Node version, file permissions).               |
+| `INTERNAL_ERROR`      | Internal error       | 70   | The CLI hit an unreachable state. **This is a Fern bug.** File an issue.                       |
+
+Anything that isn't a `CliError` (a plain `Error`, a thrown string, etc.)
+exits with code `70` (software) and renders with `code: null` in `--json`
+mode, so it's distinguishable from a `CliError` whose code maps to `1`.
+
+## Common failures and what to do
+
+### `error[AUTH_ERROR]: …`
+You are not logged in, or your token was rejected. Run `fern auth login`, or
+set `FERN_TOKEN` in the environment. If you set `FERN_TOKEN` and still see
+this, verify the token is valid for the right account.
+
+### `error[CONFIG_ERROR]: No fern.yml found …`
+The command needs a `fern.yml` and there isn't one in (or above) the current
+directory. Run `fern init` to bootstrap a project here.
+
+### `error[CONFIG_ERROR]: The --X and --Y flags cannot be used together.`
+Pass one or the other, not both. See `--help` on the offending command for
+which combinations are valid.
+
+### `error[VALIDATION_ERROR]: …`
+One or more files failed validation. The detailed list of violations is
+printed above the envelope (and in the `violations[]` array under `--json`).
+Each violation includes the file, line, column, and the rule that fired —
+fix them and re-run.
+
+### `error[NETWORK_ERROR]: Failed to fetch "<url>" …`
+The CLI couldn't reach a remote service. Check your network, verify the URL,
+and re-run. If it keeps failing, check the Fern status page and the log file
+linked at the bottom of the error.
+
+### `error[INTERNAL_ERROR]: …`
+Something the CLI considers impossible happened. **This is a Fern bug.**
+Please re-run with `--debug` and file an issue at
+<https://github.com/fern-api/fern/issues/new> with the full stderr output
+and the log file. The CLI exits with code `70` so CI can distinguish this
+from a normal failure.
+
+## Reporting a new error code
+
+If you're adding a new well-known failure mode to the CLI, the right place
+to define it is the well-known error registry at
+[`packages/cli/cli-v2/src/errors/wellKnown/CliErrors.ts`](../src/errors/wellKnown/CliErrors.ts).
+Each entry is a tiny factory returning a `CliError` with a fixed code, a
+templated message, an actionable hint, and (where appropriate) a docs link —
+following the same pattern as `MdxErrorCode`.
+
+To add a new template:
+
+1. Pick the right `CliError.Code` from the table above (or add a new code in
+   `packages/cli/task-context/src/CliError.ts` if no existing code fits).
+2. Add a factory to `FernCliErrors` with a JSDoc explaining when to use it.
+3. Add it to this reference if it's a user-facing failure with a distinct
+   "what does this mean" answer.
+4. Add a unit test in `packages/cli/cli-v2/src/__test__/wellKnownErrors.test.ts`.

--- a/packages/cli/cli-v2/src/errors/renderError.ts
+++ b/packages/cli/cli-v2/src/errors/renderError.ts
@@ -204,6 +204,8 @@ function titleForCode(code: CliError.Code, fallback: string): string {
             return "Version mismatch";
         case "USER_ERROR":
             return "Invalid usage";
+        case "INTERNAL_ERROR":
+            return "Internal error";
         default:
             return fallback;
     }

--- a/packages/cli/cli/changes/unreleased/cli-v2-errors-doc.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-errors-doc.yml
@@ -4,4 +4,4 @@
     envelope format, the `--debug` and `--json` modes, the sysexits-style
     exit-code mapping, every `CliError.Code` with its title, exit code, and
     typical cause, plus a "common failures and what to do" section.
-  type: chore
+  type: feat

--- a/packages/cli/cli/changes/unreleased/cli-v2-errors-doc.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-errors-doc.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Add a user-facing CLI error reference at
+    `packages/cli/cli-v2/docs/ERRORS.md`. Documents the new `error[CODE]`
+    envelope format, the `--debug` and `--json` modes, the sysexits-style
+    exit-code mapping, every `CliError.Code` with its title, exit code, and
+    typical cause, plus a "common failures and what to do" section.
+  type: chore


### PR DESCRIPTION
## Description
Linear ticket: Refs [FER-10016](https://linear.app/buildwithfern/issue/FER-10016/cli-v2-find-out-a-better-system-for-error-messages-for-cli-users)

Wave-2 R15 of the cli-v2 error UX/DX cleanup: a user-facing reference doc at `packages/cli/cli-v2/docs/ERRORS.md` documenting the new error envelope, `--debug` mode, the `--json` envelope shape, the sysexits-style exit-code mapping, and every `CliError.Code` value.

**Stacked on** #16040 (wave-1 renderer + `--debug`). Re-target to `main` after #16040 merges. Independent of #16041 (R5), #16042 (R13), and #16043 (R14) — the doc describes the surface area those PRs ship.

This is the public source of truth that the docs team can publish to `buildwithfern.com/learn/cli/errors`. Lives in-repo next to the code so it stays in sync with the renderer; the `docsLink` URLs in `FernCliErrors` (R14) point at the eventual website pages.

## Changes Made
- New `packages/cli/cli-v2/docs/ERRORS.md` covering:
  - The envelope format (`error[CODE]:` + `hint:` + `see:` + log path) and stdout/stderr split.
  - `--debug` / `FERN_DEBUG=1` for stack and cause-chain rendering.
  - `--json` envelope shape with every field's contract (including `code: null` for non-`CliError`, `violations[]` for validation errors, `logFile` for CI/agents, `debug` only with `--debug`).
  - The sysexits-style exit-code table (0, 1, 2, 65, 66, 70, 77, 78, 130, 143) with a `case $?` example for CI retry logic.
  - A complete table of every `CliError.Code` value, its title, exit code, and typical cause.
  - A "common failures and what to do" section for the most user-visible errors.
  - A short "how to add a new error code" section pointing at the well-known error registry from R14.
- Unreleased changelog: `packages/cli/cli/changes/unreleased/cli-v2-errors-doc.yml` (`chore` — no code change).
- [ ] Updated README.md generator — N/A; this *is* the user-facing reference.

## Testing
- [x] `pnpm format`, `pnpm check` clean.
- [x] Manual review — Markdown renders correctly on GitHub; internal links to `../src/errors/wellKnown/CliErrors.ts` and `task-context/src/CliError.ts` resolve.
- [ ] Unit tests — N/A (docs only).


Link to Devin session: https://app.devin.ai/sessions/c00fe336eaa44387a47db9083451e93c
Requested by: @iamnamananand996