### PR TITLE
fix(internal): emit millisecond precision for nullable datetime params in mock tests

### DIFF
--- a/generators/csharp/sdk/changes/unreleased/fix-mock-test-nullable-datetime-millis-sibling.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-mock-test-nullable-datetime-millis-sibling.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    `MockServerTestGenerator` now normalizes nullable date-time query and header parameters to millisecond precision, matching the fix previously applied to `MockEndpointGenerator`. Without this, mock-server tests for nullable date-time fields emitted matchers like `"2024-01-15T09:30:00Z"` while the SDK actually sent `"2024-01-15T09:30:00.000Z"`.
+  type: fix

--- a/generators/csharp/sdk/src/test-generation/mock-server/MockServerTestGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockServerTestGenerator.ts
@@ -245,14 +245,16 @@ export class MockServerTestGenerator extends FileGenerator<CSharpFile, SdkGenera
 
     private getDateTime(exampleTypeReference: ExampleTypeReference): Date | undefined {
         switch (exampleTypeReference.shape.type) {
-            case "container":
-                if (exampleTypeReference.shape.container.type !== "optional") {
-                    return undefined;
+            case "container": {
+                const container = exampleTypeReference.shape.container;
+                if (container.type === "optional") {
+                    return container.optional == null ? undefined : this.getDateTime(container.optional);
                 }
-                if (exampleTypeReference.shape.container.optional == null) {
-                    return undefined;
+                if (container.type === "nullable") {
+                    return container.nullable == null ? undefined : this.getDateTime(container.nullable);
                 }
-                return this.getDateTime(exampleTypeReference.shape.container.optional);
+                return undefined;
+            }
             case "named":
                 if (exampleTypeReference.shape.shape.type !== "alias") {
                     return undefined;

--- a/generators/go/sdk/changes/unreleased/fix-wire-test-nullable-datetime-millis.yml
+++ b/generators/go/sdk/changes/unreleased/fix-wire-test-nullable-datetime-millis.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generated `wiremock-mappings.json` now matches nullable date-time query and header parameters with millisecond precision so the stub matches what the Go SDK actually sends. Previously, when a date-time field was wrapped in a nullable container (e.g. with `respect-nullable-schemas: true` and `coerce-optional-schemas-to-nullable: true`), the stub matcher used `"2024-01-15T09:30:00Z"` while the SDK serialized `"2024-01-15T09:30:00.000Z"`, causing WireMock to return 404.
+  type: fix

--- a/packages/commons/mock-utils/src/index.ts
+++ b/packages/commons/mock-utils/src/index.ts
@@ -416,7 +416,7 @@ export class WireMock {
         return path;
     }
 
-    private exampleToQueryOrHeaderValue({ value }: { value: FernIr.ExampleTypeReference }): string | undefined {
+    public exampleToQueryOrHeaderValue({ value }: { value: FernIr.ExampleTypeReference }): string | undefined {
         if (typeof value.jsonExample === "string") {
             const maybeDatetime = this.getDateTime(value);
             return maybeDatetime != null ? maybeDatetime.toISOString() : value.jsonExample;
@@ -432,14 +432,16 @@ export class WireMock {
 
     private getDateTime(exampleTypeReference: FernIr.ExampleTypeReference): Date | undefined {
         switch (exampleTypeReference.shape.type) {
-            case "container":
-                if (exampleTypeReference.shape.container.type !== "optional") {
-                    return undefined;
+            case "container": {
+                const container = exampleTypeReference.shape.container;
+                if (container.type === "optional") {
+                    return container.optional == null ? undefined : this.getDateTime(container.optional);
                 }
-                if (exampleTypeReference.shape.container.optional == null) {
-                    return undefined;
+                if (container.type === "nullable") {
+                    return container.nullable == null ? undefined : this.getDateTime(container.nullable);
                 }
-                return this.getDateTime(exampleTypeReference.shape.container.optional);
+                return undefined;
+            }
             case "named":
                 if (exampleTypeReference.shape.shape.type !== "alias") {
                     return undefined;

--- a/packages/commons/mock-utils/test/convertToWireMock.test.ts
+++ b/packages/commons/mock-utils/test/convertToWireMock.test.ts
@@ -202,6 +202,48 @@ describe("new WireMock().convertToWireMock", () => {
     });
 });
 
+describe("WireMock query param datetime normalization", () => {
+    // Regression test for nullable<datetime> query params: the WireMock stub matcher
+    // must include millisecond precision (e.g. "2024-01-15T09:30:00.000Z") so that it
+    // matches what generated SDK runtimes actually send. Optional<datetime> already
+    // worked; nullable<datetime> previously fell through to the raw jsonExample.
+    function buildDatetimeExample(wrapper: "optional" | "nullable" | "none"): FernIr.ExampleTypeReference {
+        const datetimePrimitive = FernIr.TypeReference.primitive({
+            v1: FernIr.PrimitiveTypeV1.DateTime,
+            v2: undefined
+        });
+        const inner: FernIr.ExampleTypeReference = {
+            jsonExample: "2024-01-15T09:30:00Z",
+            shape: FernIr.ExampleTypeReferenceShape.primitive(
+                FernIr.ExamplePrimitive.datetime({
+                    datetime: new Date("2024-01-15T09:30:00Z"),
+                    raw: "2024-01-15T09:30:00Z"
+                })
+            )
+        };
+        if (wrapper === "none") {
+            return inner;
+        }
+        return {
+            jsonExample: "2024-01-15T09:30:00Z",
+            shape: FernIr.ExampleTypeReferenceShape.container(
+                wrapper === "optional"
+                    ? FernIr.ExampleContainer.optional({ optional: inner, valueType: datetimePrimitive })
+                    : FernIr.ExampleContainer.nullable({ nullable: inner, valueType: datetimePrimitive })
+            )
+        };
+    }
+
+    it.each([
+        ["bare datetime", "none" as const],
+        ["optional<datetime>", "optional" as const],
+        ["nullable<datetime>", "nullable" as const]
+    ])("normalizes %s query param to millisecond precision", (_label, wrapper) => {
+        const example = buildDatetimeExample(wrapper);
+        expect(new WireMock().exampleToQueryOrHeaderValue({ value: example })).toBe("2024-01-15T09:30:00.000Z");
+    });
+});
+
 // Helper function to build URL path template from IR endpoint (matches convertTonew WireMock().ts logic)
 function buildUrlPathTemplateFromIR(endpoint: FernIr.HttpEndpoint): string {
     // Use fullPath to include the service basePath


### PR DESCRIPTION
Closes FER-10722

## Summary

- The shared `WireMock` generator in `packages/commons/mock-utils` (consumed by the Go SDK's wire-test setup) and the C# `MockServerTestGenerator` both had a `getDateTime` helper that only drilled through `optional<datetime>` containers, not `nullable<datetime>`. The result: generated wiremock stubs and mock-test matchers used `"...:00Z"` while the runtime SDK serialized `"...:00.000Z"`, causing WireMock to return 404.
- Same pattern as PR #16019 (`fix(csharp): emit millisecond precision for nullable datetime params in mock tests`), which fixed only the csharp `MockEndpointGenerator`. This PR fixes its sibling `MockServerTestGenerator` and the shared `mock-utils` helper.

## Example

Customer fern config:

```yaml
api:
  specs:
    - openapi: ../openapi.json
      settings:
        respect-nullable-schemas: true
        coerce-optional-schemas-to-nullable: true
```

Generated `wiremock-mappings.json` for a `nullable<datetime>` query param — before:

```json
"since": { "equalTo": "2024-01-15T09:30:00Z" }
```

After:

```json
"since": { "equalTo": "2024-01-15T09:30:00.000Z" }
```

The generated Go test code already expected `.000Z`; only the stub matcher was off, so WireMock returned 404 on every request.

The fix in both `getDateTime` helpers:

```typescript
case "container": {
    const container = exampleTypeReference.shape.container;
    if (container.type === "optional") {
        return container.optional == null ? undefined : this.getDateTime(container.optional);
    }
    if (container.type === "nullable") {
        return container.nullable == null ? undefined : this.getDateTime(container.nullable);
    }
    return undefined;
}
```

## Test plan

- [x] New regression test in `packages/commons/mock-utils/test/convertToWireMock.test.ts` covering bare / optional<datetime> / nullable<datetime>. Reverting the source fix re-fails the nullable case.
- [x] Re-ran seed against the customer's fern config (`auth0-teams-fern-config`); diff vs. pre-fix output is exactly the two expected matcher lines.
- [x] Regenerated all four go-sdk seed fixtures that use query-param matchers (`go-deterministic-ordering`, `union-query-parameters`, `exhaustive/no-custom-config`, `exhaustive/omit-empty-request-wrappers`) — zero wiremock-mappings diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)