### PR TITLE
fix(cli): skip AI example enhancement in self-hosted builds

### DIFF
--- a/packages/cli/cli/changes/unreleased/skip-ai-examples-self-hosted.yml
+++ b/packages/cli/cli/changes/unreleased/skip-ai-examples-self-hosted.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Skip AI example enhancement in self-hosted builds to avoid Venus JWT 401 errors and unnecessary latency.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -482,8 +482,9 @@ export async function publishDocs({
                     apiNameOverride: apiName
                 });
 
+                const isSelfHosted = token.value === "dummy";
                 const aiEnhancerConfig = getAIEnhancerConfig(
-                    withAiExamples,
+                    withAiExamples && !isSelfHosted,
                     docsWorkspace.config.aiExamples?.style ??
                         docsWorkspace.config.experimental?.aiExampleStyleInstructions
                 );


### PR DESCRIPTION
## Description
Refs FER-10638

In self-hosted Docker builds, `generate.sh` sets `FERN_TOKEN=dummy` when running `fern generate --docs`. The AI example enhancer tries to exchange this dummy token for a Venus JWT, which fails with 401. Because Venus is reachable during Docker build (just returns unauthorized), the air-gap detection doesn't skip it. Each failed attempt adds latency, and with ~20 endpoints this causes ~1m36s of unnecessary delay.

## Changes Made
- Detect self-hosted mode by checking if `token.value === "dummy"` before enabling AI example enhancement
- When detected, `withAiExamples` is set to `false`, completely bypassing Venus JWT exchange and AI enhancement
- Added changelog entry

## Testing
- [x] Manual code review confirming the token check short-circuits AI enhancement
- [x] Lint passes (`pnpm lint:biome`)


Link to Devin session: https://app.devin.ai/sessions/ae2cb4f89e0a4c94bdaf88ea50f8b9c0
Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->