### PR TITLE
fix(ruby): generate Gemfile.lock during SDK generation

### DIFF
--- a/generators/ruby-v2/base/package.json
+++ b/generators/ruby-v2/base/package.json
@@ -41,6 +41,7 @@
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
+    "@fern-api/logging-execa": "workspace:*",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/ruby-ast": "workspace:*",
     "@fern-fern/ir-sdk": "66.2.0",

--- a/generators/ruby-v2/base/src/project/RubyProject.ts
+++ b/generators/ruby-v2/base/src/project/RubyProject.ts
@@ -1,5 +1,6 @@
 import { AbstractProject, File } from "@fern-api/base-generator";
 import { AbsoluteFilePath, join, RelativeFilePath, relative } from "@fern-api/fs-utils";
+import { loggingExeca } from "@fern-api/logging-execa";
 import { BaseRubyCustomConfigSchema } from "@fern-api/ruby-ast";
 import { FernIr } from "@fern-fern/ir-sdk";
 import dedent from "dedent";
@@ -111,6 +112,46 @@ export class RubyProject extends AbstractProject<AbstractRubyGeneratorContext<Ba
         await this.createRuboCopFile();
         await this.createGithubCiWorkflow();
         await this.createGitignore();
+        await this.generateGemfileLock();
+    }
+
+    private async generateGemfileLock(): Promise<void> {
+        this.context.logger.debug("Running bundle lock to generate Gemfile.lock");
+        try {
+            await loggingExeca(
+                this.context.logger,
+                "bundle",
+                [
+                    "lock",
+                    "--add-platform",
+                    "ruby",
+                    "--add-platform",
+                    "x86_64-linux",
+                    "--add-platform",
+                    "aarch64-linux",
+                    "--add-platform",
+                    "arm64-darwin",
+                    "--add-platform",
+                    "x86_64-darwin"
+                ],
+                {
+                    doNotPipeOutput: true,
+                    cwd: this.absolutePathToOutputDirectory,
+                    env: {
+                        ...process.env,
+                        BUNDLE_GEMFILE: undefined,
+                        GEM_HOME: undefined,
+                        GEM_PATH: undefined
+                    }
+                }
+            );
+            this.context.logger.debug("Generated Gemfile.lock successfully");
+        } catch (error) {
+            this.context.logger.warn(
+                `Failed to generate Gemfile.lock: ${error instanceof Error ? error.message : String(error)}. ` +
+                    "The generated SDK will not include a lockfile. Run 'bundle install' manually to create one."
+            );
+        }
     }
 
     private async createGemspecfile(): Promise<void> {

--- a/generators/ruby-v2/sdk/changes/unreleased/add-gemfile-lock-generation.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/add-gemfile-lock-generation.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generate Gemfile.lock during SDK generation by running `bundle lock` after
+    all project files (including Gemfile.custom and custom.gemspec.rb) have been
+    written. This ensures the lockfile includes all transitive dependencies and
+    lists common platforms (ruby, x86_64-linux, aarch64-linux, arm64-darwin,
+    x86_64-darwin), preventing CI failures from missing gems after regeneration.
+  type: fix

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1936,6 +1936,9 @@ importers:
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/fs-utils
+      '@fern-api/logging-execa':
+        specifier: workspace:*
+        version: link:../../../packages/commons/logging-execa
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-10729](https://linear.app/buildwithfern/issue/FER-10729/ruby-audit-lockfile-resolution-order-in-fern-ruby-sdk-generator)

The Ruby SDK generator (`ruby-v2`) does not generate a `Gemfile.lock` during SDK generation. When a customer's repo is regenerated, any pre-existing `Gemfile.lock` is either deleted (if not in `.fernignore`) or becomes stale (if preserved but mismatched with the new `Gemfile`). This was the root cause of the [square-ruby-sdk CI failure](https://github.com/square/square-ruby-sdk/actions/runs/26125941769/job/77001278840) (FER-10686).

## Audit findings

| Generator | Lockfile artifact | Resolved before or after customizations? | File / function reference | Needs fix? |
|-----------|------------------|----------------------------------------|--------------------------|------------|
| Ruby (`fern-ruby-sdk`) | `Gemfile.lock` | **Not resolved at all** | `generators/ruby-v2/base/src/project/RubyProject.ts:99-114` (`persist()`) | **Yes** |

`RubyProject.persist()` writes all project files (gemspec, Gemfile, Gemfile.custom, etc.) but never runs `bundle lock` or `bundle install`. History: v1.0.0-rc11 added `bundle install` (coupled to rubocop); v1.10.0 removed rubocop from generation and the `bundle install` step was lost with it.

## Changes Made
- Added `generateGemfileLock()` method to `RubyProject` that runs `bundle lock` with common platforms (`ruby`, `x86_64-linux`, `aarch64-linux`, `arm64-darwin`, `x86_64-darwin`)
- Called at the end of `persist()` after all files are written, ensuring it runs **after** all customization files (`Gemfile.custom`, `custom.gemspec.rb`) are in place
- Added `@fern-api/logging-execa` as a dependency to `@fern-api/ruby-base`
- Failure is non-fatal: logs a warning but does not fail generation (graceful degradation for environments without `bundle`)
- Clears `BUNDLE_GEMFILE`, `GEM_HOME`, `GEM_PATH` env vars to avoid interference from the host/container Bundler config
- Added unreleased changelog entry

## Testing
- [x] TypeScript compilation passes (`pnpm turbo run compile --filter @fern-api/ruby-base`)
- [x] Biome formatting passes
- [x] Knip dependency check passes (`pnpm turbo run depcheck --filter @fern-api/ruby-base`)
- [ ] CI checks

Link to Devin session: https://app.devin.ai/sessions/ac7331473caf49738d634a8127ff38cc
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->