### PR TITLE
fix(php): collapse union `fromJson` via late static binding

### DIFF
--- a/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
+++ b/generators/php/base/src/asIs/Json/JsonSerializableType.Template.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/generators/php/model/src/union/UnionGenerator.ts
+++ b/generators/php/model/src/union/UnionGenerator.ts
@@ -84,8 +84,6 @@ export class UnionGenerator extends FileGenerator<PhpFile, ModelCustomConfigSche
 
         clazz.addMethod(this.jsonSerializeMethod());
 
-        clazz.addMethod(this.fromJsonMethod());
-
         clazz.addMethod(this.jsonDeserializeMethod());
 
         return new PhpFile({
@@ -944,60 +942,6 @@ export class UnionGenerator extends FileGenerator<PhpFile, ModelCustomConfigSche
             );
 
             writer.endControlFlow();
-        });
-    }
-
-    private fromJsonMethod(): php.Method {
-        return php.method({
-            name: "fromJson",
-            access: "public",
-            parameters: [
-                php.parameter({
-                    name: "json",
-                    type: php.Type.string()
-                })
-            ],
-            return_: STATIC,
-            body: php.codeblock((writer) => {
-                writer.write("$decodedJson = ");
-                writer.writeNodeStatement(
-                    php.invokeMethod({
-                        method: "decode",
-                        arguments_: [php.codeblock("$json")],
-                        static_: true,
-                        on: this.context.getJsonDecoderClassReference()
-                    })
-                );
-
-                const negation = php.codeblock((_writer) => {
-                    _writer.write("!");
-                    _writer.writeNode(
-                        php.invokeMethod({
-                            method: "is_array",
-                            arguments_: [php.codeblock("$decodedJson")],
-                            static_: true
-                        })
-                    );
-                });
-                writer.controlFlow("if", negation);
-                writer.writeNodeStatement(
-                    php.throwException({
-                        classReference: this.context.getExceptionClassReference(),
-                        arguments_: [php.codeblock('"Unexpected non-array decoded type: " . gettype($decodedJson)')]
-                    })
-                );
-                writer.endControlFlow();
-                writer.write("return ");
-                writer.writeNodeStatement(
-                    php.invokeMethod({
-                        method: "jsonDeserialize",
-                        arguments_: [php.codeblock("$decodedJson")],
-                        static_: true,
-                        on: php.codeblock("self")
-                    })
-                );
-            }),
-            static_: true
         });
     }
 

--- a/generators/php/sdk/changes/unreleased/collapse-union-fromjson-via-lsb.yml
+++ b/generators/php/sdk/changes/unreleased/collapse-union-fromjson-via-lsb.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Generated discriminated unions no longer emit a `fromJson()` override. The base
+    `JsonSerializableType::fromJson` now uses late static binding (`static::jsonDeserialize`)
+    so subclasses' typed `jsonDeserialize` overrides dispatch correctly. This eliminates ~50
+    lines of duplicated code per union and resolves a PHPStan strict failure where the union
+    override's `$decodedJson` was narrowed to `array<array-key, mixed>` instead of
+    `array<string, mixed>`.
+  type: fix

--- a/seed/php-sdk/accept-header/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/accept-header/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/alias-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias-extends/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/alias/composer-json/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias/composer-json/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/alias/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/alias/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/allof-inline/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/allof-inline/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/allof/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/allof/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/any-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/any-auth/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/api-wide-base-path-with-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/api-wide-base-path-with-default/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/api-wide-base-path/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/api-wide-base-path/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/audiences/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/audiences/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/basic-auth-environment-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth-environment-variables/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth-pw-omitted/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/basic-auth/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/basic-auth/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/bearer-token-environment-variable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bearer-token-environment-variable/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/bytes-download/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bytes-download/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/bytes-upload/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/bytes-upload/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/circular-references-advanced/src/Ast/Types/ContainerValue.php
+++ b/seed/php-sdk/circular-references-advanced/src/Ast/Types/ContainerValue.php
@@ -4,7 +4,6 @@ namespace Seed\Ast\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class ContainerValue extends JsonSerializableType
 {
@@ -162,18 +161,6 @@ class ContainerValue extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/circular-references-advanced/src/Ast/Types/FieldValue.php
+++ b/seed/php-sdk/circular-references-advanced/src/Ast/Types/FieldValue.php
@@ -4,7 +4,6 @@ namespace Seed\Ast\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class FieldValue extends JsonSerializableType
 {
@@ -199,18 +198,6 @@ class FieldValue extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/circular-references-advanced/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references-advanced/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/circular-references-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references-extends/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/circular-references/src/Ast/Types/ContainerValue.php
+++ b/seed/php-sdk/circular-references/src/Ast/Types/ContainerValue.php
@@ -4,7 +4,6 @@ namespace Seed\Ast\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class ContainerValue extends JsonSerializableType
 {
@@ -162,18 +161,6 @@ class ContainerValue extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/circular-references/src/Ast/Types/FieldValue.php
+++ b/seed/php-sdk/circular-references/src/Ast/Types/FieldValue.php
@@ -4,7 +4,6 @@ namespace Seed\Ast\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class FieldValue extends JsonSerializableType
 {
@@ -199,18 +198,6 @@ class FieldValue extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/circular-references/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/circular-references/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cli-multi-spec-namespaced/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/cli-multi-spec/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cli-multi-spec/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/client-side-params/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/client-side-params/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/content-type/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/content-type/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/cross-package-type-names/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/cross-package-type-names/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/dollar-string-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/dollar-string-examples/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/empty-clients/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/empty-clients/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/endpoint-security-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/endpoint-security-auth/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/enum/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/enum/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/error-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/error-property/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/errors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/errors/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/examples/no-custom-config/src/Commons/Types/Types/Data.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Commons/Types/Types/Data.php
@@ -4,7 +4,6 @@ namespace Seed\Commons\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Data extends JsonSerializableType
 {
@@ -155,18 +154,6 @@ class Data extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/examples/no-custom-config/src/Commons/Types/Types/EventInfo.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Commons/Types/Types/EventInfo.php
@@ -4,7 +4,6 @@ namespace Seed\Commons\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class EventInfo extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class EventInfo extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/examples/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/examples/no-custom-config/src/Types/Types/Exception.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Types/Types/Exception.php
@@ -3,7 +3,6 @@
 namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
-use Seed\Core\Json\JsonDecoder;
 
 class Exception extends JsonSerializableType
 {
@@ -133,17 +132,6 @@ class Exception extends JsonSerializableType
         }
         
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)){
-            throw new \\Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/examples/no-custom-config/src/Types/Types/Metadata.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Types/Types/Metadata.php
@@ -6,7 +6,6 @@ use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Seed\Core\Types\ArrayType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Metadata extends JsonSerializableType
 {
@@ -181,18 +180,6 @@ class Metadata extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/examples/no-custom-config/src/Types/Types/Test.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Types/Types/Test.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Test extends JsonSerializableType
 {
@@ -155,18 +154,6 @@ class Test extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/examples/readme-config/src/Commons/Types/Types/Data.php
+++ b/seed/php-sdk/examples/readme-config/src/Commons/Types/Types/Data.php
@@ -4,7 +4,6 @@ namespace Seed\Commons\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Data extends JsonSerializableType
 {
@@ -155,18 +154,6 @@ class Data extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/examples/readme-config/src/Commons/Types/Types/EventInfo.php
+++ b/seed/php-sdk/examples/readme-config/src/Commons/Types/Types/EventInfo.php
@@ -4,7 +4,6 @@ namespace Seed\Commons\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class EventInfo extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class EventInfo extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/examples/readme-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/examples/readme-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/examples/readme-config/src/Types/Types/Exception.php
+++ b/seed/php-sdk/examples/readme-config/src/Types/Types/Exception.php
@@ -3,7 +3,6 @@
 namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
-use Seed\Core\Json\JsonDecoder;
 
 class Exception extends JsonSerializableType
 {
@@ -133,17 +132,6 @@ class Exception extends JsonSerializableType
         }
         
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)){
-            throw new \\Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/examples/readme-config/src/Types/Types/Metadata.php
+++ b/seed/php-sdk/examples/readme-config/src/Types/Types/Metadata.php
@@ -6,7 +6,6 @@ use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Seed\Core\Types\ArrayType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Metadata extends JsonSerializableType
 {
@@ -181,18 +180,6 @@ class Metadata extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/examples/readme-config/src/Types/Types/Test.php
+++ b/seed/php-sdk/examples/readme-config/src/Types/Types/Test.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Test extends JsonSerializableType
 {
@@ -155,18 +154,6 @@ class Test extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Types/Union/Types/Animal.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Types/Union/Types/Animal.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Union\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Animal extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class Animal extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/exhaustive/wire-tests/src/Types/Union/Types/Animal.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Types/Union/Types/Animal.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Union\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Animal extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class Animal extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/extends/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extends/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/extends/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extends/private/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/extra-properties/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/extra-properties/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/file-download/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-download/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/file-upload-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-upload-openapi/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/file-upload/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/file-upload/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/folders/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/folders/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/folders/with-interfaces/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/folders/with-interfaces/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/header-auth-environment-variable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/header-auth-environment-variable/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/header-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/header-auth/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/http-head/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/http-head/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/idempotency-headers/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/idempotency-headers/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/imdb/clientName/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/clientName/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/imdb/namespace/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/namespace/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/imdb/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/imdb/omit-fern-headers/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/omit-fern-headers/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/imdb/packageName/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/packageName/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/imdb/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/imdb/private/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/inferred-auth-explicit/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-explicit/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-api-key/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-no-expiry/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/inferred-auth-implicit/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/inferred-auth-implicit/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/license/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/license/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/literal-user-agent/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literal-user-agent/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/literal/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literal/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/literal/src/Inlined/Types/DiscriminatedLiteral.php
+++ b/seed/php-sdk/literal/src/Inlined/Types/DiscriminatedLiteral.php
@@ -4,7 +4,6 @@ namespace Seed\Inlined\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class DiscriminatedLiteral extends JsonSerializableType
 {
@@ -241,18 +240,6 @@ class DiscriminatedLiteral extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/literals-unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/literals-unions/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/mixed-case/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/mixed-case/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/mixed-case/src/Service/Types/Resource.php
+++ b/seed/php-sdk/mixed-case/src/Service/Types/Resource.php
@@ -5,7 +5,6 @@ namespace Seed\Service\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Resource extends JsonSerializableType
 {
@@ -170,18 +169,6 @@ class Resource extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/mixed-file-directory/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/mixed-file-directory/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/multi-line-docs/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-line-docs/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/multi-url-environment-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment-no-default/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/multi-url-environment-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment-reference/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/multi-url-environment/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multi-url-environment/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/multiple-request-bodies/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/multiple-request-bodies/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/no-content-response/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-content-response/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/no-environment/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-environment/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/no-retries/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/no-retries/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/null-type/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/null-type/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/nullable-allof-extends/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-allof-extends/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/nullable-optional/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-optional/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/nullable-optional/src/NullableOptional/Types/NotificationMethod.php
+++ b/seed/php-sdk/nullable-optional/src/NullableOptional/Types/NotificationMethod.php
@@ -4,7 +4,6 @@ namespace Seed\NullableOptional\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 /**
  * Discriminated union for testing nullable unions
@@ -202,18 +201,6 @@ class NotificationMethod extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/nullable-optional/src/NullableOptional/Types/SearchResult.php
+++ b/seed/php-sdk/nullable-optional/src/NullableOptional/Types/SearchResult.php
@@ -4,7 +4,6 @@ namespace Seed\NullableOptional\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 /**
  * Undiscriminated union for testing
@@ -202,18 +201,6 @@ class SearchResult extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/nullable-request-body/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable-request-body/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/nullable/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/nullable/src/Nullable/Types/Status.php
+++ b/seed/php-sdk/nullable/src/Nullable/Types/Status.php
@@ -6,7 +6,6 @@ use Seed\Core\Json\JsonSerializableType;
 use DateTime;
 use Exception;
 use Seed\Core\Json\JsonSerializer;
-use Seed\Core\Json\JsonDecoder;
 
 class Status extends JsonSerializableType
 {
@@ -191,18 +190,6 @@ class Status extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/oauth-client-credentials-custom/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-custom/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/oauth-client-credentials-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-default/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-mandatory-auth/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-openapi/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/oauth-client-credentials-reference/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-reference/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/oauth-client-credentials/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/object/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/object/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/objects-with-imports/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/objects-with-imports/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/openapi-request-body-ref/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/openapi-request-body-ref/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/optional/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/optional/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/package-yml/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/package-yml/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/package-yml/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/package-yml/private/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/pagination-custom/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination-custom/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/pagination-uri-path/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination-uri-path/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/pagination/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/pagination/page-index-semantics/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/page-index-semantics/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/pagination/property-accessors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/pagination/property-accessors/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters-private/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/inline-path-parameters/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/path-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/path-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/plain-text/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/plain-text/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/property-access/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/property-access/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/property-access/src/Types/UserOrAdminDiscriminated.php
+++ b/seed/php-sdk/property-access/src/Types/UserOrAdminDiscriminated.php
@@ -5,7 +5,6 @@ namespace Seed\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 /**
  * Example of an discriminated union
@@ -215,18 +214,6 @@ class UserOrAdminDiscriminated extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/public-object/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/public-object/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/query-param-name-conflict/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-param-name-conflict/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters-openapi-as-objects/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/query-parameters-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters-openapi/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/query-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/query-parameters/private/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/query-parameters/private/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/request-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/request-parameters/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/request-parameters/with-defaults/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/request-parameters/with-defaults/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/required-nullable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/required-nullable/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/reserved-keywords/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/reserved-keywords/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/response-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/response-property/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/schemaless-request-body-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/schemaless-request-body-examples/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-event-examples/src/Completions/Types/StreamEvent.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Completions/Types/StreamEvent.php
@@ -4,7 +4,6 @@ namespace Seed\Completions\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class StreamEvent extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class StreamEvent extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-event-examples/src/Completions/Types/StreamEventContextProtocol.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Completions/Types/StreamEventContextProtocol.php
@@ -4,7 +4,6 @@ namespace Seed\Completions\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class StreamEventContextProtocol extends JsonSerializableType
 {
@@ -199,18 +198,6 @@ class StreamEventContextProtocol extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-event-examples/src/Completions/Types/StreamEventDiscriminantInData.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Completions/Types/StreamEventDiscriminantInData.php
@@ -4,7 +4,6 @@ namespace Seed\Completions\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class StreamEventDiscriminantInData extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class StreamEventDiscriminantInData extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-events-openapi/src/Types/StreamDataContextResponse.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Types/StreamDataContextResponse.php
@@ -4,7 +4,6 @@ namespace Seed\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class StreamDataContextResponse extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class StreamDataContextResponse extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-events-openapi/src/Types/StreamDataContextWithEnvelopeSchemaResponse.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Types/StreamDataContextWithEnvelopeSchemaResponse.php
@@ -4,7 +4,6 @@ namespace Seed\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class StreamDataContextWithEnvelopeSchemaResponse extends JsonSerializableType
 {
@@ -241,18 +240,6 @@ class StreamDataContextWithEnvelopeSchemaResponse extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-events-openapi/src/Types/StreamNoContextResponse.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Types/StreamNoContextResponse.php
@@ -4,7 +4,6 @@ namespace Seed\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class StreamNoContextResponse extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class StreamNoContextResponse extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-events-openapi/src/Types/StreamProtocolCollisionResponse.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Types/StreamProtocolCollisionResponse.php
@@ -4,7 +4,6 @@ namespace Seed\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class StreamProtocolCollisionResponse extends JsonSerializableType
 {
@@ -241,18 +240,6 @@ class StreamProtocolCollisionResponse extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-events-openapi/src/Types/StreamProtocolNoCollisionResponse.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Types/StreamProtocolNoCollisionResponse.php
@@ -4,7 +4,6 @@ namespace Seed\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class StreamProtocolNoCollisionResponse extends JsonSerializableType
 {
@@ -241,18 +240,6 @@ class StreamProtocolNoCollisionResponse extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-events-openapi/src/Types/StreamProtocolWithFlatSchemaResponse.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Types/StreamProtocolWithFlatSchemaResponse.php
@@ -4,7 +4,6 @@ namespace Seed\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class StreamProtocolWithFlatSchemaResponse extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class StreamProtocolWithFlatSchemaResponse extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-events-openapi/src/Types/StreamXFernStreamingUnionRequest.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Types/StreamXFernStreamingUnionRequest.php
@@ -5,7 +5,6 @@ namespace Seed\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 /**
  * A discriminated union request matching the Vectara pattern (FER-9556). Each variant inherits stream_response from UnionStreamRequestBase via allOf. The importer pins stream_response to Literal[True/False] at this union level, but the allOf inheritance re-introduces it as boolean in each variant, causing the type conflict.
@@ -217,18 +216,6 @@ class StreamXFernStreamingUnionRequest extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-events-openapi/src/Types/StreamXFernStreamingUnionStreamRequest.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Types/StreamXFernStreamingUnionStreamRequest.php
@@ -5,7 +5,6 @@ namespace Seed\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 /**
  * A discriminated union request matching the Vectara pattern (FER-9556). Each variant inherits stream_response from UnionStreamRequestBase via allOf. The importer pins stream_response to Literal[True/False] at this union level, but the allOf inheritance re-introduces it as boolean in each variant, causing the type conflict.
@@ -217,18 +216,6 @@ class StreamXFernStreamingUnionStreamRequest extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-events-openapi/src/Types/UnionStreamRequest.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Types/UnionStreamRequest.php
@@ -4,7 +4,6 @@ namespace Seed\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 /**
  * A discriminated union request matching the Vectara pattern (FER-9556). Each variant inherits stream_response from UnionStreamRequestBase via allOf. The importer pins stream_response to Literal[True/False] at this union level, but the allOf inheritance re-introduces it as boolean in each variant, causing the type conflict.
@@ -202,18 +201,6 @@ class UnionStreamRequest extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-events-resumable/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events-resumable/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-sent-events/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/server-url-templating/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/server-url-templating/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/simple-api/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/simple-api/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/simple-fhir/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/simple-fhir/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/single-url-environment-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/single-url-environment-default/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/single-url-environment-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/single-url-environment-no-default/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/streaming-parameter/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/streaming-parameter/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/streaming/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/streaming/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Admin/Types/Test.php
+++ b/seed/php-sdk/trace/src/Admin/Types/Test.php
@@ -4,7 +4,6 @@ namespace Seed\Admin\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Test extends JsonSerializableType
 {
@@ -155,18 +154,6 @@ class Test extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Commons/Types/DebugVariableValue.php
+++ b/seed/php-sdk/trace/src/Commons/Types/DebugVariableValue.php
@@ -4,7 +4,6 @@ namespace Seed\Commons\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class DebugVariableValue extends JsonSerializableType
 {
@@ -583,18 +582,6 @@ class DebugVariableValue extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Commons/Types/VariableType.php
+++ b/seed/php-sdk/trace/src/Commons/Types/VariableType.php
@@ -4,7 +4,6 @@ namespace Seed\Commons\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class VariableType extends JsonSerializableType
 {
@@ -351,18 +350,6 @@ class VariableType extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Commons/Types/VariableValue.php
+++ b/seed/php-sdk/trace/src/Commons/Types/VariableValue.php
@@ -4,7 +4,6 @@ namespace Seed\Commons\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class VariableValue extends JsonSerializableType
 {
@@ -517,18 +516,6 @@ class VariableValue extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/trace/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Playlist/Types/PlaylistIdNotFoundErrorBody.php
+++ b/seed/php-sdk/trace/src/Playlist/Types/PlaylistIdNotFoundErrorBody.php
@@ -4,7 +4,6 @@ namespace Seed\Playlist\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class PlaylistIdNotFoundErrorBody extends JsonSerializableType
 {
@@ -115,18 +114,6 @@ class PlaylistIdNotFoundErrorBody extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Problem/Types/CreateProblemError.php
+++ b/seed/php-sdk/trace/src/Problem/Types/CreateProblemError.php
@@ -4,7 +4,6 @@ namespace Seed\Problem\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class CreateProblemError extends JsonSerializableType
 {
@@ -115,18 +114,6 @@ class CreateProblemError extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Problem/Types/CreateProblemResponse.php
+++ b/seed/php-sdk/trace/src/Problem/Types/CreateProblemResponse.php
@@ -4,7 +4,6 @@ namespace Seed\Problem\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class CreateProblemResponse extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class CreateProblemResponse extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Problem/Types/ProblemDescriptionBoard.php
+++ b/seed/php-sdk/trace/src/Problem/Types/ProblemDescriptionBoard.php
@@ -5,7 +5,6 @@ namespace Seed\Problem\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Commons\Types\VariableValue;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class ProblemDescriptionBoard extends JsonSerializableType
 {
@@ -198,18 +197,6 @@ class ProblemDescriptionBoard extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/ActualResult.php
+++ b/seed/php-sdk/trace/src/Submission/Types/ActualResult.php
@@ -5,7 +5,6 @@ namespace Seed\Submission\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Commons\Types\VariableValue;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class ActualResult extends JsonSerializableType
 {
@@ -200,18 +199,6 @@ class ActualResult extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/CodeExecutionUpdate.php
+++ b/seed/php-sdk/trace/src/Submission/Types/CodeExecutionUpdate.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class CodeExecutionUpdate extends JsonSerializableType
 {
@@ -535,18 +534,6 @@ class CodeExecutionUpdate extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/ErrorInfo.php
+++ b/seed/php-sdk/trace/src/Submission/Types/ErrorInfo.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class ErrorInfo extends JsonSerializableType
 {
@@ -199,18 +198,6 @@ class ErrorInfo extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/ExceptionV2.php
+++ b/seed/php-sdk/trace/src/Submission/Types/ExceptionV2.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class ExceptionV2 extends JsonSerializableType
 {
@@ -141,18 +140,6 @@ class ExceptionV2 extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/InvalidRequestCause.php
+++ b/seed/php-sdk/trace/src/Submission/Types/InvalidRequestCause.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class InvalidRequestCause extends JsonSerializableType
 {
@@ -199,18 +198,6 @@ class InvalidRequestCause extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/SubmissionRequest.php
+++ b/seed/php-sdk/trace/src/Submission/Types/SubmissionRequest.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class SubmissionRequest extends JsonSerializableType
 {
@@ -267,18 +266,6 @@ class SubmissionRequest extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/SubmissionResponse.php
+++ b/seed/php-sdk/trace/src/Submission/Types/SubmissionResponse.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class SubmissionResponse extends JsonSerializableType
 {
@@ -291,18 +290,6 @@ class SubmissionResponse extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/SubmissionStatusForTestCase.php
+++ b/seed/php-sdk/trace/src/Submission/Types/SubmissionStatusForTestCase.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class SubmissionStatusForTestCase extends JsonSerializableType
 {
@@ -199,18 +198,6 @@ class SubmissionStatusForTestCase extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/SubmissionStatusV2.php
+++ b/seed/php-sdk/trace/src/Submission/Types/SubmissionStatusV2.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class SubmissionStatusV2 extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class SubmissionStatusV2 extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/SubmissionTypeState.php
+++ b/seed/php-sdk/trace/src/Submission/Types/SubmissionTypeState.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class SubmissionTypeState extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class SubmissionTypeState extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/TestCaseGrade.php
+++ b/seed/php-sdk/trace/src/Submission/Types/TestCaseGrade.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class TestCaseGrade extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class TestCaseGrade extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/TestSubmissionStatus.php
+++ b/seed/php-sdk/trace/src/Submission/Types/TestSubmissionStatus.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class TestSubmissionStatus extends JsonSerializableType
 {
@@ -225,18 +224,6 @@ class TestSubmissionStatus extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/TestSubmissionUpdateInfo.php
+++ b/seed/php-sdk/trace/src/Submission/Types/TestSubmissionUpdateInfo.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class TestSubmissionUpdateInfo extends JsonSerializableType
 {
@@ -291,18 +290,6 @@ class TestSubmissionUpdateInfo extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/WorkspaceSubmissionStatus.php
+++ b/seed/php-sdk/trace/src/Submission/Types/WorkspaceSubmissionStatus.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class WorkspaceSubmissionStatus extends JsonSerializableType
 {
@@ -265,18 +264,6 @@ class WorkspaceSubmissionStatus extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/Submission/Types/WorkspaceSubmissionUpdateInfo.php
+++ b/seed/php-sdk/trace/src/Submission/Types/WorkspaceSubmissionUpdateInfo.php
@@ -4,7 +4,6 @@ namespace Seed\Submission\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class WorkspaceSubmissionUpdateInfo extends JsonSerializableType
 {
@@ -315,18 +314,6 @@ class WorkspaceSubmissionUpdateInfo extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/V2/Problem/Types/AssertCorrectnessCheck.php
+++ b/seed/php-sdk/trace/src/V2/Problem/Types/AssertCorrectnessCheck.php
@@ -4,7 +4,6 @@ namespace Seed\V2\Problem\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class AssertCorrectnessCheck extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class AssertCorrectnessCheck extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/V2/Problem/Types/CustomFiles.php
+++ b/seed/php-sdk/trace/src/V2/Problem/Types/CustomFiles.php
@@ -5,7 +5,6 @@ namespace Seed\V2\Problem\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Commons\Types\Language;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class CustomFiles extends JsonSerializableType
 {
@@ -158,18 +157,6 @@ class CustomFiles extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/V2/Problem/Types/FunctionSignature.php
+++ b/seed/php-sdk/trace/src/V2/Problem/Types/FunctionSignature.php
@@ -4,7 +4,6 @@ namespace Seed\V2\Problem\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class FunctionSignature extends JsonSerializableType
 {
@@ -199,18 +198,6 @@ class FunctionSignature extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/V2/Problem/Types/TestCaseFunction.php
+++ b/seed/php-sdk/trace/src/V2/Problem/Types/TestCaseFunction.php
@@ -4,7 +4,6 @@ namespace Seed\V2\Problem\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class TestCaseFunction extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class TestCaseFunction extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/V2/Problem/Types/TestCaseImplementationDescriptionBoard.php
+++ b/seed/php-sdk/trace/src/V2/Problem/Types/TestCaseImplementationDescriptionBoard.php
@@ -4,7 +4,6 @@ namespace Seed\V2\Problem\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class TestCaseImplementationDescriptionBoard extends JsonSerializableType
 {
@@ -155,18 +154,6 @@ class TestCaseImplementationDescriptionBoard extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/V2/Problem/Types/TestCaseImplementationReference.php
+++ b/seed/php-sdk/trace/src/V2/Problem/Types/TestCaseImplementationReference.php
@@ -4,7 +4,6 @@ namespace Seed\V2\Problem\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class TestCaseImplementationReference extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class TestCaseImplementationReference extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/V2/V3/Problem/Types/AssertCorrectnessCheck.php
+++ b/seed/php-sdk/trace/src/V2/V3/Problem/Types/AssertCorrectnessCheck.php
@@ -4,7 +4,6 @@ namespace Seed\V2\V3\Problem\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class AssertCorrectnessCheck extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class AssertCorrectnessCheck extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/V2/V3/Problem/Types/CustomFiles.php
+++ b/seed/php-sdk/trace/src/V2/V3/Problem/Types/CustomFiles.php
@@ -5,7 +5,6 @@ namespace Seed\V2\V3\Problem\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Commons\Types\Language;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class CustomFiles extends JsonSerializableType
 {
@@ -158,18 +157,6 @@ class CustomFiles extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/V2/V3/Problem/Types/FunctionSignature.php
+++ b/seed/php-sdk/trace/src/V2/V3/Problem/Types/FunctionSignature.php
@@ -4,7 +4,6 @@ namespace Seed\V2\V3\Problem\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class FunctionSignature extends JsonSerializableType
 {
@@ -199,18 +198,6 @@ class FunctionSignature extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/V2/V3/Problem/Types/TestCaseFunction.php
+++ b/seed/php-sdk/trace/src/V2/V3/Problem/Types/TestCaseFunction.php
@@ -4,7 +4,6 @@ namespace Seed\V2\V3\Problem\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class TestCaseFunction extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class TestCaseFunction extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/V2/V3/Problem/Types/TestCaseImplementationDescriptionBoard.php
+++ b/seed/php-sdk/trace/src/V2/V3/Problem/Types/TestCaseImplementationDescriptionBoard.php
@@ -4,7 +4,6 @@ namespace Seed\V2\V3\Problem\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class TestCaseImplementationDescriptionBoard extends JsonSerializableType
 {
@@ -155,18 +154,6 @@ class TestCaseImplementationDescriptionBoard extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/trace/src/V2/V3/Problem/Types/TestCaseImplementationReference.php
+++ b/seed/php-sdk/trace/src/V2/V3/Problem/Types/TestCaseImplementationReference.php
@@ -4,7 +4,6 @@ namespace Seed\V2\V3\Problem\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class TestCaseImplementationReference extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class TestCaseImplementationReference extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/undiscriminated-union-with-response-property/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/undiscriminated-unions/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/union-query-parameters/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/union-query-parameters/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Bigunion/Types/BigUnion.php
+++ b/seed/php-sdk/unions-with-local-date/src/Bigunion/Types/BigUnion.php
@@ -7,7 +7,6 @@ use Seed\Core\Json\JsonProperty;
 use DateTime;
 use Seed\Core\Types\Date;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class BigUnion extends JsonSerializableType
 {
@@ -1492,18 +1491,6 @@ class BigUnion extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions-with-local-date/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/Union.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/Union.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 /**
  * This is a simple union.
@@ -160,18 +159,6 @@ class Union extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithBaseProperties.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithBaseProperties.php
@@ -5,7 +5,6 @@ namespace Seed\Types\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithBaseProperties extends JsonSerializableType
 {
@@ -214,18 +213,6 @@ class UnionWithBaseProperties extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithDiscriminant.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithDiscriminant.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithDiscriminant extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class UnionWithDiscriminant extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithDuplicatePrimitive.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithDuplicatePrimitive.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithDuplicatePrimitive extends JsonSerializableType
 {
@@ -237,18 +236,6 @@ class UnionWithDuplicatePrimitive extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithDuplicateTypes.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithDuplicateTypes.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithDuplicateTypes extends JsonSerializableType
 {
@@ -155,18 +154,6 @@ class UnionWithDuplicateTypes extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithLiteral.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithLiteral.php
@@ -5,7 +5,6 @@ namespace Seed\Types\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithLiteral extends JsonSerializableType
 {
@@ -126,18 +125,6 @@ class UnionWithLiteral extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithMultipleNoProperties.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithMultipleNoProperties.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithMultipleNoProperties extends JsonSerializableType
 {
@@ -165,18 +164,6 @@ class UnionWithMultipleNoProperties extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithNoProperties.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithNoProperties.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithNoProperties extends JsonSerializableType
 {
@@ -141,18 +140,6 @@ class UnionWithNoProperties extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithOptionalTime.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithOptionalTime.php
@@ -6,7 +6,6 @@ use Seed\Core\Json\JsonSerializableType;
 use DateTime;
 use Exception;
 use Seed\Core\Json\JsonSerializer;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithOptionalTime extends JsonSerializableType
 {
@@ -165,18 +164,6 @@ class UnionWithOptionalTime extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithPrimitive.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithPrimitive.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithPrimitive extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class UnionWithPrimitive extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithSameNumberTypes.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithSameNumberTypes.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithSameNumberTypes extends JsonSerializableType
 {
@@ -197,18 +196,6 @@ class UnionWithSameNumberTypes extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithSameStringTypes.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithSameStringTypes.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithSameStringTypes extends JsonSerializableType
 {
@@ -195,18 +194,6 @@ class UnionWithSameStringTypes extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithSingleElement.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithSingleElement.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithSingleElement extends JsonSerializableType
 {
@@ -115,18 +114,6 @@ class UnionWithSingleElement extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithSubTypes.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithSubTypes.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithSubTypes extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class UnionWithSubTypes extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithTime.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithTime.php
@@ -6,7 +6,6 @@ use Seed\Core\Json\JsonSerializableType;
 use DateTime;
 use Exception;
 use Seed\Core\Json\JsonSerializer;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithTime extends JsonSerializableType
 {
@@ -199,18 +198,6 @@ class UnionWithTime extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithoutKey.php
+++ b/seed/php-sdk/unions-with-local-date/src/Types/Types/UnionWithoutKey.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithoutKey extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class UnionWithoutKey extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions-with-local-date/src/Union/Types/Shape.php
+++ b/seed/php-sdk/unions-with-local-date/src/Union/Types/Shape.php
@@ -5,7 +5,6 @@ namespace Seed\Union\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Shape extends JsonSerializableType
 {
@@ -170,18 +169,6 @@ class Shape extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Bigunion/Types/BigUnion.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Bigunion/Types/BigUnion.php
@@ -7,7 +7,6 @@ use Seed\Core\Json\JsonProperty;
 use DateTime;
 use Seed\Core\Types\Date;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class BigUnion extends JsonSerializableType
 {
@@ -1492,18 +1491,6 @@ class BigUnion extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/Union.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/Union.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 /**
  * This is a simple union.
@@ -160,18 +159,6 @@ class Union extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithBaseProperties.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithBaseProperties.php
@@ -5,7 +5,6 @@ namespace Seed\Types\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithBaseProperties extends JsonSerializableType
 {
@@ -214,18 +213,6 @@ class UnionWithBaseProperties extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDiscriminant.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDiscriminant.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithDiscriminant extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class UnionWithDiscriminant extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDuplicatePrimitive.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDuplicatePrimitive.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithDuplicatePrimitive extends JsonSerializableType
 {
@@ -237,18 +236,6 @@ class UnionWithDuplicatePrimitive extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDuplicateTypes.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDuplicateTypes.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithDuplicateTypes extends JsonSerializableType
 {
@@ -155,18 +154,6 @@ class UnionWithDuplicateTypes extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDuplicativeDiscriminants.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithDuplicativeDiscriminants.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithDuplicativeDiscriminants extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class UnionWithDuplicativeDiscriminants extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithLiteral.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithLiteral.php
@@ -5,7 +5,6 @@ namespace Seed\Types\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithLiteral extends JsonSerializableType
 {
@@ -126,18 +125,6 @@ class UnionWithLiteral extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithMultipleNoProperties.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithMultipleNoProperties.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithMultipleNoProperties extends JsonSerializableType
 {
@@ -165,18 +164,6 @@ class UnionWithMultipleNoProperties extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithNoProperties.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithNoProperties.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithNoProperties extends JsonSerializableType
 {
@@ -141,18 +140,6 @@ class UnionWithNoProperties extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithNullableReference.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithNullableReference.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithNullableReference extends JsonSerializableType
 {
@@ -165,18 +164,6 @@ class UnionWithNullableReference extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithOptionalReference.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithOptionalReference.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithOptionalReference extends JsonSerializableType
 {
@@ -165,18 +164,6 @@ class UnionWithOptionalReference extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithOptionalTime.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithOptionalTime.php
@@ -6,7 +6,6 @@ use Seed\Core\Json\JsonSerializableType;
 use DateTime;
 use Exception;
 use Seed\Core\Json\JsonSerializer;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithOptionalTime extends JsonSerializableType
 {
@@ -165,18 +164,6 @@ class UnionWithOptionalTime extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithPrimitive.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithPrimitive.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithPrimitive extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class UnionWithPrimitive extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSameNumberTypes.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSameNumberTypes.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithSameNumberTypes extends JsonSerializableType
 {
@@ -197,18 +196,6 @@ class UnionWithSameNumberTypes extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSameStringTypes.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSameStringTypes.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithSameStringTypes extends JsonSerializableType
 {
@@ -195,18 +194,6 @@ class UnionWithSameStringTypes extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSingleElement.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSingleElement.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithSingleElement extends JsonSerializableType
 {
@@ -115,18 +114,6 @@ class UnionWithSingleElement extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSubTypes.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithSubTypes.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithSubTypes extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class UnionWithSubTypes extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithTime.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithTime.php
@@ -6,7 +6,6 @@ use Seed\Core\Json\JsonSerializableType;
 use DateTime;
 use Exception;
 use Seed\Core\Json\JsonSerializer;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithTime extends JsonSerializableType
 {
@@ -199,18 +198,6 @@ class UnionWithTime extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithoutKey.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Types/Types/UnionWithoutKey.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithoutKey extends JsonSerializableType
 {
@@ -157,18 +156,6 @@ class UnionWithoutKey extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/no-custom-config/src/Union/Types/Shape.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Union/Types/Shape.php
@@ -5,7 +5,6 @@ namespace Seed\Union\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Shape extends JsonSerializableType
 {
@@ -170,18 +169,6 @@ class Shape extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Bigunion/Types/BigUnion.php
+++ b/seed/php-sdk/unions/property-accessors/src/Bigunion/Types/BigUnion.php
@@ -7,7 +7,6 @@ use Seed\Core\Json\JsonProperty;
 use DateTime;
 use Seed\Core\Types\Date;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class BigUnion extends JsonSerializableType
 {
@@ -1624,18 +1623,6 @@ class BigUnion extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unions/property-accessors/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/Union.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/Union.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 /**
  * This is a simple union.
@@ -184,18 +183,6 @@ class Union extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithBaseProperties.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithBaseProperties.php
@@ -5,7 +5,6 @@ namespace Seed\Types\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithBaseProperties extends JsonSerializableType
 {
@@ -258,18 +257,6 @@ class UnionWithBaseProperties extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDiscriminant.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDiscriminant.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithDiscriminant extends JsonSerializableType
 {
@@ -181,18 +180,6 @@ class UnionWithDiscriminant extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDuplicatePrimitive.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDuplicatePrimitive.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithDuplicatePrimitive extends JsonSerializableType
 {
@@ -263,18 +262,6 @@ class UnionWithDuplicatePrimitive extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDuplicateTypes.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDuplicateTypes.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithDuplicateTypes extends JsonSerializableType
 {
@@ -178,18 +177,6 @@ class UnionWithDuplicateTypes extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDuplicativeDiscriminants.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithDuplicativeDiscriminants.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithDuplicativeDiscriminants extends JsonSerializableType
 {
@@ -181,18 +180,6 @@ class UnionWithDuplicativeDiscriminants extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithLiteral.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithLiteral.php
@@ -5,7 +5,6 @@ namespace Seed\Types\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithLiteral extends JsonSerializableType
 {
@@ -166,18 +165,6 @@ class UnionWithLiteral extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithMultipleNoProperties.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithMultipleNoProperties.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithMultipleNoProperties extends JsonSerializableType
 {
@@ -190,18 +189,6 @@ class UnionWithMultipleNoProperties extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithNoProperties.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithNoProperties.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithNoProperties extends JsonSerializableType
 {
@@ -165,18 +164,6 @@ class UnionWithNoProperties extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithNullableReference.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithNullableReference.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithNullableReference extends JsonSerializableType
 {
@@ -190,18 +189,6 @@ class UnionWithNullableReference extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithOptionalReference.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithOptionalReference.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithOptionalReference extends JsonSerializableType
 {
@@ -190,18 +189,6 @@ class UnionWithOptionalReference extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithOptionalTime.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithOptionalTime.php
@@ -6,7 +6,6 @@ use Seed\Core\Json\JsonSerializableType;
 use DateTime;
 use Exception;
 use Seed\Core\Json\JsonSerializer;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithOptionalTime extends JsonSerializableType
 {
@@ -189,18 +188,6 @@ class UnionWithOptionalTime extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithPrimitive.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithPrimitive.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithPrimitive extends JsonSerializableType
 {
@@ -181,18 +180,6 @@ class UnionWithPrimitive extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSameNumberTypes.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSameNumberTypes.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithSameNumberTypes extends JsonSerializableType
 {
@@ -222,18 +221,6 @@ class UnionWithSameNumberTypes extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSameStringTypes.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSameStringTypes.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithSameStringTypes extends JsonSerializableType
 {
@@ -219,18 +218,6 @@ class UnionWithSameStringTypes extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSingleElement.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSingleElement.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithSingleElement extends JsonSerializableType
 {
@@ -137,18 +136,6 @@ class UnionWithSingleElement extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSubTypes.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithSubTypes.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithSubTypes extends JsonSerializableType
 {
@@ -181,18 +180,6 @@ class UnionWithSubTypes extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithTime.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithTime.php
@@ -6,7 +6,6 @@ use Seed\Core\Json\JsonSerializableType;
 use DateTime;
 use Exception;
 use Seed\Core\Json\JsonSerializer;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithTime extends JsonSerializableType
 {
@@ -224,18 +223,6 @@ class UnionWithTime extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithoutKey.php
+++ b/seed/php-sdk/unions/property-accessors/src/Types/Types/UnionWithoutKey.php
@@ -4,7 +4,6 @@ namespace Seed\Types\Types;
 
 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class UnionWithoutKey extends JsonSerializableType
 {
@@ -181,18 +180,6 @@ class UnionWithoutKey extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unions/property-accessors/src/Union/Types/Shape.php
+++ b/seed/php-sdk/unions/property-accessors/src/Union/Types/Shape.php
@@ -5,7 +5,6 @@ namespace Seed\Union\Types;
 use Seed\Core\Json\JsonSerializableType;
 use Seed\Core\Json\JsonProperty;
 use Exception;
-use Seed\Core\Json\JsonDecoder;
 
 class Shape extends JsonSerializableType
 {
@@ -212,18 +211,6 @@ class Shape extends JsonSerializableType
         }
 
         return $result;
-    }
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        $decodedJson = JsonDecoder::decode($json);
-        if (!is_array($decodedJson)) {
-            throw new Exception("Unexpected non-array decoded type: " . gettype($decodedJson));
-        }
-        return self::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/unknown/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/unknown/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/url-form-encoded/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/url-form-encoded/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/validation/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/validation/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/variables/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/variables/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/version-no-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/version-no-default/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/version/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/version/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/webhook-audience/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/webhook-audience/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/webhooks/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/webhooks/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/websocket-bearer-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-bearer-auth/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/websocket-inferred-auth/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-inferred-auth/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/websocket-multi-url/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket-multi-url/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/websocket/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/websocket/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**

--- a/seed/php-sdk/x-fern-default/src/Core/Json/JsonSerializableType.php
+++ b/seed/php-sdk/x-fern-default/src/Core/Json/JsonSerializableType.php
@@ -106,7 +106,8 @@ abstract class JsonSerializableType implements \JsonSerializable
             throw new JsonException("Unexpected non-array decoded type: " . gettype($decodedJson));
         }
         /** @var array<string, mixed> $decodedJson */
-        return self::jsonDeserialize($decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize($decodedJson);
     }
 
     /**


### PR DESCRIPTION
Closes FER-10752 (also supersedes #16070 / FER-10751).

## Summary

- Removes the discriminated union `fromJson()` override and switches the base `JsonSerializableType::fromJson` to dispatch via `static::jsonDeserialize` (late static binding). The union's typed `jsonDeserialize` now runs through the inherited base `fromJson` instead of through a duplicate override.
- Eliminates ~50 lines of duplicated PHP per union type and structurally resolves the PHPStan strict failure where the union override narrowed `$decodedJson` to `array<array-key, mixed>` instead of `array<string, mixed>` (the @var cast lives in the base template, the only place it needs to).
- Public surface unchanged: `MyUnion::fromJson(string): static` still exists (inherited), exception type narrows from `\Exception` → `\JsonException` (a subclass of `\Exception`), so any `catch (\Exception ...)` continues to work.

## Why this works

PHP's `self::` resolves at compile time. The pre-fix base template called `self::jsonDeserialize($decodedJson)` from inside `fromJson`, which always dispatched to `JsonSerializableType::jsonDeserialize` — never to a subclass override. That's why `UnionGenerator` had to emit its own `fromJson` calling `self::jsonDeserialize` from inside the union's own class scope. Switching the base to `static::jsonDeserialize` uses late static binding so subclasses' typed `jsonDeserialize` overrides dispatch correctly.

## Example diff (one union)

```diff
 namespace Seed\Types\Types;

 use Seed\Core\Json\JsonSerializableType;
 use Exception;
-use Seed\Core\Json\JsonDecoder;

 class UnionWithPrimitive extends JsonSerializableType
 {
     ...
-
-    /**
-     * @param string $json
-     */
-    public static function fromJson(string $json): static
-    {
-        \$decodedJson = JsonDecoder::decode(\$json);
-        if (!is_array(\$decodedJson)) {
-            throw new Exception(\"Unexpected non-array decoded type: \" . gettype(\$decodedJson));
-        }
-        return self::jsonDeserialize(\$decodedJson);
-    }

     /**
      * @param array<string, mixed> \$data
      */
```

And in the base template (one keyword):

```diff
         /** @var array<string, mixed> \$decodedJson */
-        return self::jsonDeserialize(\$decodedJson);
+        // static:: (not self::) so subclasses' typed jsonDeserialize overrides are dispatched via late static binding.
+        return static::jsonDeserialize(\$decodedJson);
```

## Diff scale

277 files changed: **+300 / −1877**. Every insertion is one of:
- 146× LSB explanatory comment (one per generated SDK's `JsonSerializableType.php`)
- 146× the `static::jsonDeserialize` line (one per SDK)
- The new changelog entry
- One `getExceptionClassReference` import cleanup

No surprise additions.

## Test plan

- [x] `pnpm turbo run compile --filter @fern-api/php-model` passes
- [x] `pnpm turbo run test --filter @fern-api/php-{model,sdk,base,codegen}` — 6/6 tests pass
- [x] Full PHP seed snapshot regeneration: **145/145 fixtures pass**
- [x] PHPStan max on seed `unions/no-custom-config` — zero new errors (6 pre-existing errors in `dynamic-snippets/` are unrelated and present in baseline)
- [x] **Auth0 smoke (FER-10751 reproduction):** regenerated full Auth0 SDK from local fern config — `EventStreamSubscribeEventsResponseContent.php` has no `fromJson` override, `vendor/bin/phpstan analyze` reports **0 errors**, `vendor/bin/phpunit` reports **91/91 tests pass**

## Follow-up

- PR #16070 (the `@var array<string, mixed>` cast on union `fromJson`) is superseded by this PR — the cast is now structurally unnecessary because the entire union `fromJson` override is gone. Close #16070 unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->