### PR TITLE
fix(cli): add openapi/asyncapi paths to link validator whitelist

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-openapi-link-validation.yml
+++ b/packages/cli/cli/changes/unreleased/fix-openapi-link-validation.yml
@@ -1,5 +1,5 @@
 - summary: |
     Add /openapi.json, /openapi.yaml, /openapi.yml, /asyncapi.json, /asyncapi.yaml, and /asyncapi.yml
-    to the link validator whitelist so `fern check` no longer reports false broken-link errors for these
-    special doc pages.
+    to the link validator whitelist, and add pattern-based matching for dynamic API spec paths like
+    /openapi/<id>.json so `fern check` no longer reports false broken-link errors for these special doc pages.
   type: fix

--- a/packages/cli/cli/changes/unreleased/fix-openapi-link-validation.yml
+++ b/packages/cli/cli/changes/unreleased/fix-openapi-link-validation.yml
@@ -1,5 +1,5 @@
 - summary: |
     Add /openapi.json, /openapi.yaml, /openapi.yml, /asyncapi.json, /asyncapi.yaml, and /asyncapi.yml
     to the link validator whitelist, and add pattern-based matching for dynamic API spec paths like
-    /openapi/<id>.json so `fern check` no longer reports false broken-link errors for these special doc pages.
+    /openapi/`<id>`.json so `fern check` no longer reports false broken-link errors for these special doc pages.
   type: fix

--- a/packages/cli/cli/changes/unreleased/fix-openapi-link-validation.yml
+++ b/packages/cli/cli/changes/unreleased/fix-openapi-link-validation.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Add /openapi.json, /openapi.yaml, /openapi.yml, /asyncapi.json, /asyncapi.yaml, and /asyncapi.yml
+    to the link validator whitelist so `fern check` no longer reports false broken-link errors for these
+    special doc pages.
+  type: fix

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/__test__/check-if-pathname-exists.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/__test__/check-if-pathname-exists.test.ts
@@ -38,7 +38,9 @@ describe("specialDocPages slug registration", () => {
         for (const page of specialDocPages) {
             const prefixed = withBasePathPrepended(page, basePath);
             expect(prefixed).not.toBeNull();
-            expect(visitableSlugs.has(prefixed!)).toBe(true);
+            if (prefixed != null) {
+                expect(visitableSlugs.has(prefixed)).toBe(true);
+            }
         }
     });
 });

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/__test__/check-if-pathname-exists.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/__test__/check-if-pathname-exists.test.ts
@@ -2,6 +2,47 @@ import { describe, expect, it } from "vitest";
 
 import { withBasePathPrepended } from "../with-base-path-prepended.js";
 
+describe("specialDocPages slug registration", () => {
+    const specialDocPages = [
+        "/llms-full.txt",
+        "/llms.txt",
+        "/openapi.json",
+        "/openapi.yaml",
+        "/openapi.yml",
+        "/asyncapi.json",
+        "/asyncapi.yaml",
+        "/asyncapi.yml"
+    ];
+
+    function stripLeadingSlash(s: string): string {
+        return s.startsWith("/") ? s.slice(1) : s;
+    }
+
+    it("all special pages produce valid slugs without basePath", () => {
+        const visitableSlugs = new Set<string>();
+        for (const page of specialDocPages) {
+            visitableSlugs.add(stripLeadingSlash(page));
+        }
+        for (const page of specialDocPages) {
+            expect(visitableSlugs.has(stripLeadingSlash(page))).toBe(true);
+        }
+    });
+
+    it("all special pages produce valid slugs with basePath", () => {
+        const basePath = "/docs";
+        const visitableSlugs = new Set<string>();
+        for (const page of specialDocPages) {
+            const pageWithBasePath = `${stripLeadingSlash(basePath)}${page}`;
+            visitableSlugs.add(pageWithBasePath);
+        }
+        for (const page of specialDocPages) {
+            const prefixed = withBasePathPrepended(page, basePath);
+            expect(prefixed).not.toBeNull();
+            expect(visitableSlugs.has(prefixed!)).toBe(true);
+        }
+    });
+});
+
 describe("withBasePathPrepended", () => {
     it("returns null when no basePath is configured", () => {
         expect(withBasePathPrepended("/about", undefined)).toBeNull();

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/__test__/check-if-pathname-exists.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/__test__/check-if-pathname-exists.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { isDynamicSpecialDocPage } from "../dynamic-special-doc-page.js";
 import { withBasePathPrepended } from "../with-base-path-prepended.js";
 
 describe("specialDocPages slug registration", () => {
@@ -84,5 +85,43 @@ describe("withBasePathPrepended", () => {
         // `docs-v2/about` must not match `docs/...` — the basePath segment must be
         // followed by `/` to be considered already-prefixed.
         expect(withBasePathPrepended("/docs-v2/about", "/docs")).toBe("docs/docs-v2/about");
+    });
+});
+
+describe("isDynamicSpecialDocPage", () => {
+    it("matches /openapi/<id>.json", () => {
+        expect(isDynamicSpecialDocPage("/openapi/51d85717-e70a-4282-b075-66851cd0af2b.json")).toBe(true);
+    });
+
+    it("matches /openapi/<id>.yaml and .yml", () => {
+        expect(isDynamicSpecialDocPage("/openapi/my-spec.yaml")).toBe(true);
+        expect(isDynamicSpecialDocPage("/openapi/my-spec.yml")).toBe(true);
+    });
+
+    it("matches /asyncapi/<id>.json", () => {
+        expect(isDynamicSpecialDocPage("/asyncapi/abc123.json")).toBe(true);
+    });
+
+    it("matches /asyncapi/<id>.yaml and .yml", () => {
+        expect(isDynamicSpecialDocPage("/asyncapi/abc123.yaml")).toBe(true);
+        expect(isDynamicSpecialDocPage("/asyncapi/abc123.yml")).toBe(true);
+    });
+
+    it("does not match bare /openapi.json (handled by static whitelist)", () => {
+        expect(isDynamicSpecialDocPage("/openapi.json")).toBe(false);
+    });
+
+    it("does not match unrelated paths", () => {
+        expect(isDynamicSpecialDocPage("/docs/about")).toBe(false);
+        expect(isDynamicSpecialDocPage("/api/v1/users.json")).toBe(false);
+    });
+
+    it("matches with basePath prefix", () => {
+        expect(isDynamicSpecialDocPage("/docs/openapi/spec-id.json", "/docs")).toBe(true);
+        expect(isDynamicSpecialDocPage("/docs/asyncapi/spec-id.yaml", "/docs")).toBe(true);
+    });
+
+    it("does not match basePath-prefixed path when inner path is invalid", () => {
+        expect(isDynamicSpecialDocPage("/docs/other/file.json", "/docs")).toBe(false);
     });
 });

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts
@@ -1,6 +1,7 @@
 import { wrapWithHttps } from "@fern-api/docs-resolver";
 import { AbsoluteFilePath, dirname, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 
+import { isDynamicSpecialDocPage } from "./dynamic-special-doc-page.js";
 import { getRedirectForPath } from "./redirect-for-path.js";
 import { addLeadingSlash, removeLeadingSlash, removeTrailingSlash } from "./url-utils.js";
 import { withBasePathPrepended } from "./with-base-path-prepended.js";
@@ -71,6 +72,10 @@ export async function checkIfPathnameExists({
         // This handles cases where internal paths redirect to external services
         // (e.g., /ui -> https://auth-platform.example.com)
         if (isExternalUrl(redirectedPath)) {
+            return true;
+        }
+
+        if (isDynamicSpecialDocPage(redirectedPath, baseUrl.basePath)) {
             return true;
         }
 

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/dynamic-special-doc-page.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/dynamic-special-doc-page.ts
@@ -1,0 +1,19 @@
+const DYNAMIC_SPEC_PATTERN = /^\/(openapi|asyncapi)\/.+\.(json|ya?ml)$/;
+
+/**
+ * Matches dynamic API spec paths served by the docs platform,
+ * e.g. /openapi/51d85717-e70a-4282-b075-66851cd0af2b.json
+ */
+export function isDynamicSpecialDocPage(pathname: string, basePath?: string): boolean {
+    if (DYNAMIC_SPEC_PATTERN.test(pathname)) {
+        return true;
+    }
+    if (basePath != null) {
+        const normalizedBase = basePath.startsWith("/") ? basePath : `/${basePath}`;
+        if (pathname.startsWith(normalizedBase)) {
+            const withoutBase = pathname.slice(normalizedBase.length);
+            return DYNAMIC_SPEC_PATTERN.test(withoutBase);
+        }
+    }
+    return false;
+}

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -136,7 +136,16 @@ export const ValidMarkdownLinks: Rule = {
             .filter(FernNavigation.isInternalProductNode)
             .map((p) => p.slug);
 
-        const specialDocPages = ["/llms-full.txt", "/llms.txt"];
+        const specialDocPages = [
+            "/llms-full.txt",
+            "/llms.txt",
+            "/openapi.json",
+            "/openapi.yaml",
+            "/openapi.yml",
+            "/asyncapi.json",
+            "/asyncapi.yaml",
+            "/asyncapi.yml"
+        ];
 
         for (const specialPage of specialDocPages) {
             const pageWithBasePath = baseUrl.basePath


### PR DESCRIPTION
## Description

Fix false broken-link errors from `fern check` for OpenAPI/AsyncAPI special doc page paths.

## Changes Made

### Static paths (whitelist)
- Add 6 new paths to the `specialDocPages` array in `valid-markdown-link.ts`: `/openapi.json`, `/openapi.yaml`, `/openapi.yml`, `/asyncapi.json`, `/asyncapi.yaml`, `/asyncapi.yml`

### Dynamic paths (pattern matching)
- Add `isDynamicSpecialDocPage()` in new `dynamic-special-doc-page.ts` to match dynamic API spec paths served by the docs platform (e.g. `/openapi/51d85717-e70a-4282-b075-66851cd0af2b.json`)
- Pattern: `/^\/(openapi|asyncapi)\/.+\.(json|ya?ml)$/`
- Also handles `basePath`-prefixed variants (e.g. `/docs/openapi/<id>.json`)
- Called in `checkIfPathnameExists` after redirect resolution and external URL check

### Changelog
- Updated `packages/cli/cli/changes/unreleased/fix-openapi-link-validation.yml`

## Testing

- [x] Unit tests added/updated (8 new tests for `isDynamicSpecialDocPage`, existing tests for static whitelist)
- [x] All 14 test files pass, 166 tests total
- [x] Biome lint passes

Link to Devin session: https://app.devin.ai/sessions/aaccd9fd447447738d43a4fce7693a90
Requested by: @Ryan-Amirthan