### PR TITLE
feat(parser): make request body optional when all properties are optional or none exist

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/operation/convertHttpOperation.ts
@@ -347,6 +347,7 @@ export function convertHttpOperation({
             context
         }),
         request,
+        requestBodyOptional: computeRequestBodyOptional({ request }),
         response: convertedResponse.value,
         errors: convertedResponse.errors,
         servers:
@@ -415,6 +416,29 @@ function createOperationSdkMethodName({
 
 function generateSecurity(operation: OpenAPIV3.OperationObject): EndpointSecurity | undefined {
     return sanitizeSecurityScopes(operation.security);
+}
+
+function isPropertyOptional(schema: SchemaWithExample): boolean {
+    return schema.type === "optional" || schema.type === "nullable";
+}
+
+function computeRequestBodyOptional({ request }: { request: RequestWithExample | undefined }): boolean | undefined {
+    if (request == null) {
+        return undefined;
+    }
+    if (request.type !== "json" && request.type !== "formUrlEncoded") {
+        return undefined;
+    }
+    const schema = request.schema;
+    if (schema.type === "object") {
+        const hasNoRequiredProperties =
+            schema.properties.length === 0 || schema.properties.every((prop) => isPropertyOptional(prop.schema));
+        const hasNoAllOfParents = schema.allOf.length === 0;
+        if (hasNoRequiredProperties && hasNoAllOfParents) {
+            return true;
+        }
+    }
+    return undefined;
 }
 
 function isEndpointAuthed(operation: OpenAPIV3.OperationObject, document: OpenAPIV3.Document): boolean {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/availability.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/availability.json
@@ -502,6 +502,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "OK",
         "schema": {
@@ -610,6 +611,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "OK",
         "schema": {
@@ -719,6 +721,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "OK",
         "schema": {
@@ -828,6 +831,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "OK",
         "schema": {
@@ -937,6 +941,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "OK",
         "schema": {
@@ -1046,6 +1051,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "OK",
         "schema": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/axle.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/axle.json
@@ -186,6 +186,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "",
         "schema": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/content-type.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/content-type.json
@@ -264,6 +264,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "The sample response",
         "schema": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/discriminator-base-class.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/discriminator-base-class.json
@@ -66,6 +66,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "errors": {},
       "servers": [],
       "authed": false,

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/enum-array-references.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/enum-array-references.json
@@ -311,6 +311,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "Product created",
         "schema": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/enum-normalization-edge-cases.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/enum-normalization-edge-cases.json
@@ -210,6 +210,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "errors": {},
       "servers": [],
       "authed": false,

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/inline-path-parameters.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/inline-path-parameters.json
@@ -337,6 +337,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "Successful response",
         "schema": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/multiple-request-bodies.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/multiple-request-bodies.json
@@ -112,6 +112,7 @@
         "sdkMethodName": "uploadJsonDocument",
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "Successful response",
         "schema": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/nullable-types-edge-cases.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/nullable-types-edge-cases.json
@@ -127,6 +127,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "errors": {},
       "servers": [],
       "authed": false,

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/use-bytes-for-binary-response.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/use-bytes-for-binary-response.json
@@ -60,6 +60,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "",
         "source": {
@@ -133,6 +134,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "",
         "source": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/valtown.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/valtown.json
@@ -5354,6 +5354,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "errors": {},
       "servers": [],
       "description": "Run a val, with arguments in the request body",
@@ -6384,6 +6385,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "Successfully sent email",
         "schema": {
@@ -7460,6 +7462,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "errors": {},
       "servers": [],
       "description": "Update an existing val",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-audiences.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-audiences.json
@@ -93,6 +93,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "errors": {},
       "servers": [],
       "authed": false,

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-idempotency-headers.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-idempotency-headers.json
@@ -64,6 +64,7 @@
         },
         "type": "json"
       },
+      "requestBodyOptional": true,
       "response": {
         "description": "Success!",
         "schema": {

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
@@ -532,17 +532,19 @@ function getRequest({
         const resolvedSchema =
             request.schema.type === "reference" ? context.getSchema(request.schema.schema, namespace) : request.schema;
 
-        // the request body is referenced if it is not an object or if other parts of the spec
-        // refer to the same type
+        // the request body is referenced if it is not an object, if other parts of the spec
+        // refer to the same type, or if the request body is optional (to preserve the named type
+        // and wrap it in optional<>)
         if (
             resolvedSchema?.type !== "object" ||
-            (maybeSchemaId != null && context.isResponseReachable(maybeSchemaId))
+            (maybeSchemaId != null && context.isResponseReachable(maybeSchemaId)) ||
+            (endpoint.requestBodyOptional === true && maybeSchemaId != null)
         ) {
             // When respectReadonlySchemas is enabled on a write endpoint, resolve schema
             // references to the write variant (without readOnly properties)
             const useWriteVariant = context.options.respectReadonlySchemas && isWriteMethod(endpoint.method);
             const variant: "read" | "write" | undefined = useWriteVariant ? "write" : undefined;
-            const requestTypeReference = buildTypeReference({
+            let requestTypeReference = buildTypeReference({
                 schema: request.schema,
                 fileContainingReference: declarationFile,
                 context,
@@ -550,6 +552,17 @@ function getRequest({
                 declarationDepth: 0,
                 variant
             });
+            if (endpoint.requestBodyOptional === true) {
+                if (typeof requestTypeReference === "string") {
+                    requestTypeReference = `optional<${requestTypeReference}>`;
+                } else if (
+                    typeof requestTypeReference === "object" &&
+                    requestTypeReference != null &&
+                    "type" in requestTypeReference
+                ) {
+                    requestTypeReference = { ...requestTypeReference, type: `optional<${requestTypeReference.type}>` };
+                }
+            }
             const requestValue: RawSchemas.HttpRequestSchema = {
                 body: requestTypeReference
             };

--- a/packages/cli/api-importers/openapi/openapi-ir/fern/definition/finalIr.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir/fern/definition/finalIr.yml
@@ -341,6 +341,11 @@ types:
         docs: |
           Populated by `x-request-name` on a path object.
       request: optional<Request>
+      requestBodyOptional:
+        type: optional<boolean>
+        docs: |
+          Whether the request body is optional. True when all properties on the
+          request body object are optional or the object has no properties.
       response: optional<Response>
       errors:
         type: map<commons.StatusCode, HttpError>

--- a/packages/cli/api-importers/openapi/openapi-ir/fern/definition/parseIr.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir/fern/definition/parseIr.yml
@@ -55,6 +55,11 @@ types:
         docs: |
           Populated by `x-request-name` on a path object.
       request: optional<RequestWithExample>
+      requestBodyOptional:
+        type: optional<boolean>
+        docs: |
+          Whether the request body is optional. True when all properties on the
+          request body object are optional or the object has no properties.
       response: optional<ResponseWithExample>
       errors:
         type: map<commons.StatusCode, HttpErrorWithExample>

--- a/packages/cli/api-importers/openapi/openapi-ir/src/sdk/api/resources/finalIr/types/Endpoint.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir/src/sdk/api/resources/finalIr/types/Endpoint.ts
@@ -36,6 +36,11 @@ export interface Endpoint
     /** Populated by `x-request-name` on a path object. */
     requestNameOverride: string | undefined;
     request: FernOpenapiIr.Request | undefined;
+    /**
+     * Whether the request body is optional. True when all properties on the
+     * request body object are optional or the object has no properties.
+     */
+    requestBodyOptional: boolean | undefined;
     response: FernOpenapiIr.Response | undefined;
     /**
      * Expected error status codes for this endpoint, and their corresponding schema and examples.

--- a/packages/cli/api-importers/openapi/openapi-ir/src/sdk/api/resources/parseIr/types/EndpointWithExample.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir/src/sdk/api/resources/parseIr/types/EndpointWithExample.ts
@@ -36,6 +36,11 @@ export interface EndpointWithExample
     /** Populated by `x-request-name` on a path object. */
     requestNameOverride: string | undefined;
     request: FernOpenapiIr.RequestWithExample | undefined;
+    /**
+     * Whether the request body is optional. True when all properties on the
+     * request body object are optional or the object has no properties.
+     */
+    requestBodyOptional: boolean | undefined;
     response: FernOpenapiIr.ResponseWithExample | undefined;
     /**
      * Expected error status codes for this endpoint, and their corresponding schema and examples.

--- a/packages/cli/api-importers/openapi/openapi-ir/src/sdk/serialization/resources/finalIr/types/Endpoint.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir/src/sdk/serialization/resources/finalIr/types/Endpoint.ts
@@ -43,6 +43,7 @@ export const Endpoint: core.serialization.ObjectSchema<serializers.Endpoint.Raw,
             generatedRequestName: core.serialization.string(),
             requestNameOverride: core.serialization.string().optional(),
             request: Request.optional(),
+            requestBodyOptional: core.serialization.boolean().optional(),
             response: Response.optional(),
             errors: core.serialization.record(StatusCode, HttpError),
             servers: core.serialization.list(HttpEndpointServer),
@@ -74,6 +75,7 @@ export declare namespace Endpoint {
         generatedRequestName: string;
         requestNameOverride?: string | null;
         request?: Request.Raw | null;
+        requestBodyOptional?: boolean | null;
         response?: Response.Raw | null;
         errors: Record<StatusCode.Raw, HttpError.Raw>;
         servers: HttpEndpointServer.Raw[];

--- a/packages/cli/api-importers/openapi/openapi-ir/src/sdk/serialization/resources/parseIr/types/EndpointWithExample.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir/src/sdk/serialization/resources/parseIr/types/EndpointWithExample.ts
@@ -45,6 +45,7 @@ export const EndpointWithExample: core.serialization.ObjectSchema<
         generatedRequestName: core.serialization.string(),
         requestNameOverride: core.serialization.string().optional(),
         request: RequestWithExample.optional(),
+        requestBodyOptional: core.serialization.boolean().optional(),
         response: ResponseWithExample.optional(),
         errors: core.serialization.record(StatusCode, HttpErrorWithExample),
         servers: core.serialization.list(HttpEndpointServer),
@@ -76,6 +77,7 @@ export declare namespace EndpointWithExample {
         generatedRequestName: string;
         requestNameOverride?: string | null;
         request?: RequestWithExample.Raw | null;
+        requestBodyOptional?: boolean | null;
         response?: ResponseWithExample.Raw | null;
         errors: Record<StatusCode.Raw, HttpErrorWithExample.Raw>;
         servers: HttpEndpointServer.Raw[];

--- a/packages/cli/cli/changes/unreleased/optional-request-body.yml
+++ b/packages/cli/cli/changes/unreleased/optional-request-body.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Make request body optional in generated SDKs when all properties on the
+    request body object are optional or no properties exist.
+  type: feat

--- a/packages/cli/cli/src/commands/generate-overrides/__test__/writeOverridesForWorkspaces.test.ts
+++ b/packages/cli/cli/src/commands/generate-overrides/__test__/writeOverridesForWorkspaces.test.ts
@@ -61,6 +61,7 @@ function createMinimalEndpoint(overrides: {
         generatedRequestName: "Request",
         requestNameOverride: undefined,
         request: undefined,
+        requestBodyOptional: undefined,
         response: undefined,
         errors: {},
         servers: [],


### PR DESCRIPTION
## Description

When an OpenAPI request body schema is an object with all optional properties (or no properties at all), the generated SDK wrapper type should make the `body` field optional (`body?:`) instead of required. This enables cleaner SDK ergonomics for endpoints like `POST /{api_version}/webhooks/{id}:ping` where the request body is effectively empty.

## Changes Made

- **OpenAPI IR schema** (`parseIr.yml` + `finalIr.yml`): Added `requestBodyOptional: optional<boolean>` field to `EndpointWithExample` and `Endpoint` types
- **Auto-generated TypeScript types**: Regenerated via `pnpm openapi-ir:generate` to include `requestBodyOptional: boolean | undefined`
- **Parser** (`convertHttpOperation.ts`): Added `computeRequestBodyOptional()` that checks if a JSON/formUrlEncoded request body's resolved schema is an object where:
  - All properties have `optional` or `nullable` schemas, OR
  - The object has zero properties
  - AND the object has no `allOf` parents (which could introduce required properties)
- **openapi-ir-to-fern** (`buildEndpoint.ts`):
  - When `requestBodyOptional` is true and a schema reference exists, forces the referenced-body code path (avoids inlining the empty type)
  - Wraps the body type reference in `optional<>` so downstream generators produce `body?: Type` instead of `body: Type`
- **Changelog**: Added unreleased changelog entry under `packages/cli/cli/changes/unreleased/`

**Before** (empty/all-optional body):
```ts
export interface PingFernWebhooksRequest {
    body: GeminiNextGenAPI.PingWebhookRequest;
}
```

**After**:
```ts
export interface PingFernWebhooksRequest {
    body?: GeminiNextGenAPI.PingWebhookRequest;
}
```

## Testing
- [x] `pnpm turbo run compile` passes for `@fern-api/openapi-ir`, `@fern-api/openapi-ir-parser`, and `@fern-api/openapi-ir-to-fern`
- [ ] Unit tests added/updated
- [ ] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/42b6f93130fc4964a72ac11d9fa251eb
Requested by: @aditya-arolkar-swe