### PR TITLE
fix(cli): bump fern-typescript-sdk init fallback to 3.71.2

### DIFF
--- a/packages/cli/cli/changes/unreleased/bump-typescript-sdk-fallback.yml
+++ b/packages/cli/cli/changes/unreleased/bump-typescript-sdk-fallback.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump the `fern init` fallback version for `fern-typescript-sdk` / `fern-typescript-node-sdk` from `2.3.2` to `3.71.2`.
+    The `2.3.2` container runs Node 20 and started failing `yarn install` after `mute-stream@4.0.0` (Node ≥22) was published as a transitive dep. The fallback only triggers when FDR cannot resolve a compatible generator version, so released CLIs are unaffected — this restores a working default for fresh `fern init` and for dev builds.
+  type: fix

--- a/packages/cli/configuration-loader/src/generators-yml/generatorInvocations.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/generatorInvocations.ts
@@ -34,14 +34,14 @@ export const GENERATOR_INVOCATIONS: Record<GeneratorName, Omit<generatorsYml.Gen
         version: "0.0.247"
     },
     [GeneratorName.TYPESCRIPT_SDK]: {
-        version: "2.3.2",
+        version: "3.71.2",
         output: {
             location: "local-file-system",
             path: "../sdks/typescript"
         }
     },
     [GeneratorName.TYPESCRIPT_NODE_SDK]: {
-        version: "2.3.2",
+        version: "3.71.2",
         output: {
             location: "local-file-system",
             path: "../sdks/typescript"

--- a/packages/cli/ete-tests/src/tests/add/__snapshots__/add.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/add/__snapshots__/add.test.ts.snap
@@ -32,7 +32,7 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 2.3.2
+        version: 3.71.2
   typescript:
     generators:
       - name: fern-typescript

--- a/packages/cli/ete-tests/src/tests/generators-get/__snapshots__/generators-get.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/generators-get/__snapshots__/generators-get.test.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`fern generator get > fern generator get --language 1`] = `"typescript"`;
 
-exports[`fern generator get > fern generator get --version 1`] = `"2.3.2"`;
+exports[`fern generator get > fern generator get --version 1`] = `"3.71.2"`;
 
 exports[`fern generator get > fern generator get to file 1`] = `
 "{
-  "version": "2.3.2",
+  "version": "3.71.2",
   "language": "typescript"
 }"
 `;

--- a/packages/cli/ete-tests/src/tests/init/__snapshots__/init.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/init/__snapshots__/init.test.ts.snap
@@ -125,7 +125,7 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 2.3.2
+        version: 3.71.2
 ",
         "name": "generators.yml",
         "type": "file",
@@ -221,7 +221,7 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 2.3.2
+        version: 3.71.2
 ",
         "name": "generators.yml",
         "type": "file",
@@ -381,7 +381,7 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 2.3.2
+        version: 3.71.2
 ",
     "name": "generators.yml",
     "type": "file",
@@ -632,7 +632,7 @@ groups:
         output:
           location: local-file-system
           path: ../sdks/typescript
-        version: 2.3.2
+        version: 3.71.2
 ",
     "name": "generators.yml",
     "type": "file",


### PR DESCRIPTION
## Summary
- `fern init`'s fallback generator version for `fern-typescript-sdk` / `fern-typescript-node-sdk` is bumped from `2.3.2` → `3.71.2`.
- The `2.3.2` Docker image runs Node 20.18.3 and now fails its post-generation `yarn install` because `mute-stream@4.0.0` (a transitive dep) was published with `engines.node >= ^22.22.2 || ^24.15.0 || >=26.0.0`. All current 3.x generator images already run on Node 24 (see #15827), so they don't hit this.
- The fallback only triggers when FDR can't resolve a compatible generator version for the running CLI (e.g. dev builds reporting version `0.0.0` in CI), so released CLIs in the wild are not affected by this change. This fixes 4 currently-failing `test-ete` tests (`fernignore.test.ts`, `generate.test.ts > default api`, `output-directory-prompts.test.ts`).

## Test plan
- [ ] `test-ete` passes (previously failing tests should now go green)
- [ ] Spot-check `fern init` with this CLI build still produces a valid `generators.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->