### PR TITLE
feat(cli): allow absolute API spec paths in generators.yml

### DIFF
--- a/packages/cli/cli/changes/unreleased/feat-absolute-api-spec-paths.yml
+++ b/packages/cli/cli/changes/unreleased/feat-absolute-api-spec-paths.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Allow absolute API spec, override, and overlay paths in generators.yml.
+  type: feat

--- a/packages/cli/cli/src/commands/upgrade/updateApiSpec.ts
+++ b/packages/cli/cli/src/commands/upgrade/updateApiSpec.ts
@@ -1,5 +1,5 @@
 import { generatorsYml, loadGeneratorsConfiguration } from "@fern-api/configuration-loader";
-import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, resolveConfiguredFilepath } from "@fern-api/fs-utils";
 import { Logger } from "@fern-api/logger";
 import { Project } from "@fern-api/project-loader";
 import { CliError } from "@fern-api/task-context";
@@ -381,7 +381,10 @@ async function getAndFetchFromAPIDefinitionLocation({
         return;
     }
     if (apiLocation.origin != null) {
-        const filePath = join(workspacePath, RelativeFilePath.of(apiLocation.schema.path));
+        const filePath = resolveConfiguredFilepath({
+            absolutePathToWorkspace: workspacePath,
+            configuredFilepath: apiLocation.schema.path
+        });
 
         if (apiLocation.schema.type === "graphql") {
             cliContext.logger.info(`GraphQL schema origin found, fetching schema from ${apiLocation.origin}`);

--- a/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
@@ -16,7 +16,16 @@ import { Audiences, generatorsYml } from "@fern-api/configuration";
 import { extractErrorMessage, isNonNullish } from "@fern-api/core-utils";
 import { FdrAPI } from "@fern-api/fdr-sdk";
 import { RawSchemas } from "@fern-api/fern-definition-schema";
-import { AbsoluteFilePath, cwd, dirname, join, RelativeFilePath, relativize } from "@fern-api/fs-utils";
+import {
+    AbsoluteFilePath,
+    cwd,
+    dirname,
+    join,
+    RelativeFilePath,
+    relativize,
+    resolveConfiguredFilepath,
+    resolveConfiguredFilepaths
+} from "@fern-api/fs-utils";
 import type { GraphQlOperationExamplesInput } from "@fern-api/graphql-to-fdr";
 import { IntermediateRepresentation, serialization } from "@fern-api/ir-sdk";
 import { mergeIntermediateRepresentation } from "@fern-api/ir-utils";
@@ -29,11 +38,11 @@ import {
 } from "@fern-api/openapi-to-ir";
 import { OpenRPCConverter, OpenRPCConverterContext3_1 } from "@fern-api/openrpc-to-ir";
 import { CliError, TaskContext } from "@fern-api/task-context";
-
 import { ErrorCollector } from "@fern-api/v3-importer-commons";
 import { readFile } from "fs/promises";
 import yaml from "js-yaml";
 import { OpenAPIV3_1 } from "openapi-types";
+import path from "path";
 import { v4 as uuidv4 } from "uuid";
 import { loadOpenRpc } from "./loaders/index.js";
 import { OpenAPILoader } from "./loaders/OpenAPILoader.js";
@@ -71,17 +80,6 @@ function collapseSpecBooleanSetting(
     // If at least one spec explicitly defines the setting, treat undefined as neutral.
     // Only return false if a spec explicitly sets it to false.
     return values.every((v) => v == null || v === true);
-}
-
-function toRelativePath(raw: string, field: string): RelativeFilePath {
-    try {
-        return RelativeFilePath.of(raw);
-    } catch {
-        throw new CliError({
-            message: `"${field}: ${raw}" must be a relative path, not an absolute one.`,
-            code: CliError.Code.ConfigError
-        });
-    }
 }
 
 function convertRemoveDiscriminantsFromSchemas(
@@ -342,10 +340,11 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
         const errorCollectors: ErrorCollector[] = [];
 
         for (const document of documents) {
-            const absoluteFilepathToSpec = join(
-                this.absoluteFilePath,
-                RelativeFilePath.of(document.source?.file ?? "")
-            );
+            const sourceFile = document.source?.file;
+            const absoluteFilepathToSpec =
+                sourceFile != null && path.isAbsolute(sourceFile)
+                    ? AbsoluteFilePath.of(sourceFile)
+                    : join(this.absoluteFilePath, RelativeFilePath.of(sourceFile ?? ""));
             const relativeFilepathToSpec = relativize(cwd(), absoluteFilepathToSpec);
 
             const errorCollector = new ErrorCollector({ logger: context.logger, relativeFilepathToSpec });
@@ -652,33 +651,29 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
 
         for (const spec of specsOverride) {
             if (generatorsYml.isOpenApiSpecSchema(spec)) {
-                const absoluteFilepath = join(this.absoluteFilePath, toRelativePath(spec.openapi, "openapi"));
+                const absoluteFilepath = resolveConfiguredFilepath({
+                    absolutePathToWorkspace: this.absoluteFilePath,
+                    configuredFilepath: spec.openapi
+                });
                 // Handle both single override path and array of override paths
                 let absoluteFilepathToOverrides: AbsoluteFilePath | AbsoluteFilePath[] | undefined;
-                const specOverridePaths: AbsoluteFilePath[] = [];
 
-                // Add spec-level overrides
                 if (spec.overrides != null) {
-                    if (Array.isArray(spec.overrides)) {
-                        specOverridePaths.push(
-                            ...spec.overrides.map((override) =>
-                                join(this.absoluteFilePath, toRelativePath(override, "overrides"))
-                            )
-                        );
-                    } else {
-                        specOverridePaths.push(
-                            join(this.absoluteFilePath, toRelativePath(spec.overrides, "overrides"))
-                        );
-                    }
-                }
-
-                // Set the final overrides array
-                if (specOverridePaths.length > 0) {
-                    absoluteFilepathToOverrides =
-                        specOverridePaths.length === 1 ? specOverridePaths[0] : specOverridePaths;
+                    const resolvedOverrides = resolveConfiguredFilepaths({
+                        absolutePathToWorkspace: this.absoluteFilePath,
+                        configuredFilepaths: spec.overrides
+                    });
+                    absoluteFilepathToOverrides = Array.isArray(resolvedOverrides)
+                        ? resolvedOverrides.length === 1
+                            ? resolvedOverrides[0]
+                            : resolvedOverrides
+                        : resolvedOverrides;
                 }
                 const absoluteFilepathToOverlays = spec.overlays
-                    ? join(this.absoluteFilePath, toRelativePath(spec.overlays, "overlays"))
+                    ? resolveConfiguredFilepath({
+                          absolutePathToWorkspace: this.absoluteFilePath,
+                          configuredFilepath: spec.overlays
+                      })
                     : undefined;
 
                 // Create a minimal OpenAPI spec with default settings

--- a/packages/cli/workspace/lazy-fern-workspace/src/__test__/convertSpecsOverrideToSpecs.test.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/__test__/convertSpecsOverrideToSpecs.test.ts
@@ -1,6 +1,7 @@
 import { Spec } from "@fern-api/api-workspace-commons";
 import { generatorsYml } from "@fern-api/configuration";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import assert from "assert";
 import { join } from "path";
 
 import { OSSWorkspace } from "../OSSWorkspace.js";
@@ -115,5 +116,24 @@ describe("convertSpecsOverrideToSpecs", () => {
 
         expect(specs[0]?.absoluteFilepathToOverrides).toBeUndefined();
         expect(specs[1]?.absoluteFilepathToOverrides).toBe(join(baseDir, "o.yml"));
+    });
+
+    it("accepts absolute openapi, override, and overlay paths", async () => {
+        const specs = await workspace.callConvertSpecsOverrideToSpecs([
+            {
+                openapi: "/external/api.yml",
+                overrides: ["/external/o1.yml", "/external/o2.yml"],
+                overlays: "/external/overlay.yml"
+            }
+        ]);
+
+        expect(specs).toHaveLength(1);
+        const spec = specs[0];
+        assert(spec != null);
+        expect(spec.type).toBe("openapi");
+        assert(spec.type === "openapi");
+        expect(spec.absoluteFilepath).toBe("/external/api.yml");
+        expect(spec.absoluteFilepathToOverrides).toEqual(["/external/o1.yml", "/external/o2.yml"]);
+        expect(spec.absoluteFilepathToOverlays).toBe("/external/overlay.yml");
     });
 });

--- a/packages/cli/workspace/lazy-fern-workspace/src/loaders/OpenAPILoader.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/loaders/OpenAPILoader.ts
@@ -1,5 +1,5 @@
 import { isOpenAPIV2, isOpenAPIV3, OpenAPISpec } from "@fern-api/api-workspace-commons";
-import { AbsoluteFilePath, join, relative } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, isAbsoluteFilePath, join, relativeOrOriginalPath } from "@fern-api/fs-utils";
 import { Source as OpenApiIrSource } from "@fern-api/openapi-ir";
 import { Document, getParseOptions } from "@fern-api/openapi-ir-parser";
 import { TaskContext } from "@fern-api/task-context";
@@ -36,14 +36,14 @@ export class OpenAPILoader {
     }): Promise<Document | undefined> {
         try {
             const contents = (await readFile(spec.absoluteFilepath)).toString();
-            let sourceRelativePath = relative(this.absoluteFilePath, spec.source.file);
-            if (spec.source.relativePathToDependency != null) {
-                sourceRelativePath = join(spec.source.relativePathToDependency, sourceRelativePath);
+            let sourceFilepath = relativeOrOriginalPath(this.absoluteFilePath, spec.source.file);
+            if (spec.source.relativePathToDependency != null && !isAbsoluteFilePath(sourceFilepath)) {
+                sourceFilepath = join(spec.source.relativePathToDependency, sourceFilepath);
             }
             const source =
                 spec.source.type === "protobuf"
-                    ? OpenApiIrSource.protobuf({ file: sourceRelativePath })
-                    : OpenApiIrSource.openapi({ file: sourceRelativePath });
+                    ? OpenApiIrSource.protobuf({ file: sourceFilepath })
+                    : OpenApiIrSource.openapi({ file: sourceFilepath });
 
             if (contents.includes("openapi") || contents.includes("swagger")) {
                 try {

--- a/packages/cli/workspace/loader/src/__test__/loadWorkspace.test.ts
+++ b/packages/cli/workspace/loader/src/__test__/loadWorkspace.test.ts
@@ -1,12 +1,15 @@
 import { RawSchemas } from "@fern-api/fern-definition-schema";
-import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, join, RelativeFilePath, relativePathForDisplay } from "@fern-api/fs-utils";
 import { WorkspaceLoaderFailureType } from "@fern-api/lazy-fern-workspace";
 import { Logger } from "@fern-api/logger";
 import { createMockTaskContext } from "@fern-api/task-context";
 import assert from "assert";
+import { mkdtemp, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join as pathJoin } from "path";
 
 import { handleFailedWorkspaceParserResult } from "../handleFailedWorkspaceParserResult.js";
-import { loadAPIWorkspace } from "../loadAPIWorkspace.js";
+import { loadAPIWorkspace, loadSingleNamespaceAPIWorkspace } from "../loadAPIWorkspace.js";
 
 function createCapturingLogger(): Logger & { errors: string[]; debugs: string[] } {
     const errors: string[] = [];
@@ -70,6 +73,174 @@ describe("loadWorkspace", () => {
         });
         expect(workspace.didSucceed).toBe(true);
         assert(workspace.didSucceed);
+    });
+
+    it("open api with absolute spec path", async () => {
+        const absolutePathToFixtures = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures"));
+        const absolutePathToOpenApi = join(absolutePathToFixtures, RelativeFilePath.of("openapi.yml"));
+
+        const specs = await loadSingleNamespaceAPIWorkspace({
+            absolutePathToWorkspace: absolutePathToFixtures,
+            namespace: undefined,
+            definitions: [
+                {
+                    schema: {
+                        type: "oss",
+                        path: absolutePathToOpenApi
+                    },
+                    origin: undefined,
+                    overrides: undefined,
+                    overlays: undefined,
+                    audiences: [],
+                    settings: undefined
+                }
+            ]
+        });
+
+        expect(Array.isArray(specs)).toBe(true);
+        assert(Array.isArray(specs));
+        const spec = specs[0];
+        assert(spec != null);
+        expect(spec.type).toBe("openapi");
+        assert(spec.type === "openapi");
+        expect(spec.absoluteFilepath).toBe(absolutePathToOpenApi);
+    });
+
+    it("open api with absolute override and overlay paths", async () => {
+        const absolutePathToFixtures = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures"));
+        const absolutePathToOpenApi = join(absolutePathToFixtures, RelativeFilePath.of("openapi.yml"));
+
+        const specs = await loadSingleNamespaceAPIWorkspace({
+            absolutePathToWorkspace: absolutePathToFixtures,
+            namespace: undefined,
+            definitions: [
+                {
+                    schema: {
+                        type: "oss",
+                        path: "openapi.yml"
+                    },
+                    origin: undefined,
+                    overrides: absolutePathToOpenApi,
+                    overlays: absolutePathToOpenApi,
+                    audiences: [],
+                    settings: undefined
+                }
+            ]
+        });
+
+        expect(Array.isArray(specs)).toBe(true);
+        assert(Array.isArray(specs));
+        const spec = specs[0];
+        assert(spec != null);
+        expect(spec.type).toBe("openapi");
+        assert(spec.type === "openapi");
+        expect(spec.absoluteFilepathToOverrides).toBe(absolutePathToOpenApi);
+        expect(spec.absoluteFilepathToOverlays).toBe(absolutePathToOpenApi);
+    });
+
+    it("open rpc with absolute spec path", async () => {
+        const absolutePathToFixtures = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures"));
+        const absolutePathToOpenRpc = join(absolutePathToFixtures, RelativeFilePath.of("openapi.yml"));
+
+        const specs = await loadSingleNamespaceAPIWorkspace({
+            absolutePathToWorkspace: absolutePathToFixtures,
+            namespace: undefined,
+            definitions: [
+                {
+                    schema: {
+                        type: "openrpc",
+                        path: absolutePathToOpenRpc
+                    },
+                    origin: undefined,
+                    overrides: undefined,
+                    overlays: undefined,
+                    audiences: [],
+                    settings: undefined
+                }
+            ]
+        });
+
+        expect(Array.isArray(specs)).toBe(true);
+        assert(Array.isArray(specs));
+        const spec = specs[0];
+        assert(spec != null);
+        expect(spec.type).toBe("openrpc");
+        assert(spec.type === "openrpc");
+        expect(spec.absoluteFilepath).toBe(absolutePathToOpenRpc);
+    });
+
+    it("graphql with absolute schema and examples paths", async () => {
+        const absolutePathToFixtures = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures"));
+        const absolutePathToGraphQL = join(absolutePathToFixtures, RelativeFilePath.of("openapi.yml"));
+
+        const specs = await loadSingleNamespaceAPIWorkspace({
+            absolutePathToWorkspace: absolutePathToFixtures,
+            namespace: undefined,
+            definitions: [
+                {
+                    schema: {
+                        type: "graphql",
+                        path: absolutePathToGraphQL,
+                        examples: absolutePathToGraphQL
+                    },
+                    origin: undefined,
+                    overrides: undefined,
+                    overlays: undefined,
+                    audiences: [],
+                    settings: undefined
+                }
+            ]
+        });
+
+        expect(Array.isArray(specs)).toBe(true);
+        assert(Array.isArray(specs));
+        const spec = specs[0];
+        assert(spec != null);
+        expect(spec.type).toBe("graphql");
+        assert(spec.type === "graphql");
+        expect(spec.absoluteFilepath).toBe(absolutePathToGraphQL);
+        expect(spec.absoluteFilepathToExamples).toBe(absolutePathToGraphQL);
+    });
+
+    it("protobuf with absolute root and target paths", async () => {
+        const absolutePathToFixtures = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures"));
+        const absolutePathToProtobufRoot = AbsoluteFilePath.of(await mkdtemp(pathJoin(tmpdir(), "fern-proto-root-")));
+        const absolutePathToProtobufTarget = AbsoluteFilePath.of(pathJoin(absolutePathToProtobufRoot, "service.proto"));
+        await writeFile(absolutePathToProtobufTarget, 'syntax = "proto3";\n');
+
+        const specs = await loadSingleNamespaceAPIWorkspace({
+            absolutePathToWorkspace: absolutePathToFixtures,
+            namespace: undefined,
+            definitions: [
+                {
+                    schema: {
+                        type: "protobuf",
+                        root: absolutePathToProtobufRoot,
+                        target: absolutePathToProtobufTarget,
+                        dependencies: [],
+                        localGeneration: true,
+                        fromOpenAPI: false
+                    },
+                    origin: undefined,
+                    overrides: undefined,
+                    overlays: undefined,
+                    audiences: [],
+                    settings: undefined
+                }
+            ]
+        });
+
+        expect(Array.isArray(specs)).toBe(true);
+        assert(Array.isArray(specs));
+        const spec = specs[0];
+        assert(spec != null);
+        expect(spec.type).toBe("protobuf");
+        assert(spec.type === "protobuf");
+        expect(spec.absoluteFilepathToProtobufRoot).toBe(absolutePathToProtobufRoot);
+        expect(spec.absoluteFilepathToProtobufTarget).toBe(absolutePathToProtobufTarget);
+        expect(spec.relativeFilepathToProtobufRoot).toBe(
+            relativePathForDisplay(absolutePathToFixtures, absolutePathToProtobufRoot)
+        );
     });
 });
 

--- a/packages/cli/workspace/loader/src/loadAPIWorkspace.ts
+++ b/packages/cli/workspace/loader/src/loadAPIWorkspace.ts
@@ -6,7 +6,16 @@ import {
     loadGeneratorsConfiguration,
     OPENAPI_DIRECTORY
 } from "@fern-api/configuration-loader";
-import { AbsoluteFilePath, doesPathExist, isPathEmpty, join, RelativeFilePath } from "@fern-api/fs-utils";
+import {
+    AbsoluteFilePath,
+    doesPathExist,
+    isPathEmpty,
+    join,
+    RelativeFilePath,
+    relativePathForDisplay,
+    resolveConfiguredFilepath,
+    resolveConfiguredFilepaths
+} from "@fern-api/fs-utils";
 import {
     ConjureWorkspace,
     LazyFernWorkspace,
@@ -15,7 +24,21 @@ import {
     WorkspaceLoaderFailureType
 } from "@fern-api/lazy-fern-workspace";
 import { TaskContext } from "@fern-api/task-context";
+import path from "path";
 import { loadAPIChangelog } from "./loadAPIChangelog.js";
+
+function getFailureFilepath({
+    absolutePathToWorkspace,
+    configuredFilepath
+}: {
+    absolutePathToWorkspace: AbsoluteFilePath;
+    configuredFilepath: string;
+}): RelativeFilePath {
+    if (path.isAbsolute(configuredFilepath)) {
+        return relativePathForDisplay(absolutePathToWorkspace, AbsoluteFilePath.of(configuredFilepath));
+    }
+    return RelativeFilePath.of(configuredFilepath);
+}
 
 export async function loadSingleNamespaceAPIWorkspace({
     absolutePathToWorkspace,
@@ -29,29 +52,36 @@ export async function loadSingleNamespaceAPIWorkspace({
     const specs: Spec[] = [];
 
     for (const definition of definitions) {
-        // Handle both single override path and array of override paths
-        let absoluteFilepathToOverrides: AbsoluteFilePath | AbsoluteFilePath[] | undefined;
-        if (definition.overrides != null) {
-            if (Array.isArray(definition.overrides)) {
-                absoluteFilepathToOverrides = definition.overrides.map((override) =>
-                    join(absolutePathToWorkspace, RelativeFilePath.of(override))
-                );
-            } else {
-                absoluteFilepathToOverrides = join(absolutePathToWorkspace, RelativeFilePath.of(definition.overrides));
-            }
-        }
+        const absoluteFilepathToOverrides =
+            definition.overrides != null
+                ? resolveConfiguredFilepaths({
+                      absolutePathToWorkspace,
+                      configuredFilepaths: definition.overrides
+                  })
+                : undefined;
         const absoluteFilepathToOverlays =
             definition.overlays != null
-                ? join(absolutePathToWorkspace, RelativeFilePath.of(definition.overlays))
+                ? resolveConfiguredFilepath({
+                      absolutePathToWorkspace,
+                      configuredFilepath: definition.overlays
+                  })
                 : undefined;
         if (definition.schema.type === "protobuf") {
-            const relativeFilepathToProtobufRoot = RelativeFilePath.of(definition.schema.root);
-            const absoluteFilepathToProtobufRoot = join(absolutePathToWorkspace, relativeFilepathToProtobufRoot);
+            const absoluteFilepathToProtobufRoot = resolveConfiguredFilepath({
+                absolutePathToWorkspace,
+                configuredFilepath: definition.schema.root
+            });
+            const relativeFilepathToProtobufRoot = path.isAbsolute(definition.schema.root)
+                ? relativePathForDisplay(absolutePathToWorkspace, absoluteFilepathToProtobufRoot)
+                : RelativeFilePath.of(definition.schema.root);
             if (!(await doesPathExist(absoluteFilepathToProtobufRoot))) {
                 return {
                     didSucceed: false,
                     failures: {
-                        [RelativeFilePath.of(definition.schema.root)]: {
+                        [getFailureFilepath({
+                            absolutePathToWorkspace,
+                            configuredFilepath: definition.schema.root
+                        })]: {
                             type: WorkspaceLoaderFailureType.FILE_MISSING
                         }
                     }
@@ -62,14 +92,20 @@ export async function loadSingleNamespaceAPIWorkspace({
             const absoluteFilepathToTarget: AbsoluteFilePath | undefined =
                 definition.schema.target.length === 0
                     ? undefined
-                    : join(absolutePathToWorkspace, RelativeFilePath.of(definition.schema.target));
+                    : resolveConfiguredFilepath({
+                          absolutePathToWorkspace,
+                          configuredFilepath: definition.schema.target
+                      });
 
             if (absoluteFilepathToTarget != null) {
                 if (!(await doesPathExist(absoluteFilepathToTarget))) {
                     return {
                         didSucceed: false,
                         failures: {
-                            [RelativeFilePath.of(definition.schema.target)]: {
+                            [getFailureFilepath({
+                                absolutePathToWorkspace,
+                                configuredFilepath: definition.schema.target
+                            })]: {
                                 type: WorkspaceLoaderFailureType.FILE_MISSING
                             }
                         }
@@ -96,8 +132,10 @@ export async function loadSingleNamespaceAPIWorkspace({
         }
 
         if (definition.schema.type === "openrpc") {
-            const relativeFilepathToOpenRpc = RelativeFilePath.of(definition.schema.path);
-            const absoluteFilepathToOpenRpc = join(absolutePathToWorkspace, relativeFilepathToOpenRpc);
+            const absoluteFilepathToOpenRpc = resolveConfiguredFilepath({
+                absolutePathToWorkspace,
+                configuredFilepath: definition.schema.path
+            });
             specs.push({
                 type: "openrpc",
                 absoluteFilepath: absoluteFilepathToOpenRpc,
@@ -108,13 +146,18 @@ export async function loadSingleNamespaceAPIWorkspace({
         }
 
         if (definition.schema.type === "graphql") {
-            const relativeFilepathToGraphQL = RelativeFilePath.of(definition.schema.path);
-            const absoluteFilepathToGraphQL = join(absolutePathToWorkspace, relativeFilepathToGraphQL);
+            const absoluteFilepathToGraphQL = resolveConfiguredFilepath({
+                absolutePathToWorkspace,
+                configuredFilepath: definition.schema.path
+            });
             if (!(await doesPathExist(absoluteFilepathToGraphQL))) {
                 return {
                     didSucceed: false,
                     failures: {
-                        [relativeFilepathToGraphQL]: {
+                        [getFailureFilepath({
+                            absolutePathToWorkspace,
+                            configuredFilepath: definition.schema.path
+                        })]: {
                             type: WorkspaceLoaderFailureType.FILE_MISSING
                         }
                     }
@@ -122,7 +165,10 @@ export async function loadSingleNamespaceAPIWorkspace({
             }
             const absoluteFilepathToExamples =
                 definition.schema.examples != null
-                    ? join(absolutePathToWorkspace, RelativeFilePath.of(definition.schema.examples))
+                    ? resolveConfiguredFilepath({
+                          absolutePathToWorkspace,
+                          configuredFilepath: definition.schema.examples
+                      })
                     : undefined;
             if (
                 definition.schema.examples != null &&
@@ -132,7 +178,10 @@ export async function loadSingleNamespaceAPIWorkspace({
                 return {
                     didSucceed: false,
                     failures: {
-                        [RelativeFilePath.of(definition.schema.examples)]: {
+                        [getFailureFilepath({
+                            absolutePathToWorkspace,
+                            configuredFilepath: definition.schema.examples
+                        })]: {
                             type: WorkspaceLoaderFailureType.FILE_MISSING
                         }
                     }
@@ -148,12 +197,15 @@ export async function loadSingleNamespaceAPIWorkspace({
             continue;
         }
 
-        const absoluteFilepath = join(absolutePathToWorkspace, RelativeFilePath.of(definition.schema.path));
+        const absoluteFilepath = resolveConfiguredFilepath({
+            absolutePathToWorkspace,
+            configuredFilepath: definition.schema.path
+        });
         if (!(await doesPathExist(absoluteFilepath))) {
             return {
                 didSucceed: false,
                 failures: {
-                    [RelativeFilePath.of(definition.schema.path)]: {
+                    [getFailureFilepath({ absolutePathToWorkspace, configuredFilepath: definition.schema.path })]: {
                         type: WorkspaceLoaderFailureType.FILE_MISSING
                     }
                 }
@@ -175,7 +227,10 @@ export async function loadSingleNamespaceAPIWorkspace({
                     return {
                         didSucceed: false,
                         failures: {
-                            [RelativeFilePath.of(relativeOverridePath)]: {
+                            [getFailureFilepath({
+                                absolutePathToWorkspace,
+                                configuredFilepath: relativeOverridePath
+                            })]: {
                                 type: WorkspaceLoaderFailureType.FILE_MISSING
                             }
                         }
@@ -191,7 +246,7 @@ export async function loadSingleNamespaceAPIWorkspace({
             return {
                 didSucceed: false,
                 failures: {
-                    [RelativeFilePath.of(definition.overlays)]: {
+                    [getFailureFilepath({ absolutePathToWorkspace, configuredFilepath: definition.overlays })]: {
                         type: WorkspaceLoaderFailureType.FILE_MISSING
                     }
                 }

--- a/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/no-component-schema-collisions.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-component-schema-collisions/no-component-schema-collisions.ts
@@ -1,5 +1,5 @@
 import { isOpenAPIV2 } from "@fern-api/api-workspace-commons";
-import { relative } from "@fern-api/fs-utils";
+import { relativePathForDisplay } from "@fern-api/fs-utils";
 import { convertOpenAPIV2ToV3 } from "@fern-api/lazy-fern-workspace";
 
 import { Rule } from "../../Rule";
@@ -36,7 +36,7 @@ export const NoComponentSchemaCollisionsRule: Rule = {
                 continue;
             }
 
-            const relativeFilepath = relative(workspace.absoluteFilePath, spec.source.file);
+            const relativeFilepath = relativePathForDisplay(workspace.absoluteFilePath, spec.source.file);
 
             // For OpenAPI v2, convert to v3 first
             const apiToValidate = isOpenAPIV2(document) ? await convertOpenAPIV2ToV3(document) : document;

--- a/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/no-conflicting-parameter-names.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/no-conflicting-parameter-names.ts
@@ -1,5 +1,5 @@
 import { isOpenAPIV2 } from "@fern-api/api-workspace-commons";
-import { relative } from "@fern-api/fs-utils";
+import { relativePathForDisplay } from "@fern-api/fs-utils";
 import { convertOpenAPIV2ToV3 } from "@fern-api/lazy-fern-workspace";
 
 import { Rule } from "../../Rule.js";
@@ -32,7 +32,7 @@ export const NoConflictingParameterNamesRule: Rule = {
             }
 
             const apiToValidate = isOpenAPIV2(openAPI) ? await convertOpenAPIV2ToV3(openAPI) : openAPI;
-            const relativeFilepath = relative(workspace.absoluteFilePath, spec.source.file);
+            const relativeFilepath = relativePathForDisplay(workspace.absoluteFilePath, spec.source.file);
 
             for (const [path, pathItem] of Object.entries(
                 ((apiToValidate as Record<string, unknown>).paths as Record<string, unknown>) ?? {}

--- a/packages/cli/workspace/oss-validator/src/rules/no-duplicate-auth-header-parameters/no-duplicate-auth-header-parameters.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-duplicate-auth-header-parameters/no-duplicate-auth-header-parameters.ts
@@ -1,5 +1,5 @@
 import { isOpenAPIV2 } from "@fern-api/api-workspace-commons";
-import { relative } from "@fern-api/fs-utils";
+import { relativePathForDisplay } from "@fern-api/fs-utils";
 import { convertOpenAPIV2ToV3 } from "@fern-api/lazy-fern-workspace";
 
 import { Rule } from "../../Rule.js";
@@ -37,7 +37,7 @@ export const NoDuplicateAuthHeaderParametersRule: Rule = {
                 continue;
             }
 
-            const relativeFilepath = relative(workspace.absoluteFilePath, spec.source.file);
+            const relativeFilepath = relativePathForDisplay(workspace.absoluteFilePath, spec.source.file);
 
             for (const [path, pathItem] of Object.entries(apiToValidate.paths ?? {})) {
                 if (pathItem == null) {

--- a/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/no-duplicate-overrides.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/no-duplicate-overrides.ts
@@ -1,5 +1,5 @@
 import { isOpenAPIV2 } from "@fern-api/api-workspace-commons";
-import { relative } from "@fern-api/fs-utils";
+import { relativePathForDisplay } from "@fern-api/fs-utils";
 import { convertOpenAPIV2ToV3 } from "@fern-api/lazy-fern-workspace";
 
 import { Rule } from "../../Rule.js";
@@ -61,7 +61,10 @@ export const NoDuplicateOverridesRule: Rule = {
                                     violations.push({
                                         name: "no-duplicate-overrides",
                                         severity: "fatal",
-                                        relativeFilepath: relative(workspace.absoluteFilePath, spec.source.file),
+                                        relativeFilepath: relativePathForDisplay(
+                                            workspace.absoluteFilePath,
+                                            spec.source.file
+                                        ),
                                         nodePath: ["paths", path, method],
                                         message: `SDK method ${displayGroup}.${sdkMethodName} already exists (x-fern-sdk-group-name: ${sdkGroupName}, x-fern-sdk-method-name: ${sdkMethodName})`
                                     });

--- a/packages/cli/workspace/oss-validator/src/rules/no-invalid-tag-names-or-frontmatter/no-invalid-tag-names-or-frontmatter.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-invalid-tag-names-or-frontmatter/no-invalid-tag-names-or-frontmatter.ts
@@ -1,5 +1,5 @@
 import { isOpenAPIV2 } from "@fern-api/api-workspace-commons";
-import { relative } from "@fern-api/fs-utils";
+import { relativePathForDisplay } from "@fern-api/fs-utils";
 import { convertOpenAPIV2ToV3 } from "@fern-api/lazy-fern-workspace";
 
 import { Rule } from "../../Rule.js";
@@ -34,7 +34,7 @@ export const NoInvalidTagNamesOrFrontmatterRule: Rule = {
             }
 
             const apiToValidate = isOpenAPIV2(openAPI) ? await convertOpenAPIV2ToV3(openAPI) : openAPI;
-            const relativeFilepath = relative(workspace.absoluteFilePath, spec.source.file);
+            const relativeFilepath = relativePathForDisplay(workspace.absoluteFilePath, spec.source.file);
 
             // biome-ignore lint/suspicious/noExplicitAny: OpenAPI document type
             const apiDoc = apiToValidate as Record<string, any>;

--- a/packages/cli/workspace/oss-validator/src/rules/no-schema-title-collisions/no-schema-title-collisions.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-schema-title-collisions/no-schema-title-collisions.ts
@@ -1,5 +1,5 @@
 import { isOpenAPIV2 } from "@fern-api/api-workspace-commons";
-import { relative } from "@fern-api/fs-utils";
+import { relativePathForDisplay } from "@fern-api/fs-utils";
 import { convertOpenAPIV2ToV3 } from "@fern-api/lazy-fern-workspace";
 
 import { Rule } from "../../Rule";
@@ -37,7 +37,7 @@ export const NoSchemaTitleCollisionsRule: Rule = {
                 continue;
             }
 
-            const relativeFilepath = relative(workspace.absoluteFilePath, spec.source.file);
+            const relativeFilepath = relativePathForDisplay(workspace.absoluteFilePath, spec.source.file);
 
             // For OpenAPI v2, convert to v3 first
             const apiToValidate = isOpenAPIV2(document) ? await convertOpenAPIV2ToV3(document) : document;

--- a/packages/commons/fs-utils/src/__test__/relativeOrOriginalPath.test.ts
+++ b/packages/commons/fs-utils/src/__test__/relativeOrOriginalPath.test.ts
@@ -1,0 +1,26 @@
+import path from "path";
+
+import { AbsoluteFilePath } from "../AbsoluteFilePath.js";
+import { RelativeFilePath } from "../RelativeFilePath.js";
+import { relativeOrOriginalPath } from "../relativeOrOriginalPath.js";
+
+describe("relativeOrOriginalPath", () => {
+    it("returns a relative path when one can be represented", () => {
+        expect(
+            relativeOrOriginalPath(
+                AbsoluteFilePath.of("/path/to/fern"),
+                AbsoluteFilePath.of("/path/to/fern/openapi.yml")
+            )
+        ).toEqual(RelativeFilePath.of("openapi.yml"));
+    });
+
+    it("returns the original absolute path for Windows cross-drive paths", () => {
+        expect(
+            relativeOrOriginalPath(
+                "D:\\workspace\\fern" as AbsoluteFilePath,
+                "C:\\Users\\spec\\openapi.yml" as AbsoluteFilePath,
+                path.win32
+            )
+        ).toEqual("C:\\Users\\spec\\openapi.yml" as AbsoluteFilePath);
+    });
+});

--- a/packages/commons/fs-utils/src/__test__/relativePathForDisplay.test.ts
+++ b/packages/commons/fs-utils/src/__test__/relativePathForDisplay.test.ts
@@ -1,0 +1,26 @@
+import path from "path";
+
+import { AbsoluteFilePath } from "../AbsoluteFilePath.js";
+import { RelativeFilePath } from "../RelativeFilePath.js";
+import { relativePathForDisplay } from "../relativePathForDisplay.js";
+
+describe("relativePathForDisplay", () => {
+    it("returns a relative path when one can be represented", () => {
+        expect(
+            relativePathForDisplay(
+                AbsoluteFilePath.of("/path/to/fern"),
+                AbsoluteFilePath.of("/path/to/fern/openapi.yml")
+            )
+        ).toEqual(RelativeFilePath.of("openapi.yml"));
+    });
+
+    it("returns the basename for Windows cross-drive paths", () => {
+        expect(
+            relativePathForDisplay(
+                "D:\\workspace\\fern" as AbsoluteFilePath,
+                "C:\\Users\\spec\\openapi.yml" as AbsoluteFilePath,
+                path.win32
+            )
+        ).toEqual(RelativeFilePath.of("openapi.yml"));
+    });
+});

--- a/packages/commons/fs-utils/src/__test__/resolveConfiguredFilepath.test.ts
+++ b/packages/commons/fs-utils/src/__test__/resolveConfiguredFilepath.test.ts
@@ -1,0 +1,37 @@
+import { AbsoluteFilePath } from "../AbsoluteFilePath.js";
+import { RelativeFilePath } from "../RelativeFilePath.js";
+import { resolveConfiguredFilepath, resolveConfiguredFilepaths } from "../resolveConfiguredFilepath.js";
+
+describe("resolveConfiguredFilepath", () => {
+    it("joins relative paths against the workspace", () => {
+        expect(
+            resolveConfiguredFilepath({
+                absolutePathToWorkspace: AbsoluteFilePath.of("/path/to/fern"),
+                configuredFilepath: "openapi/openapi.yml"
+            })
+        ).toEqual(AbsoluteFilePath.of("/path/to/fern/openapi/openapi.yml"));
+    });
+
+    it("returns absolute paths unchanged", () => {
+        expect(
+            resolveConfiguredFilepath({
+                absolutePathToWorkspace: AbsoluteFilePath.of("/path/to/fern"),
+                configuredFilepath: "/Users/spec/openapi.yml"
+            })
+        ).toEqual(AbsoluteFilePath.of("/Users/spec/openapi.yml"));
+    });
+});
+
+describe("resolveConfiguredFilepaths", () => {
+    it("resolves arrays of relative and absolute paths", () => {
+        expect(
+            resolveConfiguredFilepaths({
+                absolutePathToWorkspace: AbsoluteFilePath.of("/path/to/fern"),
+                configuredFilepaths: ["overrides/a.yml", "/Users/spec/overrides/b.yml"]
+            })
+        ).toEqual([
+            AbsoluteFilePath.of("/path/to/fern/overrides/a.yml"),
+            AbsoluteFilePath.of("/Users/spec/overrides/b.yml")
+        ]);
+    });
+});

--- a/packages/commons/fs-utils/src/index.ts
+++ b/packages/commons/fs-utils/src/index.ts
@@ -26,8 +26,11 @@ export {
 } from "./osPathConverter.js";
 export { RelativeFilePath } from "./RelativeFilePath.js";
 export { relative } from "./relative.js";
+export { isAbsoluteFilePath, relativeOrOriginalPath } from "./relativeOrOriginalPath.js";
+export { relativePathForDisplay } from "./relativePathForDisplay.js";
 export { relativize } from "./relativize.js";
 export { resolve } from "./resolve.js";
+export { resolveConfiguredFilepath, resolveConfiguredFilepaths } from "./resolveConfiguredFilepath.js";
 export { splitPath } from "./splitPath.js";
 export { streamObjectFromFile } from "./streamObjectFromFile.js";
 export { streamObjectToFile } from "./streamObjectToFile.js";

--- a/packages/commons/fs-utils/src/relativeOrOriginalPath.ts
+++ b/packages/commons/fs-utils/src/relativeOrOriginalPath.ts
@@ -1,0 +1,21 @@
+import path from "path";
+
+import { AbsoluteFilePath } from "./AbsoluteFilePath.js";
+import { convertToOsPath } from "./osPathConverter.js";
+import { RelativeFilePath } from "./RelativeFilePath.js";
+
+export function isAbsoluteFilePath(filepath: RelativeFilePath | AbsoluteFilePath): filepath is AbsoluteFilePath {
+    return path.isAbsolute(filepath);
+}
+
+export function relativeOrOriginalPath(
+    from: AbsoluteFilePath,
+    to: AbsoluteFilePath,
+    pathModule: Pick<typeof path, "isAbsolute" | "relative"> = path
+): RelativeFilePath | AbsoluteFilePath {
+    const relativePath = convertToOsPath(pathModule.relative(from, to));
+    if (pathModule.isAbsolute(relativePath)) {
+        return to;
+    }
+    return RelativeFilePath.of(relativePath);
+}

--- a/packages/commons/fs-utils/src/relativePathForDisplay.ts
+++ b/packages/commons/fs-utils/src/relativePathForDisplay.ts
@@ -1,0 +1,17 @@
+import path from "path";
+
+import { AbsoluteFilePath } from "./AbsoluteFilePath.js";
+import { convertToOsPath } from "./osPathConverter.js";
+import { RelativeFilePath } from "./RelativeFilePath.js";
+
+export function relativePathForDisplay(
+    from: AbsoluteFilePath,
+    to: AbsoluteFilePath,
+    pathModule: Pick<typeof path, "isAbsolute" | "relative" | "basename"> = path
+): RelativeFilePath {
+    const relativePath = convertToOsPath(pathModule.relative(from, to));
+    if (!pathModule.isAbsolute(relativePath)) {
+        return RelativeFilePath.of(relativePath);
+    }
+    return RelativeFilePath.of(pathModule.basename(to));
+}

--- a/packages/commons/fs-utils/src/resolveConfiguredFilepath.ts
+++ b/packages/commons/fs-utils/src/resolveConfiguredFilepath.ts
@@ -1,0 +1,33 @@
+import path from "path";
+
+import { AbsoluteFilePath } from "./AbsoluteFilePath.js";
+import { join } from "./join.js";
+import { RelativeFilePath } from "./RelativeFilePath.js";
+
+export function resolveConfiguredFilepath({
+    absolutePathToWorkspace,
+    configuredFilepath
+}: {
+    absolutePathToWorkspace: AbsoluteFilePath;
+    configuredFilepath: string;
+}): AbsoluteFilePath {
+    if (path.isAbsolute(configuredFilepath)) {
+        return AbsoluteFilePath.of(configuredFilepath);
+    }
+    return join(absolutePathToWorkspace, RelativeFilePath.of(configuredFilepath));
+}
+
+export function resolveConfiguredFilepaths({
+    absolutePathToWorkspace,
+    configuredFilepaths
+}: {
+    absolutePathToWorkspace: AbsoluteFilePath;
+    configuredFilepaths: string | string[];
+}): AbsoluteFilePath | AbsoluteFilePath[] {
+    if (Array.isArray(configuredFilepaths)) {
+        return configuredFilepaths.map((configuredFilepath) =>
+            resolveConfiguredFilepath({ absolutePathToWorkspace, configuredFilepath })
+        );
+    }
+    return resolveConfiguredFilepath({ absolutePathToWorkspace, configuredFilepath: configuredFilepaths });
+}


### PR DESCRIPTION
## Summary
- Allow absolute paths in `generators.yml` for OpenAPI, GraphQL, OpenRPC, and protobuf specs, plus overrides and overlays.
- Add shared path helpers in `@fern-api/fs-utils` and propagate resolved paths through workspace loading, OSS validation, generation prep, and `fern api update`.

## Context
This is the feature follow-up to #15953, which intentionally **rejects** absolute OpenAPI paths with a user-facing config error to fix Sentry CLI-18 / CLI-46 without changing supported configuration semantics yet.

Linear: https://linear.app/buildwithfern/issue/FER-10741/allow-absolute-api-spec-paths-in-generatorsyml

## Test plan
- [x] `pnpm turbo run test --filter @fern-api/fs-utils --filter @fern-api/workspace-loader --filter @fern-api/lazy-fern-workspace --filter @fern-api/oss-validator --filter @fern-api/cli`
- [ ] Manual: `generators.yml` with absolute OpenAPI path loads and `fern generate --local` succeeds when the file exists locally