### PR TITLE
fix(cli): pass basepathAware to finishDocsRegister for preview publishes

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-preview-basepath-aware.yml
+++ b/packages/cli/cli/changes/unreleased/fix-preview-basepath-aware.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix multi-source preview publishing: pass `basepathAware` to `finishDocsRegister` for
+    preview publishes so that each workspace writes to its own basepath in S3 and registers
+    basepath routes in Edge Config. Previously, preview publishes excluded this flag, causing
+    all multi-source workspaces to overwrite each other at the root path.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -639,7 +639,7 @@ export async function publishDocs({
                 docsRegistrationId,
                 docsDefinition,
                 excludeApis,
-                ...(isBasepathAware && !preview && { basepathAware: true })
+                ...(isBasepathAware && { basepathAware: true })
             });
         } catch (error) {
             return context.failAndThrow("Failed to publish docs to " + domain, error, {


### PR DESCRIPTION
## Description

Fixes multi-source preview publishing so that basepath-aware routing works in preview mode.

## Changes Made

- Removed the `!preview` guard from the `basepathAware` flag in `finishDocsRegister` (`publishDocs.ts:642`)
- Previously, preview publishes excluded `basepathAware: true`, causing all multi-source workspaces to write to the root S3 path and skip Edge Config basepath route registration. The last workspace to publish would overwrite all others.
- Now `basepathAware` is passed for both preview and production publishes, so each workspace writes to its own basepath in S3 and registers its route in Edge Config.

**Before:** All multi-source preview URLs redirect to the last-published workspace's basepath.
**After:** Each basepath (`/us`, `/eu`, etc.) correctly resolves to its own workspace content.

## Testing

- Reproduced the issue with the [Trustly multi-source setup](https://github.com/fern-demo/trustly/pull/23): all preview paths (`/`, `/us`, `/eu`) redirected to `/eu` (the last-published workspace)
- Verified that `startDocsRegister` already passes `basepathAware` for previews (the inconsistency was only in `finishDocsRegister`)
- The `startDocsPreviewRegister` endpoint already receives and stores the `basePath` correctly — this fix ensures `finishDocsRegister` uses it for S3 writes and Edge Config updates

Link to Devin session: https://app.devin.ai/sessions/920397c6edde49f5a200b5a8fabc8970
Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->