### PR TITLE
fix(cli): optimize fern docs dev hot reload for markdown-only changes

### DIFF
--- a/packages/cli/cli/changes/unreleased/docs-dev-fast-reload.yml
+++ b/packages/cli/cli/changes/unreleased/docs-dev-fast-reload.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Optimize `fern docs dev` hot reload for markdown-only changes. Skip full
+    project reload (re-reading all API specs and config files) and full snippet
+    dependency rebuild when only `.md`/`.mdx` files are edited, significantly
+    reducing reload times for large docs projects.
+  type: fix

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -41,6 +41,10 @@ import { downloadBundle, getPathToBundleFolder, getPathToPreviewFolder } from ".
 import { writeNodePolyfillScript } from "./nodePolyfills.js";
 import { getPreviewDocsDefinition, type PreviewDocsResult } from "./previewDocs.js";
 
+function isMarkdownFile(filepath: string): boolean {
+    return filepath.endsWith(".mdx") || filepath.endsWith(".md");
+}
+
 const EMPTY_DOCS_DEFINITION: DocsV1Read.DocsDefinition = {
     pages: {},
     apis: {},
@@ -370,6 +374,46 @@ class SnippetDependencyTracker {
             }
         }
         return false;
+    }
+
+    /**
+     * Update dependency map only for specific changed files (incremental update).
+     * Much faster than rebuilding the entire map for markdown-only changes.
+     */
+    async updateDependencyMapForFiles(
+        changedFiles: AbsoluteFilePath[],
+        fernFolderPath: AbsoluteFilePath
+    ): Promise<void> {
+        for (const filePath of changedFiles) {
+            if (!isMarkdownFile(filePath)) {
+                continue;
+            }
+
+            // Remove old entries for this page
+            const oldSnippets = this.pageToSnippets.get(filePath);
+            if (oldSnippets) {
+                for (const snippet of oldSnippets) {
+                    this.snippetToPages.get(snippet)?.delete(filePath);
+                }
+            }
+
+            try {
+                const content = await readFile(filePath, "utf-8");
+                const referencedFiles = this.extractReferences(content, filePath, fernFolderPath);
+
+                this.pageToSnippets.set(filePath, referencedFiles);
+
+                for (const referencedFile of referencedFiles) {
+                    if (!this.snippetToPages.has(referencedFile)) {
+                        this.snippetToPages.set(referencedFile, new Set());
+                    }
+                    this.snippetToPages.get(referencedFile)?.add(filePath);
+                }
+            } catch {
+                this.context.logger.debug(`Failed to read markdown file ${filePath} for incremental update`);
+                this.pageToSnippets.delete(filePath);
+            }
+        }
     }
 
     /**
@@ -880,7 +924,10 @@ export async function runAppPreviewServer({
         return translations;
     }
 
-    const reloadDocsDefinition = async (editedAbsoluteFilepaths?: AbsoluteFilePath[]) => {
+    const reloadDocsDefinition = async (
+        editedAbsoluteFilepaths?: AbsoluteFilePath[],
+        { skipProjectReload = false }: { skipProjectReload?: boolean } = {}
+    ) => {
         context.logger.info("Reloading docs...");
         const startTime = Date.now();
 
@@ -888,27 +935,41 @@ export async function runAppPreviewServer({
         void debugLogger.logCliReloadStart();
 
         try {
-            project = await reloadProject();
+            if (skipProjectReload) {
+                context.logger.debug("Skipping project reload (markdown-only change)");
+                // Incrementally update snippet dependencies for changed files only
+                const fernFolderPath = project.docsWorkspaces?.absoluteFilePath;
+                if (fernFolderPath != null && editedAbsoluteFilepaths != null) {
+                    await snippetTracker.updateDependencyMapForFiles(editedAbsoluteFilepaths, fernFolderPath);
+                }
+            } else {
+                project = await reloadProject();
 
-            // Rebuild dependency map after reloading project
-            await snippetTracker.buildDependencyMap(project);
+                // Rebuild dependency map after reloading project
+                await snippetTracker.buildDependencyMap(project);
+            }
 
             // Start validation in background - don't block the reload
-            const validationStartTime = Date.now();
-            void validateProject(project)
-                .then(() => {
-                    const validationTime = Date.now() - validationStartTime;
-                    void debugLogger.logCliValidation(validationTime, true);
-                })
-                .catch((err) => {
-                    const validationTime = Date.now() - validationStartTime;
-                    void debugLogger.logCliValidation(validationTime, false);
-                    context.logger.error(`Validation failed (took ${validationTime}ms): ${extractErrorMessage(err)}`);
-                    // Still log validation errors to help developers
-                    if (err instanceof Error && err.stack) {
-                        context.logger.debug(`Validation error stack: ${err.stack}`);
-                    }
-                });
+            // Skip background validation for markdown-only changes since config hasn't changed
+            if (!skipProjectReload) {
+                const validationStartTime = Date.now();
+                void validateProject(project)
+                    .then(() => {
+                        const validationTime = Date.now() - validationStartTime;
+                        void debugLogger.logCliValidation(validationTime, true);
+                    })
+                    .catch((err) => {
+                        const validationTime = Date.now() - validationStartTime;
+                        void debugLogger.logCliValidation(validationTime, false);
+                        context.logger.error(
+                            `Validation failed (took ${validationTime}ms): ${extractErrorMessage(err)}`
+                        );
+                        // Still log validation errors to help developers
+                        if (err instanceof Error && err.stack) {
+                            context.logger.debug(`Validation error stack: ${err.stack}`);
+                        }
+                    });
+            }
 
             const docsGenStartTime = Date.now();
             const newPreviewResult = await getPreviewDocsDefinition({
@@ -1259,7 +1320,22 @@ export async function runAppPreviewServer({
                         );
                     }
 
-                    const reloadedPreviewResult = await reloadDocsDefinition(filesToReload);
+                    // Skip full project reload for markdown-only changes.
+                    // The project config (docs.yml, API specs) hasn't changed,
+                    // so we can reuse the existing project and go straight to
+                    // the incremental markdown update path.
+                    const allMarkdown = editedAbsoluteFilepaths.every(isMarkdownFile);
+                    const canSkipProjectReload = allMarkdown && previewResult != null;
+
+                    if (canSkipProjectReload) {
+                        context.logger.debug(
+                            `Markdown-only change detected (${editedAbsoluteFilepaths.length} file(s)), using fast reload path`
+                        );
+                    }
+
+                    const reloadedPreviewResult = await reloadDocsDefinition(filesToReload, {
+                        skipProjectReload: canSkipProjectReload
+                    });
 
                     // Update the docs definition BEFORE notifying the browser,
                     // so the backend serves fresh data when the browser refreshes.


### PR DESCRIPTION
## Description

Addresses the `fern docs dev` performance regression reported by LaunchDarkly (Pylon #20848), where page changes take ~40 seconds to reload.

## Root Cause

On every file change (even simple markdown edits), the hot reload handler runs three expensive operations unconditionally:

1. **`reloadProject()`** — re-reads all config files, `generators.yml`, and re-creates all API workspace objects from disk. For large projects with many OpenAPI specs, this is very expensive.
2. **`snippetTracker.buildDependencyMap()`** — scans and reads ALL markdown files in the workspace directory to rebuild the entire snippet dependency graph from scratch.
3. **`validateProject()`** — runs full docs workspace validation in the background.

While `getPreviewDocsDefinition()` already has a fast path for markdown-only changes (skipping full docs resolution), it is only reached after steps 1-3 have already completed. For large projects, these operations dominate the reload time.

## Changes Made

- Add early detection of markdown-only changes in the watcher handler, before entering the reload flow
- Skip `reloadProject()` for markdown-only changes — the project config (docs.yml, API specs) hasn't changed, so the existing project object is reused
- Skip full `buildDependencyMap()` rebuild for markdown-only changes — add `updateDependencyMapForFiles()` that incrementally updates snippet dependencies only for the changed files
- Skip background validation for markdown-only changes since config hasn't changed
- Non-markdown file changes (YAML, images, config) continue to use the full reload path

## Testing

- [x] Compilation passes (`pnpm turbo run compile --filter=@fern-api/docs-preview`)
- [x] Biome lint/format passes
- [x] Manual code review of the fast path logic ensures correctness:
  - Markdown-only changes → skip project reload, incremental snippet update, fast path in `getPreviewDocsDefinition`
  - Non-markdown changes or no previous result → full reload path (unchanged behavior)
  - Nav-affecting markdown changes (position/sidebar-title/slug frontmatter) → handled by existing logic in `getPreviewDocsDefinition` which falls through to full resolve when needed

Link to Devin session: https://app.devin.ai/sessions/7009c31af27f4ef18d3562db7cdb1cc1
Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->