### PR TITLE
fix(cli): restore overlay test fixture to fix seed snapshot failures

### DIFF
--- a/generators/cli/sdk/src/openapi/__fixtures__/openapi.json
+++ b/generators/cli/sdk/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/generators/cli/sdk/src/openapi/overlay.rs
+++ b/generators/cli/sdk/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/allof-inline/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/allof-inline/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/allof-inline/src/openapi/overlay.rs
+++ b/seed/cli/allof-inline/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/allof/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/allof/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/allof/src/openapi/overlay.rs
+++ b/seed/cli/allof/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/api-wide-base-path-with-default/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/api-wide-base-path-with-default/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/api-wide-base-path-with-default/src/openapi/overlay.rs
+++ b/seed/cli/api-wide-base-path-with-default/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/openapi/overlay.rs
+++ b/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/cli-multi-spec/no-custom-config/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/cli-multi-spec/no-custom-config/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/cli-multi-spec/no-custom-config/src/openapi/overlay.rs
+++ b/seed/cli/cli-multi-spec/no-custom-config/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/file-upload-openapi/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/file-upload-openapi/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/file-upload-openapi/src/openapi/overlay.rs
+++ b/seed/cli/file-upload-openapi/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/imdb/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/imdb/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/imdb/src/openapi/overlay.rs
+++ b/seed/cli/imdb/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/multi-url-environment-reference/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/multi-url-environment-reference/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/multi-url-environment-reference/src/openapi/overlay.rs
+++ b/seed/cli/multi-url-environment-reference/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/no-content-response/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/no-content-response/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/no-content-response/src/openapi/overlay.rs
+++ b/seed/cli/no-content-response/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/null-type/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/null-type/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/null-type/src/openapi/overlay.rs
+++ b/seed/cli/null-type/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/nullable-allof-extends/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/nullable-allof-extends/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/nullable-allof-extends/src/openapi/overlay.rs
+++ b/seed/cli/nullable-allof-extends/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/nullable-request-body/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/nullable-request-body/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/nullable-request-body/src/openapi/overlay.rs
+++ b/seed/cli/nullable-request-body/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/oauth-client-credentials-openapi/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/oauth-client-credentials-openapi/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/oauth-client-credentials-openapi/src/openapi/overlay.rs
+++ b/seed/cli/oauth-client-credentials-openapi/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/openapi-request-body-ref/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/openapi-request-body-ref/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/openapi-request-body-ref/src/openapi/overlay.rs
+++ b/seed/cli/openapi-request-body-ref/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/query-param-name-conflict/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/query-param-name-conflict/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/query-param-name-conflict/src/openapi/overlay.rs
+++ b/seed/cli/query-param-name-conflict/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/query-parameters-openapi-as-objects/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/query-parameters-openapi-as-objects/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/query-parameters-openapi-as-objects/src/openapi/overlay.rs
+++ b/seed/cli/query-parameters-openapi-as-objects/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/query-parameters-openapi/no-custom-config/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/query-parameters-openapi/no-custom-config/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/query-parameters-openapi/no-custom-config/src/openapi/overlay.rs
+++ b/seed/cli/query-parameters-openapi/no-custom-config/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/schemaless-request-body-examples/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/schemaless-request-body-examples/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/schemaless-request-body-examples/src/openapi/overlay.rs
+++ b/seed/cli/schemaless-request-body-examples/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/server-sent-events-openapi/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/server-sent-events-openapi/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/server-sent-events-openapi/src/openapi/overlay.rs
+++ b/seed/cli/server-sent-events-openapi/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/server-url-templating/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/server-url-templating/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/server-url-templating/src/openapi/overlay.rs
+++ b/seed/cli/server-url-templating/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/url-form-encoded/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/url-form-encoded/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/url-form-encoded/src/openapi/overlay.rs
+++ b/seed/cli/url-form-encoded/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/webhook-audience/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/webhook-audience/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/webhook-audience/src/openapi/overlay.rs
+++ b/seed/cli/webhook-audience/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:

--- a/seed/cli/x-fern-default/src/openapi/__fixtures__/openapi.json
+++ b/seed/cli/x-fern-default/src/openapi/__fixtures__/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test Fixture API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "x-fern-sdk-group-name": ["users"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "users_list",
+        "summary": "List users",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "get",
+        "operationId": "files_get",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "patch": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "update",
+        "operationId": "files_update",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/files/{file_id}/thumbnail": {
+      "get": {
+        "x-fern-sdk-group-name": ["files"],
+        "x-fern-sdk-method-name": "getThumbnail",
+        "operationId": "files_getThumbnail",
+        "parameters": [
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/folders": {
+      "get": {
+        "x-fern-sdk-group-name": ["folders"],
+        "x-fern-sdk-method-name": "list",
+        "operationId": "folders_list",
+        "summary": "List folders",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    }
+  }
+}

--- a/seed/cli/x-fern-default/src/openapi/overlay.rs
+++ b/seed/cli/x-fern-default/src/openapi/overlay.rs
@@ -1832,7 +1832,7 @@ actions:
 
     #[test]
     fn test_overlay_on_fixture_spec() {
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:
@@ -1891,7 +1891,7 @@ actions:
     fn test_overlay_on_fixture_spec_builds_cli_app() {
         use crate::openapi::CliApp;
 
-        let spec = include_str!("../../cli/openapi-fixture/openapi.yaml");
+        let spec = include_str!("__fixtures__/openapi.json");
         let overlay = r#"
 overlay: "1.0.0"
 info:


### PR DESCRIPTION
## Description

Fixes CLI seed snapshot test failures that have been occurring since commit 8c3588d9d (#16056, May 22).

## Changes Made

- Restored `src/openapi/__fixtures__/openapi.json` fixture file that ships with generated output
- Changed `include_str!` references in `overlay.rs` tests from `"../../cli/openapi-fixture/openapi.yaml"` (excluded via `SDK_IGNORE`) back to `"__fixtures__/openapi.json"` (included in generated output)
- Updated all 23 seed snapshot `overlay.rs` files and added the `__fixtures__/openapi.json` fixture to each

**Root cause:** PR #16056 changed the overlay integration tests to reference the template dev fixture (`cli/openapi-fixture/openapi.yaml`) which is intentionally excluded from generated output via `SDK_IGNORE` in `build.mjs`. When seed tests run `cargo build --locked --all-features --tests` on the generated output, Rust's `include_str!` macro fails with "No such file or directory" because the referenced file doesn't exist in the output tree.

The original design (documented in `build.mjs` comments) was for overlay tests to reference the smaller `__fixtures__/openapi.json` fixture that IS shipped with the generated output. This PR restores that design.

## Testing

- Verified fixture file exists at the correct relative path for `include_str!` resolution
- Updated all seed snapshot files to match the new generator output
- The `__fixtures__/openapi.json` fixture includes all paths/groups required by both overlay integration tests (`users`, `files` with `get`/`update`/`getThumbnail`, `folders`)

Link to Devin session: https://app.devin.ai/sessions/463167a4b711497096527a7c8a2099f2
Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->