### PR TITLE
fix(ir): skip duplicate type declarations when component schema collides with inline endpoint type

### DIFF
--- a/packages/cli/api-importers/commons/src/FernDefinitionBuilder.ts
+++ b/packages/cli/api-importers/commons/src/FernDefinitionBuilder.ts
@@ -1,6 +1,6 @@
 import { FERN_PACKAGE_MARKER_FILENAME, ROOT_API_FILENAME } from "@fern-api/configuration";
 import { RawSchemas, RootApiFileSchema, visitRawEnvironmentDeclaration } from "@fern-api/fern-definition-schema";
-import { AbsoluteFilePath, basename, dirname, join, RelativeFilePath, relative } from "@fern-api/path-utils";
+import { AbsoluteFilePath, basename, dirname, join, RelativeFilePath, relative, sep } from "@fern-api/path-utils";
 import { camelCase, isEqual } from "lodash-es";
 
 import { FernDefinitionDirectory } from "./utils/FernDefinitionDirectory.js";
@@ -66,6 +66,12 @@ export interface FernDefinitionBuilder {
 
     addType(file: RelativeFilePath, { name, schema }: { name: string; schema: RawSchemas.TypeDeclarationSchema }): void;
 
+    /**
+     * Returns true if a type or request wrapper with the given name is already
+     * declared in a different file within the same Fern package (directory).
+     */
+    isNameDeclaredInOtherFile(name: string, file: RelativeFilePath): boolean;
+
     addError(
         file: RelativeFilePath,
         { name, schema }: { name: string; schema: RawSchemas.ErrorDeclarationSchema }
@@ -118,12 +124,26 @@ export interface FernDefinition {
     definitionFiles: Record<RelativeFilePath, RawSchemas.DefinitionFileSchema>;
 }
 
+/**
+ * Returns the package (parent directory) for a given file path.
+ * Root-level files return an empty string.
+ */
+function getPackageForFile(file: RelativeFilePath): string {
+    const parts = file.split(sep);
+    if (parts.length <= 1) {
+        return "";
+    }
+    return parts.slice(0, -1).join(sep);
+}
+
 export class FernDefinitionBuilderImpl implements FernDefinitionBuilder {
     private root: FernDefinitionDirectory;
     private rootApiFile: RawSchemas.RootApiFileSchema;
     private packageMarkerFile: RawSchemas.PackageMarkerFileSchema = {};
     private basePath: string | undefined = undefined;
     private rootPathParameters: Record<string, RawSchemas.HttpPathParameterSchema> | undefined = undefined;
+    /** Tracks declared type/request-wrapper names per package to detect cross-file collisions. */
+    private declaredNamesByPackage = new Map<string, Map<string, RelativeFilePath>>();
 
     public constructor(public readonly enableUniqueErrorsPerEndpoint: boolean) {
         this.root = new FernDefinitionDirectory();
@@ -346,6 +366,30 @@ export class FernDefinitionBuilderImpl implements FernDefinitionBuilder {
             fernFile.types = {};
         }
         fernFile.types[name] = schema;
+        this.trackDeclaredName(name, file);
+    }
+
+    public isNameDeclaredInOtherFile(name: string, file: RelativeFilePath): boolean {
+        const pkg = getPackageForFile(file);
+        const packageNames = this.declaredNamesByPackage.get(pkg);
+        if (packageNames == null) {
+            return false;
+        }
+        const existingFile = packageNames.get(name);
+        return existingFile != null && existingFile !== file;
+    }
+
+    private trackDeclaredName(name: string, file: RelativeFilePath): void {
+        const pkg = getPackageForFile(file);
+        let packageNames = this.declaredNamesByPackage.get(pkg);
+        if (packageNames == null) {
+            packageNames = new Map();
+            this.declaredNamesByPackage.set(pkg, packageNames);
+        }
+        // First declaration wins; don't overwrite
+        if (!packageNames.has(name)) {
+            packageNames.set(name, file);
+        }
     }
 
     public addTypeExample(file: RelativeFilePath, name: string, convertedExample: RawSchemas.ExampleTypeSchema): void {
@@ -431,6 +475,11 @@ export class FernDefinitionBuilderImpl implements FernDefinitionBuilder {
             fernFile.service.source = source;
         }
         fernFile.service.endpoints[name] = schema;
+
+        // Track request wrapper names so that addSchemas() can detect collisions
+        if (typeof schema.request !== "string" && schema.request?.name != null) {
+            this.trackDeclaredName(schema.request.name, file);
+        }
     }
 
     public addWebhook(

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildFernDefinition.ts
@@ -53,10 +53,13 @@ function addSchemas({
                 declarationDepth: 0,
                 variant: "read"
             });
-            context.builder.addType(declarationFile, {
-                name: readDeclaration.name ?? id,
-                schema: readDeclaration.schema
-            });
+            const readName = readDeclaration.name ?? id;
+            if (!context.builder.isNameDeclaredInOtherFile(readName, declarationFile)) {
+                context.builder.addType(declarationFile, {
+                    name: readName,
+                    schema: readDeclaration.schema
+                });
+            }
 
             // Generate Write variant (without readOnly properties, original name)
             const writeDeclaration = buildObjectTypeDeclaration({
@@ -68,10 +71,13 @@ function addSchemas({
                 skipReadonlyProperties: true,
                 variant: "write"
             });
-            context.builder.addType(declarationFile, {
-                name: writeDeclaration.name ?? id,
-                schema: writeDeclaration.schema
-            });
+            const writeName = writeDeclaration.name ?? id;
+            if (!context.builder.isNameDeclaredInOtherFile(writeName, declarationFile)) {
+                context.builder.addType(declarationFile, {
+                    name: writeName,
+                    schema: writeDeclaration.schema
+                });
+            }
 
             continue;
         }
@@ -91,10 +97,13 @@ function addSchemas({
                 skipReadonlyProperties: true,
                 variant: "write"
             });
-            context.builder.addType(declarationFile, {
-                name: writeDeclaration.name ?? id,
-                schema: writeDeclaration.schema
-            });
+            const writeName = writeDeclaration.name ?? id;
+            if (!context.builder.isNameDeclaredInOtherFile(writeName, declarationFile)) {
+                context.builder.addType(declarationFile, {
+                    name: writeName,
+                    schema: writeDeclaration.schema
+                });
+            }
 
             continue;
         }
@@ -116,21 +125,32 @@ function addSchemas({
             variant
         });
 
+        const typeName = typeDeclaration.name ?? id;
+
         // HACKHACK: Skip self-referencing schemas. I'm not sure if this is the right way to do this.
         if (isRawAliasDefinition(typeDeclaration.schema)) {
             const aliasType = getTypeFromTypeReference(typeDeclaration.schema);
             if (
-                aliasType === (typeDeclaration.name ?? id) ||
-                aliasType === `optional<${typeDeclaration.name ?? id}>` ||
-                aliasType === `nullable<${typeDeclaration.name ?? id}>` ||
-                aliasType === `optional<nullable<${typeDeclaration.name ?? id}>>`
+                aliasType === typeName ||
+                aliasType === `optional<${typeName}>` ||
+                aliasType === `nullable<${typeName}>` ||
+                aliasType === `optional<nullable<${typeName}>>`
             ) {
                 continue;
             }
         }
 
+        // Skip component schemas whose name collides with a type or request wrapper
+        // already declared in a different file within the same package. This happens
+        // when an OpenAPI spec defines both a component schema and an identical inline
+        // request/response body on an endpoint — the endpoint-generated type takes
+        // precedence since it is associated with the correct service file.
+        if (context.builder.isNameDeclaredInOtherFile(typeName, declarationFile)) {
+            continue;
+        }
+
         context.builder.addType(declarationFile, {
-            name: typeDeclaration.name ?? id,
+            name: typeName,
             schema: typeDeclaration.schema
         });
     }

--- a/packages/cli/cli/changes/unreleased/fix-duplicate-schema-inline-type.yml
+++ b/packages/cli/cli/changes/unreleased/fix-duplicate-schema-inline-type.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix duplicate type declarations when an OpenAPI spec defines both a component
+    schema and an identical inline request/response body on an endpoint. The
+    endpoint-generated type now takes precedence and the redundant component schema
+    is skipped, preventing "already declared" errors during fern check.
+  type: fix

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type__Item.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type__Item.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "name": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type__ListItemsResponseMeta.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type__ListItemsResponseMeta.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "pageSize": {
+      "type": "integer"
+    },
+    "nextToken": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "required": [
+    "pageSize"
+  ],
+  "additionalProperties": false,
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type__OperatorVersion.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type__OperatorVersion.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "version": {
+      "oneOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type_configurations_CreateConfigurationResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type_configurations_CreateConfigurationResponse.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "displayName": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type_configurations_UpdateConfigurationResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type_configurations_UpdateConfigurationResponse.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "displayName": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {}
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type_items_ListItemsResponse.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type_items_ListItemsResponse.json
@@ -1,0 +1,69 @@
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Item"
+      }
+    },
+    "meta": {
+      "$ref": "#/definitions/items.ListItemsResponseMeta"
+    }
+  },
+  "required": [
+    "items",
+    "meta"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "Item": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "items.ListItemsResponseMeta": {
+      "type": "object",
+      "properties": {
+        "pageSize": {
+          "type": "integer"
+        },
+        "nextToken": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "pageSize"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type_items_ListItemsResponseMeta.json
+++ b/packages/cli/fern-definition/ir-to-jsonschema/src/__test__/__snapshots__/duplicate-schema-inline-type/type_items_ListItemsResponseMeta.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "pageSize": {
+      "type": "integer"
+    },
+    "nextToken": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "required": [
+    "pageSize"
+  ],
+  "additionalProperties": false,
+  "definitions": {}
+}

--- a/test-definitions/fern/apis/duplicate-schema-inline-type/generators.yml
+++ b/test-definitions/fern/apis/duplicate-schema-inline-type/generators.yml
@@ -1,0 +1,3 @@
+api:
+  specs:
+    - openapi: ./openapi.yml

--- a/test-definitions/fern/apis/duplicate-schema-inline-type/openapi.yml
+++ b/test-definitions/fern/apis/duplicate-schema-inline-type/openapi.yml
@@ -1,0 +1,197 @@
+openapi: 3.0.1
+info:
+  title: Duplicate Schema Inline Type Test
+  description: >
+    Tests that component schemas do not collide with inline request/response types
+    generated from endpoints. This reproduces a pattern where an OpenAPI spec defines
+    both a component schema and an identical inline request/response body on an endpoint,
+    causing duplicate type declarations across different Fern definition files.
+  version: v1
+security:
+  - bearerAuth: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    # These component schemas are defined but NOT referenced via $ref by any endpoint.
+    # Endpoints instead define identical inline bodies.
+    CreateConfigurationRequest:
+      type: object
+      description: Request body for creating a configuration.
+      properties:
+        displayName:
+          type: string
+          description: The display name.
+        rules:
+          type: array
+          items:
+            type: string
+      required:
+        - displayName
+        - rules
+    UpdateConfigurationRequest:
+      type: object
+      required:
+        - displayName
+        - rules
+      properties:
+        displayName:
+          type: string
+        rules:
+          type: array
+          items:
+            type: string
+    ListItemsResponse:
+      type: object
+      required:
+        - items
+        - meta
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Item"
+        meta:
+          type: object
+          properties:
+            pageSize:
+              type: integer
+            nextToken:
+              type: string
+          required:
+            - pageSize
+    Item:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    OperatorVersion:
+      type: object
+      properties:
+        id:
+          type: string
+        version:
+          type: integer
+servers:
+  - url: https://api.example.com
+tags:
+  - name: Configurations
+    description: Configuration management endpoints.
+  - name: Items
+    description: Item retrieval endpoints.
+paths:
+  /v1/configurations:
+    post:
+      summary: Create a Configuration
+      tags:
+        - Configurations
+      operationId: CreateConfiguration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Request body for creating a configuration.
+              properties:
+                displayName:
+                  type: string
+                  description: The display name.
+                rules:
+                  type: array
+                  items:
+                    type: string
+              required:
+                - displayName
+                - rules
+      responses:
+        "201":
+          description: Configuration created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  displayName:
+                    type: string
+  /v1/configurations/{id}:
+    put:
+      summary: Update a Configuration
+      tags:
+        - Configurations
+      operationId: UpdateConfiguration
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - displayName
+                - rules
+              properties:
+                displayName:
+                  type: string
+                rules:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        "200":
+          description: Configuration updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  displayName:
+                    type: string
+  /v1/items:
+    get:
+      summary: List Items
+      tags:
+        - Items
+      operationId: ListItems
+      parameters:
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: A list of items.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - items
+                  - meta
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Item"
+                  meta:
+                    type: object
+                    properties:
+                      pageSize:
+                        type: integer
+                      nextToken:
+                        type: string
+                    required:
+                      - pageSize


### PR DESCRIPTION
## Description

Fixes duplicate type declaration errors when an OpenAPI spec defines both unreferenced component schemas and inline request/response bodies on endpoints that generate types with identical names.

**Root cause**: The IR-to-Fern conversion places component schemas and endpoint-generated types in different definition files. When both share the same name within a package, `fern check` reports "already declared" errors.

**Fix**: Track declared type and request-wrapper names per Fern package in `FernDefinitionBuilder`. Before adding a component schema in `addSchemas()`, check if the name already exists in a different file within the same package. If so, skip it — the endpoint-generated type takes precedence.

Reported on Twilio Intelligence v3 spec (`twilio_intelligence_v3.yaml`) with 9 duplicate type errors:
```
CreateConfigurationRequest, UpdateConfigurationRequest, ListConversationsResponse,
ListConversationsResponseMeta, ListOperatorsResponse, ListOperatorsResponseMeta,
ListOperatorVersionsResponse, ListOperatorVersionsResponseItemsItem,
ListOperatorVersionsResponseMeta
```

## Changes Made

- `FernDefinitionBuilder.ts`: Added per-package name tracking (`declaredNamesByPackage`) and `isNameDeclaredInOtherFile()` method
- `buildFernDefinition.ts`: Added collision checks in `addSchemas()` for all code paths (read/write variants and default)
- New test fixture `duplicate-schema-inline-type` with minimal OpenAPI spec reproducing the issue
- Added ir-to-jsonschema snapshots for the new fixture
- Changelog entry under `packages/cli/cli/changes/unreleased/`

## Testing

- [x] `fern check` on Twilio Intelligence v3 spec: **0 errors** (was 9)
- [x] All 297 existing `openapi-ir-to-fern` tests pass (no regressions)
- [x] All 1188 `ir-to-jsonschema` tests pass (7 new snapshots written)
- [x] Compilation and formatting pass
- [x] `test-ete` failure is pre-existing (Node.js version mismatch with `mute-stream@4.0.0` — unrelated)

Link to Devin session: https://app.devin.ai/sessions/0490b6973f8c41cda2422d38fe4582de
Requested by: @iamnamananand996