### PR TITLE
chore(docs): refresh README — update messaging, remove Spec Generators, replace Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@
 
 # 🌿 What is Fern?
 
-Fern is a platform that transforms your API definitions into production-ready SDKs and beautiful documentation in minutes. 
+Docs, SDKs, and CLIs for your API. Designed for the AI era.
 
 With Fern, you can offer your users:
 
-- 🧩 **Type-safe SDKs** in multiple languages, including TypeScript, Python, Java, Go, Ruby, PHP, and C#
-- 📘 **Developer documentation** featuring an interactive UI and auto-generated API + SDK references
-- ✨ **AI Search** powered by an assistant trained on your docs, APIs, and SDKs that can instantly answer a developer's questions
+- 📘 **Agent-friendly documentation** with built-in AI search, auto-generated [`llms.txt`](https://buildwithfern.com/learn/docs/ai-features/llms-txt), and an [MCP server](https://buildwithfern.com/learn/docs/ai-features/mcp-server) so AI tools can query your API in real time
+- 🧩 **Type-safe SDKs** in TypeScript, Python, Java, Go, Ruby, PHP, C#, Swift, and Rust
+- ✨ **AI search** powered by an assistant trained on your docs, APIs, and SDKs that can instantly answer developer questions
 
-Fern supports leading API specifications including OpenAPI (REST, Webhooks), AsyncAPI (WebSockets), Protobuf (gRPC), and OpenRPC.
+Fern supports OpenAPI (REST, Webhooks), AsyncAPI (WebSockets), Protobuf (gRPC), and GraphQL.
 
 <div align="center">
     <a href="/fern/images/overview-dark.png" target="_blank">
@@ -94,8 +94,6 @@ Get started [here](https://github.com/fern-api/docs-starter).
 
 Generators are processes that take your API Definition as input and output artifacts (SDKs, Server boilerplate, etc.). To add a generator, run `fern add <generator id>`.
 
-### SDK Generators
-
 | Generator ID                       | Latest Version                                                                                    | Changelog                                                                                                      |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | `fernapi/fern-typescript-sdk`      | ![Typescript Generator Version](https://img.shields.io/docker/v/fernapi/fern-typescript-sdk)      | [Changelog](https://buildwithfern.com/learn/sdks/generators/typescript/changelog)                               |
@@ -107,16 +105,6 @@ Generators are processes that take your API Definition as input and output artif
 | `fernapi/fern-php-sdk`             | ![PHP Generator Version](https://img.shields.io/docker/v/fernapi/fern-php-sdk)                    | [Changelog](https://buildwithfern.com/learn/sdks/generators/php/changelog)                                      |
 | `fernapi/fern-swift-sdk`           | ![Swift Generator Version](https://img.shields.io/docker/v/fernapi/fern-swift-sdk)                | [Changelog](https://buildwithfern.com/learn/sdks/generators/swift/changelog)                                    |
 | `fernapi/fern-rust-sdk`            | ![Rust Generator Version](https://img.shields.io/docker/v/fernapi/fern-rust-sdk)                  | [Changelog](https://buildwithfern.com/learn/sdks/generators/rust/changelog)                                     |
-
-### Spec Generators
-
-Fern's spec generators can output an OpenAPI spec.
-
-> **Note**: The OpenAPI spec generator is primarily intended for Fern Definition users. This prevents lock-in so that one can always export to OpenAPI.
-
-| Generator ID           | Latest Version                                                                     | Changelog                                              |
-| ---------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `fernapi/fern-openapi` | ![OpenAPI Generator Version](https://img.shields.io/docker/v/fernapi/fern-openapi) | [versions.yml](./generators/openapi/versions.yml)      |
 
 ## 🌿 CLI Commands
 
@@ -138,7 +126,11 @@ Fern is inspired by internal tooling built to enhance the developer experience. 
 
 ## Community
 
-[Join our Slack!](https://buildwithfern.com/slack) We are here to answer questions and help you get the most out of Fern.
+We're here to answer questions and help you get the most out of Fern.
+
+- [𝕏 Follow us on X](https://x.com/buildwithfern)
+- [GitHub Issues](https://github.com/fern-api/fern/issues) — Bug reports and feature requests
+- [LinkedIn](https://www.linkedin.com/company/buildwithfern)
 
 ## Contributing
 


### PR DESCRIPTION
## Description
Refs [FER-10749](https://linear.app/buildwithfern/issue/FER-10749/refresh-fern-apifern-readme-and-calls-to-action)

Refreshes the fern-api/fern README to better align with the current site messaging and remove outdated references.

## Changes Made
- **Updated tagline** to "Docs, SDKs, and CLIs for your API. Designed for the AI era." — consistent with buildwithfern.com
- **Updated feature bullets** to lead with agent-friendly docs, llms.txt, and MCP server; expanded SDK languages to include Swift and Rust
- **Removed the "Spec Generators" section** as requested
- **Removed Slack community link** (Slack was deleted) and replaced with X, GitHub Issues, and LinkedIn
- **Removed "SDK Generators" subheading** since Spec Generators section is gone and there's only one generator table now
- **Updated supported specs** — replaced OpenRPC with GraphQL to match the site

> **Note for repo maintainers**: The GitHub repo "About" description is currently "Input OpenAPI. Output SDKs and Docs." — consider updating it to "Docs, SDKs, and CLIs for your API. Designed for the AI era." to match.

## Testing
- [x] Manual review of rendered markdown
- No code changes — documentation only

Link to Devin session: https://app.devin.ai/sessions/b6c745efa79b45d0af019a552d7bb049
Requested by: @matlegault