### PR TITLE
fix(python): bypass expensive dealiasing in parse_sse_obj for ~28x SSE speedup

### DIFF
--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -4,7 +4,6 @@ import inspect
 import json
 import logging
 from collections import defaultdict
-from dataclasses import asdict
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -209,6 +208,30 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+_sse_type_info_cache: Dict[int, Tuple[Optional[str], Optional[List[Type[Any]]]]] = {}
+
+
+def _get_sse_type_info(type_: Type[Any]) -> Tuple[Optional[str], Optional[List[Type[Any]]]]:
+    key = id(type_)
+    info = _sse_type_info_cache.get(key)
+    if info is None:
+        info = _get_discriminator_and_variants(type_)
+        _sse_type_info_cache[key] = info
+    return info
+
+
+def _validate_sse_data(type_: Type[T], data: Any) -> T:
+    """Validate SSE wire data directly, bypassing convert_and_respect_annotation_metadata.
+
+    SSE data arrives as JSON from the wire and already uses wire-format keys,
+    so the TypedDict dealiasing pass is unnecessary and extremely expensive
+    for large discriminated unions.
+    """
+    if IS_PYDANTIC_V2:
+        return _get_type_adapter(type_).validate_python(data)  # type: ignore[no-any-return]
+    return pydantic.parse_obj_as(type_, data)
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -219,93 +242,66 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
        The union describes the data content, not the SSE envelope.
        -> Returns: json.loads(data) parsed into the type
 
-       Example: ChatStreamResponse with discriminator='type'
-       Input:  ServerSentEvent(event="message", data='{"type": "content-delta", ...}', id="")
-       Output: ContentDeltaEvent (parsed from data, SSE envelope stripped)
-
     2. Event-level discrimination: The discriminator (e.g., 'event') is at the SSE event level.
        The union describes the full SSE event structure.
        -> Returns: SSE envelope with 'data' field JSON-parsed only if the variant expects non-string
-
-       Example: JobStreamResponse with discriminator='event'
-       Input:  ServerSentEvent(event="ERROR", data='{"code": "FAILED", ...}', id="123")
-       Output: JobStreamResponse_Error with data as ErrorData object
-
-       But for variants where data is str (like STATUS_UPDATE):
-       Input:  ServerSentEvent(event="STATUS_UPDATE", data='{"status": "processing"}', id="1")
-       Output: JobStreamResponse_StatusUpdate with data as string (not parsed)
 
     Args:
         sse: The ServerSentEvent object to parse
         type_: The target discriminated union type
 
-    Returns:
-        The parsed object of type T
-
     Note:
         This function is only available in SDK contexts where http_sse module exists.
     """
-    sse_event = asdict(sse)
-    discriminator, variants = _get_discriminator_and_variants(type_)
+    data_value = sse.data
+    discriminator, variants = _get_sse_type_info(type_)
 
     if discriminator is None or variants is None:
-        # Not a discriminated union - parse the data field as JSON
-        data_value = sse_event.get("data")
         if isinstance(data_value, str) and data_value:
             try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
+                return _validate_sse_data(type_, json.loads(data_value))
             except json.JSONDecodeError as e:
                 _logger.warning(
                     "Failed to parse SSE data field as JSON: %s, data: %s",
                     e,
                     data_value[:100] if len(data_value) > 100 else data_value,
                 )
-        return parse_obj_as(type_, sse_event)
+        return _validate_sse_data(type_, {"event": sse.event, "data": data_value, "id": sse.id, "retry": sse.retry})
 
-    data_value = sse_event.get("data")
+    sse_fields = {"event": sse.event, "data": data_value, "id": sse.id, "retry": sse.retry}
 
-    # Check if discriminator is at the top level (event-level discrimination)
-    if discriminator in sse_event:
-        # Case 2: Event-level discrimination
-        # Find the matching variant to check if 'data' field needs JSON parsing
-        disc_value = sse_event.get(discriminator)
+    if discriminator in sse_fields:
+        # Event-level discrimination
+        disc_value = sse_fields.get(discriminator)
         matching_variant = _find_variant_by_discriminator(variants, discriminator, disc_value)
 
         if matching_variant is not None:
-            # Check what type the variant expects for 'data'
             data_type = _get_field_annotation(matching_variant, "data")
             if data_type is not None and not _is_string_type(data_type):
-                # Variant expects non-string data - parse JSON
                 if isinstance(data_value, str) and data_value:
                     try:
-                        parsed_data = json.loads(data_value)
-                        new_object = dict(sse_event)
-                        new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        sse_fields["data"] = json.loads(data_value)
+                        return _validate_sse_data(type_, sse_fields)
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
                             e,
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
-        # Either no matching variant, data is string type, or JSON parse failed
-        return parse_obj_as(type_, sse_event)
+        return _validate_sse_data(type_, sse_fields)
 
     else:
-        # Case 1: Data-level discrimination
-        # The discriminator is inside the data payload - extract and parse data only
+        # Data-level discrimination
         if isinstance(data_value, str) and data_value:
             try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
+                return _validate_sse_data(type_, json.loads(data_value))
             except json.JSONDecodeError as e:
                 _logger.warning(
                     "Failed to parse SSE data field as JSON for data-level discrimination: %s, data: %s",
                     e,
                     data_value[:100] if len(data_value) > 100 else data_value,
                 )
-        return parse_obj_as(type_, sse_event)
+        return _validate_sse_data(type_, sse_fields)
 
 
 _type_adapter_cache: Dict[int, Any] = {}

--- a/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
@@ -4,7 +4,6 @@ import inspect
 import json
 import logging
 from collections import defaultdict
-from dataclasses import asdict
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -207,6 +206,30 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+_sse_type_info_cache: Dict[int, Tuple[Optional[str], Optional[List[Type[Any]]]]] = {}
+
+
+def _get_sse_type_info(type_: Type[Any]) -> Tuple[Optional[str], Optional[List[Type[Any]]]]:
+    key = id(type_)
+    info = _sse_type_info_cache.get(key)
+    if info is None:
+        info = _get_discriminator_and_variants(type_)
+        _sse_type_info_cache[key] = info
+    return info
+
+
+def _validate_sse_data(type_: Type[T], data: Any) -> T:
+    """Validate SSE wire data directly, bypassing convert_and_respect_annotation_metadata.
+
+    SSE data arrives as JSON from the wire and already uses wire-format keys,
+    so the TypedDict dealiasing pass is unnecessary and extremely expensive
+    for large discriminated unions.
+    """
+    if IS_PYDANTIC_V2:
+        return _get_type_adapter(type_).validate_python(data)  # type: ignore[no-any-return]
+    return pydantic.parse_obj_as(type_, data)
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -225,73 +248,58 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
         sse: The ServerSentEvent object to parse
         type_: The target discriminated union type
 
-    Returns:
-        The parsed object of type T
-
     Note:
         This function is only available in SDK contexts where http_sse module exists.
     """
-    sse_event = asdict(sse)
-    discriminator, variants = _get_discriminator_and_variants(type_)
+    data_value = sse.data
+    discriminator, variants = _get_sse_type_info(type_)
 
     if discriminator is None or variants is None:
-        # Not a discriminated union - parse the data field as JSON
-        data_value = sse_event.get("data")
         if isinstance(data_value, str) and data_value:
             try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
+                return _validate_sse_data(type_, json.loads(data_value))
             except json.JSONDecodeError as e:
                 _logger.warning(
                     "Failed to parse SSE data field as JSON: %s, data: %s",
                     e,
                     data_value[:100] if len(data_value) > 100 else data_value,
                 )
-        return parse_obj_as(type_, sse_event)
+        return _validate_sse_data(type_, {"event": sse.event, "data": data_value, "id": sse.id, "retry": sse.retry})
 
-    data_value = sse_event.get("data")
+    sse_fields = {"event": sse.event, "data": data_value, "id": sse.id, "retry": sse.retry}
 
-    # Check if discriminator is at the top level (event-level discrimination)
-    if discriminator in sse_event:
-        # Case 2: Event-level discrimination
-        # Find the matching variant to check if 'data' field needs JSON parsing
-        disc_value = sse_event.get(discriminator)
+    if discriminator in sse_fields:
+        # Event-level discrimination
+        disc_value = sse_fields.get(discriminator)
         matching_variant = _find_variant_by_discriminator(variants, discriminator, disc_value)
 
         if matching_variant is not None:
-            # Check what type the variant expects for 'data'
             data_type = _get_field_annotation(matching_variant, "data")
             if data_type is not None and not _is_string_type(data_type):
-                # Variant expects non-string data - parse JSON
                 if isinstance(data_value, str) and data_value:
                     try:
-                        parsed_data = json.loads(data_value)
-                        new_object = dict(sse_event)
-                        new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        sse_fields["data"] = json.loads(data_value)
+                        return _validate_sse_data(type_, sse_fields)
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
                             e,
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
-        # Either no matching variant, data is string type, or JSON parse failed
-        return parse_obj_as(type_, sse_event)
+        return _validate_sse_data(type_, sse_fields)
 
     else:
-        # Case 1: Data-level discrimination
-        # The discriminator is inside the data payload - extract and parse data only
+        # Data-level discrimination
         if isinstance(data_value, str) and data_value:
             try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
+                return _validate_sse_data(type_, json.loads(data_value))
             except json.JSONDecodeError as e:
                 _logger.warning(
                     "Failed to parse SSE data field as JSON for data-level discrimination: %s, data: %s",
                     e,
                     data_value[:100] if len(data_value) > 100 else data_value,
                 )
-        return parse_obj_as(type_, sse_event)
+        return _validate_sse_data(type_, sse_fields)
 
 
 _type_adapter_cache: Dict[int, Any] = {}

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
@@ -5,7 +5,6 @@ import json
 import logging
 import warnings
 from collections import defaultdict
-from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
 import pydantic
@@ -125,6 +124,28 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+_sse_type_info_cache: Dict[int, Tuple[Optional[str], Optional[List[Type[Any]]]]] = {}
+
+
+def _get_sse_type_info(type_: Type[Any]) -> Tuple[Optional[str], Optional[List[Type[Any]]]]:
+    key = id(type_)
+    info = _sse_type_info_cache.get(key)
+    if info is None:
+        info = _get_discriminator_and_variants(type_)
+        _sse_type_info_cache[key] = info
+    return info
+
+
+def _validate_sse_data(type_: Type[T], data: Any) -> T:
+    """Validate SSE wire data directly, bypassing convert_and_respect_annotation_metadata.
+
+    SSE data arrives as JSON from the wire and already uses wire-format keys,
+    so the TypedDict dealiasing pass is unnecessary and extremely expensive
+    for large discriminated unions.
+    """
+    return pydantic.v1.parse_obj_as(type_, data)
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -143,73 +164,58 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
         sse: The ServerSentEvent object to parse
         type_: The target discriminated union type
 
-    Returns:
-        The parsed object of type T
-
     Note:
         This function is only available in SDK contexts where http_sse module exists.
     """
-    sse_event = asdict(sse)
-    discriminator, variants = _get_discriminator_and_variants(type_)
+    data_value = sse.data
+    discriminator, variants = _get_sse_type_info(type_)
 
     if discriminator is None or variants is None:
-        # Not a discriminated union - parse the data field as JSON
-        data_value = sse_event.get("data")
         if isinstance(data_value, str) and data_value:
             try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
+                return _validate_sse_data(type_, json.loads(data_value))
             except json.JSONDecodeError as e:
                 _logger.warning(
                     "Failed to parse SSE data field as JSON: %s, data: %s",
                     e,
                     data_value[:100] if len(data_value) > 100 else data_value,
                 )
-        return parse_obj_as(type_, sse_event)
+        return _validate_sse_data(type_, {"event": sse.event, "data": data_value, "id": sse.id, "retry": sse.retry})
 
-    data_value = sse_event.get("data")
+    sse_fields = {"event": sse.event, "data": data_value, "id": sse.id, "retry": sse.retry}
 
-    # Check if discriminator is at the top level (event-level discrimination)
-    if discriminator in sse_event:
-        # Case 2: Event-level discrimination
-        # Find the matching variant to check if 'data' field needs JSON parsing
-        disc_value = sse_event.get(discriminator)
+    if discriminator in sse_fields:
+        # Event-level discrimination
+        disc_value = sse_fields.get(discriminator)
         matching_variant = _find_variant_by_discriminator(variants, discriminator, disc_value)
 
         if matching_variant is not None:
-            # Check what type the variant expects for 'data'
             data_type = _get_field_annotation_v1(matching_variant, "data")
             if data_type is not None and not _is_string_type(data_type):
-                # Variant expects non-string data - parse JSON
                 if isinstance(data_value, str) and data_value:
                     try:
-                        parsed_data = json.loads(data_value)
-                        new_object = dict(sse_event)
-                        new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        sse_fields["data"] = json.loads(data_value)
+                        return _validate_sse_data(type_, sse_fields)
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
                             e,
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
-        # Either no matching variant, data is string type, or JSON parse failed
-        return parse_obj_as(type_, sse_event)
+        return _validate_sse_data(type_, sse_fields)
 
     else:
-        # Case 1: Data-level discrimination
-        # The discriminator is inside the data payload - extract and parse data only
+        # Data-level discrimination
         if isinstance(data_value, str) and data_value:
             try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
+                return _validate_sse_data(type_, json.loads(data_value))
             except json.JSONDecodeError as e:
                 _logger.warning(
                     "Failed to parse SSE data field as JSON for data-level discrimination: %s, data: %s",
                     e,
                     data_value[:100] if len(data_value) > 100 else data_value,
                 )
-        return parse_obj_as(type_, sse_event)
+        return _validate_sse_data(type_, sse_fields)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
@@ -5,7 +5,6 @@ import json
 import logging
 import warnings
 from collections import defaultdict
-from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, TypeVar, Union, cast
 
 import pydantic
@@ -122,6 +121,28 @@ def _is_string_type(type_: Type[Any]) -> bool:
     return False
 
 
+_sse_type_info_cache: Dict[int, Tuple[Optional[str], Optional[List[Type[Any]]]]] = {}
+
+
+def _get_sse_type_info(type_: Type[Any]) -> Tuple[Optional[str], Optional[List[Type[Any]]]]:
+    key = id(type_)
+    info = _sse_type_info_cache.get(key)
+    if info is None:
+        info = _get_discriminator_and_variants(type_)
+        _sse_type_info_cache[key] = info
+    return info
+
+
+def _validate_sse_data(type_: Type[T], data: Any) -> T:
+    """Validate SSE wire data directly, bypassing convert_and_respect_annotation_metadata.
+
+    SSE data arrives as JSON from the wire and already uses wire-format keys,
+    so the TypedDict dealiasing pass is unnecessary and extremely expensive
+    for large discriminated unions.
+    """
+    return pydantic.v1.parse_obj_as(type_, data)
+
+
 def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
     Parse a ServerSentEvent into the appropriate type.
@@ -140,73 +161,58 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
         sse: The ServerSentEvent object to parse
         type_: The target discriminated union type
 
-    Returns:
-        The parsed object of type T
-
     Note:
         This function is only available in SDK contexts where http_sse module exists.
     """
-    sse_event = asdict(sse)
-    discriminator, variants = _get_discriminator_and_variants(type_)
+    data_value = sse.data
+    discriminator, variants = _get_sse_type_info(type_)
 
     if discriminator is None or variants is None:
-        # Not a discriminated union - parse the data field as JSON
-        data_value = sse_event.get("data")
         if isinstance(data_value, str) and data_value:
             try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
+                return _validate_sse_data(type_, json.loads(data_value))
             except json.JSONDecodeError as e:
                 _logger.warning(
                     "Failed to parse SSE data field as JSON: %s, data: %s",
                     e,
                     data_value[:100] if len(data_value) > 100 else data_value,
                 )
-        return parse_obj_as(type_, sse_event)
+        return _validate_sse_data(type_, {"event": sse.event, "data": data_value, "id": sse.id, "retry": sse.retry})
 
-    data_value = sse_event.get("data")
+    sse_fields = {"event": sse.event, "data": data_value, "id": sse.id, "retry": sse.retry}
 
-    # Check if discriminator is at the top level (event-level discrimination)
-    if discriminator in sse_event:
-        # Case 2: Event-level discrimination
-        # Find the matching variant to check if 'data' field needs JSON parsing
-        disc_value = sse_event.get(discriminator)
+    if discriminator in sse_fields:
+        # Event-level discrimination
+        disc_value = sse_fields.get(discriminator)
         matching_variant = _find_variant_by_discriminator(variants, discriminator, disc_value)
 
         if matching_variant is not None:
-            # Check what type the variant expects for 'data'
             data_type = _get_field_annotation_v1(matching_variant, "data")
             if data_type is not None and not _is_string_type(data_type):
-                # Variant expects non-string data - parse JSON
                 if isinstance(data_value, str) and data_value:
                     try:
-                        parsed_data = json.loads(data_value)
-                        new_object = dict(sse_event)
-                        new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
+                        sse_fields["data"] = json.loads(data_value)
+                        return _validate_sse_data(type_, sse_fields)
                     except json.JSONDecodeError as e:
                         _logger.warning(
                             "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
                             e,
                             data_value[:100] if len(data_value) > 100 else data_value,
                         )
-        # Either no matching variant, data is string type, or JSON parse failed
-        return parse_obj_as(type_, sse_event)
+        return _validate_sse_data(type_, sse_fields)
 
     else:
-        # Case 1: Data-level discrimination
-        # The discriminator is inside the data payload - extract and parse data only
+        # Data-level discrimination
         if isinstance(data_value, str) and data_value:
             try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
+                return _validate_sse_data(type_, json.loads(data_value))
             except json.JSONDecodeError as e:
                 _logger.warning(
                     "Failed to parse SSE data field as JSON for data-level discrimination: %s, data: %s",
                     e,
                     data_value[:100] if len(data_value) > 100 else data_value,
                 )
-        return parse_obj_as(type_, sse_event)
+        return _validate_sse_data(type_, sse_fields)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:

--- a/generators/python/sdk/changes/unreleased/fix-sse-parse-bypass-dealiasing.yml
+++ b/generators/python/sdk/changes/unreleased/fix-sse-parse-bypass-dealiasing.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Fix major SSE streaming performance bottleneck by bypassing `convert_and_respect_annotation_metadata`
+    in `parse_sse_obj`. This function recursively introspects all union variants on every event,
+    accounting for ~75% of parse time. SSE data arrives as wire-format JSON and does not need
+    the TypedDict dealiasing pass. Also caches discriminator/variant analysis and replaces
+    `dataclasses.asdict()` with direct attribute access. Benchmarked ~28x faster on
+    Cohere V2ChatStreamResponse (100k events: 4059 → 147 µs/event).
+  type: fix


### PR DESCRIPTION
## Description

Fixes the major SSE streaming performance regression reported by Cohere. The previous TypeAdapter caching fix (PR #16013) addressed only ~17% of the cost. This PR eliminates the remaining ~75% bottleneck.

## Root Cause

`parse_sse_obj` → `parse_obj_as` → `convert_and_respect_annotation_metadata` runs expensive recursive type introspection on **every single SSE event**. For a large discriminated union like `V2ChatStreamResponse`, this function iterates through all union variants and calls `_convert_mapping` for each Pydantic model variant — O(variants × fields) per event.

This dealiasing pass is designed for TypedDict aliasing support and is completely unnecessary for SSE data, which arrives as wire-format JSON and maps directly to Pydantic models.

### Profiling breakdown (cohere 6.1.0, 10K events)

| Component | us/event | % of total |
|---|---|---|
| `convert_and_respect_annotation_metadata` | **2952** | **75.4%** |
| `TypeAdapter()` creation (uncached) | 654 | 16.7% |
| `TypeAdapter.validate_python` | 132 | 3.4% |
| `asdict` / discriminator / json.loads | ~6 | ~0.1% |

## Changes Made

- Added `_validate_sse_data()` helper that calls `TypeAdapter.validate_python()` directly, bypassing the unnecessary `convert_and_respect_annotation_metadata` dealiasing step
- Added `_get_sse_type_info()` cache for discriminator/variant analysis per type (avoids repeated type introspection)
- Replaced `dataclasses.asdict(sse)` with direct attribute access (`sse.data`, `sse.event`, etc.)
- Applied fix to all 4 `pydantic_utilities.py` variants:
  - `shared/pydantic_utilities.py` (pydantic v2 native)
  - `shared/with_pydantic_aliases/pydantic_utilities.py` (pydantic v2 with aliases)
  - `shared/with_pydantic_v1_on_v2/pydantic_utilities.py` (pydantic v1 compat)
  - `shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py` (v1 compat with aliases)

## Cohere SDK Benchmark Results

Comprehensive benchmark (100K events, `V2ChatStreamResponse`):

```
================================================================================
                      COMPREHENSIVE SSE BENCHMARK RESULTS                       
================================================================================
Label                                         Total      Per Event     vs SOL
--------------------------------------------------------------------------------
json.loads only (speed of light)            0.780s        7.80 us      1.0x
5.20.4 (construct_type)                    51.104s      511.04 us     65.5x
7.0.0 BEFORE (original)                   332.036s     3320.36 us    425.7x
7.0.0 AFTER (this PR)                      16.070s      160.70 us     20.6x
--------------------------------------------------------------------------------

Speedup of patch vs 7.0.0 original: 20.7x
Patch overhead vs json.loads only:   20.6x
================================================================================
```

| Version / Path | us/event | vs speed-of-light | Notes |
|---|---|---|---|
| `json.loads` only | **7.8** | 1.0x | Theoretical minimum (no typing) |
| 5.20.4 (`construct_type`) | 511 | 65.5x | Old path before `parse_sse_obj` |
| **7.0.0 BEFORE** (`parse_sse_obj` original) | **3320** | 425.7x | Current regression |
| **7.0.0 AFTER** (this PR) | **161** | 20.6x | Fixed |

The ~20x overhead vs `json.loads`-only is the irreducible cost of Pydantic's `TypeAdapter.validate_python()` which provides proper typing, discriminated union dispatch, and field validation. This is **3x faster than the old 5.20.4 `construct_type` path** that preceded the `parse_sse_obj` regression.

### Additional per-version results

**cohere 7.0.0** (latest):
```
BEFORE:  338.4s   3384 us/event
AFTER:    14.7s    147 us/event  →  22.9x faster
```

**cohere 6.1.0**:
```
BEFORE:  405.9s   4059 us/event
AFTER:    14.7s    147 us/event  →  27.6x faster
```

## Testing

- [x] Comprehensive benchmark: 5.20.4, 7.0.0 before/after, json.loads speed-of-light
- [x] Before/after Cohere 7.0.0: **20.7x speedup** (3320 → 161 µs/event)
- [x] Before/after Cohere 6.1.0: **27.6x speedup** (4059 → 147 µs/event)
- [x] Patched path is **3.2x faster** than pre-regression 5.20.4 `construct_type` (161 vs 511 µs)
- [x] All 53 existing SSE tests pass (`test_http_sse.py`)
- [x] All 3 `parse_obj_as` tests pass (`test_parse_obj_as.py`)
- [x] Pydantic v1-on-v2 hardening test passes
- [x] `poetry run pre-commit run -a` passes cleanly
- [x] All CI checks green (56 passed)

Link to Devin session: https://app.devin.ai/sessions/44e42c69b1c240cc8d38f1b9416aaa3a
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->