### PR TITLE
feat(cli): gate CLI generator usage with org-level cliGeneratorsEnabled flag

### DIFF
--- a/packages/cli/cli/changes/unreleased/gate-cli-generators-enabled.yml
+++ b/packages/cli/cli/changes/unreleased/gate-cli-generators-enabled.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Gate CLI generator usage with an org-level `cliGeneratorsEnabled` flag from Venus.
+    When the flag is explicitly `false`, generation is blocked with an actionable error message.
+    This is forward-compatible — existing organizations without the flag are unaffected.
+  type: feat

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -214,6 +214,15 @@ export async function runLocalGenerationForWorkspace({
                 }
 
                 if (organization.ok) {
+                    if (isCliGenerationDisabled(organization.body)) {
+                        interactiveTaskContext.failWithoutThrowing(
+                            "CLI generator usage is not enabled for your organization. " +
+                                "Please contact support or your organization admin to enable this feature.",
+                            undefined,
+                            { code: CliError.Code.ConfigError }
+                        );
+                        return;
+                    }
                     if (organization.body.isWhitelabled) {
                         if (intermediateRepresentation.readmeConfig == null) {
                             intermediateRepresentation.readmeConfig = emptyReadmeConfig;
@@ -830,4 +839,15 @@ function getSelfhostedGithubConfig(
         };
     }
     return undefined;
+}
+
+/**
+ * Checks if CLI generation is disabled for the organization.
+ * Forward-compatible with the `cliGeneratorsEnabled` field that Venus will add to
+ * the Organization response. The SDK's passthrough deserialization preserves it at runtime.
+ * Only gates when the property is explicitly `false`; absent/undefined means allowed.
+ */
+function isCliGenerationDisabled(org: FernVenusApi.Organization): boolean {
+    const extended = org as FernVenusApi.Organization & { cliGeneratorsEnabled?: boolean };
+    return extended.cliGeneratorsEnabled === false;
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -20,6 +20,7 @@ import { getOriginalName } from "@fern-api/ir-utils";
 import { detectAirGappedMode } from "@fern-api/lazy-fern-workspace";
 import { convertIrToFdrApi } from "@fern-api/register";
 import { CliError, InteractiveTaskContext } from "@fern-api/task-context";
+import type { FernVenusApi } from "@fern-api/venus-api-sdk";
 import { FernWorkspace, IdentifiableSource } from "@fern-api/workspace-loader";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
 import { createAndStartJob } from "./createAndStartJob.js";
@@ -197,6 +198,14 @@ export async function runRemoteGenerationForGenerator({
         const orgResponse = await venus.organization.get(projectConfig.organization);
 
         if (orgResponse.ok) {
+            if (isCliGenerationDisabled(orgResponse.body)) {
+                interactiveTaskContext.failAndThrow(
+                    "CLI generator usage is not enabled for your organization. " +
+                        "Please contact support or your organization admin to enable this feature.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
+                );
+            }
             if (orgResponse.body.isWhitelabled) {
                 if (ir.readmeConfig == null) {
                     ir.readmeConfig = emptyReadmeConfig;
@@ -577,4 +586,15 @@ export function resolveVersionFallback(resolvedVersion: string | undefined): str
         return undefined;
     }
     return resolvedVersion;
+}
+
+/**
+ * Checks if CLI generation is disabled for the organization.
+ * Forward-compatible with the `cliGeneratorsEnabled` field that Venus will add to
+ * the Organization response. The SDK's passthrough deserialization preserves it at runtime.
+ * Only gates when the property is explicitly `false`; absent/undefined means allowed.
+ */
+function isCliGenerationDisabled(org: FernVenusApi.Organization): boolean {
+    const extended = org as FernVenusApi.Organization & { cliGeneratorsEnabled?: boolean };
+    return extended.cliGeneratorsEnabled === false;
 }


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-10833

Wire up a forward-compatible check for the Venus `cliGeneratorsEnabled` org property. When Venus starts returning this field and it is explicitly `false`, generation (both local and remote) is blocked with a clear error message.

This is a **no-op today** — Venus does not yet serve the `cliGeneratorsEnabled` property. But once Venus adds the field to the `Organization` response, this code will activate automatically because:
1. The Venus SDK deserializes responses with `unrecognizedObjectKeys: "passthrough"`, preserving extra properties at runtime
2. The check only gates when the property is explicitly `false`; absent/undefined means allowed (backwards compatible)

## Changes Made
- Added `isCliGenerationDisabled()` type guard in both local and remote generation paths
- Blocks generation with `ConfigError` and an actionable error message when the flag is `false`
- Added CLI changelog entry
- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [x] Compiled both `@fern-api/local-workspace-runner` and `@fern-api/remote-workspace-runner` successfully
- [x] Formatting checks pass
- The check is forward-compatible: no existing behavior changes until Venus adds the field


Link to Devin session: https://app.devin.ai/sessions/b931b1e2c1b24883a62ad7b37fd78b60
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->