### PR TITLE
fix(php): cast `$decodedJson` in union `fromJson` for PHPStan

### DIFF
--- a/generators/php/model/src/union/UnionGenerator.ts
+++ b/generators/php/model/src/union/UnionGenerator.ts
@@ -987,6 +987,7 @@ export class UnionGenerator extends FileGenerator<PhpFile, ModelCustomConfigSche
                     })
                 );
                 writer.endControlFlow();
+                writer.writeLine("/** @var array<string, mixed> $decodedJson */");
                 writer.write("return ");
                 writer.writeNodeStatement(
                     php.invokeMethod({

--- a/generators/php/sdk/changes/unreleased/fix-union-fromjson-phpstan.yml
+++ b/generators/php/sdk/changes/unreleased/fix-union-fromjson-phpstan.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Add a phpdoc `@var array<string, mixed>` cast to the generated union `fromJson()` method so that PHPStan strict analysis accepts the call to `jsonDeserialize()`.
+  type: fix

--- a/seed/php-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/unions/no-custom-config/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions/no-custom-config/src/Bigunion/Types/BigUnion.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Bigunion/Types/BigUnion.php
@@ -1503,6 +1503,7 @@ class BigUnion extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/Union.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/Union.php
@@ -171,6 +171,7 @@ class Union extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithBaseProperties.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithBaseProperties.php
@@ -225,6 +225,7 @@ class UnionWithBaseProperties extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDiscriminant.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDiscriminant.php
@@ -168,6 +168,7 @@ class UnionWithDiscriminant extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDuplicatePrimitive.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDuplicatePrimitive.php
@@ -248,6 +248,7 @@ class UnionWithDuplicatePrimitive extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDuplicateTypes.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDuplicateTypes.php
@@ -166,6 +166,7 @@ class UnionWithDuplicateTypes extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDuplicativeDiscriminants.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDuplicativeDiscriminants.php
@@ -168,6 +168,7 @@ class UnionWithDuplicativeDiscriminants extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithLiteral.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithLiteral.php
@@ -137,6 +137,7 @@ class UnionWithLiteral extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithMultipleNoProperties.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithMultipleNoProperties.php
@@ -176,6 +176,7 @@ class UnionWithMultipleNoProperties extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithNoProperties.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithNoProperties.php
@@ -152,6 +152,7 @@ class UnionWithNoProperties extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithNullableReference.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithNullableReference.php
@@ -176,6 +176,7 @@ class UnionWithNullableReference extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithOptionalReference.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithOptionalReference.php
@@ -176,6 +176,7 @@ class UnionWithOptionalReference extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithOptionalTime.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithOptionalTime.php
@@ -176,6 +176,7 @@ class UnionWithOptionalTime extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithPrimitive.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithPrimitive.php
@@ -168,6 +168,7 @@ class UnionWithPrimitive extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSameNumberTypes.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSameNumberTypes.php
@@ -208,6 +208,7 @@ class UnionWithSameNumberTypes extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSameStringTypes.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSameStringTypes.php
@@ -206,6 +206,7 @@ class UnionWithSameStringTypes extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSingleElement.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSingleElement.php
@@ -126,6 +126,7 @@ class UnionWithSingleElement extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSubTypes.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSubTypes.php
@@ -168,6 +168,7 @@ class UnionWithSubTypes extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithTime.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithTime.php
@@ -210,6 +210,7 @@ class UnionWithTime extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithoutKey.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithoutKey.php
@@ -168,6 +168,7 @@ class UnionWithoutKey extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/no-custom-config/src/Union/Types/Shape.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Union/Types/Shape.php
@@ -181,6 +181,7 @@ class Shape extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/.fern/metadata.json
+++ b/seed/php-sdk/unions/property-accessors/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions/property-accessors/src/Bigunion/Types/BigUnion.php
+++ b/seed/php-sdk/unions/property-accessors/src/Bigunion/Types/BigUnion.php
@@ -1635,6 +1635,7 @@ class BigUnion extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/Union.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/Union.php
@@ -195,6 +195,7 @@ class Union extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithBaseProperties.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithBaseProperties.php
@@ -269,6 +269,7 @@ class UnionWithBaseProperties extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDiscriminant.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDiscriminant.php
@@ -192,6 +192,7 @@ class UnionWithDiscriminant extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDuplicatePrimitive.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDuplicatePrimitive.php
@@ -274,6 +274,7 @@ class UnionWithDuplicatePrimitive extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDuplicateTypes.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDuplicateTypes.php
@@ -189,6 +189,7 @@ class UnionWithDuplicateTypes extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDuplicativeDiscriminants.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDuplicativeDiscriminants.php
@@ -192,6 +192,7 @@ class UnionWithDuplicativeDiscriminants extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithLiteral.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithLiteral.php
@@ -177,6 +177,7 @@ class UnionWithLiteral extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithMultipleNoProperties.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithMultipleNoProperties.php
@@ -201,6 +201,7 @@ class UnionWithMultipleNoProperties extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithNoProperties.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithNoProperties.php
@@ -176,6 +176,7 @@ class UnionWithNoProperties extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithNullableReference.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithNullableReference.php
@@ -201,6 +201,7 @@ class UnionWithNullableReference extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithOptionalReference.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithOptionalReference.php
@@ -201,6 +201,7 @@ class UnionWithOptionalReference extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithOptionalTime.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithOptionalTime.php
@@ -200,6 +200,7 @@ class UnionWithOptionalTime extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithPrimitive.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithPrimitive.php
@@ -192,6 +192,7 @@ class UnionWithPrimitive extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSameNumberTypes.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSameNumberTypes.php
@@ -233,6 +233,7 @@ class UnionWithSameNumberTypes extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSameStringTypes.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSameStringTypes.php
@@ -230,6 +230,7 @@ class UnionWithSameStringTypes extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSingleElement.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSingleElement.php
@@ -148,6 +148,7 @@ class UnionWithSingleElement extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSubTypes.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSubTypes.php
@@ -192,6 +192,7 @@ class UnionWithSubTypes extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithTime.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithTime.php
@@ -235,6 +235,7 @@ class UnionWithTime extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithoutKey.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithoutKey.php
@@ -192,6 +192,7 @@ class UnionWithoutKey extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 

--- a/seed/php-sdk/unions/property-accessors/src/Union/Types/Shape.php
+++ b/seed/php-sdk/unions/property-accessors/src/Union/Types/Shape.php
@@ -223,6 +223,7 @@ class Shape extends JsonSerializableType
         if (!is_array($decodedJson)) {
             throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
+        /** @var array<string, mixed> $decodedJson */
         return self::jsonDeserialize($decodedJson);
     }
 


### PR DESCRIPTION
Closes FER-10751.

## Summary

The PHP generator's `UnionGenerator.fromJsonMethod()` emits a `fromJson()` override on every discriminated union that calls `self::jsonDeserialize($decodedJson)` after an `is_array()` narrowing. PHPStan strict mode rejects this — `JsonDecoder::decode()` returns `mixed`, `is_array` narrows to `array<array-key, mixed>`, but `jsonDeserialize()` declares `array<string, mixed>`.

The base class `JsonSerializableType::fromJson()` already handles this with a phpdoc cast; the union just needs it too.

## Example

Reproduced against `auth0/auth0-PHP` PR [#820](https://github.com/auth0/auth0-PHP/pull/820), where the new SSE streaming type `EventStreamSubscribeEventsResponseContent` (their first discriminated union) trips PHPStan in CI:

```
Parameter #1 $data of static method ...::jsonDeserialize()
expects array<string, mixed>, array<mixed, mixed> given.
```

### Change

In `generators/php/model/src/union/UnionGenerator.ts`, between the `is_array` check and the `return`:

```diff
 writer.endControlFlow();
+writer.writeLine("/** @var array<string, mixed> $decodedJson */");
 writer.write("return ");
```

### Generated output (before → after)

```php
public static function fromJson(string $json): static
{
    $decodedJson = JsonDecoder::decode($json);
    if (!is_array($decodedJson)) {
        throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
    }
+   /** @var array<string, mixed> $decodedJson */
    return self::jsonDeserialize($decodedJson);
}
```