### PR TITLE
feat(cli): add hidden `fern docs theme delete` command

### DIFF
--- a/packages/cli/cli/changes/unreleased/add-docs-theme-delete.yml
+++ b/packages/cli/cli/changes/unreleased/add-docs-theme-delete.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Add hidden `fern docs theme delete --name <theme name>` CLI command to delete a named theme from an org. Includes a confirmation prompt (skippable with `--yes`).
+  type: feat

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1855,20 +1855,16 @@ function addDocsThemeDeleteCommand(cli: Argv<GlobalCliOptions>, cliContext: CliC
                     description: "Name of the theme to delete",
                     demandOption: true
                 })
-                .option("org", {
-                    type: "string",
-                    description: "Override the org ID from fern.config.json"
-                })
-                .option("yes", {
-                    alias: "y",
+                .option("force", {
+                    alias: "f",
                     type: "boolean",
                     description: "Skip the confirmation prompt"
                 })
                 .example("$0 docs theme delete --name dark", "Delete the theme named 'dark'")
-                .example("$0 docs theme delete --name dark --yes", "Delete without confirmation"),
+                .example("$0 docs theme delete --name dark --force", "Delete without confirmation"),
         async (argv) => {
             cliContext.instrumentPostHogEvent({ command: "fern docs theme delete" });
-            await deleteDocsTheme({ cliContext, name: argv.name, org: argv.org, yes: argv.yes });
+            await deleteDocsTheme({ cliContext, name: argv.name, force: argv.force });
         }
     );
 }

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -63,6 +63,7 @@ import { docsDiff } from "./commands/docs-diff/docsDiff.js";
 import { generateLibraryDocs } from "./commands/docs-md-generate/generateLibraryDocs.js";
 import { deleteDocsPreview } from "./commands/docs-preview/deleteDocsPreview.js";
 import { listDocsPreview } from "./commands/docs-preview/listDocsPreview.js";
+import { deleteDocsTheme } from "./commands/docs-theme/deleteDocsTheme.js";
 import { exportDocsTheme } from "./commands/docs-theme/exportDocsTheme.js";
 import { listDocsThemes } from "./commands/docs-theme/listDocsThemes.js";
 import { uploadDocsTheme } from "./commands/docs-theme/uploadDocsTheme.js";
@@ -1834,11 +1835,42 @@ function addDocsCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
 
 function addDocsThemeCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
     cli.command("theme", "Manage org-level themes for your documentation", (yargs) => {
+        addDocsThemeDeleteCommand(yargs, cliContext);
         addDocsThemeExportCommand(yargs, cliContext);
         addDocsThemeListCommand(yargs, cliContext);
         addDocsThemeUploadCommand(yargs, cliContext);
         return yargs;
     });
+}
+
+function addDocsThemeDeleteCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
+    cli.command(
+        "delete",
+        false,
+        (yargs) =>
+            yargs
+                .option("name", {
+                    alias: "n",
+                    type: "string",
+                    description: "Name of the theme to delete",
+                    demandOption: true
+                })
+                .option("org", {
+                    type: "string",
+                    description: "Override the org ID from fern.config.json"
+                })
+                .option("yes", {
+                    alias: "y",
+                    type: "boolean",
+                    description: "Skip the confirmation prompt"
+                })
+                .example("$0 docs theme delete --name dark", "Delete the theme named 'dark'")
+                .example("$0 docs theme delete --name dark --yes", "Delete without confirmation"),
+        async (argv) => {
+            cliContext.instrumentPostHogEvent({ command: "fern docs theme delete" });
+            await deleteDocsTheme({ cliContext, name: argv.name, org: argv.org, yes: argv.yes });
+        }
+    );
 }
 
 function addDocsThemeExportCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {

--- a/packages/cli/cli/src/commands/docs-theme/deleteDocsTheme.ts
+++ b/packages/cli/cli/src/commands/docs-theme/deleteDocsTheme.ts
@@ -1,0 +1,86 @@
+import { createInterface } from "node:readline";
+import { FernToken } from "@fern-api/auth";
+import { askToLogin } from "@fern-api/login";
+import { CliError } from "@fern-api/task-context";
+import { CliContext } from "../../cli-context/CliContext.js";
+import { loadProjectAndRegisterWorkspacesWithContext } from "../../cliCommons.js";
+import { describeFetchError, FDR_ORIGIN, parseErrorDetail } from "./themeOrigin.js";
+
+async function confirmDeletion(themeName: string): Promise<boolean> {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    return new Promise((resolve) => {
+        rl.question(`Are you sure you want to delete the theme "${themeName}"? (y/N) `, (answer) => {
+            rl.close();
+            resolve(answer.trim().toLowerCase() === "y");
+        });
+    });
+}
+
+export async function deleteDocsTheme({
+    cliContext,
+    name,
+    org,
+    yes
+}: {
+    cliContext: CliContext;
+    name: string;
+    org?: string;
+    yes?: boolean;
+}): Promise<void> {
+    const token: FernToken | null = await cliContext.runTask(async (context) => {
+        return askToLogin(context);
+    });
+
+    if (token == null) {
+        cliContext.failAndThrow("Failed to authenticate. Please run 'fern login' first.", undefined, {
+            code: CliError.Code.AuthError
+        });
+        return;
+    }
+
+    const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
+        commandLineApiWorkspace: undefined,
+        defaultToAllApiWorkspaces: true
+    });
+
+    const orgId = org ?? project.config.organization;
+
+    if (!yes) {
+        const confirmed = await confirmDeletion(name);
+        if (!confirmed) {
+            cliContext.logger.info("Deletion cancelled.");
+            return;
+        }
+    }
+
+    await cliContext.runTask(async (context) => {
+        const deleteUrl = `${FDR_ORIGIN}/v2/registry/themes/${orgId}/${encodeURIComponent(name)}`;
+        context.logger.debug(`Deleting theme at ${deleteUrl}`);
+
+        let res: Response;
+        try {
+            res = await fetch(deleteUrl, {
+                method: "DELETE",
+                headers: { Authorization: `Bearer ${token.value}` }
+            });
+        } catch (err) {
+            context.failAndThrow(
+                `Failed to delete theme "${name}" — could not reach ${FDR_ORIGIN}: ${describeFetchError(err)}`,
+                undefined,
+                { code: CliError.Code.NetworkError }
+            );
+            return;
+        }
+
+        if (!res.ok) {
+            const body = await res.text();
+            const detail = parseErrorDetail(body) ?? body;
+            context.failAndThrow(`Failed to delete theme "${name}": HTTP ${res.status} — ${detail}`, undefined, {
+                code: CliError.Code.NetworkError
+            });
+            return;
+        }
+
+        context.logger.info(`Theme "${name}" deleted for org "${orgId}"`);
+    });
+}

--- a/packages/cli/cli/src/commands/docs-theme/deleteDocsTheme.ts
+++ b/packages/cli/cli/src/commands/docs-theme/deleteDocsTheme.ts
@@ -19,13 +19,11 @@ async function confirmDeletion(themeName: string): Promise<boolean> {
 export async function deleteDocsTheme({
     cliContext,
     name,
-    org,
-    yes
+    force
 }: {
     cliContext: CliContext;
     name: string;
-    org?: string;
-    yes?: boolean;
+    force?: boolean;
 }): Promise<void> {
     const token: FernToken | null = await cliContext.runTask(async (context) => {
         return askToLogin(context);
@@ -43,9 +41,9 @@ export async function deleteDocsTheme({
         defaultToAllApiWorkspaces: true
     });
 
-    const orgId = org ?? project.config.organization;
+    const orgId = project.config.organization;
 
-    if (!yes) {
+    if (!force) {
         const confirmed = await confirmDeletion(name);
         if (!confirmed) {
             cliContext.logger.info("Deletion cancelled.");


### PR DESCRIPTION
## Description

Adds a new hidden CLI command `fern docs theme delete --name <theme name>` that calls the existing FDR `DELETE /v2/registry/themes/:orgId/:name` endpoint to remove a named theme from an org.

## Changes Made

- Added `deleteDocsTheme.ts` — implements the delete command with an interactive confirmation prompt ("Are you sure you want to delete the theme?") that can be skipped with `--force`/`-f`
- Wired `addDocsThemeDeleteCommand` into the theme subcommand group in `cli.ts`
- The command is hidden (description set to `false` in yargs) per the request
- Supports `--name` (required) option; org is always resolved from `fern.config.json`
- Added unreleased changelog entry

## Testing

- [x] `pnpm run check` passes
- [x] `pnpm format` passes
- [x] Follows the exact same patterns as `listDocsThemes.ts` and `uploadDocsTheme.ts` for auth, org resolution, error handling, and FDR interaction


Link to Devin session: https://app.devin.ai/sessions/90af0b62ff0243669589b88794ad7266
Requested by: @aditya-arolkar-swe