### PR TITLE
fix(cli): include settings in theme export eligible keys

### DIFF
--- a/packages/cli/cli/changes/unreleased/theme-export-settings.yml
+++ b/packages/cli/cli/changes/unreleased/theme-export-settings.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Include `settings` in theme export so that `fern docs theme export` captures the settings configuration from docs.yml.
+  type: fix

--- a/packages/cli/cli/src/commands/docs-theme/ThemeExporter.ts
+++ b/packages/cli/cli/src/commands/docs-theme/ThemeExporter.ts
@@ -19,7 +19,8 @@ const THEME_ELIGIBLE_KEYS = new Set([
     "js",
     "header",
     "footer",
-    "metadata"
+    "metadata",
+    "settings"
 ]);
 
 export class ThemeExporter {


### PR DESCRIPTION
## Description

The `fern docs theme export` command was missing `settings` from its eligible keys list, so the `settings` configuration block in `docs.yml` was silently dropped during theme export. The stitching side (`stitchGlobalTheme.ts`) already handles `settings` with `"global"` policy, so this was just an omission in the exporter.

## Changes Made

- Added `"settings"` to `THEME_ELIGIBLE_KEYS` in `ThemeExporter.ts` so that `fern docs theme export` now captures the `settings` block from `docs.yml` into `theme.yml`
- Added unreleased changelog entry

## Testing

- [x] Verified the stitcher (`stitchGlobalTheme.ts`) already includes `settings: "global"` in `THEME_FIELD_POLICIES`, confirming it will be applied correctly once exported
- [x] Code change is a single-line addition to a `Set` — no logic changes

Link to Devin session: https://app.devin.ai/sessions/819f71e918f9478c912925c1e55bd28c
Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->