### PR TITLE
chore(ci): add cli-generator to PR title scopes

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -53,6 +53,7 @@ jobs:
             parser
             ir
             cli-v2
+            cli-generator
           requireScope: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,7 +343,7 @@ When creating pull requests in this repository:
 
    **Allowed types**: `fix`, `feat`, `revert`, `break`, `chore`
 
-   **Allowed scopes**: `docs`, `changelog`, `internal`, `cli`, `typescript`, `python`, `java`, `csharp`, `go`, `php`, `ruby`, `seed`, `ci`, `lint`, `fastapi`, `spring`, `openapi`, `deps`, `deps-dev`, `pydantic`, `ai-search`, `swift`, `rust`
+   **Allowed scopes**: `docs`, `changelog`, `internal`, `cli`, `typescript`, `python`, `java`, `csharp`, `go`, `php`, `ruby`, `seed`, `ci`, `lint`, `openapi`, `deps`, `deps-dev`, `pydantic`, `ai-search`, `swift`, `rust`, `generator-cli`, `parser`, `ir`, `cli-v2`, `cli-generator`
 
    **Examples**: `chore(docs): update guidelines`, `feat(python): add new feature`, `fix(cli): resolve config loading bug`
 

--- a/packages/cli/cli/changes/unreleased/add-cli-generator-pr-scope.yml
+++ b/packages/cli/cli/changes/unreleased/add-cli-generator-pr-scope.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Add `cli-generator` to the allowed PR title scopes enforced by the lint-pr-title workflow.
+  type: chore


### PR DESCRIPTION
Closes FER-10756

## Summary

- Adds `cli-generator` to the allowed PR title scopes enforced by `.github/workflows/lint-pr-title.yml`.
- Reconciles the documented scopes list in `CLAUDE.md` with what the workflow actually enforces.