### PR TITLE
fix(python): cache annotation metadata to speed up SDK SSE parsing

### DIFF
--- a/generators/python/core_utilities/shared/serialization.py
+++ b/generators/python/core_utilities/shared/serialization.py
@@ -24,6 +24,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -55,6 +124,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -158,12 +234,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -219,12 +290,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/generators/python/sdk/changes/unreleased/cache-annotation-metadata-conversion.yml
+++ b/generators/python/sdk/changes/unreleased/cache-annotation-metadata-conversion.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Improve SSE event parsing and deserialization performance by caching resolved type hints
+    and short-circuiting `convert_and_respect_annotation_metadata` when a type has no aliased
+    fields. Previously every call recomputed `typing.get_type_hints` and walked the entire type
+    graph, which was very expensive for streams parsing many events against large discriminated
+    unions. Output is unchanged.
+  type: fix

--- a/seed/python-sdk/accept-header/src/seed/core/serialization.py
+++ b/seed/python-sdk/accept-header/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/serialization.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/alias/src/seed/core/serialization.py
+++ b/seed/python-sdk/alias/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/allof/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/any-auth/src/seed/core/serialization.py
+++ b/seed/python-sdk/any-auth/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/serialization.py
+++ b/seed/python-sdk/api-wide-base-path-with-default/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/serialization.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/audiences/src/seed/core/serialization.py
+++ b/seed/python-sdk/audiences/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/serialization.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/serialization.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/basic-auth/src/seed/core/serialization.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/serialization.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/bytes-download/src/seed/core/serialization.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/bytes-upload/src/seed/core/serialization.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/serialization.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/serialization.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/serialization.py
+++ b/seed/python-sdk/cli-multi-spec-namespaced/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/cli-multi-spec/src/seed/core/serialization.py
+++ b/seed/python-sdk/cli-multi-spec/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/client-side-params/src/seed/core/serialization.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/content-type/src/seed/core/serialization.py
+++ b/seed/python-sdk/content-type/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/serialization.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/serialization.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/empty-clients/src/seed/core/serialization.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/serialization.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/serialization.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/enum/real-enum/src/seed/core/serialization.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/enum/strenum/src/seed/core/serialization.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/error-property/src/seed/core/serialization.py
+++ b/seed/python-sdk/error-property/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/errors/src/seed/core/serialization.py
+++ b/seed/python-sdk/errors/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/serialization.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/examples/client-filename/src/seed/core/serialization.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/serialization.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/core/serialization.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/examples/readme/src/seed/core/serialization.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/output-directory-project-root/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/serialization.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-no-package-root/sub/dir/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/serialization.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root-with-package-path/seed/my_org/my_sdk/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/output-directory-source-root/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/serialization.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/serialization.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/extends/src/seed/core/serialization.py
+++ b/seed/python-sdk/extends/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/extra-properties/src/seed/core/serialization.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/serialization.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/serialization.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/serialization.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/serialization.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/folders/src/seed/core/serialization.py
+++ b/seed/python-sdk/folders/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/serialization.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/header-auth/src/seed/core/serialization.py
+++ b/seed/python-sdk/header-auth/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/http-head/src/seed/core/serialization.py
+++ b/seed/python-sdk/http-head/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/idempotency-headers/src/seed/core/serialization.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/imdb/src/seed/core/serialization.py
+++ b/seed/python-sdk/imdb/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/serialization.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/serialization.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/serialization.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/serialization.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/serialization.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/license/src/seed/core/serialization.py
+++ b/seed/python-sdk/license/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/literal-user-agent/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/serialization.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/literals-unions/src/seed/core/serialization.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/mixed-case/src/seed/core/serialization.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/serialization.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/multi-line-docs/src/seed/core/serialization.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/serialization.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/core/serialization.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/multi-url-environment/src/seed/core/serialization.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/serialization.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/no-content-response/src/seed/core/serialization.py
+++ b/seed/python-sdk/no-content-response/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/no-environment/src/seed/core/serialization.py
+++ b/seed/python-sdk/no-environment/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/no-retries/src/seed/core/serialization.py
+++ b/seed/python-sdk/no-retries/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/null-type/src/seed/core/serialization.py
+++ b/seed/python-sdk/null-type/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/serialization.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/nullable-optional/src/seed/core/serialization.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/nullable-request-body/src/seed/core/serialization.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/serialization.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/serialization.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/serialization.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/serialization.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/serialization.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/serialization.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/serialization.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/serialization.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/serialization.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/object/src/seed/core/serialization.py
+++ b/seed/python-sdk/object/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/objects-with-imports/src/seed/core/serialization.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/openapi-request-body-ref/src/seed/core/serialization.py
+++ b/seed/python-sdk/openapi-request-body-ref/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/optional/src/seed/core/serialization.py
+++ b/seed/python-sdk/optional/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/package-yml/src/seed/core/serialization.py
+++ b/seed/python-sdk/package-yml/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/pagination-custom/src/seed/core/serialization.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/serialization.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/serialization.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/serialization.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/path-parameters/src/seed/core/serialization.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/plain-text/src/seed/core/serialization.py
+++ b/seed/python-sdk/plain-text/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/property-access/src/seed/core/serialization.py
+++ b/seed/python-sdk/property-access/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/public-object/src/seed/core/serialization.py
+++ b/seed/python-sdk/public-object/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/serialization.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/serialization.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/serialization.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/serialization.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/serialization.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/query-param-name-conflict/src/seed/core/serialization.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/request-parameters/src/seed/core/serialization.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/required-nullable/src/seed/core/serialization.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/reserved-keywords/src/seed/core/serialization.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/response-property/src/seed/core/serialization.py
+++ b/seed/python-sdk/response-property/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/core/serialization.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/serialization.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/serialization.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/server-sent-events-resumable/src/seed/core/serialization.py
+++ b/seed/python-sdk/server-sent-events-resumable/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/serialization.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/simple-api/src/seed/core/serialization.py
+++ b/seed/python-sdk/simple-api/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/serialization.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/serialization.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/serialization.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/streaming-parameter/src/seed/core/serialization.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/serialization.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/trace/src/seed/core/serialization.py
+++ b/seed/python-sdk/trace/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/serialization.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/serialization.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/union-query-parameters/src/seed/core/serialization.py
+++ b/seed/python-sdk/union-query-parameters/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/serialization.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/serialization.py
+++ b/seed/python-sdk/unions/flatten-union-request-bodies/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/serialization.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/serialization.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/unions/union-utils/src/seed/core/serialization.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/unknown/src/seed/core/serialization.py
+++ b/seed/python-sdk/unknown/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/url-form-encoded/src/seed/core/serialization.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/serialization.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/serialization.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/serialization.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/variables/src/seed/core/serialization.py
+++ b/seed/python-sdk/variables/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/version-no-default/src/seed/core/serialization.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/version/src/seed/core/serialization.py
+++ b/seed/python-sdk/version/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/webhook-audience/src/seed/core/serialization.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/webhooks/src/seed/core/serialization.py
+++ b/seed/python-sdk/webhooks/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/serialization.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/serialization.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/websocket-multi-url/src/seed/core/serialization.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/serialization.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/serialization.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/serialization.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 

--- a/seed/python-sdk/x-fern-default/src/seed/core/serialization.py
+++ b/seed/python-sdk/x-fern-default/src/seed/core/serialization.py
@@ -26,6 +26,75 @@ class FieldMetadata:
         self.alias = alias
 
 
+# Resolving type hints (typing.get_type_hints) is expensive because it eval/compiles
+# forward-reference annotations. The result is constant for a given type, so we cache it.
+# This is critical for hot paths like SSE event parsing, where the same (often large
+# discriminated-union) type is converted on every single event.
+_type_hints_cache: typing.Dict[typing.Any, typing.Dict[str, typing.Any]] = {}
+
+
+def _get_cached_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        cached = _type_hints_cache.get(expected_type)
+    except TypeError:
+        # Unhashable type; resolve without caching.
+        return _resolve_type_hints(expected_type)
+    if cached is None:
+        cached = _resolve_type_hints(expected_type)
+        _type_hints_cache[expected_type] = cached
+    return cached
+
+
+def _resolve_type_hints(expected_type: typing.Any) -> typing.Dict[str, typing.Any]:
+    try:
+        return typing_extensions.get_type_hints(expected_type, include_extras=True)
+    except NameError:
+        # The type contains a circular reference, so we use the __annotations__ attribute directly.
+        return getattr(expected_type, "__annotations__", {})
+
+
+# Whether convert_and_respect_annotation_metadata can possibly rewrite anything for a given
+# annotation, i.e. whether any reachable model/TypedDict field carries a FieldMetadata alias.
+# This is constant per type, so we cache it and use it to short-circuit the recursive walk.
+_requires_conversion_cache: typing.Dict[typing.Any, bool] = {}
+
+
+def _requires_conversion(type_: typing.Any) -> bool:
+    try:
+        cached = _requires_conversion_cache.get(type_)
+    except TypeError:
+        # Unhashable annotation; compute without caching.
+        return _compute_requires_conversion(type_, set())
+    if cached is None:
+        cached = _compute_requires_conversion(type_, set())
+        _requires_conversion_cache[type_] = cached
+    return cached
+
+
+def _compute_requires_conversion(type_: typing.Any, seen: typing.Set[typing.Any]) -> bool:
+    clean_type = _remove_annotations(type_)
+
+    try:
+        if clean_type in seen:
+            return False
+        seen = seen | {clean_type}
+    except TypeError:
+        # Unhashable type; skip cycle tracking (the type graph is finite in practice).
+        pass
+
+    # Models / TypedDicts: a field alias here means we must dealias; otherwise recurse into fields.
+    if (inspect.isclass(clean_type) and issubclass(clean_type, pydantic.BaseModel)) or typing_extensions.is_typeddict(
+        clean_type
+    ):
+        annotations = _get_cached_type_hints(clean_type)
+        if _get_alias_to_field_name(annotations):
+            return True
+        return any(_compute_requires_conversion(hint, seen) for hint in annotations.values())
+
+    # Containers / unions: recurse into the type arguments (List/Set/Sequence/Dict/Union/etc.).
+    return any(_compute_requires_conversion(arg, seen) for arg in typing_extensions.get_args(clean_type))
+
+
 def convert_and_respect_annotation_metadata(
     *,
     object_: typing.Any,
@@ -57,6 +126,13 @@ def convert_and_respect_annotation_metadata(
         return None
     if inner_type is None:
         inner_type = annotation
+        # The only thing this function ever rewrites is keys that carry a FieldMetadata
+        # alias. If nothing in the (cached) type graph has such an alias, the conversion is
+        # a content-identity transform, so we can skip the entire recursive walk. This is
+        # the hot path for SSE streaming, where a large discriminated union would otherwise
+        # be traversed on every single event.
+        if not _requires_conversion(annotation):
+            return object_
 
     clean_type = _remove_annotations(inner_type)
     # Pydantic models
@@ -160,12 +236,7 @@ def _convert_mapping(
     direction: typing.Literal["read", "write"],
 ) -> typing.Mapping[str, object]:
     converted_object: typing.Dict[str, object] = {}
-    try:
-        annotations = typing_extensions.get_type_hints(expected_type, include_extras=True)
-    except NameError:
-        # The TypedDict contains a circular reference, so
-        # we use the __annotations__ attribute directly.
-        annotations = getattr(expected_type, "__annotations__", {})
+    annotations = _get_cached_type_hints(expected_type)
     aliases_to_field_names = _get_alias_to_field_name(annotations)
     for key, value in object_.items():
         if direction == "read" and key in aliases_to_field_names:
@@ -221,12 +292,12 @@ def _remove_annotations(type_: typing.Any) -> typing.Any:
 
 
 def get_alias_to_field_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_alias_to_field_name(annotations)
 
 
 def get_field_to_alias_mapping(type_: typing.Any) -> typing.Dict[str, str]:
-    annotations = typing_extensions.get_type_hints(type_, include_extras=True)
+    annotations = _get_cached_type_hints(type_)
     return _get_field_to_alias_name(annotations)
 
 


### PR DESCRIPTION
## Description

Fixes a large SSE-parsing performance regression in generated Python SDKs (reported by Cohere). When parsing a server-sent-event stream whose payload type is a large discriminated union, the generated client called `convert_and_respect_annotation_metadata()` on **every single event**, which recomputed `typing.get_type_hints()` and recursively walked the entire reachable type graph each time. `get_type_hints()` `eval`/`compile`s forward-reference annotations, so for a 12-member union this dominated parse time.

### Root cause
For a `Union` payload type, `parse_obj_as` falls into the branch that calls `convert_and_respect_annotation_metadata(...)` per event. cProfile of the Cohere `V2ChatStreamResponse` stream (7.0.1) showed `convert_and_respect_annotation_metadata` was ~93% of total parse time, of which `typing.get_type_hints` alone was ~65%. The actual pydantic `validate_python` was only ~6%. This matches the "expensive type introspection on every event" hypothesis from the support thread.

### Fix
In the shared core utility `generators/python/core_utilities/shared/serialization.py`:
1. **Cache resolved type hints** per type (`_get_cached_type_hints`). `get_type_hints()` output is constant for a given type, so we memoize it instead of recomputing per event. Used by `convert_and_respect_annotation_metadata`, `get_alias_to_field_mapping`, and `get_field_to_alias_mapping`.
2. **Short-circuit when no aliasing is possible** (`_requires_conversion`). The only thing `convert_and_respect_annotation_metadata` ever rewrites is keys carrying a `FieldMetadata` alias. We walk the type graph once per type to determine whether any reachable model/TypedDict field has such an alias and cache the boolean. If nothing in the graph is aliased, the conversion is a content-identity transform and the entire recursive walk is skipped.

Both caches fall back gracefully for unhashable annotations. Output is unchanged for all inputs.

## Changes Made
- Add type-hint caching and an alias-detection short-circuit to `core_utilities/shared/serialization.py` (the file copied into every generated Python SDK).
- Regenerate the embedded `serialization.py` in all 191 `seed/python-sdk` fixtures to match the updated core utility.
- Add an unreleased `fix` changelog entry under `generators/python/sdk/changes/unreleased/`.

## Testing
- [x] **Local CLI, real Cohere spec, before/after** — generated the Cohere SDK locally with this generator and benchmarked the exact `V2ChatStreamResponse` stream from the report (20k events). Identical generated code, only `serialization.py` differing:
  - before (current generator): **3240 µs/event**
  - after (this fix): **185 µs/event** → ~17.5x faster
- [x] **Correctness** — all representative SSE event types (incl. unknown/forward-compatible events) parse byte-identically before vs. after the change.
- [x] **Aliased types still convert** — ran `tests/utils/test_serialization.py` and `tests/utils/test_parse_obj_as.py` with this `serialization.py` swapped into the fixtures; aliased TypedDicts/models (e.g. `shape_type` → `shapeType`, `long_` → `long`) still dealias correctly, confirming the short-circuit only fires when there is genuinely nothing to rewrite (8 passed).
- [x] `poetry run mypy` (335 files) and `poetry run pre-commit run` on the changed source both pass.


Link to Devin session: https://app.devin.ai/sessions/3fa6e8f9e15f4bc0b1350bcb61c234d6
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->