### PR TITLE
chore(cli): consolidate theme-eligible field keys

### DIFF
--- a/packages/cli/cli/changes/unreleased/consolidate-theme-eligible-fields.yml
+++ b/packages/cli/cli/changes/unreleased/consolidate-theme-eligible-fields.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Centralize theme-eligible docs.yml field definitions in @fern-api/configuration
+    so theme export, upload, and global theme stitching reference the same source
+    of truth.
+  type: patch

--- a/packages/cli/cli/changes/unreleased/consolidate-theme-eligible-fields.yml
+++ b/packages/cli/cli/changes/unreleased/consolidate-theme-eligible-fields.yml
@@ -2,4 +2,4 @@
     Centralize theme-eligible docs.yml field definitions in @fern-api/configuration
     so theme export, upload, and global theme stitching reference the same source
     of truth.
-  type: patch
+  type: chore

--- a/packages/cli/cli/src/commands/docs-theme/ThemeExporter.ts
+++ b/packages/cli/cli/src/commands/docs-theme/ThemeExporter.ts
@@ -1,27 +1,10 @@
+import { docsYml } from "@fern-api/configuration";
 import { isURL } from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 import { DocsWorkspace } from "@fern-api/workspace-loader";
 import { copyFile, mkdir, readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 import path from "path";
-
-const THEME_ELIGIBLE_KEYS = new Set([
-    "logo",
-    "favicon",
-    "colors",
-    "typography",
-    "layout",
-    "navbar-links",
-    "footer-links",
-    "background-image",
-    "theme",
-    "css",
-    "js",
-    "header",
-    "footer",
-    "metadata",
-    "settings"
-]);
 
 export class ThemeExporter {
     public constructor(private readonly docsWorkspace: DocsWorkspace) {}
@@ -39,7 +22,7 @@ export class ThemeExporter {
         const raw = yaml.load(await readFile(docsYmlPath, "utf-8")) as Record<string, unknown>;
         const themeConfig: Record<string, unknown> = {};
         for (const [k, v] of Object.entries(raw)) {
-            if (THEME_ELIGIBLE_KEYS.has(k)) {
+            if (docsYml.THEME_ELIGIBLE_YAML_KEYS.has(k)) {
                 themeConfig[k] = v;
             }
         }

--- a/packages/cli/configuration/src/docs-yml/index.ts
+++ b/packages/cli/configuration/src/docs-yml/index.ts
@@ -1,3 +1,4 @@
 export * as DocsYmlSchemas from "./DocsYmlSchemas.js";
 export * from "./ParsedDocsConfiguration.js";
 export * as RawSchemas from "./schemas/index.js";
+export * from "./themeEligibleFields.js";

--- a/packages/cli/configuration/src/docs-yml/themeEligibleFields.ts
+++ b/packages/cli/configuration/src/docs-yml/themeEligibleFields.ts
@@ -1,0 +1,38 @@
+// "global" — the theme value always wins; local docs.yml cannot override it.
+// "local"  — the local docs.yml value wins when present; theme is the fallback.
+export type ThemeFieldPolicy = "global" | "local";
+
+// Controls, per eligible key, whether the global theme takes precedence or the
+// local docs.yml can override. Add new theme-eligible keys here.
+// Keys use the camelCase form that DocsConfiguration uses internally.
+export const THEME_FIELD_POLICIES = {
+    logo: "global",
+    favicon: "global",
+    backgroundImage: "global",
+    colors: "global",
+    typography: "global",
+    layout: "global",
+    settings: "global",
+    theme: "global",
+    integrations: "global",
+    css: "global",
+    js: "global",
+    header: "global",
+    footer: "global",
+    navbarLinks: "global",
+    footerLinks: "global",
+    aiSearch: "global",
+    announcement: "global",
+    metadata: "global"
+} as const satisfies Record<string, ThemeFieldPolicy>;
+
+export type ThemeEligibleField = keyof typeof THEME_FIELD_POLICIES;
+
+export const THEME_ELIGIBLE_FIELDS = Object.keys(THEME_FIELD_POLICIES) as ThemeEligibleField[];
+
+function camelToKebab(value: string): string {
+    return value.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+/** Kebab-case top-level keys as they appear in raw docs.yml / theme.yml. */
+export const THEME_ELIGIBLE_YAML_KEYS = new Set(THEME_ELIGIBLE_FIELDS.map(camelToKebab));

--- a/packages/cli/docs-resolver/src/stitchGlobalTheme.ts
+++ b/packages/cli/docs-resolver/src/stitchGlobalTheme.ts
@@ -214,35 +214,7 @@ export function deepMergeGlobalWins(
     return result;
 }
 
-// "global" — the theme value always wins; local docs.yml cannot override it.
-// "local"  — the local docs.yml value wins when present; theme is the fallback.
-type ThemeFieldPolicy = "global" | "local";
-
-// Controls, per eligible key, whether the global theme takes precedence or the
-// local docs.yml can override. Add new theme-eligible keys here.
-// Keys use the camelCase form that DocsConfiguration uses internally.
-const THEME_FIELD_POLICIES: Readonly<Record<string, ThemeFieldPolicy>> = {
-    logo: "global",
-    favicon: "global",
-    backgroundImage: "global",
-    colors: "global",
-    typography: "global",
-    layout: "global",
-    settings: "global",
-    theme: "global",
-    integrations: "global",
-    css: "global",
-    js: "global",
-    header: "global",
-    footer: "global",
-    navbarLinks: "global",
-    footerLinks: "global",
-    aiSearch: "global",
-    announcement: "global",
-    metadata: "global"
-};
-
-const THEME_ELIGIBLE_KEYS = Object.keys(THEME_FIELD_POLICIES) as ReadonlyArray<keyof RawDocsConfig>;
+const { THEME_ELIGIBLE_FIELDS, THEME_FIELD_POLICIES } = docsYml;
 
 function kebabToCamel(str: string): string {
     return str.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
@@ -276,7 +248,7 @@ export function mergeThemeOverride(local: RawDocsConfig, themeOverride: Record<s
     const normalized = normalizeThemeKeys(themeOverride);
     const localRecord = local as unknown as Record<string, unknown>;
     const merged: Record<string, unknown> = { ...localRecord };
-    for (const key of THEME_ELIGIBLE_KEYS) {
+    for (const key of THEME_ELIGIBLE_FIELDS) {
         const themeValue = normalized[key];
         const localValue = localRecord[key];
         const policy = THEME_FIELD_POLICIES[key] ?? "global";


### PR DESCRIPTION
## Context

Theme-eligible docs.yml field keys were duplicated in `ThemeExporter.ts` and `stitchGlobalTheme.ts`, and the two lists had drifted — export was missing fields like `integrations`, `aiSearch`, and `announcement` that global theme stitching already handled. Keeping separate lists makes it easy for export, upload, and merge behavior to fall out of sync when new theme fields are added.

## What's Changed

- Added `themeEligibleFields.ts` in `@fern-api/configuration` as the single source of truth for theme-eligible keys and merge policies
- Updated `stitchGlobalTheme.ts` to import `THEME_FIELD_POLICIES` and `THEME_ELIGIBLE_FIELDS` from configuration
- Updated `ThemeExporter.ts` to use `THEME_ELIGIBLE_YAML_KEYS` for raw docs.yml filtering
- Added an unreleased CLI changelog entry

## Testing

- `pnpm turbo run compile --filter @fern-api/configuration --filter @fern-api/docs-resolver --filter @fern-api/cli`
- `pnpm vitest --run src/__test__/stitchGlobalTheme.test.ts` in `packages/cli/docs-resolver` (49 tests passed)


Made with [Cursor](https://cursor.com)