### PR TITLE
feat(cli-generator): generate README.md for GitHub output repositories

### DIFF
--- a/generators/cli/changes/unreleased/add-readme-generation.yml
+++ b/generators/cli/changes/unreleased/add-readme-generation.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Generate a README.md when the output target is a GitHub repository.
+    The README includes installation instructions, usage examples, and
+    authentication setup derived from the IR's auth schemes.
+  type: feat

--- a/generators/cli/src/__test__/generateReadme.test.ts
+++ b/generators/cli/src/__test__/generateReadme.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import type { DetectedAuthBinding } from "../detectAuth.js";
+import { renderReadme } from "../generateReadme.js";
+
+describe("renderReadme", () => {
+    const github = {
+        repoUrl: "https://github.com/acme/acme-cli",
+        version: "1.0.0"
+    };
+
+    it("renders a basic README with no auth bindings", () => {
+        const result = renderReadme({
+            binaryName: "acme",
+            authBindings: [],
+            github
+        });
+
+        expect(result).toContain("# acme");
+        expect(result).toContain("A command-line interface for the acme API.");
+        expect(result).toContain("cargo install --git https://github.com/acme/acme-cli");
+        expect(result).toContain("acme --help");
+        expect(result).toContain("releases page](https://github.com/acme/acme-cli/releases)");
+        expect(result).not.toContain("## Authentication");
+    });
+
+    it("includes an authentication section for bearer auth", () => {
+        const authBindings: DetectedAuthBinding[] = [
+            {
+                schemeName: "BearerAuth",
+                rustCall: '.auth(BearerAuth::new("BearerAuth").env("ACME_TOKEN"))',
+                placement: "root",
+                authTypeImport: "BearerAuth"
+            }
+        ];
+
+        const result = renderReadme({
+            binaryName: "acme",
+            authBindings,
+            github
+        });
+
+        expect(result).toContain("## Authentication");
+        expect(result).toContain("`ACME_TOKEN`");
+        expect(result).toContain('export ACME_TOKEN="your-token"');
+    });
+
+    it("includes an authentication section for header (API key) auth", () => {
+        const authBindings: DetectedAuthBinding[] = [
+            {
+                schemeName: "ApiKeyAuth",
+                rustCall: '.auth(ApiKeyAuth::new("ApiKeyAuth").env("ACME_API_KEY"))',
+                placement: "root",
+                authTypeImport: "ApiKeyAuth"
+            }
+        ];
+
+        const result = renderReadme({
+            binaryName: "acme",
+            authBindings,
+            github
+        });
+
+        expect(result).toContain("`ACME_API_KEY`");
+        expect(result).toContain('export ACME_API_KEY="your-token"');
+    });
+
+    it("includes an authentication section for basic auth with both credentials", () => {
+        const authBindings: DetectedAuthBinding[] = [
+            {
+                schemeName: "BasicAuth",
+                rustCall:
+                    '.auth_basic_scheme("BasicAuth", AuthCredentialSource::from_env("ACME_USERNAME"), AuthCredentialSource::from_env("ACME_PASSWORD"))',
+                placement: "binding",
+                authTypeImport: "AuthCredentialSource"
+            }
+        ];
+
+        const result = renderReadme({
+            binaryName: "acme",
+            authBindings,
+            github
+        });
+
+        expect(result).toContain("`ACME_USERNAME`");
+        expect(result).toContain("`ACME_PASSWORD`");
+        expect(result).toContain('export ACME_USERNAME="your-token"');
+    });
+
+    it("includes an authentication section for basic auth with password omitted", () => {
+        const authBindings: DetectedAuthBinding[] = [
+            {
+                schemeName: "ApiKeyAuth",
+                rustCall:
+                    '.auth_provider("ApiKeyAuth", BasicAuthProvider::username_only("ApiKeyAuth", AuthCredentialSource::from_env("CLOSE_API_KEY")))',
+                placement: "binding",
+                authTypeImport: "AuthCredentialSource, BasicAuthProvider"
+            }
+        ];
+
+        const result = renderReadme({
+            binaryName: "close",
+            authBindings,
+            github
+        });
+
+        expect(result).toContain("`CLOSE_API_KEY`");
+        expect(result).toContain('export CLOSE_API_KEY="your-token"');
+    });
+
+    it("lists multiple auth bindings", () => {
+        const authBindings: DetectedAuthBinding[] = [
+            {
+                schemeName: "ApiKeyAuth",
+                rustCall:
+                    '.auth_provider("ApiKeyAuth", BasicAuthProvider::username_only("ApiKeyAuth", AuthCredentialSource::from_env("CLOSE_API_KEY")))',
+                placement: "binding",
+                authTypeImport: "AuthCredentialSource, BasicAuthProvider"
+            },
+            {
+                schemeName: "OAuth2",
+                rustCall: '.auth(BearerAuth::new("OAuth2").env("CLOSE_TOKEN"))',
+                placement: "root",
+                authTypeImport: "BearerAuth"
+            }
+        ];
+
+        const result = renderReadme({
+            binaryName: "close",
+            authBindings,
+            github
+        });
+
+        expect(result).toContain("`CLOSE_API_KEY`");
+        expect(result).toContain("`CLOSE_TOKEN`");
+    });
+
+    it("uses the binary name in the usage section", () => {
+        const result = renderReadme({
+            binaryName: "my-custom-cli",
+            authBindings: [],
+            github: { repoUrl: "https://github.com/org/my-custom-cli", version: "2.0.0" }
+        });
+
+        expect(result).toContain("# my-custom-cli");
+        expect(result).toContain("my-custom-cli --help");
+        expect(result).toContain("cargo install --git https://github.com/org/my-custom-cli");
+    });
+});

--- a/generators/cli/src/__test__/runPipeline.test.ts
+++ b/generators/cli/src/__test__/runPipeline.test.ts
@@ -211,4 +211,78 @@ describe("runPipeline", () => {
         // The error came BEFORE any output got created.
         await expect(access(outputDir)).rejects.toThrow();
     });
+
+    it("generates README.md when github config is provided", async () => {
+        await stageSdkTemplate();
+        await stageSpecs([
+            { filename: "openapi0.json", body: { openapi: "3.0.0", info: { title: "Should Not Be Used" } } }
+        ]);
+
+        const outcome = await runPipeline({
+            outputDir,
+            customConfig: {},
+            ir: ir({ apiDisplayName: "My API" }),
+            sdkTemplateDir,
+            specsDir,
+            github: { repoUrl: "https://github.com/acme/my-api-cli", version: "1.0.0" }
+        });
+
+        expect(outcome).toEqual({ status: "generated", binaryName: "my-api" });
+
+        const readme = await readFile(path.join(outputDir, "README.md"), "utf-8");
+        expect(readme).toContain("# my-api");
+        expect(readme).toContain("cargo install --git https://github.com/acme/my-api-cli");
+        expect(readme).toContain("my-api --help");
+    });
+
+    it("generates README.md with auth section when github config and auth bindings are present", async () => {
+        await stageSdkTemplate();
+        await stageSpecs([{ filename: "openapi0.json", body: { openapi: "3.0.0" } }]);
+
+        const outcome = await runPipeline({
+            outputDir,
+            customConfig: { binaryName: "close" },
+            ir: ir({
+                apiDisplayName: "Close API",
+                auth: {
+                    schemes: [
+                        FernIr.AuthScheme.header({
+                            key: "ApiKeyAuth",
+                            name: "Authorization",
+                            valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
+                            headerEnvVar: "CLOSE_API_KEY",
+                            headerPlaceholder: undefined,
+                            prefix: undefined,
+                            docs: undefined
+                        })
+                    ]
+                }
+            }),
+            sdkTemplateDir,
+            specsDir,
+            github: { repoUrl: "https://github.com/closeio/close-cli", version: "1.0.0" }
+        });
+
+        expect(outcome).toEqual({ status: "generated", binaryName: "close" });
+
+        const readme = await readFile(path.join(outputDir, "README.md"), "utf-8");
+        expect(readme).toContain("## Authentication");
+        expect(readme).toContain("`CLOSE_API_KEY`");
+        expect(readme).toContain('export CLOSE_API_KEY="your-token"');
+    });
+
+    it("does not generate README.md when no github config is provided", async () => {
+        await stageSdkTemplate();
+        await stageSpecs([{ filename: "openapi0.json", body: { openapi: "3.0.0" } }]);
+
+        await runPipeline({
+            outputDir,
+            customConfig: {},
+            ir: ir({ apiDisplayName: "My API" }),
+            sdkTemplateDir,
+            specsDir
+        });
+
+        await expect(access(path.join(outputDir, "README.md"))).rejects.toThrow();
+    });
 });

--- a/generators/cli/src/cli.ts
+++ b/generators/cli/src/cli.ts
@@ -1,5 +1,6 @@
 import {
     ExitStatusUpdate,
+    FernGeneratorExec,
     GeneratorNotificationService,
     GeneratorUpdate,
     parseGeneratorConfig,
@@ -9,6 +10,7 @@ import {
     shouldTrackLocalVariablesInSentry
 } from "@fern-api/base-generator";
 import { getCustomConfig } from "./customConfig.js";
+import type { GithubInfo } from "./generateReadme.js";
 import { readIrSummary } from "./ir.js";
 import { runPipeline } from "./runPipeline.js";
 
@@ -45,10 +47,12 @@ async function generate(configPath: string): Promise<void> {
             );
 
             const ir = await readIrSummary(config.irFilepath);
+            const github = extractGithubInfo(config);
             const outcome = await runPipeline({
                 outputDir: config.output.path,
                 customConfig: getCustomConfig(config),
-                ir
+                ir,
+                github
             });
 
             if (outcome.status === "skipped") {
@@ -82,4 +86,16 @@ async function generate(configPath: string): Promise<void> {
         // Flush queued Sentry events before the process exits.
         await sentryClient?.flush();
     }
+}
+
+function extractGithubInfo(config: FernGeneratorExec.GeneratorConfig): GithubInfo | undefined {
+    return config.output.mode._visit<GithubInfo | undefined>({
+        publish: () => undefined,
+        downloadFiles: () => undefined,
+        github: (github) => ({
+            repoUrl: github.repoUrl,
+            version: github.version
+        }),
+        _other: () => undefined
+    });
 }

--- a/generators/cli/src/generateReadme.ts
+++ b/generators/cli/src/generateReadme.ts
@@ -1,0 +1,106 @@
+import { writeFile } from "fs/promises";
+import path from "path";
+import type { DetectedAuthBinding } from "./detectAuth.js";
+
+/**
+ * Minimal info extracted from the generator config's GitHub output mode.
+ * Kept narrow so the pipeline doesn't depend on the full GeneratorConfig type.
+ */
+export interface GithubInfo {
+    repoUrl: string;
+    version: string;
+}
+
+/**
+ * Write a README.md into `outputDir` documenting the generated CLI binary.
+ *
+ * The README is intentionally concise — it tells the user what the CLI
+ * does, how to install it, how to authenticate, and where to find more
+ * help. It's only generated when the output target is a GitHub repository,
+ * since that's the context where a README provides the most value.
+ */
+export async function generateReadme(args: {
+    outputDir: string;
+    binaryName: string;
+    authBindings: DetectedAuthBinding[];
+    github: GithubInfo;
+}): Promise<void> {
+    const content = renderReadme(args);
+    await writeFile(path.join(args.outputDir, "README.md"), content);
+}
+
+export function renderReadme(args: {
+    binaryName: string;
+    authBindings: DetectedAuthBinding[];
+    github: GithubInfo;
+}): string {
+    const { binaryName, authBindings, github } = args;
+    const lines: string[] = [];
+
+    lines.push(`# ${binaryName}`);
+    lines.push("");
+    lines.push(`A command-line interface for the ${binaryName} API.`);
+    lines.push("");
+
+    // Installation
+    lines.push("## Installation");
+    lines.push("");
+    lines.push("### From GitHub Releases");
+    lines.push("");
+    lines.push(`Download the latest release for your platform from the [releases page](${github.repoUrl}/releases).`);
+    lines.push("");
+    lines.push("### From source");
+    lines.push("");
+    lines.push("```bash");
+    lines.push(`cargo install --git ${github.repoUrl}`);
+    lines.push("```");
+    lines.push("");
+
+    // Usage
+    lines.push("## Usage");
+    lines.push("");
+    lines.push("```bash");
+    lines.push(`${binaryName} --help`);
+    lines.push("```");
+    lines.push("");
+
+    // Authentication
+    if (authBindings.length > 0) {
+        lines.push("## Authentication");
+        lines.push("");
+        lines.push("Set the following environment variable(s) to authenticate:");
+        lines.push("");
+        for (const binding of authBindings) {
+            const envVars = extractEnvVars(binding);
+            for (const envVar of envVars) {
+                lines.push(`- \`${envVar}\``);
+            }
+        }
+        lines.push("");
+        lines.push("For example:");
+        lines.push("");
+        const firstEnvVar = extractEnvVars(authBindings[0]!)[0];
+        lines.push("```bash");
+        lines.push(`export ${firstEnvVar}="your-token"`);
+        lines.push(`${binaryName} --help`);
+        lines.push("```");
+        lines.push("");
+    }
+
+    return lines.join("\n");
+}
+
+/**
+ * Extract environment variable names from a detected auth binding's
+ * Rust call string. The env vars appear as string literals inside
+ * `from_env("...")` or `.env("...")` calls.
+ */
+function extractEnvVars(binding: DetectedAuthBinding): string[] {
+    const envVarPattern = /(?:from_env|\.env)\("([^"]+)"\)/g;
+    const envVars: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = envVarPattern.exec(binding.rustCall)) !== null) {
+        envVars.push(match[1]!);
+    }
+    return envVars;
+}

--- a/generators/cli/src/generateReadme.ts
+++ b/generators/cli/src/generateReadme.ts
@@ -79,12 +79,15 @@ export function renderReadme(args: {
         lines.push("");
         lines.push("For example:");
         lines.push("");
-        const firstEnvVar = extractEnvVars(authBindings[0]!)[0];
-        lines.push("```bash");
-        lines.push(`export ${firstEnvVar}="your-token"`);
-        lines.push(`${binaryName} --help`);
-        lines.push("```");
-        lines.push("");
+        const firstBinding = authBindings[0];
+        const firstEnvVar = firstBinding != null ? extractEnvVars(firstBinding)[0] : undefined;
+        if (firstEnvVar != null) {
+            lines.push("```bash");
+            lines.push(`export ${firstEnvVar}="your-token"`);
+            lines.push(`${binaryName} --help`);
+            lines.push("```");
+            lines.push("");
+        }
     }
 
     return lines.join("\n");
@@ -100,7 +103,10 @@ function extractEnvVars(binding: DetectedAuthBinding): string[] {
     const envVars: string[] = [];
     let match: RegExpExecArray | null;
     while ((match = envVarPattern.exec(binding.rustCall)) !== null) {
-        envVars.push(match[1]!);
+        const captured = match[1];
+        if (captured != null) {
+            envVars.push(captured);
+        }
     }
     return envVars;
 }

--- a/generators/cli/src/index.ts
+++ b/generators/cli/src/index.ts
@@ -10,6 +10,7 @@ export {
 } from "./copySpecs.js";
 export { type FernCliCustomConfig, getCustomConfig } from "./customConfig.js";
 export { type DetectedAuthBinding, detectAuthBindings } from "./detectAuth.js";
+export { type GithubInfo, generateReadme, renderReadme } from "./generateReadme.js";
 export { deriveBinaryName, TEMPLATE_BINARY_NAME, toEnvVarPrefix, toKebabCase } from "./identity.js";
 export { type IrSummary, readIrSummary } from "./ir.js";
 export { applyCargoTomlPatch, patchCargoToml } from "./patchCargoToml.js";

--- a/generators/cli/src/runPipeline.ts
+++ b/generators/cli/src/runPipeline.ts
@@ -3,6 +3,7 @@ import { copySdk, SDK_TEMPLATE_DIRECTORY } from "./copySdk.js";
 import { copySpecs, hasOpenApiSpecs } from "./copySpecs.js";
 import type { FernCliCustomConfig } from "./customConfig.js";
 import { detectAuthBindings } from "./detectAuth.js";
+import { type GithubInfo, generateReadme } from "./generateReadme.js";
 import { deriveBinaryName } from "./identity.js";
 import type { IrSummary } from "./ir.js";
 import { patchCargoToml } from "./patchCargoToml.js";
@@ -32,8 +33,9 @@ export async function runPipeline(args: {
     ir: IrSummary;
     sdkTemplateDir?: string;
     specsDir?: string;
+    github?: GithubInfo;
 }): Promise<PipelineOutcome> {
-    const { outputDir, customConfig, ir, sdkTemplateDir, specsDir } = args;
+    const { outputDir, customConfig, ir, sdkTemplateDir, specsDir, github } = args;
 
     if (!(await hasOpenApiSpecs(specsDir))) {
         return { status: "skipped", reason: "no-openapi-specs" };
@@ -60,6 +62,10 @@ export async function runPipeline(args: {
     await patchCargoToml({ outputDir, binaryName });
     await patchDistWorkspaceToml({ outputDir });
     await copySpecs({ outputDir, binaryName, authBindings, specsDir });
+
+    if (github != null) {
+        await generateReadme({ outputDir, binaryName, authBindings, github });
+    }
 
     return { status: "generated", binaryName };
 }


### PR DESCRIPTION
## Description

When the `fernapi/fern-cli` generator targets a GitHub output repository, no `README.md` was included in the generated output. This PR adds README generation so that users get a useful README in their CLI repository.

## Changes Made

- Added `src/generateReadme.ts` — renders a README template with:
  - Title and description using the derived binary name
  - Installation instructions (GitHub Releases + `cargo install --git`)
  - Usage section (`<binary> --help`)
  - Authentication section listing required environment variables (derived from the IR's auth bindings)
- Updated `src/runPipeline.ts` to accept an optional `github` parameter and call `generateReadme` when present
- Updated `src/cli.ts` to extract GitHub info from `config.output.mode` using exhaustive `_visit` dispatch and pass it to the pipeline
- Exported `GithubInfo`, `generateReadme`, and `renderReadme` from `src/index.ts`
- [x] Updated README.md generator (if applicable)

## Testing

- [x] Unit tests added/updated
  - `generateReadme.test.ts`: 7 tests covering no-auth, bearer, header (API key), basic auth (both, password-omitted), multiple bindings, and custom binary names
  - `runPipeline.test.ts`: 3 new integration tests verifying README is generated with GitHub config, README includes auth section, and README is **not** generated without GitHub config
- [x] All 82 tests pass across 10 test files
- [x] TypeScript compilation clean (`pnpm turbo run compile --filter @fern-api/cli-generator`)
- [x] Formatting clean (`pnpm format`)


Link to Devin session: https://app.devin.ai/sessions/f4ec2ef3a2394d6e9df15ce434417f39
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->