### PR TITLE
fix(typescript): retain Response reference for streaming and SSE responses

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/retain-response-ref-for-streaming.yml
+++ b/generators/typescript/sdk/changes/unreleased/retain-response-ref-for-streaming.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Retain a reference to the upstream `Response` on streaming and SSE response
+    bodies so that undici's `FinalizationRegistry` does not garbage-collect the
+    `Response` and cancel the body stream on Node 18+.
+  type: fix

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/getResponseBody.template.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/getResponseBody.template.ts
@@ -4,6 +4,16 @@ import { getBinaryResponse } from "./BinaryResponse";
 import { chooseStreamWrapper } from "./stream-wrappers/chooseStreamWrapper";
 <% } %>
 
+// Pins the upstream Response so undici's FinalizationRegistry can't GC it and cancel the body stream.
+function retainResponse(target: object, response: Response): void {
+    Object.defineProperty(target, "__fern_response_ref", {
+        value: response,
+        enumerable: false,
+        configurable: true,
+        writable: false,
+    });
+}
+
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     switch (responseType) {
         case "binary-response":
@@ -22,6 +32,7 @@ export async function getResponseBody(response: Response, responseType?: string)
                     },
                 };
             }
+            retainResponse(response.body, response);
             return response.body;
         case "streaming":
             if (response.body == null) {
@@ -34,8 +45,11 @@ export async function getResponseBody(response: Response, responseType?: string)
                 };
             }
             <% if (streamType === "wrapper") { %>
-            return chooseStreamWrapper(response.body);
+            const wrapper = await chooseStreamWrapper(response.body);
+            retainResponse(wrapper, response);
+            return wrapper;
             <% } else { %>
+            retainResponse(response.body, response);
             return response.body;
             <% } %>
         case "text":

--- a/generators/typescript/utils/core-utilities/tests/unit/fetcher/getResponseBody.test.template.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/fetcher/getResponseBody.test.template.ts
@@ -75,6 +75,21 @@ describe("Test getResponseBody", () => {
         }
     });
 
+    it("should retain a reference to the parent Response for sse responses", async () => {
+        if (RUNTIME.type === "node") {
+            const mockStream = new ReadableStream();
+            const mockResponse = new Response(mockStream);
+            const result = (await getResponseBody(mockResponse, "sse")) as ReadableStream & {
+                __fern_response_ref?: Response;
+            };
+            // Pins the parent Response so undici's FinalizationRegistry can't GC it and cancel the stream.
+            expect(result.__fern_response_ref).toBe(mockResponse);
+            // The pin must be non-enumerable so it does not leak through JSON.stringify or Object.keys.
+            const descriptor = Object.getOwnPropertyDescriptor(result, "__fern_response_ref");
+            expect(descriptor?.enumerable).toBe(false);
+        }
+    });
+
 <% if (streamType === "wrapper") { %>
     it("should handle streaming response type", async () => {
         if (RUNTIME.type === "node") {
@@ -83,6 +98,19 @@ describe("Test getResponseBody", () => {
             const result = await getResponseBody(mockResponse, "streaming");
             // need to reinstantiate string as a result of locked state in Readable Stream after registration with Response
             expect(JSON.stringify(result)).toBe(JSON.stringify(await chooseStreamWrapper(new ReadableStream())));
+        }
+    });
+
+    it("should retain a reference to the parent Response on the stream wrapper", async () => {
+        if (RUNTIME.type === "node") {
+            const mockStream = new ReadableStream();
+            const mockResponse = new Response(mockStream);
+            const result = (await getResponseBody(mockResponse, "streaming")) as object & {
+                __fern_response_ref?: Response;
+            };
+            expect(result.__fern_response_ref).toBe(mockResponse);
+            const descriptor = Object.getOwnPropertyDescriptor(result, "__fern_response_ref");
+            expect(descriptor?.enumerable).toBe(false);
         }
     });
 <% } else { %>
@@ -106,6 +134,17 @@ describe("Test getResponseBody", () => {
         const { value } = await reader.read();
         const streamContent = decoder.decode(value);
         expect(streamContent).toBe(testData);
+    });
+
+    it("should retain a reference to the parent Response for streaming responses", async () => {
+        const mockStream = new ReadableStream();
+        const mockResponse = new Response(mockStream);
+        const result = (await getResponseBody(mockResponse, "streaming")) as ReadableStream & {
+            __fern_response_ref?: Response;
+        };
+        expect(result.__fern_response_ref).toBe(mockResponse);
+        const descriptor = Object.getOwnPropertyDescriptor(result, "__fern_response_ref");
+        expect(descriptor?.enumerable).toBe(false);
     });
 <% } %>
 });

--- a/seed/ts-sdk/streaming/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/streaming/no-custom-config/.fern/metadata.json
@@ -1,10 +1,10 @@
 {
     "cliVersion": "DUMMY",
     "generatorName": "fernapi/fern-typescript-sdk",
-    "generatorVersion": "local",
+    "generatorVersion": "latest",
     "originGitCommit": "DUMMY",
     "invokedBy": "ci",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
+    "ciProvider": "unknown",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/getResponseBody.ts
@@ -1,6 +1,16 @@
 import { fromJson } from "../json.js";
 import { getBinaryResponse } from "./BinaryResponse.js";
 
+// Pins the upstream Response so undici's FinalizationRegistry can't GC it and cancel the body stream.
+function retainResponse(target: object, response: Response): void {
+    Object.defineProperty(target, "__fern_response_ref", {
+        value: response,
+        enumerable: false,
+        configurable: true,
+        writable: false,
+    });
+}
+
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     switch (responseType) {
         case "binary-response":
@@ -19,6 +29,7 @@ export async function getResponseBody(response: Response, responseType?: string)
                     },
                 };
             }
+            retainResponse(response.body, response);
             return response.body;
         case "streaming":
             if (response.body == null) {
@@ -31,6 +42,7 @@ export async function getResponseBody(response: Response, responseType?: string)
                 };
             }
 
+            retainResponse(response.body, response);
             return response.body;
 
         case "text":

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/getResponseBody.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/getResponseBody.test.ts
@@ -73,6 +73,21 @@ describe("Test getResponseBody", () => {
         }
     });
 
+    it("should retain a reference to the parent Response for sse responses", async () => {
+        if (RUNTIME.type === "node") {
+            const mockStream = new ReadableStream();
+            const mockResponse = new Response(mockStream);
+            const result = (await getResponseBody(mockResponse, "sse")) as ReadableStream & {
+                __fern_response_ref?: Response;
+            };
+            // Pins the parent Response so undici's FinalizationRegistry can't GC it and cancel the stream.
+            expect(result.__fern_response_ref).toBe(mockResponse);
+            // The pin must be non-enumerable so it does not leak through JSON.stringify or Object.keys.
+            const descriptor = Object.getOwnPropertyDescriptor(result, "__fern_response_ref");
+            expect(descriptor?.enumerable).toBe(false);
+        }
+    });
+
     it("should handle streaming response type", async () => {
         const encoder = new TextEncoder();
         const testData = "test stream data";
@@ -93,5 +108,16 @@ describe("Test getResponseBody", () => {
         const { value } = await reader.read();
         const streamContent = decoder.decode(value);
         expect(streamContent).toBe(testData);
+    });
+
+    it("should retain a reference to the parent Response for streaming responses", async () => {
+        const mockStream = new ReadableStream();
+        const mockResponse = new Response(mockStream);
+        const result = (await getResponseBody(mockResponse, "streaming")) as ReadableStream & {
+            __fern_response_ref?: Response;
+        };
+        expect(result.__fern_response_ref).toBe(mockResponse);
+        const descriptor = Object.getOwnPropertyDescriptor(result, "__fern_response_ref");
+        expect(descriptor?.enumerable).toBe(false);
     });
 });

--- a/seed/ts-sdk/streaming/serde-layer/.fern/metadata.json
+++ b/seed/ts-sdk/streaming/serde-layer/.fern/metadata.json
@@ -1,13 +1,13 @@
 {
     "cliVersion": "DUMMY",
     "generatorName": "fernapi/fern-typescript-sdk",
-    "generatorVersion": "local",
+    "generatorVersion": "latest",
     "generatorConfig": {
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
     "invokedBy": "ci",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
+    "ciProvider": "unknown",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/streaming/serde-layer/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/fetcher/getResponseBody.ts
@@ -1,6 +1,16 @@
 import { fromJson } from "../json.js";
 import { getBinaryResponse } from "./BinaryResponse.js";
 
+// Pins the upstream Response so undici's FinalizationRegistry can't GC it and cancel the body stream.
+function retainResponse(target: object, response: Response): void {
+    Object.defineProperty(target, "__fern_response_ref", {
+        value: response,
+        enumerable: false,
+        configurable: true,
+        writable: false,
+    });
+}
+
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     switch (responseType) {
         case "binary-response":
@@ -19,6 +29,7 @@ export async function getResponseBody(response: Response, responseType?: string)
                     },
                 };
             }
+            retainResponse(response.body, response);
             return response.body;
         case "streaming":
             if (response.body == null) {
@@ -31,6 +42,7 @@ export async function getResponseBody(response: Response, responseType?: string)
                 };
             }
 
+            retainResponse(response.body, response);
             return response.body;
 
         case "text":

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/fetcher/getResponseBody.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/fetcher/getResponseBody.test.ts
@@ -73,6 +73,21 @@ describe("Test getResponseBody", () => {
         }
     });
 
+    it("should retain a reference to the parent Response for sse responses", async () => {
+        if (RUNTIME.type === "node") {
+            const mockStream = new ReadableStream();
+            const mockResponse = new Response(mockStream);
+            const result = (await getResponseBody(mockResponse, "sse")) as ReadableStream & {
+                __fern_response_ref?: Response;
+            };
+            // Pins the parent Response so undici's FinalizationRegistry can't GC it and cancel the stream.
+            expect(result.__fern_response_ref).toBe(mockResponse);
+            // The pin must be non-enumerable so it does not leak through JSON.stringify or Object.keys.
+            const descriptor = Object.getOwnPropertyDescriptor(result, "__fern_response_ref");
+            expect(descriptor?.enumerable).toBe(false);
+        }
+    });
+
     it("should handle streaming response type", async () => {
         const encoder = new TextEncoder();
         const testData = "test stream data";
@@ -93,5 +108,16 @@ describe("Test getResponseBody", () => {
         const { value } = await reader.read();
         const streamContent = decoder.decode(value);
         expect(streamContent).toBe(testData);
+    });
+
+    it("should retain a reference to the parent Response for streaming responses", async () => {
+        const mockStream = new ReadableStream();
+        const mockResponse = new Response(mockStream);
+        const result = (await getResponseBody(mockResponse, "streaming")) as ReadableStream & {
+            __fern_response_ref?: Response;
+        };
+        expect(result.__fern_response_ref).toBe(mockResponse);
+        const descriptor = Object.getOwnPropertyDescriptor(result, "__fern_response_ref");
+        expect(descriptor?.enumerable).toBe(false);
     });
 });

--- a/seed/ts-sdk/streaming/wrapper/.fern/metadata.json
+++ b/seed/ts-sdk/streaming/wrapper/.fern/metadata.json
@@ -1,7 +1,7 @@
 {
     "cliVersion": "DUMMY",
     "generatorName": "fernapi/fern-typescript-sdk",
-    "generatorVersion": "local",
+    "generatorVersion": "latest",
     "generatorConfig": {
         "streamType": "wrapper",
         "testFramework": "jest"
@@ -9,6 +9,6 @@
     "originGitCommit": "DUMMY",
     "invokedBy": "ci",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
+    "ciProvider": "unknown",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/streaming/wrapper/src/core/fetcher/getResponseBody.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/fetcher/getResponseBody.ts
@@ -3,6 +3,16 @@ import { getBinaryResponse } from "./BinaryResponse.js";
 
 import { chooseStreamWrapper } from "./stream-wrappers/chooseStreamWrapper.js";
 
+// Pins the upstream Response so undici's FinalizationRegistry can't GC it and cancel the body stream.
+function retainResponse(target: object, response: Response): void {
+    Object.defineProperty(target, "__fern_response_ref", {
+        value: response,
+        enumerable: false,
+        configurable: true,
+        writable: false,
+    });
+}
+
 export async function getResponseBody(response: Response, responseType?: string): Promise<unknown> {
     switch (responseType) {
         case "binary-response":
@@ -21,8 +31,9 @@ export async function getResponseBody(response: Response, responseType?: string)
                     },
                 };
             }
+            retainResponse(response.body, response);
             return response.body;
-        case "streaming":
+        case "streaming": {
             if (response.body == null) {
                 return {
                     ok: false,
@@ -33,7 +44,10 @@ export async function getResponseBody(response: Response, responseType?: string)
                 };
             }
 
-            return chooseStreamWrapper(response.body);
+            const wrapper = await chooseStreamWrapper(response.body);
+            retainResponse(wrapper, response);
+            return wrapper;
+        }
 
         case "text":
             return await response.text();

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/getResponseBody.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/getResponseBody.test.ts
@@ -75,6 +75,21 @@ describe("Test getResponseBody", () => {
         }
     });
 
+    it("should retain a reference to the parent Response for sse responses", async () => {
+        if (RUNTIME.type === "node") {
+            const mockStream = new ReadableStream();
+            const mockResponse = new Response(mockStream);
+            const result = (await getResponseBody(mockResponse, "sse")) as ReadableStream & {
+                __fern_response_ref?: Response;
+            };
+            // Pins the parent Response so undici's FinalizationRegistry can't GC it and cancel the stream.
+            expect(result.__fern_response_ref).toBe(mockResponse);
+            // The pin must be non-enumerable so it does not leak through JSON.stringify or Object.keys.
+            const descriptor = Object.getOwnPropertyDescriptor(result, "__fern_response_ref");
+            expect(descriptor?.enumerable).toBe(false);
+        }
+    });
+
     it("should handle streaming response type", async () => {
         if (RUNTIME.type === "node") {
             const mockStream = new ReadableStream();
@@ -82,6 +97,19 @@ describe("Test getResponseBody", () => {
             const result = await getResponseBody(mockResponse, "streaming");
             // need to reinstantiate string as a result of locked state in Readable Stream after registration with Response
             expect(JSON.stringify(result)).toBe(JSON.stringify(await chooseStreamWrapper(new ReadableStream())));
+        }
+    });
+
+    it("should retain a reference to the parent Response on the stream wrapper", async () => {
+        if (RUNTIME.type === "node") {
+            const mockStream = new ReadableStream();
+            const mockResponse = new Response(mockStream);
+            const result = (await getResponseBody(mockResponse, "streaming")) as object & {
+                __fern_response_ref?: Response;
+            };
+            expect(result.__fern_response_ref).toBe(mockResponse);
+            const descriptor = Object.getOwnPropertyDescriptor(result, "__fern_response_ref");
+            expect(descriptor?.enumerable).toBe(false);
         }
     });
 });


### PR DESCRIPTION
Closes FER-10830

## Summary

On Node 18+, streaming and SSE responses returned from generated TypeScript SDKs become unusable if held across an `await`. The fetcher's `getResponseBody` returned `response.body` (or a stream wrapper around it) without retaining a reference to the parent `Response`. Once V8 collected the orphaned `Response`, undici's `FinalizationRegistry` finalizer cancelled the body stream, causing later `new Response(stream)` calls to throw `TypeError: Response body object should not be disturbed or locked`.

Reported upstream by ElevenLabs: https://github.com/elevenlabs/elevenlabs-js/issues/400

## Fix

Attach the parent `Response` to the returned stream / wrapper as a non-enumerable `__fern_response_ref` property so it stays reachable for the lifetime of the body. Three branches affected: `sse`, `streaming` (raw), and `streaming` (wrapper).

```ts
// generators/typescript/utils/core-utilities/src/core/fetcher/getResponseBody.template.ts
function retainResponse(target: object, response: Response): void {
    Object.defineProperty(target, "__fern_response_ref", {
        value: response,
        enumerable: false,
        configurable: true,
        writable: false,
    });
}

case "streaming": {
    if (response.body == null) { ... }
    const wrapper = await chooseStreamWrapper(response.body);
    retainResponse(wrapper, response);
    return wrapper;
}
```

`enumerable: false` keeps the pin invisible to `JSON.stringify` / `Object.keys` and to the existing snapshot equality tests.

## Repro (from the upstream issue)

```ts
const stream = await el.textToSpeech.convert(/* ... */);
await new Promise((r) => setTimeout(r, 17_000)); // give V8 time to GC
const blob = await new Response(stream).blob(); // before: throws; after: works
```

## Test plan

- [x] Added regression tests in `getResponseBody.test.template.ts` for `sse` and both `streaming` variants — assert `result.__fern_response_ref === parentResponse` and `enumerable: false`.
- [x] `pnpm seed test --generator ts-sdk --fixture streaming --local --skip-scripts` — 3/3 passing (no-custom-config, serde-layer, wrapper). Generated diff is limited to `getResponseBody.ts` and `getResponseBody.test.ts` in the three streaming fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)