### PR TITLE
fix(cli): validate broken links in API reference descriptions

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-broken-links-api-reference-descriptions.yml
+++ b/packages/cli/cli/changes/unreleased/fix-broken-links-api-reference-descriptions.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix `fern check --broken-links` (and `fern docs broken-links`) silently
+    skipping broken links inside API Reference description fields. Links in
+    endpoint, type, property, path-parameter, and other `docs` / `description`
+    fields are now validated against the rest of the docs navigation.
+  type: fix

--- a/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
+++ b/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
@@ -96,4 +96,27 @@ describe("fern docs broken-links", () => {
         // property are validated for broken links (not just pages)
         expect(stripAnsi(stdout).slice(0, -15)).toMatchSnapshot();
     }, 20_000);
+
+    it("broken links in API Reference description fields should be detected", async ({ signal }) => {
+        const { stdout } = await runFernCli(["docs", "broken-links"], {
+            cwd: join(fixturesDir, RelativeFilePath.of("api-reference-descriptions")),
+            reject: false,
+            signal
+        });
+        // This fixture tests that broken links inside API Reference description
+        // fields (e.g. endpoint docs, type docs, property docs, path parameter
+        // docs) are detected by `fern check`.
+        //
+        // The fixture's Fern API definition contains four broken links:
+        //   - /guides/does-not-exist        (Movie type docs)
+        //   - /conventions/missing          (Movie.id property docs)
+        //   - /api/missing-endpoint-doc     (getMovie endpoint docs)
+        //   - /docs/missing-path-param      (movieId path-parameter docs)
+        const output = stripAnsi(stdout);
+        expect(output).not.toContain("All checks passed");
+        expect(output).toContain("/guides/does-not-exist");
+        expect(output).toContain("/conventions/missing");
+        expect(output).toContain("/api/missing-endpoint-doc");
+        expect(output).toContain("/docs/missing-path-param");
+    }, 30_000);
 });

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/api-reference-descriptions/fern/definition/api.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/api-reference-descriptions/fern/definition/api.yml
@@ -1,0 +1,4 @@
+name: my-api
+default-environment: Production
+environments:
+  Production: https://api.example.com

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/api-reference-descriptions/fern/definition/movies.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/api-reference-descriptions/fern/definition/movies.yml
@@ -1,0 +1,24 @@
+types:
+  Movie:
+    docs: See the [Movies guide](/guides/does-not-exist) for more details.
+    properties:
+      id:
+        type: string
+        docs: A unique identifier. Learn more in our [ID conventions](/conventions/missing).
+      title: string
+
+service:
+  auth: false
+  base-path: /movies
+  endpoints:
+    getMovie:
+      docs: |
+        Get a movie by its ID.
+
+        See [the related broken guide](/api/missing-endpoint-doc) for more context.
+      method: GET
+      path: /{movieId}
+      path-parameters:
+        movieId:
+          type: string
+          docs: The movie ID. See [path param docs](/docs/missing-path-param).

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/api-reference-descriptions/fern/docs.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/api-reference-descriptions/fern/docs.yml
@@ -1,0 +1,7 @@
+instances:
+  - url: ferndevtest.docs.dev.buildwithfern.com
+
+navigation:
+  - page: Overview
+    path: overview.mdx
+  - api: API Reference

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/api-reference-descriptions/fern/fern.config.json
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/api-reference-descriptions/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "test-org",
+  "version": "0.0.0"
+}

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/api-reference-descriptions/fern/generators.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/api-reference-descriptions/fern/generators.yml
@@ -1,0 +1,4 @@
+default-group: public
+groups:
+  public:
+    generators: []

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/api-reference-descriptions/fern/overview.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/api-reference-descriptions/fern/overview.mdx
@@ -1,0 +1,3 @@
+# Overview
+
+Welcome to the API reference docs fixture.

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -250,6 +250,8 @@ export const ValidMarkdownLinks: Rule = {
                     }
                 }
 
+                const apiReferenceTitle = typeof config.api === "string" ? config.api : "API Reference";
+
                 // Batch-check all unique pathnames
                 const pathToCheckViolations = await Promise.all(
                     [...uniquePathnames.values()].map(async (pathnameToCheck) => {
@@ -269,17 +271,21 @@ export const ValidMarkdownLinks: Rule = {
                             return [];
                         }
 
-                        return exists.map((brokenPathname) => {
-                            const [message, relFilePath] = createLinkViolationMessage({
+                        // API descriptions have no source-page context, so `exists` may be an
+                        // empty array. Emit at least one violation either way; otherwise broken
+                        // links in endpoint, type, property, etc. docs are silently dropped
+                        // (see FER-10165).
+                        const numBrokenSourceContexts = exists.length > 0 ? exists.length : 1;
+                        return Array.from({ length: numBrokenSourceContexts }, () => {
+                            const [message, relFilePath] = createApiReferenceLinkViolationMessage({
                                 pathnameToCheck,
-                                targetPathname: brokenPathname,
-                                absoluteFilepathToWorkspace: workspace.absoluteFilePath
+                                apiReferenceTitle
                             });
                             return {
                                 name: ValidMarkdownLinks.name,
                                 severity: "error" as const,
                                 message,
-                                relFilepath: relFilePath
+                                relativeFilepath: relFilePath
                             };
                         });
                     })
@@ -316,6 +322,27 @@ function createLinkViolationMessage({
     const relativeFilepath = relative(absoluteFilepathToWorkspace, sourceFilepath);
     msg += `\n\tfix here: ${relativeFilepath}:${position.start.line}:${position.start.column}`;
     return [msg, relativeFilepath];
+}
+
+/**
+ * Build a violation message for a broken link found inside an API Reference
+ * description (e.g. an endpoint, type, property, or parameter `docs` / OpenAPI
+ * `description` field).
+ *
+ * Descriptions in API definitions are not tracked with source positions in the
+ * IR, so we can't point the user at a specific file:line:column the way we do
+ * for markdown pages. Surface the API Reference title instead so authors at
+ * least know which navigation section to look in.
+ */
+function createApiReferenceLinkViolationMessage({
+    pathnameToCheck,
+    apiReferenceTitle
+}: {
+    pathnameToCheck: PathnameToCheck;
+    apiReferenceTitle: string;
+}): [msg: string, relFilePath: RelativeFilePath] {
+    const msg = `broken link to ${chalk.bold(pathnameToCheck.pathname)} in ${apiReferenceTitle} description`;
+    return [msg, RelativeFilePath.of("")];
 }
 
 function toLatest(apiDefinition: APIV1Read.ApiDefinition) {


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-10165

Fixes `fern check --broken-links` / `fern docs broken-links` skipping links inside API Reference description fields, such as endpoint docs, type docs, property docs, and parameter docs.

## Changes Made
- Added an ete fixture covering broken links in API Reference description fields.
- Updated broken-link validation to emit violations for API descriptions, even when there is no markdown source-page context.
- Added an unreleased CLI changelog entry.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed
- `pnpm fern-dev:build`
- `pnpm --dir packages/cli/ete-tests vitest --run broken-links.test`
- `pnpm --dir packages/cli/ete-tests vitest --run validate.test`
- `pnpm turbo run test --filter @fern-api/docs-validator`