### PR TITLE
chore(deps): bump Node.js base image from 24.15 to 24.16 in all generator Dockerfiles

### DIFF
--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -26,7 +26,7 @@ RUN git config --global user.email "build@example.com" && \
     CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/tsgolint ./cmd/tsgolint && \
     ls -la /out/tsgolint
 
-FROM node:24.15.0-trixie-slim
+FROM node:24.16.0-trixie-slim
 
 ENV PNPM_STORE_PATH=/.pnpm-cache
 ENV YARN_CACHE_FOLDER=/.yarn-cache
@@ -44,7 +44,7 @@ RUN apt-get update \
 
 # Upgrade bundled npm to 11.14.1 to pick up patched transitive dependencies
 # (picomatch 4.0.4, minimatch 10.2.5, tar 7.5.13).
-# node:24.15.0 ships npm 11.12.1 which still vendors picomatch 4.0.3 and
+# node:24.16.0 ships npm 11.12.1 which still vendors picomatch 4.0.3 and
 # brace-expansion 5.0.4. Replace ip-address with 10.1.1 to fix
 # GHSA-v2v4-37r5-5v8g (still bundled at 10.1.0 even in npm 11.14.1).
 # Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; npm 11.14.1 vendors 5.0.5).

--- a/generators/cli/Dockerfile
+++ b/generators/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15-trixie-slim
+FROM node:24.16-trixie-slim
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get -y autoremove \

--- a/generators/cli/changes/unreleased/bump-node-24.16.yml
+++ b/generators/cli/changes/unreleased/bump-node-24.16.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump Node.js base image from 24.15 to 24.16.
+  type: chore
+

--- a/generators/csharp/model/Dockerfile
+++ b/generators/csharp/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15-alpine3.23 AS node
+FROM node:24.16-alpine3.23 AS node
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine
 
 ENV YARN_CACHE_FOLDER=/.yarn
@@ -24,7 +24,7 @@ COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
-# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.15 vendors 5.0.5).
+# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.16 vendors 5.0.5).
 RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     npm pack brace-expansion@5.0.6 && \
     rm -rf brace-expansion && \

--- a/generators/csharp/sdk/Dockerfile
+++ b/generators/csharp/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Node.js
-FROM node:24.15-alpine3.23 AS node
+FROM node:24.16-alpine3.23 AS node
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine
 

--- a/generators/csharp/sdk/changes/unreleased/bump-node-24.16.yml
+++ b/generators/csharp/sdk/changes/unreleased/bump-node-24.16.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump Node.js base image from 24.15 to 24.16.
+  type: chore
+

--- a/generators/go/model/Dockerfile
+++ b/generators/go/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15-alpine3.23 AS node
+FROM node:24.16-alpine3.23 AS node
 
 FROM golang:1.26.3-alpine3.23
 

--- a/generators/go/sdk/Dockerfile
+++ b/generators/go/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Node CLI
-FROM node:24.15-alpine3.23 AS node
+FROM node:24.16-alpine3.23 AS node
 
 RUN apk --no-cache add git zip
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \

--- a/generators/go/sdk/changes/unreleased/bump-node-24.16.yml
+++ b/generators/go/sdk/changes/unreleased/bump-node-24.16.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump Node.js base image from 24.15 to 24.16.
+  type: chore
+

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Java V2
 # Non-slim trixie because the patch RUN steps below shell out to curl and tar.
-FROM node:24.15-trixie AS node
+FROM node:24.16-trixie AS node
 COPY generators/java-v2/sdk/dist/cli.cjs /dist/cli.cjs
 COPY generators/java-v2/sdk/features.yml /assets/features.yml
 

--- a/generators/java/sdk/changes/unreleased/bump-node-24.16.yml
+++ b/generators/java/sdk/changes/unreleased/bump-node-24.16.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump Node.js base image from 24.15 to 24.16.
+  type: chore
+

--- a/generators/openapi/Dockerfile
+++ b/generators/openapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15-alpine3.23
+FROM node:24.16-alpine3.23
 RUN apk update && apk upgrade --no-cache \
     && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 COPY dist /dist

--- a/generators/php/model/Dockerfile
+++ b/generators/php/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15-alpine3.23 AS node
+FROM node:24.16-alpine3.23 AS node
 FROM composer:2.9.7
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/php/sdk/Dockerfile
+++ b/generators/php/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15-alpine3.23 AS node
+FROM node:24.16-alpine3.23 AS node
 FROM composer:2.9.7
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/php/sdk/changes/unreleased/bump-node-24.16.yml
+++ b/generators/php/sdk/changes/unreleased/bump-node-24.16.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump Node.js base image from 24.15 to 24.16.
+  type: chore
+

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -1,6 +1,6 @@
 # Bundled npm globals are removed below so npm's JS dependencies cannot be
 # flagged or invoked at runtime — this image only runs the bundled CLI via node.
-FROM node:24.15-trixie-slim
+FROM node:24.16-trixie-slim
 # Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
 # and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
 # CVE-2026-40356 (krb5), CVE-2026-1965/4873/5545/6253/6429 (curl),

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15-trixie-slim
+FROM node:24.16-trixie-slim
 # Security update 2026-05-18: trixie's krb5 (1.21.3-5), curl (8.14.1),
 # and gnutls28 (3.8.9) are still vulnerable to CVE-2026-40355,
 # CVE-2026-40356 (krb5), CVE-2026-1965/4873/5545/6253/6429 (curl),
@@ -20,7 +20,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
        curl libcurl4t64 libgnutls30t64 \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
-# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.15 vendors 5.0.5).
+# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.16 vendors 5.0.5).
 RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     npm pack brace-expansion@5.0.6 && \
     rm -rf brace-expansion && \

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Copy Node.js from official image
-FROM node:24.15-trixie-slim AS node
+FROM node:24.16-trixie-slim AS node
 
 # Stage 2: Base Python image with dependencies
 FROM python:3.13.7-slim AS python-base

--- a/generators/python/sdk/changes/unreleased/bump-node-24.16.yml
+++ b/generators/python/sdk/changes/unreleased/bump-node-24.16.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump Node.js base image from 24.15 to 24.16.
+  type: chore
+

--- a/generators/rust/model/Dockerfile
+++ b/generators/rust/model/Dockerfile
@@ -8,7 +8,7 @@ RUN rustup component add rustfmt \
     && cp "$RUSTFMT" /rustfmt/rustfmt \
     && cp "$(dirname "$RUSTFMT")/../lib"/librustc_driver-*.so /rustfmt/lib/
 
-FROM node:24.15-alpine3.23
+FROM node:24.16-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 
@@ -24,7 +24,7 @@ ENV PATH=/usr/local/lib/rustfmt:$PATH \
     LD_LIBRARY_PATH=/usr/local/lib/rustfmt/lib
 RUN rustfmt --version
 
-# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.15 vendors 5.0.5).
+# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.16 vendors 5.0.5).
 RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     npm pack brace-expansion@5.0.6 && \
     rm -rf brace-expansion && \

--- a/generators/rust/sdk/Dockerfile
+++ b/generators/rust/sdk/Dockerfile
@@ -5,7 +5,7 @@
 FROM rust:1.91-alpine3.23 AS rust
 RUN rustup component add rustfmt
 
-FROM node:24.15-alpine3.23
+FROM node:24.16-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 

--- a/generators/rust/sdk/changes/unreleased/bump-node-24.16.yml
+++ b/generators/rust/sdk/changes/unreleased/bump-node-24.16.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump Node.js base image from 24.15 to 24.16.
+  type: chore
+

--- a/generators/swift/model/Dockerfile
+++ b/generators/swift/model/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:24.15-alpine3.23
+FROM node:24.16-alpine3.23
 
 RUN apk update && apk upgrade --no-cache && apk --no-cache add curl
 
 # Patch npm's bundled picomatch@4.0.3 -> 4.0.4 (GHSA-c2c7-rcm5-vvqj,
 # GHSA-3v7f-55p6-f55p) and brace-expansion@5.0.4 -> 5.0.6
-# (GHSA-jxxr-4gwj-5jf2) in node:24.15's bundled npm 11.12.1.
+# (GHSA-jxxr-4gwj-5jf2) in node:24.16's bundled npm 11.12.1.
 RUN for dir in \
       /usr/local/lib/node_modules/npm/node_modules/picomatch \
       /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch; do \

--- a/generators/swift/sdk/Dockerfile
+++ b/generators/swift/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15-alpine3.23
+FROM node:24.16-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 RUN apk --no-cache add bash curl git zip
@@ -8,7 +8,7 @@ RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github
 # Patch picomatch to 4.0.4 (GHSA-c2c7-rcm5-vvqj ReDoS via extglob quantifiers,
 # GHSA-3v7f-55p6-f55p method injection in POSIX character classes) and
 # brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2 zero-step sequence hangs)
-# in npm's bundled node_modules. node:24.15 ships npm 11.12.1 with
+# in npm's bundled node_modules. node:24.16 ships npm 11.12.1 with
 # picomatch@4.0.3 and brace-expansion@5.0.4.
 RUN for dir in \
       /usr/local/lib/node_modules/npm/node_modules/picomatch \

--- a/generators/swift/sdk/changes/unreleased/bump-node-24.16.yml
+++ b/generators/swift/sdk/changes/unreleased/bump-node-24.16.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump Node.js base image from 24.15 to 24.16.
+  type: chore
+

--- a/generators/typescript/sdk/changes/unreleased/bump-node-24.16.yml
+++ b/generators/typescript/sdk/changes/unreleased/bump-node-24.16.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump Node.js base image from 24.15 to 24.16.
+  type: chore
+

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -26,7 +26,7 @@ RUN git config --global user.email "build@example.com" && \
     CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/tsgolint ./cmd/tsgolint && \
     ls -la /out/tsgolint
 
-FROM node:24.15-trixie-slim
+FROM node:24.16-trixie-slim
 
 # Apply latest Debian security updates so that grype-tracked OS package
 # vulnerabilities (glibc, dpkg, nghttp2, libcap2, systemd, libgcrypt20,

--- a/generators/typescript/sdk/validator/Dockerfile
+++ b/generators/typescript/sdk/validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15-trixie-slim
+FROM node:24.16-trixie-slim
 
 # Apply latest Debian security updates so that grype-tracked OS package
 # vulnerabilities (glibc, dpkg, nghttp2, libcap2, systemd, libgcrypt20,
@@ -35,7 +35,7 @@ RUN cd /tmp/warm-cache \
     && pnpm install --ignore-scripts --prefer-offline \
     && rm -rf /tmp/warm-cache/node_modules
 
-# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.15 vendors 5.0.5).
+# Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.16 vendors 5.0.5).
 RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     npm pack brace-expansion@5.0.6 && \
     rm -rf brace-expansion && \


### PR DESCRIPTION
## Description

Bump the Node.js base image from 24.15 to 24.16 across all generator and seed Dockerfiles.

## Changes Made

- Updated `FROM node:24.15-*` → `node:24.16-*` in 19 Dockerfiles across all generators (TypeScript, Python, Python v2, Java, Go, C#, PHP, Ruby-model/sdk-less, Rust, Swift, CLI, OpenAPI) and the seed container
- Updated comments referencing the old version
- Added unreleased changelog entries for all affected generators

### Files changed

| Generator | Dockerfiles |
|---|---|
| C# | `generators/csharp/model/Dockerfile`, `generators/csharp/sdk/Dockerfile` |
| Go | `generators/go/model/Dockerfile`, `generators/go/sdk/Dockerfile` |
| Java | `generators/java/sdk/Dockerfile` |
| PHP | `generators/php/model/Dockerfile`, `generators/php/sdk/Dockerfile` |
| Python | `generators/python/sdk/Dockerfile` |
| Python v2 | `generators/python-v2/sdk/Dockerfile`, `generators/python-v2/pydantic-model/Dockerfile` |
| Rust | `generators/rust/model/Dockerfile`, `generators/rust/sdk/Dockerfile` |
| Swift | `generators/swift/model/Dockerfile`, `generators/swift/sdk/Dockerfile` |
| TypeScript | `generators/typescript/sdk/cli/Dockerfile`, `generators/typescript/sdk/validator/Dockerfile` |
| CLI | `generators/cli/Dockerfile` |
| OpenAPI | `generators/openapi/Dockerfile` |
| Seed | `docker/seed/Dockerfile.ts` |

## Testing

- [x] Verified no remaining references to `24.15` in any Dockerfile
- [ ] CI checks pass

Link to Devin session: https://app.devin.ai/sessions/31597337e2714281a836e28e283aea03
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->