### PR TITLE
fix(cli): add -w flag to pnpm esbuild install in docs preview bundle

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-pnpm-workspace-root-esbuild.yml
+++ b/packages/cli/cli/changes/unreleased/fix-pnpm-workspace-root-esbuild.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix `fern docs dev` failing with `ERR_PNPM_ADDING_TO_ROOT` when installing esbuild in the preview bundle directory. The `-w` flag is now passed to `pnpm i` since the bundle folder contains a `pnpm-workspace.yaml`.
+  type: fix

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -574,7 +574,7 @@ export async function downloadBundle({
             try {
                 // install esbuild
                 logger.debug("Installing esbuild");
-                await loggingExeca(logger, "pnpm", ["i", "esbuild"], {
+                await loggingExeca(logger, "pnpm", ["i", "-w", "esbuild"], {
                     cwd: absolutePathToBundleFolder,
                     doNotPipeOutput: true
                 });
@@ -603,7 +603,7 @@ export async function downloadBundle({
                         try {
                             // Try installing esbuild again after upgrading corepack
                             logger.debug("Installing esbuild after upgrading corepack");
-                            await loggingExeca(logger, "pnpm", ["i", "esbuild"], {
+                            await loggingExeca(logger, "pnpm", ["i", "-w", "esbuild"], {
                                 cwd: absolutePathToBundleFolder,
                                 doNotPipeOutput: true
                             });


### PR DESCRIPTION
## Description

Fixes `fern docs dev` failing with `ERR_PNPM_ADDING_TO_ROOT` when installing esbuild in the preview bundle directory.

## Changes Made

- Added `-w` (workspace root) flag to both `pnpm i esbuild` calls in `downloadLocalDocsBundle.ts`

The docs preview bundle directory (`~/.fern/app-preview/`) contains a `pnpm-workspace.yaml` file (created by the CLI to allowlist esbuild build scripts via `onlyBuiltDependencies`). This makes pnpm treat the directory as a workspace root, and newer pnpm versions refuse to install packages at the workspace root without the `-w` flag — resulting in:

```
ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root, 
which might not be what you want - if you really meant it, make it explicit by running this 
command again with the -w flag (or --workspace-root).
```

Since we intentionally install esbuild at this location, the `-w` flag is the correct fix.

## Testing

- [x] Verified lint passes (`biome lint` — no issues)
- [ ] Manual testing: requires running `fern docs dev` with a newer pnpm version

Link to Devin session: https://app.devin.ai/sessions/9f10d34b45cc4679a9e6d1706a2ab918
Requested by: @Ryan-Amirthan