### PR TITLE
fix(generator-cli): move TypeScript lockfile generation after replay in PostGenerationPipeline

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/lockfile-after-replay.yml
+++ b/generators/typescript/sdk/changes/unreleased/lockfile-after-replay.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Move lockfile generation from the generator's github output-mode handler
+    to a new LockfileStep in the PostGenerationPipeline, ensuring the lockfile
+    reflects the final package.json after Replay patches, .fernignore
+    preservation, and manifest customizations.
+  type: fix

--- a/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
@@ -204,6 +204,11 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
                             packageManager: this.getPackageManager(customConfig)
                         });
                     });
+                    // Generate the lockfile eagerly so the Fiddle/remote path
+                    // (which does not run PostGenerationPipeline) still ships one.
+                    // When the local-gen pipeline IS active, LockfileStep will
+                    // regenerate it after Replay to pick up any manifest changes.
+                    await typescriptProject.generateLockfile(logger);
                     if (!(await typescriptProject.areCheckFixToolsAvailable(logger))) {
                         await typescriptProject.installCheckFixDependencies(logger);
                     }

--- a/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
@@ -25,6 +25,7 @@ import { GeneratorContext } from "@fern-typescript/contexts";
 import { publishPackage } from "./publishPackage.js";
 import { writeGenerationMetadata } from "./writeGenerationMetadata.js";
 import { writeGitHubWorkflows } from "./writeGitHubWorkflows.js";
+import { writeLockfileScript } from "./writeLockfileScript.js";
 import { writeVerifyScript } from "./writeVerifyScript.js";
 
 const OUTPUT_ZIP_FILENAME = "output.zip";
@@ -152,6 +153,10 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
                     pathToProject,
                     packageManager: typescriptProject.getPackageManager()
                 });
+                await writeLockfileScript({
+                    pathToProject,
+                    packageManager: typescriptProject.getPackageManager()
+                });
             });
 
             // Run npm pkg fix to normalize package.json (enabled by default)
@@ -199,7 +204,6 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
                             packageManager: this.getPackageManager(customConfig)
                         });
                     });
-                    await typescriptProject.generateLockfile(logger);
                     if (!(await typescriptProject.areCheckFixToolsAvailable(logger))) {
                         await typescriptProject.installCheckFixDependencies(logger);
                     }

--- a/generators/typescript/utils/abstract-generator-cli/src/writeLockfileScript.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/writeLockfileScript.ts
@@ -1,0 +1,35 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+
+import type { SupportedPackageManager } from "./packageManagerCommands";
+
+const LOCKFILE_SCRIPT_FILENAME = "regenerate-lockfile.sh";
+const LOCKFILE_SCRIPT_DIRNAME = ".fern";
+const LOCKFILE_SCRIPT_MODE = 0o755;
+
+export function buildLockfileScript(packageManager: SupportedPackageManager): string {
+    if (packageManager === "yarn") {
+        return `#!/bin/bash
+set -euo pipefail
+YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install --mode=update-lockfile --ignore-scripts --prefer-offline
+`;
+    }
+    return `#!/bin/bash
+set -euo pipefail
+PNPM_FROZEN_LOCKFILE=false pnpm install --lockfile-only --ignore-scripts --prefer-offline
+`;
+}
+
+export async function writeLockfileScript({
+    pathToProject,
+    packageManager
+}: {
+    pathToProject: AbsoluteFilePath;
+    packageManager: SupportedPackageManager;
+}): Promise<void> {
+    const dir = path.join(pathToProject, LOCKFILE_SCRIPT_DIRNAME);
+    await mkdir(dir, { recursive: true });
+    const scriptPath = path.join(dir, LOCKFILE_SCRIPT_FILENAME);
+    await writeFile(scriptPath, buildLockfileScript(packageManager), { mode: LOCKFILE_SCRIPT_MODE });
+}

--- a/packages/cli/cli/changes/unreleased/lockfile-pipeline-step.yml
+++ b/packages/cli/cli/changes/unreleased/lockfile-pipeline-step.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Wire LockfileStep in the PostGenerationPipeline so the package-manager
+    lockfile is regenerated after Replay and .fernignore are applied.
+  type: fix

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -425,6 +425,7 @@ export async function runLocalGenerationForWorkspace({
                             replay: githubPipelineEnabled
                                 ? { enabled: replay?.enabled === true, skipApplication: noReplay, stageOnly: false }
                                 : undefined,
+                            lockfile: githubPipelineEnabled ? { enabled: true, runner } : undefined,
                             verify: { enabled: verify === true, runner },
                             github:
                                 githubPipelineEnabled && selfhostedGithubConfig != null

--- a/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
+++ b/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
@@ -6,6 +6,7 @@ import { AutoVersionStep } from "./steps/AutoVersionStep";
 import { BaseStep } from "./steps/BaseStep";
 import { GenerationCommitStep } from "./steps/GenerationCommitStep";
 import { GithubStep } from "./steps/GithubStep";
+import { LockfileStep } from "./steps/LockfileStep";
 import { ReplayStep } from "./steps/ReplayStep";
 import { VerificationStep } from "./steps/VerificationStep";
 import type {
@@ -13,6 +14,7 @@ import type {
     FernignoreStepResult,
     GenerationCommitStepResult,
     GithubStepResult,
+    LockfileStepResult,
     PipelineConfig,
     PipelineContext,
     PipelineResult,
@@ -90,6 +92,22 @@ export class PostGenerationPipeline {
         //   this.steps.push(new FernignoreStep(config.outputDir, this.logger));
         // }
 
+        // LockfileStep regenerates the package-manager lockfile inside the
+        // validator container so it reflects the final package.json (after
+        // replay, fernignore, and manifest customizations). Runs after replay
+        // and before verification.
+        if (config.lockfile?.enabled) {
+            this.steps.push(
+                new LockfileStep(
+                    config.outputDir,
+                    this.logger,
+                    config.lockfile,
+                    config.generatorName,
+                    config.generatorVersions
+                )
+            );
+        }
+
         // VerificationStep runs after replay and before GithubStep so a failing
         // verify aborts the pipeline before we open a PR. Wired only when the
         // generator emitted `.fern/verify.sh` (no-ops otherwise).
@@ -154,6 +172,10 @@ export class PostGenerationPipeline {
                     pipelineContext.previousStepResults.autoVersion = stepResult as AutoVersionStepResult;
                 } else if (step.name === "fernignore") {
                     result.steps.fernignore = stepResult as FernignoreStepResult;
+                } else if (step.name === "lockfile") {
+                    const lockfileResult = stepResult as LockfileStepResult;
+                    result.steps.lockfile = lockfileResult;
+                    pipelineContext.previousStepResults.lockfile = lockfileResult;
                 } else if (step.name === "verify") {
                     const verifyResult = stepResult as VerificationStepResult;
                     result.steps.verify = verifyResult;

--- a/packages/generator-cli/src/pipeline/index.ts
+++ b/packages/generator-cli/src/pipeline/index.ts
@@ -9,6 +9,8 @@ export type {
     FernignoreStepResult,
     GithubStepConfig,
     GithubStepResult,
+    LockfileStepConfig,
+    LockfileStepResult,
     PipelineConfig,
     PipelineContext,
     PipelineResult,

--- a/packages/generator-cli/src/pipeline/steps/LockfileStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/LockfileStep.ts
@@ -118,7 +118,9 @@ export class LockfileStep extends BaseStep {
                     this.logger.info(`Copied regenerated ${candidate} back from container`);
                     break;
                 } catch (error) {
-                    this.logger.debug(`Lockfile candidate ${candidate} not found in container: ${extractErrorMessage(error)}`);
+                    this.logger.debug(
+                        `Lockfile candidate ${candidate} not found in container: ${extractErrorMessage(error)}`
+                    );
                 }
             }
 
@@ -167,7 +169,9 @@ export class LockfileStep extends BaseStep {
                         stdio: "pipe"
                     });
                 } catch (error) {
-                    this.logger.debug(`Lockfile candidate ${candidate} not present on disk, skipping git add: ${extractErrorMessage(error)}`);
+                    this.logger.debug(
+                        `Lockfile candidate ${candidate} not present on disk, skipping git add: ${extractErrorMessage(error)}`
+                    );
                 }
             }
             const diff = execFileSync("git", ["diff", "--cached", "--name-only"], {

--- a/packages/generator-cli/src/pipeline/steps/LockfileStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/LockfileStep.ts
@@ -1,0 +1,221 @@
+import { ContainerRunner, extractErrorMessage } from "@fern-api/core-utils";
+import {
+    copyFromContainer,
+    copyToContainer,
+    execInContainer,
+    startContainer,
+    stopContainer
+} from "@fern-api/docker-utils";
+import { createLogger, LogLevel } from "@fern-api/logger";
+import { execFileSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+import type { PipelineLogger } from "../PipelineLogger";
+import type { LockfileStepConfig, LockfileStepResult, PipelineContext } from "../types";
+import { BaseStep } from "./BaseStep";
+
+const CONTAINER_WORKSPACE_PATH = "/workspace";
+const LOCKFILE_SCRIPT_RELATIVE_PATH = ".fern/regenerate-lockfile.sh";
+const LOCKFILE_SCRIPT_CONTAINER_PATH = `${CONTAINER_WORKSPACE_PATH}/${LOCKFILE_SCRIPT_RELATIVE_PATH}`;
+
+/** Known lockfile filenames, checked in order. */
+const LOCKFILE_CANDIDATES = ["pnpm-lock.yaml", "yarn.lock"];
+
+/**
+ * Regenerates the package-manager lockfile inside the validator container so
+ * it reflects the final `package.json` — including any edits from ReplayStep,
+ * `.fernignore` preservation, or per-SDK manifest customizations.
+ *
+ * No-ops when `.fern/regenerate-lockfile.sh` is absent (only the TypeScript
+ * SDK generator emits it today).
+ */
+export class LockfileStep extends BaseStep {
+    readonly name = "lockfile";
+
+    constructor(
+        outputDir: string,
+        logger: PipelineLogger,
+        private readonly config: LockfileStepConfig,
+        private readonly generatorName?: string,
+        private readonly generatorVersions?: Record<string, string>
+    ) {
+        super(outputDir, logger);
+    }
+
+    async execute(_context: PipelineContext): Promise<LockfileStepResult> {
+        const scriptHostPath = join(this.outputDir, LOCKFILE_SCRIPT_RELATIVE_PATH);
+        if (!existsSync(scriptHostPath)) {
+            return { executed: true, success: true, skipped: true };
+        }
+
+        const validatorImage = this.deriveValidatorImage();
+        if (validatorImage == null) {
+            this.logger.warn(
+                "Cannot derive validator image for lockfile regeneration: generatorName and generatorVersions are required."
+            );
+            return { executed: true, success: true, skipped: true };
+        }
+
+        const runner: ContainerRunner = this.config.runner ?? "docker";
+        const dockerLogger = createDockerLoggerAdapter(this.logger);
+
+        let containerId: string | undefined;
+        try {
+            try {
+                containerId = await startContainer({
+                    logger: dockerLogger,
+                    imageName: validatorImage,
+                    runner
+                });
+            } catch (error) {
+                const message = `Failed to start lockfile container from image ${validatorImage}: ${extractErrorMessage(error)}`;
+                this.logger.error(message);
+                return { executed: true, success: false, skipped: false, errorMessage: message };
+            }
+
+            try {
+                await copyToContainer({
+                    logger: dockerLogger,
+                    containerId,
+                    hostPath: `${this.outputDir}/.`,
+                    containerPath: CONTAINER_WORKSPACE_PATH,
+                    runner
+                });
+            } catch (error) {
+                const message = `Failed to copy workspace into lockfile container: ${extractErrorMessage(error)}`;
+                this.logger.error(message);
+                return { executed: true, success: false, skipped: false, errorMessage: message };
+            }
+
+            const { stderr, exitCode } = await execInContainer({
+                logger: dockerLogger,
+                containerId,
+                command: ["bash", LOCKFILE_SCRIPT_CONTAINER_PATH],
+                runner,
+                writeLogsToFile: false,
+                reject: false
+            });
+
+            if (exitCode !== 0) {
+                const message = `Lockfile regeneration failed (exit code ${exitCode}): ${stderr}`;
+                this.logger.error(message);
+                return { executed: true, success: false, skipped: false, errorMessage: message };
+            }
+
+            // Copy the regenerated lockfile back from the container.
+            let lockfileCopied = false;
+            for (const candidate of LOCKFILE_CANDIDATES) {
+                const containerLockfilePath = `${CONTAINER_WORKSPACE_PATH}/${candidate}`;
+                try {
+                    await copyFromContainer({
+                        logger: dockerLogger,
+                        containerId,
+                        containerPath: containerLockfilePath,
+                        hostPath: join(this.outputDir, candidate),
+                        runner
+                    });
+                    lockfileCopied = true;
+                    this.logger.info(`Copied regenerated ${candidate} back from container`);
+                    break;
+                } catch {
+                    // Lockfile candidate doesn't exist in the container — try next.
+                }
+            }
+
+            if (!lockfileCopied) {
+                this.logger.warn("Lockfile script ran but no known lockfile was produced");
+                return { executed: true, success: true, skipped: false };
+            }
+
+            // Commit the updated lockfile if the output directory is a git repo
+            // and there are uncommitted changes (e.g. after ReplayStep committed).
+            this.commitLockfileIfNeeded();
+
+            this.logger.info("Lockfile regeneration succeeded");
+            return { executed: true, success: true, skipped: false };
+        } finally {
+            if (containerId != null) {
+                try {
+                    await stopContainer({ logger: dockerLogger, containerId, runner });
+                } catch (error) {
+                    this.logger.debug(
+                        `Best-effort cleanup: failed to stop lockfile container ${containerId}: ${extractErrorMessage(error)}`
+                    );
+                }
+            }
+        }
+    }
+
+    private commitLockfileIfNeeded(): void {
+        try {
+            // Check if inside a git repository.
+            execFileSync("git", ["rev-parse", "--is-inside-work-tree"], {
+                cwd: this.outputDir,
+                stdio: "pipe"
+            });
+        } catch {
+            return;
+        }
+
+        try {
+            // Stage lockfile changes and check if there's anything to commit.
+            for (const candidate of LOCKFILE_CANDIDATES) {
+                try {
+                    execFileSync("git", ["add", candidate], {
+                        cwd: this.outputDir,
+                        stdio: "pipe"
+                    });
+                } catch {
+                    // File doesn't exist — skip.
+                }
+            }
+            const diff = execFileSync("git", ["diff", "--cached", "--name-only"], {
+                cwd: this.outputDir,
+                encoding: "utf-8",
+                stdio: "pipe"
+            }).trim();
+
+            if (diff.length > 0) {
+                execFileSync("git", ["commit", "-m", "[fern-lockfile] regenerate lockfile after replay"], {
+                    cwd: this.outputDir,
+                    stdio: "pipe"
+                });
+                this.logger.debug("Committed lockfile update as [fern-lockfile]");
+            }
+        } catch (error) {
+            this.logger.debug(`Best-effort lockfile commit failed: ${extractErrorMessage(error)}`);
+        }
+    }
+
+    private deriveValidatorImage(): string | undefined {
+        if (this.generatorName == null) {
+            return undefined;
+        }
+        const version = this.generatorVersions?.[this.generatorName];
+        if (version == null) {
+            return undefined;
+        }
+        return `${this.generatorName}-validator:${version}`;
+    }
+}
+
+function createDockerLoggerAdapter(pipelineLogger: PipelineLogger) {
+    return createLogger((level, ...args) => {
+        const message = args.join(" ");
+        switch (level) {
+            case LogLevel.Trace:
+            case LogLevel.Debug:
+                pipelineLogger.debug(message);
+                return;
+            case LogLevel.Info:
+                pipelineLogger.info(message);
+                return;
+            case LogLevel.Warn:
+                pipelineLogger.warn(message);
+                return;
+            case LogLevel.Error:
+                pipelineLogger.error(message);
+                return;
+        }
+    });
+}

--- a/packages/generator-cli/src/pipeline/steps/LockfileStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/LockfileStep.ts
@@ -117,8 +117,8 @@ export class LockfileStep extends BaseStep {
                     lockfileCopied = true;
                     this.logger.info(`Copied regenerated ${candidate} back from container`);
                     break;
-                } catch {
-                    // Lockfile candidate doesn't exist in the container — try next.
+                } catch (error) {
+                    this.logger.debug(`Lockfile candidate ${candidate} not found in container: ${extractErrorMessage(error)}`);
                 }
             }
 
@@ -153,7 +153,8 @@ export class LockfileStep extends BaseStep {
                 cwd: this.outputDir,
                 stdio: "pipe"
             });
-        } catch {
+        } catch (error) {
+            this.logger.debug(`Not inside a git repository, skipping lockfile commit: ${extractErrorMessage(error)}`);
             return;
         }
 
@@ -165,8 +166,8 @@ export class LockfileStep extends BaseStep {
                         cwd: this.outputDir,
                         stdio: "pipe"
                     });
-                } catch {
-                    // File doesn't exist — skip.
+                } catch (error) {
+                    this.logger.debug(`Lockfile candidate ${candidate} not present on disk, skipping git add: ${extractErrorMessage(error)}`);
                 }
             }
             const diff = execFileSync("git", ["diff", "--cached", "--name-only"], {

--- a/packages/generator-cli/src/pipeline/types.ts
+++ b/packages/generator-cli/src/pipeline/types.ts
@@ -5,6 +5,7 @@ export interface PipelineConfig {
     replay?: ReplayStepConfig;
     autoVersion?: AutoVersionStepConfig;
     fernignore?: FernignoreStepConfig; // PHASE 2: not implemented yet
+    lockfile?: LockfileStepConfig;
     verify?: VerifyStepConfig;
     github?: GithubStepConfig;
 
@@ -20,6 +21,7 @@ export interface PipelineContext {
         replay?: ReplayStepResult;
         autoVersion?: AutoVersionStepResult;
         fernignore?: FernignoreStepResult;
+        lockfile?: LockfileStepResult;
         verify?: VerificationStepResult;
     };
 }
@@ -96,6 +98,12 @@ export interface FernignoreStepConfig {
     customContents?: string;
 }
 
+export interface LockfileStepConfig {
+    enabled: boolean;
+    /** Container runtime to use. Defaults to "docker". */
+    runner?: "docker" | "podman";
+}
+
 export interface VerifyStepConfig {
     enabled: boolean;
     /** Container runtime to use. Defaults to "docker". */
@@ -165,6 +173,7 @@ export interface PipelineResult {
         replay?: ReplayStepResult;
         autoVersion?: AutoVersionStepResult;
         fernignore?: FernignoreStepResult;
+        lockfile?: LockfileStepResult;
         verify?: VerificationStepResult;
         github?: GithubStepResult;
     };
@@ -227,6 +236,11 @@ export interface ReplayStepResult extends StepResult {
 
 export interface FernignoreStepResult extends StepResult {
     pathsPreserved?: string[];
+}
+
+export interface LockfileStepResult extends StepResult {
+    /** True when no `.fern/regenerate-lockfile.sh` was emitted by the generator — the step short-circuits silently. */
+    skipped: boolean;
 }
 
 export interface VerificationStepResult extends StepResult {


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-10731](https://linear.app/buildwithfern/issue/FER-10731/typescript-audit-lockfile-resolution-order-in-fern-typescript)

The TypeScript generator's `generateLockfile()` call ran **before** the `PostGenerationPipeline`, meaning the lockfile was based on the generator's initial `package.json` rather than the final one that includes Replay patches, `.fernignore` preservation, and per-SDK manifest customizations. This PR adds a `LockfileStep` to the pipeline that re-generates the lockfile **after** ReplayStep, ensuring correctness.

The generator still calls `generateLockfile()` eagerly for backward compatibility with the Fiddle/remote generation path (which does not run the pipeline). The `LockfileStep` overwrites it with a correct lockfile in the local-gen pipeline path.

## Changes Made
- **`generators/typescript/utils/abstract-generator-cli/src/writeLockfileScript.ts`** (new): emits `.fern/regenerate-lockfile.sh` script
- **`generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts`**: calls `writeLockfileScript()` in `writeArbitraryFiles`, keeps `generateLockfile()` in github mode for Fiddle backward compat
- **`packages/generator-cli/src/pipeline/steps/LockfileStep.ts`** (new): runs `.fern/regenerate-lockfile.sh` in the validator container after replay, copies lockfile back, commits it
- **`packages/generator-cli/src/pipeline/PostGenerationPipeline.ts`**: wires LockfileStep between ReplayStep and VerificationStep
- **`packages/generator-cli/src/pipeline/types.ts`** + **`index.ts`**: adds `LockfileStepConfig` / `LockfileStepResult` types
- **`packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts`**: enables lockfile step when `githubPipelineEnabled`
- Changelog entries for both `generators/typescript/sdk` and `packages/cli/cli`

Pipeline order: GenerationCommit → AutoVersion → Replay → **Lockfile** → Verification → Github

## Testing
- [x] Targeted compilation passed for all modified packages
- [x] Biome lint passed
- [x] CI pending

Link to Devin session: https://app.devin.ai/sessions/d607cf2d202f45c0b6717398a98c43b9
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->