### PR TITLE
feat(go): expose Stream[T].LastRetryMs() on the SSE runtime

### DIFF
--- a/generators/go-v2/base/src/asIs/core/stream.go_
+++ b/generators/go-v2/base/src/asIs/core/stream.go_
@@ -56,6 +56,7 @@ type Stream[T any] struct {
 	stopFunc          func() bool
 	options           *streamOptions
 	lastEventID       string // snapshot of sseReader.LastEventID() taken just before each reconnect; survives the reader swap
+	lastRetryMs       int    // snapshot of sseReader.LastRetryMs() taken just before each reconnect; survives the reader swap
 	reconnectAttempts uint
 }
 
@@ -297,6 +298,27 @@ func (s *Stream[T]) LastEventID() string {
 	return s.lastEventID
 }
 
+// LastRetryMs returns the most recently advertised SSE `retry:` reconnection
+// time in milliseconds, or 0 if the server has not sent one. Per the SSE spec
+// the value is sticky: a `retry:` directive — even one sent in its own frame
+// with no `data:` — remains in effect for subsequent events until the server
+// sends a new one, so the per-event StreamEvent.Retry can be 0 while this
+// returns the advertised interval. The runtime already honors this value when
+// gating reconnect backoff; this accessor exposes it so callers can observe
+// it, mirroring LastEventID.
+//
+// When WithReconnect is configured, the value persists across reconnects: each
+// new reader starts with no retry directive, so callers see the pre-reconnect
+// snapshot until the resumed stream advertises a `retry:` of its own.
+func (s *Stream[T]) LastRetryMs() int {
+	if s.sseReader != nil {
+		if ms := s.sseReader.LastRetryMs(); ms > 0 {
+			return ms
+		}
+	}
+	return s.lastRetryMs
+}
+
 // shouldReconnectOnError reports whether the given error from the underlying
 // reader should trigger a reconnect attempt.
 func (s *Stream[T]) shouldReconnectOnError(err error) bool {
@@ -329,6 +351,7 @@ func (s *Stream[T]) reconnect() error {
 			s.lastEventID = id
 		}
 		if ms := s.sseReader.LastRetryMs(); ms > 0 {
+			s.lastRetryMs = ms
 			delay := time.Duration(ms) * time.Millisecond
 			if delay > maxReconnectBackoff {
 				delay = maxReconnectBackoff

--- a/generators/go-v2/base/src/asIs/core/stream_test.go_
+++ b/generators/go-v2/base/src/asIs/core/stream_test.go_
@@ -733,6 +733,48 @@ func TestStream_LastEventID(t *testing.T) {
 	assert.Equal(t, "3", stream.LastEventID())
 }
 
+func TestStream_LastRetryMs(t *testing.T) {
+	// A server may advertise the reconnection time in its own SSE frame (no
+	// data:), as the spec recommends. The directive is sticky: it must remain
+	// readable via LastRetryMs across subsequent events that carry no retry: of
+	// their own, even though those events' per-frame Retry is 0.
+	sseData := "retry: 2000\n\n" +
+		"data: {\"content\":\"first\"}\n\n" +
+		"data: {\"content\":\"second\"}\n\n" +
+		"retry: 4000\ndata: {\"content\":\"third\"}\n\n"
+
+	server := newSSEServer(t, sseData)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	stream := NewStream[TestMessage](context.Background(), resp, WithFormat(StreamFormatSSE))
+	defer func() { _ = stream.Close() }()
+
+	// Before reading anything, no retry: has been advertised.
+	assert.Equal(t, 0, stream.LastRetryMs())
+
+	// First data event: the standalone "retry: 2000" frame was consumed first,
+	// so the sticky value is 2000 even though this event carries no retry:.
+	event, err := stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, "first", event.Data.Content)
+	assert.Equal(t, 0, event.Retry)
+	assert.Equal(t, 2000, stream.LastRetryMs())
+
+	// Second data event: still no retry:, sticky value unchanged.
+	_, err = stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, 2000, stream.LastRetryMs())
+
+	// Third event carries retry: 4000, updating the sticky value.
+	_, err = stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, 4000, stream.LastRetryMs())
+}
+
 func TestStream_RecvEventRaw(t *testing.T) {
 	sseData := "id: abc\nevent: update\nretry: 3000\ndata: not valid json\n\n"
 

--- a/generators/go/sdk/changes/unreleased/expose-stream-last-retry-ms.yml
+++ b/generators/go/sdk/changes/unreleased/expose-stream-last-retry-ms.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Expose `Stream[T].LastRetryMs()` on the SSE runtime, mirroring `LastEventID()`.
+    It returns the most recently advertised `retry:` reconnection time in
+    milliseconds (sticky per the SSE spec), so callers can read the directive
+    even when the server sends it in its own frame with no `data:` — in which
+    case the per-event `StreamEvent.Retry` is 0. The value persists across
+    reconnects.
+  type: feat

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/core/stream.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/core/stream.go
@@ -56,6 +56,7 @@ type Stream[T any] struct {
 	stopFunc          func() bool
 	options           *streamOptions
 	lastEventID       string // snapshot of sseReader.LastEventID() taken just before each reconnect; survives the reader swap
+	lastRetryMs       int    // snapshot of sseReader.LastRetryMs() taken just before each reconnect; survives the reader swap
 	reconnectAttempts uint
 }
 
@@ -297,6 +298,27 @@ func (s *Stream[T]) LastEventID() string {
 	return s.lastEventID
 }
 
+// LastRetryMs returns the most recently advertised SSE `retry:` reconnection
+// time in milliseconds, or 0 if the server has not sent one. Per the SSE spec
+// the value is sticky: a `retry:` directive — even one sent in its own frame
+// with no `data:` — remains in effect for subsequent events until the server
+// sends a new one, so the per-event StreamEvent.Retry can be 0 while this
+// returns the advertised interval. The runtime already honors this value when
+// gating reconnect backoff; this accessor exposes it so callers can observe
+// it, mirroring LastEventID.
+//
+// When WithReconnect is configured, the value persists across reconnects: each
+// new reader starts with no retry directive, so callers see the pre-reconnect
+// snapshot until the resumed stream advertises a `retry:` of its own.
+func (s *Stream[T]) LastRetryMs() int {
+	if s.sseReader != nil {
+		if ms := s.sseReader.LastRetryMs(); ms > 0 {
+			return ms
+		}
+	}
+	return s.lastRetryMs
+}
+
 // shouldReconnectOnError reports whether the given error from the underlying
 // reader should trigger a reconnect attempt.
 func (s *Stream[T]) shouldReconnectOnError(err error) bool {
@@ -329,6 +351,7 @@ func (s *Stream[T]) reconnect() error {
 			s.lastEventID = id
 		}
 		if ms := s.sseReader.LastRetryMs(); ms > 0 {
+			s.lastRetryMs = ms
 			delay := time.Duration(ms) * time.Millisecond
 			if delay > maxReconnectBackoff {
 				delay = maxReconnectBackoff

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/core/stream_test.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/core/stream_test.go
@@ -733,6 +733,48 @@ func TestStream_LastEventID(t *testing.T) {
 	assert.Equal(t, "3", stream.LastEventID())
 }
 
+func TestStream_LastRetryMs(t *testing.T) {
+	// A server may advertise the reconnection time in its own SSE frame (no
+	// data:), as the spec recommends. The directive is sticky: it must remain
+	// readable via LastRetryMs across subsequent events that carry no retry: of
+	// their own, even though those events' per-frame Retry is 0.
+	sseData := "retry: 2000\n\n" +
+		"data: {\"content\":\"first\"}\n\n" +
+		"data: {\"content\":\"second\"}\n\n" +
+		"retry: 4000\ndata: {\"content\":\"third\"}\n\n"
+
+	server := newSSEServer(t, sseData)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	stream := NewStream[TestMessage](context.Background(), resp, WithFormat(StreamFormatSSE))
+	defer func() { _ = stream.Close() }()
+
+	// Before reading anything, no retry: has been advertised.
+	assert.Equal(t, 0, stream.LastRetryMs())
+
+	// First data event: the standalone "retry: 2000" frame was consumed first,
+	// so the sticky value is 2000 even though this event carries no retry:.
+	event, err := stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, "first", event.Data.Content)
+	assert.Equal(t, 0, event.Retry)
+	assert.Equal(t, 2000, stream.LastRetryMs())
+
+	// Second data event: still no retry:, sticky value unchanged.
+	_, err = stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, 2000, stream.LastRetryMs())
+
+	// Third event carries retry: 4000, updating the sticky value.
+	_, err = stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, 4000, stream.LastRetryMs())
+}
+
 func TestStream_RecvEventRaw(t *testing.T) {
 	sseData := "id: abc\nevent: update\nretry: 3000\ndata: not valid json\n\n"
 

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/core/stream.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/core/stream.go
@@ -56,6 +56,7 @@ type Stream[T any] struct {
 	stopFunc          func() bool
 	options           *streamOptions
 	lastEventID       string // snapshot of sseReader.LastEventID() taken just before each reconnect; survives the reader swap
+	lastRetryMs       int    // snapshot of sseReader.LastRetryMs() taken just before each reconnect; survives the reader swap
 	reconnectAttempts uint
 }
 
@@ -297,6 +298,27 @@ func (s *Stream[T]) LastEventID() string {
 	return s.lastEventID
 }
 
+// LastRetryMs returns the most recently advertised SSE `retry:` reconnection
+// time in milliseconds, or 0 if the server has not sent one. Per the SSE spec
+// the value is sticky: a `retry:` directive — even one sent in its own frame
+// with no `data:` — remains in effect for subsequent events until the server
+// sends a new one, so the per-event StreamEvent.Retry can be 0 while this
+// returns the advertised interval. The runtime already honors this value when
+// gating reconnect backoff; this accessor exposes it so callers can observe
+// it, mirroring LastEventID.
+//
+// When WithReconnect is configured, the value persists across reconnects: each
+// new reader starts with no retry directive, so callers see the pre-reconnect
+// snapshot until the resumed stream advertises a `retry:` of its own.
+func (s *Stream[T]) LastRetryMs() int {
+	if s.sseReader != nil {
+		if ms := s.sseReader.LastRetryMs(); ms > 0 {
+			return ms
+		}
+	}
+	return s.lastRetryMs
+}
+
 // shouldReconnectOnError reports whether the given error from the underlying
 // reader should trigger a reconnect attempt.
 func (s *Stream[T]) shouldReconnectOnError(err error) bool {
@@ -329,6 +351,7 @@ func (s *Stream[T]) reconnect() error {
 			s.lastEventID = id
 		}
 		if ms := s.sseReader.LastRetryMs(); ms > 0 {
+			s.lastRetryMs = ms
 			delay := time.Duration(ms) * time.Millisecond
 			if delay > maxReconnectBackoff {
 				delay = maxReconnectBackoff

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/core/stream_test.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/core/stream_test.go
@@ -733,6 +733,48 @@ func TestStream_LastEventID(t *testing.T) {
 	assert.Equal(t, "3", stream.LastEventID())
 }
 
+func TestStream_LastRetryMs(t *testing.T) {
+	// A server may advertise the reconnection time in its own SSE frame (no
+	// data:), as the spec recommends. The directive is sticky: it must remain
+	// readable via LastRetryMs across subsequent events that carry no retry: of
+	// their own, even though those events' per-frame Retry is 0.
+	sseData := "retry: 2000\n\n" +
+		"data: {\"content\":\"first\"}\n\n" +
+		"data: {\"content\":\"second\"}\n\n" +
+		"retry: 4000\ndata: {\"content\":\"third\"}\n\n"
+
+	server := newSSEServer(t, sseData)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	stream := NewStream[TestMessage](context.Background(), resp, WithFormat(StreamFormatSSE))
+	defer func() { _ = stream.Close() }()
+
+	// Before reading anything, no retry: has been advertised.
+	assert.Equal(t, 0, stream.LastRetryMs())
+
+	// First data event: the standalone "retry: 2000" frame was consumed first,
+	// so the sticky value is 2000 even though this event carries no retry:.
+	event, err := stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, "first", event.Data.Content)
+	assert.Equal(t, 0, event.Retry)
+	assert.Equal(t, 2000, stream.LastRetryMs())
+
+	// Second data event: still no retry:, sticky value unchanged.
+	_, err = stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, 2000, stream.LastRetryMs())
+
+	// Third event carries retry: 4000, updating the sticky value.
+	_, err = stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, 4000, stream.LastRetryMs())
+}
+
 func TestStream_RecvEventRaw(t *testing.T) {
 	sseData := "id: abc\nevent: update\nretry: 3000\ndata: not valid json\n\n"
 

--- a/seed/go-sdk/server-sent-events-resumable/core/stream.go
+++ b/seed/go-sdk/server-sent-events-resumable/core/stream.go
@@ -56,6 +56,7 @@ type Stream[T any] struct {
 	stopFunc          func() bool
 	options           *streamOptions
 	lastEventID       string // snapshot of sseReader.LastEventID() taken just before each reconnect; survives the reader swap
+	lastRetryMs       int    // snapshot of sseReader.LastRetryMs() taken just before each reconnect; survives the reader swap
 	reconnectAttempts uint
 }
 
@@ -297,6 +298,27 @@ func (s *Stream[T]) LastEventID() string {
 	return s.lastEventID
 }
 
+// LastRetryMs returns the most recently advertised SSE `retry:` reconnection
+// time in milliseconds, or 0 if the server has not sent one. Per the SSE spec
+// the value is sticky: a `retry:` directive — even one sent in its own frame
+// with no `data:` — remains in effect for subsequent events until the server
+// sends a new one, so the per-event StreamEvent.Retry can be 0 while this
+// returns the advertised interval. The runtime already honors this value when
+// gating reconnect backoff; this accessor exposes it so callers can observe
+// it, mirroring LastEventID.
+//
+// When WithReconnect is configured, the value persists across reconnects: each
+// new reader starts with no retry directive, so callers see the pre-reconnect
+// snapshot until the resumed stream advertises a `retry:` of its own.
+func (s *Stream[T]) LastRetryMs() int {
+	if s.sseReader != nil {
+		if ms := s.sseReader.LastRetryMs(); ms > 0 {
+			return ms
+		}
+	}
+	return s.lastRetryMs
+}
+
 // shouldReconnectOnError reports whether the given error from the underlying
 // reader should trigger a reconnect attempt.
 func (s *Stream[T]) shouldReconnectOnError(err error) bool {
@@ -329,6 +351,7 @@ func (s *Stream[T]) reconnect() error {
 			s.lastEventID = id
 		}
 		if ms := s.sseReader.LastRetryMs(); ms > 0 {
+			s.lastRetryMs = ms
 			delay := time.Duration(ms) * time.Millisecond
 			if delay > maxReconnectBackoff {
 				delay = maxReconnectBackoff

--- a/seed/go-sdk/server-sent-events-resumable/core/stream_test.go
+++ b/seed/go-sdk/server-sent-events-resumable/core/stream_test.go
@@ -733,6 +733,48 @@ func TestStream_LastEventID(t *testing.T) {
 	assert.Equal(t, "3", stream.LastEventID())
 }
 
+func TestStream_LastRetryMs(t *testing.T) {
+	// A server may advertise the reconnection time in its own SSE frame (no
+	// data:), as the spec recommends. The directive is sticky: it must remain
+	// readable via LastRetryMs across subsequent events that carry no retry: of
+	// their own, even though those events' per-frame Retry is 0.
+	sseData := "retry: 2000\n\n" +
+		"data: {\"content\":\"first\"}\n\n" +
+		"data: {\"content\":\"second\"}\n\n" +
+		"retry: 4000\ndata: {\"content\":\"third\"}\n\n"
+
+	server := newSSEServer(t, sseData)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	stream := NewStream[TestMessage](context.Background(), resp, WithFormat(StreamFormatSSE))
+	defer func() { _ = stream.Close() }()
+
+	// Before reading anything, no retry: has been advertised.
+	assert.Equal(t, 0, stream.LastRetryMs())
+
+	// First data event: the standalone "retry: 2000" frame was consumed first,
+	// so the sticky value is 2000 even though this event carries no retry:.
+	event, err := stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, "first", event.Data.Content)
+	assert.Equal(t, 0, event.Retry)
+	assert.Equal(t, 2000, stream.LastRetryMs())
+
+	// Second data event: still no retry:, sticky value unchanged.
+	_, err = stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, 2000, stream.LastRetryMs())
+
+	// Third event carries retry: 4000, updating the sticky value.
+	_, err = stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, 4000, stream.LastRetryMs())
+}
+
 func TestStream_RecvEventRaw(t *testing.T) {
 	sseData := "id: abc\nevent: update\nretry: 3000\ndata: not valid json\n\n"
 

--- a/seed/go-sdk/server-sent-events/with-wire-tests/core/stream.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/core/stream.go
@@ -56,6 +56,7 @@ type Stream[T any] struct {
 	stopFunc          func() bool
 	options           *streamOptions
 	lastEventID       string // snapshot of sseReader.LastEventID() taken just before each reconnect; survives the reader swap
+	lastRetryMs       int    // snapshot of sseReader.LastRetryMs() taken just before each reconnect; survives the reader swap
 	reconnectAttempts uint
 }
 
@@ -297,6 +298,27 @@ func (s *Stream[T]) LastEventID() string {
 	return s.lastEventID
 }
 
+// LastRetryMs returns the most recently advertised SSE `retry:` reconnection
+// time in milliseconds, or 0 if the server has not sent one. Per the SSE spec
+// the value is sticky: a `retry:` directive — even one sent in its own frame
+// with no `data:` — remains in effect for subsequent events until the server
+// sends a new one, so the per-event StreamEvent.Retry can be 0 while this
+// returns the advertised interval. The runtime already honors this value when
+// gating reconnect backoff; this accessor exposes it so callers can observe
+// it, mirroring LastEventID.
+//
+// When WithReconnect is configured, the value persists across reconnects: each
+// new reader starts with no retry directive, so callers see the pre-reconnect
+// snapshot until the resumed stream advertises a `retry:` of its own.
+func (s *Stream[T]) LastRetryMs() int {
+	if s.sseReader != nil {
+		if ms := s.sseReader.LastRetryMs(); ms > 0 {
+			return ms
+		}
+	}
+	return s.lastRetryMs
+}
+
 // shouldReconnectOnError reports whether the given error from the underlying
 // reader should trigger a reconnect attempt.
 func (s *Stream[T]) shouldReconnectOnError(err error) bool {
@@ -329,6 +351,7 @@ func (s *Stream[T]) reconnect() error {
 			s.lastEventID = id
 		}
 		if ms := s.sseReader.LastRetryMs(); ms > 0 {
+			s.lastRetryMs = ms
 			delay := time.Duration(ms) * time.Millisecond
 			if delay > maxReconnectBackoff {
 				delay = maxReconnectBackoff

--- a/seed/go-sdk/server-sent-events/with-wire-tests/core/stream_test.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/core/stream_test.go
@@ -733,6 +733,48 @@ func TestStream_LastEventID(t *testing.T) {
 	assert.Equal(t, "3", stream.LastEventID())
 }
 
+func TestStream_LastRetryMs(t *testing.T) {
+	// A server may advertise the reconnection time in its own SSE frame (no
+	// data:), as the spec recommends. The directive is sticky: it must remain
+	// readable via LastRetryMs across subsequent events that carry no retry: of
+	// their own, even though those events' per-frame Retry is 0.
+	sseData := "retry: 2000\n\n" +
+		"data: {\"content\":\"first\"}\n\n" +
+		"data: {\"content\":\"second\"}\n\n" +
+		"retry: 4000\ndata: {\"content\":\"third\"}\n\n"
+
+	server := newSSEServer(t, sseData)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	stream := NewStream[TestMessage](context.Background(), resp, WithFormat(StreamFormatSSE))
+	defer func() { _ = stream.Close() }()
+
+	// Before reading anything, no retry: has been advertised.
+	assert.Equal(t, 0, stream.LastRetryMs())
+
+	// First data event: the standalone "retry: 2000" frame was consumed first,
+	// so the sticky value is 2000 even though this event carries no retry:.
+	event, err := stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, "first", event.Data.Content)
+	assert.Equal(t, 0, event.Retry)
+	assert.Equal(t, 2000, stream.LastRetryMs())
+
+	// Second data event: still no retry:, sticky value unchanged.
+	_, err = stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, 2000, stream.LastRetryMs())
+
+	// Third event carries retry: 4000, updating the sticky value.
+	_, err = stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, 4000, stream.LastRetryMs())
+}
+
 func TestStream_RecvEventRaw(t *testing.T) {
 	sseData := "id: abc\nevent: update\nretry: 3000\ndata: not valid json\n\n"
 

--- a/seed/go-sdk/streaming/core/stream.go
+++ b/seed/go-sdk/streaming/core/stream.go
@@ -56,6 +56,7 @@ type Stream[T any] struct {
 	stopFunc          func() bool
 	options           *streamOptions
 	lastEventID       string // snapshot of sseReader.LastEventID() taken just before each reconnect; survives the reader swap
+	lastRetryMs       int    // snapshot of sseReader.LastRetryMs() taken just before each reconnect; survives the reader swap
 	reconnectAttempts uint
 }
 
@@ -297,6 +298,27 @@ func (s *Stream[T]) LastEventID() string {
 	return s.lastEventID
 }
 
+// LastRetryMs returns the most recently advertised SSE `retry:` reconnection
+// time in milliseconds, or 0 if the server has not sent one. Per the SSE spec
+// the value is sticky: a `retry:` directive — even one sent in its own frame
+// with no `data:` — remains in effect for subsequent events until the server
+// sends a new one, so the per-event StreamEvent.Retry can be 0 while this
+// returns the advertised interval. The runtime already honors this value when
+// gating reconnect backoff; this accessor exposes it so callers can observe
+// it, mirroring LastEventID.
+//
+// When WithReconnect is configured, the value persists across reconnects: each
+// new reader starts with no retry directive, so callers see the pre-reconnect
+// snapshot until the resumed stream advertises a `retry:` of its own.
+func (s *Stream[T]) LastRetryMs() int {
+	if s.sseReader != nil {
+		if ms := s.sseReader.LastRetryMs(); ms > 0 {
+			return ms
+		}
+	}
+	return s.lastRetryMs
+}
+
 // shouldReconnectOnError reports whether the given error from the underlying
 // reader should trigger a reconnect attempt.
 func (s *Stream[T]) shouldReconnectOnError(err error) bool {
@@ -329,6 +351,7 @@ func (s *Stream[T]) reconnect() error {
 			s.lastEventID = id
 		}
 		if ms := s.sseReader.LastRetryMs(); ms > 0 {
+			s.lastRetryMs = ms
 			delay := time.Duration(ms) * time.Millisecond
 			if delay > maxReconnectBackoff {
 				delay = maxReconnectBackoff

--- a/seed/go-sdk/streaming/core/stream_test.go
+++ b/seed/go-sdk/streaming/core/stream_test.go
@@ -733,6 +733,48 @@ func TestStream_LastEventID(t *testing.T) {
 	assert.Equal(t, "3", stream.LastEventID())
 }
 
+func TestStream_LastRetryMs(t *testing.T) {
+	// A server may advertise the reconnection time in its own SSE frame (no
+	// data:), as the spec recommends. The directive is sticky: it must remain
+	// readable via LastRetryMs across subsequent events that carry no retry: of
+	// their own, even though those events' per-frame Retry is 0.
+	sseData := "retry: 2000\n\n" +
+		"data: {\"content\":\"first\"}\n\n" +
+		"data: {\"content\":\"second\"}\n\n" +
+		"retry: 4000\ndata: {\"content\":\"third\"}\n\n"
+
+	server := newSSEServer(t, sseData)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	stream := NewStream[TestMessage](context.Background(), resp, WithFormat(StreamFormatSSE))
+	defer func() { _ = stream.Close() }()
+
+	// Before reading anything, no retry: has been advertised.
+	assert.Equal(t, 0, stream.LastRetryMs())
+
+	// First data event: the standalone "retry: 2000" frame was consumed first,
+	// so the sticky value is 2000 even though this event carries no retry:.
+	event, err := stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, "first", event.Data.Content)
+	assert.Equal(t, 0, event.Retry)
+	assert.Equal(t, 2000, stream.LastRetryMs())
+
+	// Second data event: still no retry:, sticky value unchanged.
+	_, err = stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, 2000, stream.LastRetryMs())
+
+	// Third event carries retry: 4000, updating the sticky value.
+	_, err = stream.RecvEvent()
+	require.NoError(t, err)
+	assert.Equal(t, 4000, stream.LastRetryMs())
+}
+
 func TestStream_RecvEventRaw(t *testing.T) {
 	sseData := "id: abc\nevent: update\nretry: 3000\ndata: not valid json\n\n"
 


### PR DESCRIPTION
Closes FER-10852

## Summary

Exposes `Stream[T].LastRetryMs()` on the generated Go SSE runtime, mirroring the existing `LastEventID()`. It returns the most recently advertised `retry:` reconnection time in milliseconds, falling back to a snapshot that survives reconnects. Additive and non-breaking.

## Motivation

A customer's `/events` stream advertises the reconnection time in its own SSE frame, as the spec recommends:

```
retry: 2000
                  ← frame boundary (no data)
event: offset-only
id: ...
data: {...}
                  ← the frame the user actually receives
```

The runtime already captures `retry:` stickily on the internal `SseStreamReader.lastRetryMs` and honors it when gating reconnect backoff. But because the directive arrives in a frame with no `data:`, the per-event `StreamEvent.Retry` is `0` for every event the user receives, and the sticky value was only readable via the internal `sseEventReader` interface — so from the caller's side it looked like the server never sent `retry:` at all.

## Change

```go
func (s *Stream[T]) LastRetryMs() int {
	if s.sseReader != nil {
		if ms := s.sseReader.LastRetryMs(); ms > 0 {
			return ms
		}
	}
	return s.lastRetryMs
}
```

Plus a `lastRetryMs` snapshot field on `Stream[T]` and a snapshot assignment in `reconnect()`, exactly mirroring how `lastEventID` persists across the reader swap.

## Test plan

- [x] New `TestStream_LastRetryMs` in the runtime template reproduces the standalone-`retry:`-frame scenario (RED before the method existed, GREEN after).
- [x] Regenerated all 5 affected go-sdk seed fixtures; `go test ./core/` passes in each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->