### PR TITLE
fix(deps): bump @fern-api/fdr-sdk to 1.2.16

### DIFF
--- a/packages/cli/api-importers/graphql/package.json
+++ b/packages/cli/api-importers/graphql/package.json
@@ -31,7 +31,7 @@
     "test:update": "vitest --run -u --passWithNoTests"
   },
   "dependencies": {
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "graphql": "catalog:"

--- a/packages/cli/cli/changes/unreleased/bump-fdr-sdk.yml
+++ b/packages/cli/cli/changes/unreleased/bump-fdr-sdk.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump @fern-api/fdr-sdk to 1.2.16 to fix crash when generating examples for
+    endpoints that reference types excluded by audience filtering.
+  type: fix

--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -70,7 +70,7 @@
     "@fern-api/docs-preview": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",
     "@fern-api/docs-validator": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fern-definition-formatter": "workspace:*",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/fern-definition-validator": "workspace:*",

--- a/packages/cli/configuration-loader/package.json
+++ b/packages/cli/configuration-loader/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/github": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",

--- a/packages/cli/configuration/package.json
+++ b/packages/cli/configuration/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/path-utils": "workspace:*",
     "@fern-fern/fiddle-sdk": "catalog:",

--- a/packages/cli/docs-importers/commons/package.json
+++ b/packages/cli/docs-importers/commons/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/configuration": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "js-yaml": "catalog:"

--- a/packages/cli/docs-importers/mintlify/package.json
+++ b/packages/cli/docs-importers/mintlify/package.json
@@ -35,7 +35,7 @@
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-importer-commons": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/task-context": "workspace:*",

--- a/packages/cli/docs-importers/readme/package.json
+++ b/packages/cli/docs-importers/readme/package.json
@@ -35,7 +35,7 @@
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-importer-commons": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/task-context": "workspace:*",

--- a/packages/cli/docs-markdown-utils/package.json
+++ b/packages/cli/docs-markdown-utils/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --run -u"
   },
   "dependencies": {
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "estree-walker": "catalog:",

--- a/packages/cli/docs-preview/package.json
+++ b/packages/cli/docs-preview/package.json
@@ -36,7 +36,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-markdown-utils": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/ir-sdk": "workspace:*",
     "@fern-api/ir-utils": "workspace:*",

--- a/packages/cli/ete-tests/package.json
+++ b/packages/cli/ete-tests/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@fern-api/configuration": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/lazy-fern-workspace": "workspace:*",
     "@fern-api/logger": "workspace:*",

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
@@ -42,7 +42,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",
     "@fern-api/fai-sdk": "catalog:",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/generator-cli": "workspace:*",
     "@fern-api/ir-generator": "workspace:*",

--- a/packages/cli/register/package.json
+++ b/packages/cli/register/package.json
@@ -38,7 +38,7 @@
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/ir-generator": "workspace:*",
     "@fern-api/ir-sdk": "workspace:*",

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/fixtures/audience-filtered-missing-type/generators.yml
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/fixtures/audience-filtered-missing-type/generators.yml
@@ -1,0 +1,3 @@
+api:
+  specs:
+    - openapi: openapi.yml

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/fixtures/audience-filtered-missing-type/openapi.yml
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/fixtures/audience-filtered-missing-type/openapi.yml
@@ -1,0 +1,71 @@
+openapi: 3.0.3
+info:
+  title: Audience Filtered Missing Type Test
+  version: 1.0.0
+paths:
+  /v2/chat:
+    post:
+      operationId: chat
+      x-fern-audiences:
+        - public
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                messages:
+                  x-fern-audiences:
+                    - public
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/ChatMessageV2"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  text:
+                    type: string
+components:
+  schemas:
+    ChatMessageV2:
+      title: ChatMessageV2
+      oneOf:
+        - $ref: "#/components/schemas/UserMessage"
+        - $ref: "#/components/schemas/AssistantMessage"
+      discriminator:
+        propertyName: role
+        mapping:
+          USER: "#/components/schemas/UserMessage"
+          ASSISTANT: "#/components/schemas/AssistantMessage"
+    UserMessage:
+      title: UserMessage
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - USER
+        content:
+          type: string
+      required:
+        - role
+        - content
+    AssistantMessage:
+      title: AssistantMessage
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+            - ASSISTANT
+        content:
+          type: string
+      required:
+        - role
+        - content

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts
@@ -3366,4 +3366,64 @@ describe("OpenAPI v3 Parser Pipeline (--from-openapi flag)", () => {
         expect(ir).toBeDefined();
         expect(ir.services).toBeDefined();
     });
+
+    it("should handle audience-filtered types referenced by endpoints without crashing", async () => {
+        const context = createMockTaskContext();
+        const workspace = await loadAPIWorkspace({
+            absolutePathToWorkspace: join(
+                AbsoluteFilePath.of(__dirname),
+                RelativeFilePath.of("fixtures/audience-filtered-missing-type")
+            ),
+            context,
+            cliVersion: "0.0.0",
+            workspaceName: "audience-filtered-missing-type"
+        });
+
+        expect(workspace.didSucceed).toBe(true);
+        assert(workspace.didSucceed);
+
+        if (!(workspace.workspace instanceof OSSWorkspace)) {
+            throw new Error(
+                `Expected OSSWorkspace for OpenAPI processing, got ${workspace.workspace.constructor.name}`
+            );
+        }
+
+        // Use selective audiences so that untagged schemas are excluded from IR.
+        // Previously, this caused "Failed to find ChatMessageV2" during FDR
+        // example generation because the type was dropped by audience filtering
+        // while endpoint references to it remained.
+        const ir = await workspace.workspace.getIntermediateRepresentation({
+            context,
+            audiences: { type: "select", audiences: ["public"] },
+            enableUniqueErrorsPerEndpoint: true,
+            generateV1Examples: false,
+            logWarnings: false
+        });
+
+        expect(ir).toBeDefined();
+        expect(ir.services).toBeDefined();
+
+        const fdrApiDefinition = await convertIrToFdrApi({
+            ir,
+            snippetsConfig: {
+                typescriptSdk: undefined,
+                pythonSdk: undefined,
+                javaSdk: undefined,
+                rubySdk: undefined,
+                goSdk: undefined,
+                csharpSdk: undefined,
+                phpSdk: undefined,
+                swiftSdk: undefined,
+                rustSdk: undefined
+            },
+            playgroundConfig: {
+                oauth: true
+            },
+            context
+        });
+
+        expect(fdrApiDefinition).toBeDefined();
+        expect(fdrApiDefinition.types).toBeDefined();
+        expect(fdrApiDefinition.rootPackage).toBeDefined();
+    });
 });

--- a/packages/cli/workspace/browser-compatible-fern-workspace/package.json
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/package.json
@@ -37,7 +37,7 @@
     "@fern-api/asyncapi-to-ir": "workspace:*",
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/ir-sdk": "workspace:*",
     "@fern-api/openapi-ir": "workspace:*",
     "@fern-api/openapi-ir-parser": "workspace:*",

--- a/packages/cli/workspace/lazy-fern-workspace/package.json
+++ b/packages/cli/workspace/lazy-fern-workspace/package.json
@@ -41,7 +41,7 @@
     "@fern-api/conjure-to-fern": "workspace:*",
     "@fern-api/core": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/graphql-to-fdr": "workspace:*",

--- a/packages/cli/yaml/docs-validator/package.json
+++ b/packages/cli/yaml/docs-validator/package.json
@@ -40,7 +40,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-markdown-utils": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/ir-generator": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
+    "@fern-api/fdr-sdk": "1.2.16-3b754a56be",
     "@fern-api/venus-api-sdk": "catalog:",
     "@fern-fern/fdr-test-sdk": "catalog:",
     "@fern-fern/fiddle-sdk": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,7 +593,7 @@ overrides:
   minimatch: '>=10.2.3'
   qs: 6.15.0
   url-join: ^4.0.1
-  '@fern-api/fdr-sdk': 1.2.4-f661387fb2
+  '@fern-api/fdr-sdk': 1.2.16-3b754a56be
   form-data: ^4.0.4
   '@fern-api/ui-core-utils': 0.145.12-b50d999d1
   vite: ^7.3.2
@@ -3873,8 +3873,8 @@ importers:
   packages/cli/api-importers/graphql:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -4249,8 +4249,8 @@ importers:
         specifier: workspace:*
         version: link:../../configuration
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/ir-generator':
         specifier: workspace:*
         version: link:../../generation/ir-generator
@@ -4376,8 +4376,8 @@ importers:
         specifier: workspace:*
         version: link:../yaml/docs-validator
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-formatter':
         specifier: workspace:*
         version: link:../fern-definition/formatter
@@ -4822,8 +4822,8 @@ importers:
         specifier: workspace:*
         version: link:../yaml/docs-validator
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../fern-definition/schema
@@ -5024,8 +5024,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../fern-definition/schema
@@ -5061,8 +5061,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5140,8 +5140,8 @@ importers:
         specifier: workspace:*
         version: link:../../configuration
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -5180,8 +5180,8 @@ importers:
         specifier: workspace:*
         version: link:../commons
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -5220,8 +5220,8 @@ importers:
         specifier: workspace:*
         version: link:../commons
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -5287,8 +5287,8 @@ importers:
   packages/cli/docs-markdown-utils:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5378,8 +5378,8 @@ importers:
         specifier: workspace:*
         version: link:../docs-resolver
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5493,8 +5493,8 @@ importers:
         specifier: workspace:*
         version: link:../docs-markdown-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5596,8 +5596,8 @@ importers:
         specifier: workspace:*
         version: link:../configuration
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -6301,8 +6301,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.6-2ee1b7e28
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../../commons/fs-utils
@@ -6523,8 +6523,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -6766,8 +6766,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -6962,8 +6962,8 @@ importers:
         specifier: workspace:*
         version: link:../../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../../ir-sdk
@@ -7047,8 +7047,8 @@ importers:
         specifier: workspace:*
         version: link:../../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../../fern-definition/schema
@@ -7287,8 +7287,8 @@ importers:
         specifier: workspace:*
         version: link:../../docs-resolver
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../../fern-definition/schema
@@ -7932,8 +7932,8 @@ importers:
   packages/core:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.2.4-f661387fb2
-        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.16-3b754a56be
+        version: 1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
         version: 0.22.34
@@ -9489,8 +9489,8 @@ packages:
     resolution: {integrity: sha512-3qhAAuc4ZJWLaFtyZzaYXfF9OQ5iviNrvLDXtjKScKUNS134fR3v3c3xedCidTq5KedapuBECziUaOmmd6KXVA==}
     engines: {node: '>=18.0.0'}
 
-  '@fern-api/fdr-sdk@1.2.4-f661387fb2':
-    resolution: {integrity: sha512-wlk1lTCIZ7biND4vQf8jvhUw9P/rBQ5pXASCrumv8R96up0B3DY6yiY1C4VmFyHmp/kPhcjzc5T9TvHZZxFdrA==}
+  '@fern-api/fdr-sdk@1.2.16-3b754a56be':
+    resolution: {integrity: sha512-0qWBYHUv2uS0JQ33t1ZhslTeJXSxR92lWJxNrj7t0PZGo63GgSilpu0VLYJDCBl3EH1jVoctdL/NfzyzdKBBWw==}
 
   '@fern-api/generator-cli@0.9.35':
     resolution: {integrity: sha512-84+K5K4jquuqpMo3p2NDk/OJuiyZtRcQW5tlEYH3R9y7G5wX71qwAWM21qWqu6+vYfN1oZ+4fUcqgqp6tOhxVA==}
@@ -16439,7 +16439,7 @@ snapshots:
 
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28': {}
 
-  '@fern-api/fdr-sdk@1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)':
+  '@fern-api/fdr-sdk@1.2.16-3b754a56be(@opentelemetry/api@1.9.1)(typescript@5.9.3)':
     dependencies:
       '@fern-api/ui-core-utils': 0.145.12-b50d999d1
       '@orpc/client': 1.13.9(@opentelemetry/api@1.9.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,7 @@ catalog:
   "@bufbuild/protobuf": ^2.2.5
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
-  "@fern-api/fdr-sdk": 1.2.4-f661387fb2
+  "@fern-api/fdr-sdk": 1.2.16-3b754a56be
   "@fern-api/generator-cli": 0.9.35
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
@@ -270,7 +270,7 @@ overrides:
   minimatch: '>=10.2.3'
   qs: 6.15.0
   url-join: ^4.0.1
-  '@fern-api/fdr-sdk': 1.2.4-f661387fb2
+  '@fern-api/fdr-sdk': 1.2.16-3b754a56be
   form-data: ^4.0.4
   '@fern-api/ui-core-utils': 0.145.12-b50d999d1
   vite: ^7.3.2


### PR DESCRIPTION
## Description
Bumps `@fern-api/fdr-sdk` from `1.2.4-f661387fb2` to `1.2.16-3b754a56be` to pick up the fix from https://github.com/fern-api/fern-platform/pull/11356.

## Changes Made
- Updated `@fern-api/fdr-sdk` version in `pnpm-workspace.yaml` (catalog + overrides)
- Updated all 16 `package.json` files that pin the version directly
- Updated `pnpm-lock.yaml`
- Added changelog entry
- Added regression test for audience-filtered missing type scenario

The key fix in fdr-sdk 1.2.16: `resolveTypeById` now returns `undefined` instead of throwing when a type is missing from the API definition's types map. This prevents crashes during example generation when audience filtering (`x-fern-audiences`) excludes types that are still referenced by endpoints.

**Sentry issue:** https://buildwithfern.sentry.io/issues/7498080005/
**Customer CI failure:** https://github.com/cohere-ai/cohere-developer-experience/actions/runs/26247038262/job/77247973554?pr=748

## Testing
- [x] `pnpm install` succeeds with the new version
- [x] Unit tests in fern-platform PR validated the fix
- [x] New regression test added: `openapi-from-flag.test.ts` → "should handle audience-filtered types referenced by endpoints without crashing" — passes locally


Link to Devin session: https://app.devin.ai/sessions/1de6bbbec07a48e1a2f590cf6bf9c47b
Requested by: @thesandlord