### PR TITLE
fix(cli): prevent YAML 1.1 date coercion when parsing docs.yml

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-yaml-date-coercion-docs-yml.yml
+++ b/packages/cli/cli/changes/unreleased/fix-yaml-date-coercion-docs-yml.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix docs.yml parsing failure when values like repo names resemble dates (e.g. `2026-05-26`).
+    YAML 1.1 auto-converts date-like strings into Date objects; the parser now uses JSON_SCHEMA
+    to prevent this coercion.
+  type: fix

--- a/packages/cli/workspace/loader/src/__test__/loadDocsWorkspace.test.ts
+++ b/packages/cli/workspace/loader/src/__test__/loadDocsWorkspace.test.ts
@@ -7,6 +7,45 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { loadRawDocsConfiguration } from "../loadDocsWorkspace.js";
 
+describe("loadRawDocsConfiguration — YAML date coercion", () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), "fern-docs-yml-test-"));
+    });
+
+    afterEach(async () => {
+        await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    async function writeDocsYml(contents: string): Promise<AbsoluteFilePath> {
+        const docsYmlPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(docsYmlPath, contents);
+        return docsYmlPath;
+    }
+
+    it("parses date-like repo names as strings, not Date objects", async () => {
+        const docsYmlPath = await writeDocsYml(
+            [
+                "instances:",
+                "  - url: acme.docs.buildwithfern.com",
+                "    edit-this-page:",
+                "      github:",
+                "        owner: my-org",
+                "        repo: 2026-05-26",
+                "        branch: main"
+            ].join("\n")
+        );
+        const result = await loadRawDocsConfiguration({
+            absolutePathOfConfiguration: docsYmlPath,
+            context: createMockTaskContext()
+        });
+        const editThisPage = result.instances[0]?.editThisPage;
+        expect(editThisPage?.github?.repo).toBe("2026-05-26");
+        expect(typeof editThisPage?.github?.repo).toBe("string");
+    });
+});
+
 describe("loadRawDocsConfiguration — translation locales", () => {
     let tmpDir: string;
 

--- a/packages/cli/workspace/loader/src/loadDocsWorkspace.ts
+++ b/packages/cli/workspace/loader/src/loadDocsWorkspace.ts
@@ -67,7 +67,7 @@ export async function loadRawDocsConfiguration({
     const contentsStr = await readFile(absolutePathOfConfiguration);
     let contentsJson: unknown;
     try {
-        contentsJson = yaml.load(contentsStr.toString());
+        contentsJson = yaml.load(contentsStr.toString(), { schema: yaml.JSON_SCHEMA });
     } catch (error) {
         if (!(error instanceof yaml.YAMLException)) {
             throw error;


### PR DESCRIPTION
## Description

Fixes a `docs.yml` parsing failure when string values resemble ISO dates (e.g. a repo named `2026-05-26`).

YAML 1.1's default schema auto-converts patterns like `2026-05-26` into JavaScript `Date` objects. When the dashboard writes `repo: 2026-05-26` to `docs.yml`, the CLI's `js-yaml` parser produces a `Date` object instead of a string, causing the JSON schema validator to reject it with:

```
Incorrect type at path $.instances[0].edit-this-page.github.repo: expected string but received object
```

## Changes Made

- Switch `yaml.load()` in `loadRawDocsConfiguration` to use `yaml.JSON_SCHEMA`, which only recognizes JSON-compatible types (string, number, boolean, null) and prevents date coercion. This matches the existing precedent in `uploadDocsTheme.ts`.
- Add a regression test that verifies date-like repo names (`2026-05-26`) are parsed as strings.
- Add unreleased changelog entry (`fix`).

## Testing

- [x] Unit tests added/updated — new test in `loadDocsWorkspace.test.ts`
- [x] All 11 tests in `@fern-api/workspace-loader` pass
- [x] `pnpm run check` (biome lint) passes

Link to Devin session: https://app.devin.ai/sessions/3fea598da65f49ec805cf5a45f33fc87
Requested by: @pgragg