### PR TITLE
fix(python): re-resolve lockfile after replay patches (FER-10730)

### DIFF
--- a/generators/python/sdk/changes/unreleased/emit-resolve-lockfile-script.yml
+++ b/generators/python/sdk/changes/unreleased/emit-resolve-lockfile-script.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Emit `.fern/resolve-lockfile.sh` for GitHub output mode so the
+    PostGenerationPipeline can re-resolve `poetry.lock` after replay
+    patches or `.fernignore`-preserved files modify `pyproject.toml`.
+  type: fix

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -222,6 +222,7 @@ class AbstractGenerator(ABC):
             publisher.run_poetry_lock()
             publisher.run_ruff_check_fix()
             publisher.run_ruff_format()
+            self._write_resolve_lockfile_script(generator_config)
         elif output_mode_union.type == "publish":
             publisher.run_poetry_lock()
             publisher.run_ruff_check_fix()
@@ -238,6 +239,27 @@ class AbstractGenerator(ABC):
     def _clean_organization_name(self, organization: str) -> str:
         # Replace non-alphanumeric characters with underscores
         return re.sub("[^a-zA-Z0-9]", "_", organization)
+
+    def _write_resolve_lockfile_script(self, generator_config: GeneratorConfig) -> None:
+        """Emit .fern/resolve-lockfile.sh so the PostGenerationPipeline can
+        re-resolve the lockfile after replay patches or .fernignore restoration
+        may have modified pyproject.toml."""
+        output_path = generator_config.output.path
+        fern_dir = os.path.join(output_path, ".fern")
+        os.makedirs(fern_dir, exist_ok=True)
+        script_path = os.path.join(fern_dir, "resolve-lockfile.sh")
+        with open(script_path, "w") as f:
+            f.write(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    cd "$(dirname "$0")/.."
+                    poetry lock --no-update
+                    """
+                )
+            )
+        os.chmod(script_path, 0o755)
 
     def _get_github_publish_config(
         self, generator_config: GeneratorConfig, output_mode: GithubOutputMode

--- a/packages/cli/cli/changes/unreleased/lockfile-resolution-step.yml
+++ b/packages/cli/cli/changes/unreleased/lockfile-resolution-step.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Add `LockfileResolutionStep` to `PostGenerationPipeline` that runs
+    `.fern/resolve-lockfile.sh` after ReplayStep, ensuring lockfiles
+    reflect any dependency changes introduced by replay patches.
+  type: fix

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -425,6 +425,7 @@ export async function runLocalGenerationForWorkspace({
                             replay: githubPipelineEnabled
                                 ? { enabled: replay?.enabled === true, skipApplication: noReplay, stageOnly: false }
                                 : undefined,
+                            lockfileResolution: { enabled: true },
                             verify: { enabled: verify === true, runner },
                             github:
                                 githubPipelineEnabled && selfhostedGithubConfig != null

--- a/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
+++ b/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
@@ -6,6 +6,7 @@ import { AutoVersionStep } from "./steps/AutoVersionStep";
 import { BaseStep } from "./steps/BaseStep";
 import { GenerationCommitStep } from "./steps/GenerationCommitStep";
 import { GithubStep } from "./steps/GithubStep";
+import { LockfileResolutionStep } from "./steps/LockfileResolutionStep";
 import { ReplayStep } from "./steps/ReplayStep";
 import { VerificationStep } from "./steps/VerificationStep";
 import type {
@@ -13,6 +14,7 @@ import type {
     FernignoreStepResult,
     GenerationCommitStepResult,
     GithubStepResult,
+    LockfileResolutionStepResult,
     PipelineConfig,
     PipelineContext,
     PipelineResult,
@@ -90,6 +92,13 @@ export class PostGenerationPipeline {
         //   this.steps.push(new FernignoreStep(config.outputDir, this.logger));
         // }
 
+        // LockfileResolutionStep re-resolves the package-manager lockfile after
+        // replay/fernignore may have modified the manifest (e.g. pyproject.toml).
+        // Generators opt in by emitting `.fern/resolve-lockfile.sh`.
+        if (config.lockfileResolution?.enabled) {
+            this.steps.push(new LockfileResolutionStep(config.outputDir, this.logger));
+        }
+
         // VerificationStep runs after replay and before GithubStep so a failing
         // verify aborts the pipeline before we open a PR. Wired only when the
         // generator emitted `.fern/verify.sh` (no-ops otherwise).
@@ -154,6 +163,9 @@ export class PostGenerationPipeline {
                     pipelineContext.previousStepResults.autoVersion = stepResult as AutoVersionStepResult;
                 } else if (step.name === "fernignore") {
                     result.steps.fernignore = stepResult as FernignoreStepResult;
+                } else if (step.name === "lockfileResolution") {
+                    result.steps.lockfileResolution = stepResult as LockfileResolutionStepResult;
+                    pipelineContext.previousStepResults.lockfileResolution = stepResult as LockfileResolutionStepResult;
                 } else if (step.name === "verify") {
                     const verifyResult = stepResult as VerificationStepResult;
                     result.steps.verify = verifyResult;

--- a/packages/generator-cli/src/pipeline/index.ts
+++ b/packages/generator-cli/src/pipeline/index.ts
@@ -9,6 +9,8 @@ export type {
     FernignoreStepResult,
     GithubStepConfig,
     GithubStepResult,
+    LockfileResolutionStepConfig,
+    LockfileResolutionStepResult,
     PipelineConfig,
     PipelineContext,
     PipelineResult,

--- a/packages/generator-cli/src/pipeline/steps/LockfileResolutionStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/LockfileResolutionStep.ts
@@ -37,12 +37,12 @@ export class LockfileResolutionStep extends BaseStep {
 
             this.logger.debug(`Lockfile resolution output: ${result.toString().trim()}`);
 
+            this.commitIfChanged();
+
             return { executed: true, success: true, skipped: false };
         } catch (error) {
             const message = `Lockfile resolution failed: ${extractErrorMessage(error)}`;
             this.logger.warn(message);
-            // Non-fatal: generation can proceed with the pre-replay lockfile.
-            // The lockfile may be stale but the SDK is still usable.
             return {
                 executed: true,
                 success: true,
@@ -50,5 +50,36 @@ export class LockfileResolutionStep extends BaseStep {
                 errorMessage: message
             };
         }
+    }
+
+    /**
+     * Stage and commit lockfile changes so they are included when GithubStep
+     * pushes — even when `skipCommit` is true (replay already committed).
+     * No-ops when the working tree is clean.
+     */
+    private commitIfChanged(): void {
+        const hasChanges =
+            execFileSync("git", ["status", "--porcelain"], {
+                cwd: this.outputDir,
+                encoding: "utf-8",
+                stdio: "pipe"
+            }).trim().length > 0;
+
+        if (!hasChanges) {
+            this.logger.debug("Lockfile unchanged — nothing to commit.");
+            return;
+        }
+
+        execFileSync("git", ["add", "-A"], {
+            cwd: this.outputDir,
+            stdio: "pipe"
+        });
+
+        execFileSync("git", ["commit", "-m", "[fern-lockfile] Re-resolve lockfile"], {
+            cwd: this.outputDir,
+            stdio: "pipe"
+        });
+
+        this.logger.info("Committed lockfile changes as [fern-lockfile].");
     }
 }

--- a/packages/generator-cli/src/pipeline/steps/LockfileResolutionStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/LockfileResolutionStep.ts
@@ -1,0 +1,59 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
+import { execFileSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+import type { PipelineLogger } from "../PipelineLogger";
+import type { LockfileResolutionStepResult, PipelineContext } from "../types";
+import { BaseStep } from "./BaseStep";
+
+const RESOLVE_LOCKFILE_RELATIVE_PATH = ".fern/resolve-lockfile.sh";
+
+/**
+ * Runs `.fern/resolve-lockfile.sh` (when emitted by the generator) to regenerate
+ * the package-manager lockfile after ReplayStep has applied customer patches.
+ *
+ * This ensures the lockfile reflects any dependency changes introduced by replay
+ * patches or `.fernignore`-preserved manifest files.
+ *
+ * No-ops when `.fern/resolve-lockfile.sh` is absent (only Python emits it today;
+ * other languages will follow via sibling FER-10687 subissues).
+ */
+export class LockfileResolutionStep extends BaseStep {
+    readonly name = "lockfileResolution";
+
+    constructor(outputDir: string, logger: PipelineLogger) {
+        super(outputDir, logger);
+    }
+
+    async execute(_context: PipelineContext): Promise<LockfileResolutionStepResult> {
+        const scriptPath = join(this.outputDir, RESOLVE_LOCKFILE_RELATIVE_PATH);
+        if (!existsSync(scriptPath)) {
+            return { executed: true, success: true, skipped: true };
+        }
+
+        this.logger.info("Re-resolving lockfile after customization steps...");
+
+        try {
+            const result = execFileSync("bash", [scriptPath], {
+                cwd: this.outputDir,
+                timeout: 120_000,
+                stdio: ["ignore", "pipe", "pipe"]
+            });
+
+            this.logger.debug(`Lockfile resolution output: ${result.toString().trim()}`);
+
+            return { executed: true, success: true, skipped: false };
+        } catch (error) {
+            const message = `Lockfile resolution failed: ${extractErrorMessage(error)}`;
+            this.logger.warn(message);
+            // Non-fatal: generation can proceed with the pre-replay lockfile.
+            // The lockfile may be stale but the SDK is still usable.
+            return {
+                executed: true,
+                success: true,
+                skipped: false,
+                errorMessage: message
+            };
+        }
+    }
+}

--- a/packages/generator-cli/src/pipeline/steps/LockfileResolutionStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/LockfileResolutionStep.ts
@@ -28,9 +28,9 @@ export class LockfileResolutionStep extends BaseStep {
 
         this.logger.info("Re-resolving lockfile after customization steps...");
 
-        const statusBefore = this.gitStatusSnapshot();
-
         try {
+            const statusBefore = this.gitStatusSnapshot();
+
             const result = execFileSync("bash", [scriptPath], {
                 cwd: this.outputDir,
                 timeout: 120_000,

--- a/packages/generator-cli/src/pipeline/steps/LockfileResolutionStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/LockfileResolutionStep.ts
@@ -28,6 +28,8 @@ export class LockfileResolutionStep extends BaseStep {
 
         this.logger.info("Re-resolving lockfile after customization steps...");
 
+        const statusBefore = this.gitStatusSnapshot();
+
         try {
             const result = execFileSync("bash", [scriptPath], {
                 cwd: this.outputDir,
@@ -37,7 +39,7 @@ export class LockfileResolutionStep extends BaseStep {
 
             this.logger.debug(`Lockfile resolution output: ${result.toString().trim()}`);
 
-            this.commitIfChanged();
+            this.commitNewChanges(statusBefore);
 
             return { executed: true, success: true, skipped: false };
         } catch (error) {
@@ -52,34 +54,51 @@ export class LockfileResolutionStep extends BaseStep {
         }
     }
 
-    /**
-     * Stage and commit lockfile changes so they are included when GithubStep
-     * pushes — even when `skipCommit` is true (replay already committed).
-     * No-ops when the working tree is clean.
-     */
-    private commitIfChanged(): void {
-        const hasChanges =
-            execFileSync("git", ["status", "--porcelain"], {
-                cwd: this.outputDir,
-                encoding: "utf-8",
-                stdio: "pipe"
-            }).trim().length > 0;
+    private gitStatusSnapshot(): Set<string> {
+        const output = execFileSync("git", ["status", "--porcelain"], {
+            cwd: this.outputDir,
+            encoding: "utf-8",
+            stdio: "pipe"
+        }).trim();
+        return new Set(output ? output.split("\n") : []);
+    }
 
-        if (!hasChanges) {
+    /**
+     * Stage and commit only the files that changed as a result of running the
+     * lockfile script, not pre-existing uncommitted files. Compares a before/after
+     * snapshot of `git status --porcelain` and only stages new or modified entries.
+     */
+    private commitNewChanges(statusBefore: Set<string>): void {
+        const statusAfter = this.gitStatusSnapshot();
+
+        const newEntries: string[] = [];
+        for (const entry of statusAfter) {
+            if (!statusBefore.has(entry)) {
+                // porcelain format: "XY path" — extract the path after the 3-char prefix
+                const filePath = entry.slice(3);
+                if (filePath.length > 0) {
+                    newEntries.push(filePath);
+                }
+            }
+        }
+
+        if (newEntries.length === 0) {
             this.logger.debug("Lockfile unchanged — nothing to commit.");
             return;
         }
 
-        execFileSync("git", ["add", "-A"], {
-            cwd: this.outputDir,
-            stdio: "pipe"
-        });
+        for (const filePath of newEntries) {
+            execFileSync("git", ["add", "--", filePath], {
+                cwd: this.outputDir,
+                stdio: "pipe"
+            });
+        }
 
         execFileSync("git", ["commit", "-m", "[fern-lockfile] Re-resolve lockfile"], {
             cwd: this.outputDir,
             stdio: "pipe"
         });
 
-        this.logger.info("Committed lockfile changes as [fern-lockfile].");
+        this.logger.info(`Committed lockfile changes as [fern-lockfile]: ${newEntries.join(", ")}`);
     }
 }

--- a/packages/generator-cli/src/pipeline/steps/LockfileResolutionStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/LockfileResolutionStep.ts
@@ -2,7 +2,6 @@ import { extractErrorMessage } from "@fern-api/core-utils";
 import { execFileSync } from "child_process";
 import { existsSync } from "fs";
 import { join } from "path";
-import type { PipelineLogger } from "../PipelineLogger";
 import type { LockfileResolutionStepResult, PipelineContext } from "../types";
 import { BaseStep } from "./BaseStep";
 
@@ -20,10 +19,6 @@ const RESOLVE_LOCKFILE_RELATIVE_PATH = ".fern/resolve-lockfile.sh";
  */
 export class LockfileResolutionStep extends BaseStep {
     readonly name = "lockfileResolution";
-
-    constructor(outputDir: string, logger: PipelineLogger) {
-        super(outputDir, logger);
-    }
 
     async execute(_context: PipelineContext): Promise<LockfileResolutionStepResult> {
         const scriptPath = join(this.outputDir, RESOLVE_LOCKFILE_RELATIVE_PATH);

--- a/packages/generator-cli/src/pipeline/types.ts
+++ b/packages/generator-cli/src/pipeline/types.ts
@@ -5,6 +5,7 @@ export interface PipelineConfig {
     replay?: ReplayStepConfig;
     autoVersion?: AutoVersionStepConfig;
     fernignore?: FernignoreStepConfig; // PHASE 2: not implemented yet
+    lockfileResolution?: LockfileResolutionStepConfig;
     verify?: VerifyStepConfig;
     github?: GithubStepConfig;
 
@@ -20,6 +21,7 @@ export interface PipelineContext {
         replay?: ReplayStepResult;
         autoVersion?: AutoVersionStepResult;
         fernignore?: FernignoreStepResult;
+        lockfileResolution?: LockfileResolutionStepResult;
         verify?: VerificationStepResult;
     };
 }
@@ -96,6 +98,10 @@ export interface FernignoreStepConfig {
     customContents?: string;
 }
 
+export interface LockfileResolutionStepConfig {
+    enabled: boolean;
+}
+
 export interface VerifyStepConfig {
     enabled: boolean;
     /** Container runtime to use. Defaults to "docker". */
@@ -165,6 +171,7 @@ export interface PipelineResult {
         replay?: ReplayStepResult;
         autoVersion?: AutoVersionStepResult;
         fernignore?: FernignoreStepResult;
+        lockfileResolution?: LockfileResolutionStepResult;
         verify?: VerificationStepResult;
         github?: GithubStepResult;
     };
@@ -223,6 +230,11 @@ export interface ReplayStepResult extends StepResult {
         }>;
     }>;
     warnings?: string[];
+}
+
+export interface LockfileResolutionStepResult extends StepResult {
+    /** True when no `.fern/resolve-lockfile.sh` was emitted by the generator — the step short-circuits silently. */
+    skipped: boolean;
 }
 
 export interface FernignoreStepResult extends StepResult {


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-10730](https://linear.app/buildwithfern/issue/FER-10730/python-audit-lockfile-resolution-order-in-fern-python-sdk-generator)

The Python SDK generator runs `poetry lock` **inside** the Docker container during code generation — **before** the `PostGenerationPipeline` runs `ReplayStep` (which applies customer patches) and before `.fernignore`-preserved files are restored. If a customer's replay patches modify `pyproject.toml` (e.g. adding a dependency), the committed `poetry.lock` is stale and missing those deps.

This is the same class of bug as the Ruby incident ([FER-10686](https://linear.app/buildwithfern/issue/FER-10686)) where `Gemfile.lock` was missing runtime deps after regeneration.

## Changes Made

### Python generator (`generators/python/`)
- Emit `.fern/resolve-lockfile.sh` for `github` output mode after initial `poetry lock` + ruff formatting. The script runs `poetry lock --no-update` from the project root.

### PostGenerationPipeline (`packages/generator-cli/`)
- New `LockfileResolutionStep` that runs after `ReplayStep` and before `VerificationStep`. Checks for `.fern/resolve-lockfile.sh` in the output directory and executes it. No-ops when absent. Non-fatal on failure (logs a warning and continues).
- `LockfileResolutionStep` commits lockfile changes via `commitIfChanged()` using `git add -A && git commit` so they survive `GithubStep`'s `skipCommit=true` path (active when replay has already committed).
- New types: `LockfileResolutionStepConfig`, `LockfileResolutionStepResult`
- Pipeline step order is now: `GenerationCommitStep → AutoVersionStep → ReplayStep → (FernignoreStep placeholder) → **LockfileResolutionStep** → VerificationStep → GithubStep`

### Local generation runner (`packages/cli/`)
- Wire `lockfileResolution: { enabled: true }` into the `PostGenerationPipeline` config so the step runs for all local generations with self-hosted GitHub.

### Pipeline execution order (after fix)
1. v1 Python generator generates code + writes `pyproject.toml`
2. `publisher.run_poetry_lock()` — initial lockfile (best-effort)
3. ruff check/format
4. `.fern/resolve-lockfile.sh` emitted to output
5. v2 TypeScript generator (README, reference, CONTRIBUTING)
6. Container exits → `.fernignore` restoration → PostGenerationPipeline
7. `GenerationCommitStep → AutoVersionStep → ReplayStep` (patches applied)
8. **`LockfileResolutionStep`** — re-runs `poetry lock --no-update` via the emitted script, commits as `[fern-lockfile]`
9. `VerificationStep → GithubStep`

## Testing
- [x] Python pre-commit hooks pass (`pre-commit run --files abstract_generator.py`)
- [x] TypeScript type-check confirms no new errors (all 45 errors are pre-existing)
- [x] Biome check passes on all changed files


Link to Devin session: https://app.devin.ai/sessions/a311120c23544aa8a8117b43aed27f8c
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->