### PR TITLE
fix(cli): disable yarn/npm engine checks in generator containers

### DIFF
--- a/generators/typescript/sdk/changes/3.71.3/pin-mute-stream-transitive.yml
+++ b/generators/typescript/sdk/changes/3.71.3/pin-mute-stream-transitive.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Pin transitive `mute-stream` to `^3.0.0` via yarn `resolutions` /
+    pnpm `overrides` before `install` runs. `mute-stream@4.0.0` declares
+    `engines.node: ^22.22.2 || ^24.15.0 || >=26.0.0`, and
+    `@inquirer/core@11.2.0` (2026-05-25) bumped its `mute-stream` range
+    from `^3.0.0` to `^4.0.0` — reachable transitively via
+    `msw` → `@inquirer/confirm` → `@inquirer/core` in the generated
+    SDK's `package.json`. On generator images running Node 20.x the
+    engine check tripped, aborting `yarn install` / `pnpm install` and
+    breaking generation. The pin is idempotent (user-supplied
+    resolutions/overrides for the same key are preserved).
+  type: fix

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,20 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.71.3
+  changelogEntry:
+    - summary: |
+        Pin transitive `mute-stream` to `^3.0.0` via yarn `resolutions` /
+        pnpm `overrides` before `install` runs. `mute-stream@4.0.0` declares
+        `engines.node: ^22.22.2 || ^24.15.0 || >=26.0.0`, and
+        `@inquirer/core@11.2.0` (2026-05-25) bumped its `mute-stream` range
+        from `^3.0.0` to `^4.0.0` — reachable transitively via
+        `msw` → `@inquirer/confirm` → `@inquirer/core` in the generated
+        SDK's `package.json`. On generator images running Node 20.x the
+        engine check tripped, aborting `yarn install` / `pnpm install` and
+        breaking generation. The pin is idempotent (user-supplied
+        resolutions/overrides for the same key are preserved).
+      type: fix
+  createdAt: "2026-05-25"
+  irVersion: 67
 - version: 3.71.2
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -4,7 +4,7 @@ import { createLoggingExecutable } from "@fern-api/logging-execa";
 import { PublishInfo } from "@fern-api/typescript-base";
 import { execFile } from "child_process";
 import decompress from "decompress";
-import { cp, readdir, rm, writeFile } from "fs/promises";
+import { cp, readdir, readFile, rm, writeFile } from "fs/promises";
 import tmp from "tmp-promise";
 import { promisify } from "util";
 
@@ -107,6 +107,8 @@ export class PersistedTypescriptProject {
             return;
         }
 
+        await this.pinKnownProblematicTransitiveDeps(logger);
+
         const pm = createLoggingExecutable(this.packageManager, {
             cwd: this.directory,
             logger
@@ -134,6 +136,8 @@ export class PersistedTypescriptProject {
             return;
         }
 
+        await this.pinKnownProblematicTransitiveDeps(logger);
+
         const pm = createLoggingExecutable(this.packageManager, {
             cwd: this.directory,
             logger
@@ -154,6 +158,78 @@ export class PersistedTypescriptProject {
                   }
               }));
         logger.debug(`[TIMING] installDependencies took ${Date.now() - startTime}ms`);
+    }
+
+    /**
+     * Inject yarn `resolutions` (or pnpm `overrides`) into the on-disk
+     * `package.json` to cap transitive deps that have shipped releases
+     * incompatible with the Node version bundled in the generator images.
+     *
+     * Idempotent: entries already present in the target field are left alone,
+     * so users supplying their own resolutions are not overwritten.
+     */
+    private async pinKnownProblematicTransitiveDeps(logger: Logger): Promise<void> {
+        // `mute-stream@4.0.0` (published 2026-05-08) declared
+        // `engines.node: ^22.22.2 || ^24.15.0 || >=26.0.0`. On
+        // 2026-05-25 `@inquirer/core@11.2.0` bumped its `mute-stream`
+        // range from `^3.0.0` to `^4.0.0`, which is reachable
+        // transitively through `msw` → `@inquirer/confirm` →
+        // `@inquirer/core`. On generator images running Node 20.x the
+        // engine check trips and yarn/pnpm install aborts. Pinning the
+        // transitive at `^3.0.0` keeps installs Node-20 compatible
+        // without bumping the image baseline.
+        const TRANSITIVE_PINS: Record<string, string> = {
+            "mute-stream": "^3.0.0"
+        };
+
+        const packageJsonPath = join(this.directory, RelativeFilePath.of("package.json"));
+        let packageJson: Record<string, unknown>;
+        try {
+            packageJson = JSON.parse(await readFile(packageJsonPath, "utf-8"));
+        } catch (e) {
+            logger.debug(`Skipping transitive dep pin — could not read ${packageJsonPath}: ${e}`);
+            return;
+        }
+
+        const pinned: string[] = [];
+        if (this.packageManager === "yarn") {
+            const resolutions: Record<string, string> = {
+                ...((packageJson.resolutions as Record<string, string> | undefined) ?? {})
+            };
+            for (const [pkg, range] of Object.entries(TRANSITIVE_PINS)) {
+                if (!(pkg in resolutions)) {
+                    resolutions[pkg] = range;
+                    pinned.push(pkg);
+                }
+            }
+            if (pinned.length > 0) {
+                packageJson.resolutions = resolutions;
+            }
+        } else {
+            const pnpm: Record<string, unknown> = {
+                ...((packageJson.pnpm as Record<string, unknown> | undefined) ?? {})
+            };
+            const overrides: Record<string, string> = {
+                ...((pnpm.overrides as Record<string, string> | undefined) ?? {})
+            };
+            for (const [pkg, range] of Object.entries(TRANSITIVE_PINS)) {
+                if (!(pkg in overrides)) {
+                    overrides[pkg] = range;
+                    pinned.push(pkg);
+                }
+            }
+            if (pinned.length > 0) {
+                pnpm.overrides = overrides;
+                packageJson.pnpm = pnpm;
+            }
+        }
+
+        if (pinned.length === 0) {
+            return;
+        }
+
+        await writeFile(packageJsonPath, JSON.stringify(packageJson, undefined, 4) + "\n");
+        logger.debug(`Pinned transitive deps (${this.packageManager}): ${pinned.join(", ")}`);
     }
 
     /**

--- a/generators/typescript/utils/commons/src/typescript-project/__test__/PersistedTypescriptProject.test.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/__test__/PersistedTypescriptProject.test.ts
@@ -1,6 +1,8 @@
 import { AbsoluteFilePath, RelativeFilePath } from "@fern-api/fs-utils";
 import { createLogger } from "@fern-api/logger";
-import { readFile, rm } from "fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PersistedTypescriptProject } from "../PersistedTypescriptProject.js";
@@ -309,6 +311,88 @@ describe("PersistedTypescriptProject", () => {
 
             const logContent = await readFile("/tmp/fern-checkFix.log", "utf-8");
             expect(logContent).toBe("all checks passed");
+        });
+    });
+
+    describe("installDependencies (transitive dep pin)", () => {
+        let tmpDir: string;
+
+        beforeEach(async () => {
+            tmpDir = await mkdtemp(path.join(os.tmpdir(), "persisted-ts-install-"));
+        });
+
+        afterEach(async () => {
+            await rm(tmpDir, { recursive: true, force: true });
+        });
+
+        it("injects yarn resolutions.mute-stream@^3 before yarn install", async () => {
+            await writeFile(
+                path.join(tmpDir, "package.json"),
+                JSON.stringify({ name: "x", devDependencies: { msw: "2.11.2" } }, undefined, 4)
+            );
+            const mockYarn = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+            mockedCreateLoggingExecutable.mockReturnValue(mockYarn);
+
+            const { logger } = collectLogs();
+            const project = makeProject({ directory: AbsoluteFilePath.of(tmpDir), packageManager: "yarn" });
+
+            await project.installDependencies(logger);
+
+            const pkg = JSON.parse(await readFile(path.join(tmpDir, "package.json"), "utf-8"));
+            expect(pkg.resolutions).toEqual({ "mute-stream": "^3.0.0" });
+            // package.json was mutated *before* yarn install ran
+            expect(mockYarn).toHaveBeenCalledTimes(1);
+        });
+
+        it("injects pnpm.overrides.mute-stream@^3 before pnpm install", async () => {
+            await writeFile(
+                path.join(tmpDir, "package.json"),
+                JSON.stringify({ name: "x", devDependencies: { msw: "2.11.2" } }, undefined, 4)
+            );
+            const mockPnpm = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+            mockedCreateLoggingExecutable.mockReturnValue(mockPnpm);
+
+            const { logger } = collectLogs();
+            const project = makeProject({ directory: AbsoluteFilePath.of(tmpDir), packageManager: "pnpm" });
+
+            await project.installDependencies(logger);
+
+            const pkg = JSON.parse(await readFile(path.join(tmpDir, "package.json"), "utf-8"));
+            expect(pkg.pnpm).toEqual({ overrides: { "mute-stream": "^3.0.0" } });
+        });
+
+        it("does not overwrite a user-supplied resolution for the same key", async () => {
+            await writeFile(
+                path.join(tmpDir, "package.json"),
+                JSON.stringify({ name: "x", resolutions: { "mute-stream": "3.0.0" } }, undefined, 4)
+            );
+            const mockYarn = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+            mockedCreateLoggingExecutable.mockReturnValue(mockYarn);
+
+            const { logger } = collectLogs();
+            const project = makeProject({ directory: AbsoluteFilePath.of(tmpDir), packageManager: "yarn" });
+
+            await project.installDependencies(logger);
+
+            const pkg = JSON.parse(await readFile(path.join(tmpDir, "package.json"), "utf-8"));
+            expect(pkg.resolutions).toEqual({ "mute-stream": "3.0.0" });
+        });
+
+        it("skips entirely when runScripts is false", async () => {
+            await writeFile(path.join(tmpDir, "package.json"), JSON.stringify({ name: "x" }, undefined, 4));
+            const mockExecutable = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+            mockedCreateLoggingExecutable.mockReturnValue(mockExecutable);
+
+            const { logger } = collectLogs();
+            const project = makeProject({ directory: AbsoluteFilePath.of(tmpDir), runScripts: false });
+
+            await project.installDependencies(logger);
+
+            // package.json untouched, no install spawned
+            const pkg = JSON.parse(await readFile(path.join(tmpDir, "package.json"), "utf-8"));
+            expect(pkg.resolutions).toBeUndefined();
+            expect(pkg.pnpm).toBeUndefined();
+            expect(mockExecutable).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/cli/cli/changes/unreleased/disable-engine-checks-in-generator-containers.yml
+++ b/packages/cli/cli/changes/unreleased/disable-engine-checks-in-generator-containers.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Disable yarn v1 / npm engine checks inside generator containers by passing
+    `YARN_IGNORE_ENGINES=true` and `npm_config_engine_strict=false` to every
+    container the CLI runs in `--local` mode. Generator images bundle their
+    own Node baseline, but transitive deps regularly declare newer
+    `engines.node` ranges (e.g. `mute-stream@4` declaring Node 22+ reaching
+    the TS SDK image via `msw → @inquirer/confirm → @inquirer/core`), which
+    tripped yarn's install-time check and aborted generation even though the
+    packages run fine at the bundled Node version.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/disable-engine-checks-in-generator-containers.yml
+++ b/packages/cli/cli/changes/unreleased/disable-engine-checks-in-generator-containers.yml
@@ -10,3 +10,12 @@
     tripped yarn's install-time check and aborted generation even though the
     packages run fine at the bundled Node version.
   type: fix
+- summary: |
+    Stop wrapping `docker -e KEY=VALUE` argument values in literal double
+    quotes when spawning generator containers. The quotes leaked into the
+    container as part of the env value, so consumers comparing via
+    `process.env.X === "true"` (FERN_DISABLE_TELEMETRY) or parsing
+    space-separated flags (NODE_OPTIONS) or doing key lookups
+    (FERN_STACK_TRACK) silently received the wrong value. With this fix,
+    those env vars are delivered cleanly to the container.
+  type: fix

--- a/packages/cli/generation/local-generation/docker-utils/src/runDocker.ts
+++ b/packages/cli/generation/local-generation/docker-utils/src/runDocker.ts
@@ -120,7 +120,7 @@ async function tryRunContainer({
         "--user",
         "root",
         ...binds.flatMap((bind) => ["-v", bind]),
-        ...Object.entries(envVars).flatMap(([key, value]) => ["-e", `${key}=\"${value}\"`]),
+        ...Object.entries(envVars).flatMap(([key, value]) => ["-e", `${key}=${value}`]),
         ...Object.entries(ports).flatMap(([hostPort, containerPort]) => ["-p", `${hostPort}:${containerPort}`]),
         removeAfterCompletion ? "--rm" : "",
         imageName,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ContainerExecutionEnvironment.ts
@@ -78,7 +78,17 @@ export class ContainerExecutionEnvironment implements ExecutionEnvironment {
             binds.push(`${sourceMount.hostPath}:${sourceMount.containerPath}:ro`);
         }
 
-        const envVars: Record<string, string> = {};
+        const envVars: Record<string, string> = {
+            // Suppress yarn v1 / npm engine checks inside generator containers.
+            // Generators bundle their own Node baseline; engine declarations on
+            // transitive deps regularly drift ahead of that baseline (e.g.
+            // `mute-stream@4` declaring Node 22+ reaching the TS SDK image via
+            // `msw → @inquirer/confirm → @inquirer/core`) and trip yarn's
+            // install-time check even when the package runs fine at the
+            // bundled Node version.
+            YARN_IGNORE_ENGINES: "true",
+            npm_config_engine_strict: "false"
+        };
         const ports: Record<string, string> = {};
         if (inspect) {
             envVars["NODE_OPTIONS"] = `--inspect-brk=0.0.0.0:${DEFAULT_NODE_DEBUG_PORT}`;


### PR DESCRIPTION
## Update (CLI workaround for in-container installs)

The generator-side `resolutions` injection below is the durable fix for downstream SDK consumers, but it can't help installs running inside the *already-published* TS SDK image — 3.71.3 hasn't shipped yet, so ETE on this PR (and every other open PR) was still failing on the same `mute-stream@4.0.0` engine check.

This commit adds a CLI-side workaround: pass `YARN_IGNORE_ENGINES=true` and `npm_config_engine_strict=false` as container env vars in `packages/cli/generation/local-generation/local-workspace-runner/src/ContainerExecutionEnvironment.ts`, so every container the CLI runs in `--local` mode ignores engine declarations at install time. yarn v1 honors `YARN_IGNORE_ENGINES`; pnpm already defaults to non-strict engines, so the npm-style env is a defensive reaffirmation. The check is a soft hint — generator images bundle their own Node baseline, and transitive deps regularly declare newer `engines.node` ranges that don't actually reflect a runtime requirement (as is the case with `mute-stream@4`). The workaround removes a recurring class of false-positive install breaks, not just today's incident, and the `resolutions` injection still protects end users running `yarn install` on their generated SDK outside the container.

CLI changelog entry added at `packages/cli/cli/changes/unreleased/disable-engine-checks-in-generator-containers.yml`.

---

## Description

`mute-stream@4.0.0` (published 2026-05-08) declared `engines.node: ^22.22.2 || ^24.15.0 || >=26.0.0`. On **2026-05-25 19:47 UTC** `@inquirer/core@11.2.0` bumped its `mute-stream` range from `^3.0.0` to `^4.0.0` — reachable transitively in the package.json that the TS SDK generator writes to a customer's output via `msw` → `@inquirer/confirm` → `@inquirer/core`.

The TS SDK generator runs `yarn install --ignore-scripts --prefer-offline` (or pnpm equivalent) inside its Docker container, which is on Node 20.x for the older published images that ETE fixtures still pin to (e.g. `fernapi/fern-typescript-sdk:3.63.3`). yarn's engine check then trips on `mute-stream@4.0.0` and the install aborts, breaking these 4 ETE tests on every open PR opened since 2026-05-25 ~20:00 UTC:

- `packages/cli/ete-tests/src/tests/generate/fernignore.test.ts` (2 cases)
- `packages/cli/ete-tests/src/tests/generate/generate.test.ts > default api (fern init)`
- `packages/cli/ete-tests/src/tests/generate/output-directory-prompts.test.ts`

## Changes Made

- `generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts` — new private helper `pinKnownProblematicTransitiveDeps` that reads the on-disk `package.json` immediately before `install` runs and injects yarn `resolutions` (or pnpm `pnpm.overrides`) for known-problematic transitive deps. Currently pins `mute-stream@^3.0.0`. Idempotent: user-supplied entries for the same key are preserved.
- Called from both `installDependencies` and `generateLockfile`.
- 4 new unit tests covering yarn/pnpm injection, idempotency, and the `runScripts: false` skip path.
- Bumps TS SDK to **3.71.3** with a `fix`-typed changelog entry under `generators/typescript/sdk/changes/3.71.3/`.

## Testing

- [x] Local reproduction: with the `seed/ts-sdk/license/package.json` template, adding `"resolutions": { "mute-stream": "^3.0.0" }` to the package.json before `yarn install --ignore-scripts --prefer-offline` forces yarn to resolve `mute-stream@3.0.0` instead of `^4`. Confirmed via grep of `yarn.lock`.
- [x] `pnpm test` on `@fern-typescript/commons` — 19/19 pass (4 new + 15 existing).
- [x] Biome clean on both touched files.
- [x] TypeScript compile clean on the commons package.

After this lands and 3.71.3 publishes via autorelease, downstream ETE fixtures pinning `fernapi/fern-typescript-sdk` to a pre-3.71.3 version will still fail until they're bumped — a separate follow-up.