### PR TITLE
fix(python): revert manual versions.yml entry, add proper changelog file

### DIFF
--- a/generators/python/sdk/changes/unreleased/fix-sse-discrimination.yml
+++ b/generators/python/sdk/changes/unreleased/fix-sse-discrimination.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix SSE union discrimination for both data-level and protocol-level contexts.
+
+    Data-level: Simplify `parse_sse_obj` to always parse the SSE `data` field as
+    JSON instead of using runtime heuristics. This fixes incorrect routing when the
+    discriminant field name (e.g., `event`) collides with an SSE envelope field.
+
+    Protocol-level: Generate an if/elif dispatch chain at code-generation time that
+    routes on `_sse.event`, parsing each variant's data payload into its concrete
+    type. No runtime heuristic — the generator decides the code path statically.
+  type: fix

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -751,21 +751,6 @@
   createdAt: "2026-03-27"
   irVersion: 65
 
-- version: 5.0.9
-  changelogEntry:
-    - summary: |
-        Fix SSE union discrimination for both data-level and protocol-level contexts.
-
-        Data-level: Simplify `parse_sse_obj` to always parse the SSE `data` field as
-        JSON instead of using runtime heuristics. This fixes incorrect routing when the
-        discriminant field name (e.g., `event`) collides with an SSE envelope field.
-
-        Protocol-level: Generate an if/elif dispatch chain at code-generation time that
-        routes on `_sse.event`, parsing each variant's data payload into its concrete
-        type. No runtime "if casing" — the generator decides the code path statically.
-      type: fix
-  createdAt: "2026-03-27"
-  irVersion: 65
 
 - version: 5.0.8
   changelogEntry:


### PR DESCRIPTION
## Description

Refs #14154

The merged PR #14154 incorrectly added a manual `versions.yml` entry for version `5.0.9`. Manual edits to `versions.yml` conflict with the automated release pipeline. This PR removes that entry and adds a proper unreleased changelog file instead.

## Changes Made

- Removed the manual `5.0.9` entry from `generators/python/sdk/versions.yml`
- Added `generators/python/sdk/changes/unreleased/fix-sse-discrimination.yml` with the same changelog summary, so the automated release pipeline picks it up correctly

## Testing

- No code changes — only changelog/versioning metadata
- [x] Verified the `versions.yml` diff only removes the bad entry
- [x] Verified the new changelog file follows the `.template.yml` format

Link to Devin session: https://app.devin.ai/sessions/8faf7a5834bf46c795485879b9b6c1e4
Requested by: @Ryan-Amirthan