### PR TITLE
fix(cli): add security scheme case regression

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/convertSecurityScheme.test.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/convertSecurityScheme.test.ts
@@ -89,4 +89,24 @@ describe("convertSecurityScheme", () => {
         expect(result.tokenVariableName).toBeUndefined();
         expect(result.tokenEnvVar).toBeUndefined();
     });
+
+    it("should convert HTTP security schemes case-insensitively", () => {
+        const bearerSecurityScheme: OpenAPIV3.SecuritySchemeObject = {
+            type: "http",
+            scheme: "Bearer",
+            bearerFormat: "JWT"
+        };
+        const basicSecurityScheme: OpenAPIV3.SecuritySchemeObject = {
+            type: "http",
+            scheme: "BaSiC"
+        };
+
+        const bearerResult = convertSecurityScheme(bearerSecurityScheme, source, mockTaskContext);
+        const basicResult = convertSecurityScheme(basicSecurityScheme, source, mockTaskContext);
+
+        expect.assert(bearerResult != null);
+        expect.assert(bearerResult.type === "bearer");
+        expect.assert(basicResult != null);
+        expect.assert(basicResult.type === "basic");
+    });
 });


### PR DESCRIPTION
## Summary

Adds regression coverage for OpenAPI HTTP security scheme parsing so capitalized or mixed-case `scheme` values continue to convert correctly.

Closes #6033.

## Details

- Covers `scheme: Bearer` converting to bearer auth.
- Covers mixed-case `scheme: BaSiC` converting to basic auth.
- Keeps the change scoped to the existing `convertSecurityScheme` unit test because the converter already normalizes `scheme` with `toLowerCase()`.

## Testing

- `..\..\..\..\..\node_modules\.bin\vitest.cmd --run src\__test__\convertSecurityScheme.test.ts` from `packages/cli/api-importers/openapi/openapi-ir-parser`
- Result: 1 test file passed, 4 tests passed.