### PR TITLE
feat(rust): forward-compatible discriminated unions

### DIFF
--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_event_message.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_event_message.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum EventMessage {
         #[serde(rename = "payload")]
         #[non_exhaustive]
@@ -14,6 +15,12 @@ pub enum EventMessage {
         Raw {
             value: String,
         },
+
+        /// Catch-all variant for unrecognized discriminant values.
+        /// If the server sends a discriminant not recognized by the current SDK
+        /// version, the raw payload is captured here so callers can still inspect it.
+        #[serde(untagged)]
+        __Unknown(serde_json::Value),
 }
 
 impl EventMessage {
@@ -23,5 +30,9 @@ impl EventMessage {
 
     pub fn raw(value: String) -> Self {
         Self::Raw { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_flexible_value.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_flexible_value.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum FlexibleValue {
         #[serde(rename = "string")]
         #[non_exhaustive]
@@ -32,6 +33,12 @@ pub enum FlexibleValue {
         StringList {
             value: Vec<String>,
         },
+
+        /// Catch-all variant for unrecognized discriminant values.
+        /// If the server sends a discriminant not recognized by the current SDK
+        /// version, the raw payload is captured here so callers can still inspect it.
+        #[serde(untagged)]
+        __Unknown(serde_json::Value),
 }
 
 impl FlexibleValue {
@@ -53,5 +60,9 @@ impl FlexibleValue {
 
     pub fn string_list(value: Vec<String>) -> Self {
         Self::StringList { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_response.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_response.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Response {
         #[serde(rename = "success")]
         #[non_exhaustive]
@@ -22,6 +23,12 @@ pub enum Response {
             #[serde(skip_serializing_if = "Option::is_none")]
             details: Option<Vec<String>>,
         },
+
+        /// Catch-all variant for unrecognized discriminant values.
+        /// If the server sends a discriminant not recognized by the current SDK
+        /// version, the raw payload is captured here so callers can still inspect it.
+        #[serde(untagged)]
+        __Unknown(serde_json::Value),
 }
 
 impl Response {
@@ -35,5 +42,9 @@ impl Response {
 
     pub fn error_with_details(error: String, code: i64, details: Vec<String>) -> Self {
         Self::Error { error, code, details: Some(details) }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_search_result.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_search_result.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum SearchResult {
         #[serde(rename = "user")]
         #[non_exhaustive]
@@ -40,6 +41,12 @@ pub enum SearchResult {
             #[serde(skip_serializing_if = "Option::is_none")]
             parent_id: Option<String>,
         },
+
+        /// Catch-all variant for unrecognized discriminant values.
+        /// If the server sends a discriminant not recognized by the current SDK
+        /// version, the raw payload is captured here so callers can still inspect it.
+        #[serde(untagged)]
+        __Unknown(serde_json::Value),
 }
 
 impl SearchResult {
@@ -57,5 +64,9 @@ impl SearchResult {
 
     pub fn category_with_parent_id(id: String, name: String, description: String, parent_id: String) -> Self {
         Self::Category { id, name, description, parent_id: Some(parent_id) }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_string_or_number.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_string_or_number.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum StringOrNumber {
         #[serde(rename = "string")]
         #[non_exhaustive]
@@ -14,6 +15,12 @@ pub enum StringOrNumber {
         Number {
             value: i64,
         },
+
+        /// Catch-all variant for unrecognized discriminant values.
+        /// If the server sends a discriminant not recognized by the current SDK
+        /// version, the raw payload is captured here so callers can still inspect it.
+        #[serde(untagged)]
+        __Unknown(serde_json::Value),
 }
 
 impl StringOrNumber {
@@ -23,5 +30,9 @@ impl StringOrNumber {
 
     pub fn number(value: i64) -> Self {
         Self::Number { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_animal.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_animal.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Animal {
         #[serde(rename = "dog")]
         #[non_exhaustive]
@@ -37,6 +38,12 @@ pub enum Animal {
             #[serde(with = "crate::core::number_serializers::option")]
             wing_span: Option<f64>,
         },
+
+        /// Catch-all variant for unrecognized discriminant values.
+        /// If the server sends a discriminant not recognized by the current SDK
+        /// version, the raw payload is captured here so callers can still inspect it.
+        #[serde(untagged)]
+        __Unknown(serde_json::Value),
 }
 
 impl Animal {
@@ -54,5 +61,9 @@ impl Animal {
 
     pub fn bird_with_wing_span(name: String, can_fly: bool, wing_span: f64) -> Self {
         Self::Bird { name, can_fly, wing_span: Some(wing_span) }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_payment_method.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_payment_method.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum PaymentMethod {
         #[serde(rename = "cash")]
         #[non_exhaustive]
@@ -24,6 +25,12 @@ pub enum PaymentMethod {
             #[serde(default)]
             routing_number: String,
         },
+
+        /// Catch-all variant for unrecognized discriminant values.
+        /// If the server sends a discriminant not recognized by the current SDK
+        /// version, the raw payload is captured here so callers can still inspect it.
+        #[serde(untagged)]
+        __Unknown(serde_json::Value),
 }
 
 impl PaymentMethod {
@@ -37,5 +44,9 @@ impl PaymentMethod {
 
     pub fn bank_transfer(account_number: String, routing_number: String) -> Self {
         Self::BankTransfer { account_number, routing_number }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_shape.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_shape.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "kind")]
+#[non_exhaustive]
 pub enum Shape {
         #[serde(rename = "circle")]
         #[non_exhaustive]
@@ -25,6 +26,12 @@ pub enum Shape {
         Square {
             value: f64,
         },
+
+        /// Catch-all variant for unrecognized discriminant values.
+        /// If the server sends a discriminant not recognized by the current SDK
+        /// version, the raw payload is captured here so callers can still inspect it.
+        #[serde(untagged)]
+        __Unknown(serde_json::Value),
 }
 
 impl Shape {
@@ -38,5 +45,9 @@ impl Shape {
 
     pub fn square(value: f64) -> Self {
         Self::Square { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_vehicle.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_vehicle.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "vehicle_type")]
+#[non_exhaustive]
 pub enum Vehicle {
         #[serde(rename = "car")]
         #[non_exhaustive]
@@ -40,6 +41,12 @@ pub enum Vehicle {
             manufacturer: String,
             year: i64,
         },
+
+        /// Catch-all variant for unrecognized discriminant values.
+        /// If the server sends a discriminant not recognized by the current SDK
+        /// version, the raw payload is captured here so callers can still inspect it.
+        #[serde(untagged)]
+        __Unknown(serde_json::Value),
 }
 
 impl Vehicle {
@@ -55,11 +62,16 @@ impl Vehicle {
         Self::Truck { payload_capacity, axles, id, manufacturer, year }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_id(&self) -> &str {
         match self {
                     Self::Car { id, .. } => id,
                     Self::Motorcycle { id, .. } => id,
                     Self::Truck { id, .. } => id,
+                    Self::__Unknown(_) => panic!("get_id() called on __Unknown variant; inspect the raw JSON value directly"),
                 }
     }
 
@@ -68,6 +80,7 @@ impl Vehicle {
                     Self::Car { manufacturer, .. } => manufacturer,
                     Self::Motorcycle { manufacturer, .. } => manufacturer,
                     Self::Truck { manufacturer, .. } => manufacturer,
+                    Self::__Unknown(_) => panic!("get_manufacturer() called on __Unknown variant; inspect the raw JSON value directly"),
                 }
     }
 
@@ -76,6 +89,7 @@ impl Vehicle {
                     Self::Car { year, .. } => year,
                     Self::Motorcycle { year, .. } => year,
                     Self::Truck { year, .. } => year,
+                    Self::__Unknown(_) => panic!("get_year() called on __Unknown variant; inspect the raw JSON value directly"),
                 }
     }
 }

--- a/generators/rust/model/src/union/UnionGenerator.ts
+++ b/generators/rust/model/src/union/UnionGenerator.ts
@@ -22,6 +22,16 @@ import {
 import { isFieldRecursive } from "../utils/recursiveTypeUtils.js";
 import { canDeriveHashAndEq, canDerivePartialEq, generateFieldAttributes, hasHashMapFields, hasHashSetFields } from "../utils/structUtils.js";
 
+/**
+ * Name of the forward-compatible catch-all variant. Generated discriminated unions
+ * include this variant so unknown discriminant values deserialize into a wrapper
+ * holding the raw JSON instead of erroring. The double-underscore prefix matches
+ * the convention used by forward-compatible enums (`__Unknown`) and reduces the
+ * chance of colliding with a user-declared discriminant.
+ */
+const UNKNOWN_VARIANT_NAME = "__Unknown";
+const UNKNOWN_CONSTRUCTOR_NAME = "unknown";
+
 export class UnionGenerator {
     private readonly typeDeclaration: FernIr.TypeDeclaration;
     private readonly unionTypeDeclaration: FernIr.UnionTypeDeclaration;
@@ -35,6 +45,18 @@ export class UnionGenerator {
         this.typeDeclaration = typeDeclaration;
         this.unionTypeDeclaration = unionTypeDeclaration;
         this.context = context;
+    }
+
+    /**
+     * Discriminated unions are forward-compatible by default. A trailing
+     * `__Unknown(serde_json::Value)` variant marked `#[serde(untagged)]` acts as a
+     * fallback so unrecognized discriminant values (e.g. variants added server-side
+     * after this SDK was generated) deserialize into the raw JSON payload instead
+     * of failing. This matches the behavior already provided for multi-variant
+     * enums in this generator and the C#/Java/TypeScript SDKs.
+     */
+    private isForwardCompatible(): boolean {
+        return true;
     }
 
     public generate(): RustFile {
@@ -139,10 +161,31 @@ export class UnionGenerator {
                 }
                 this.generateUnionVariant(writer, unionType);
             });
+
+            if (this.isForwardCompatible()) {
+                if (this.unionTypeDeclaration.types.length > 0) {
+                    writer.newLine();
+                }
+                this.generateUnknownVariant(writer);
+            }
         });
 
         // Generate implementation block if needed
         this.generateImplementationBlock(writer, typeName);
+    }
+
+    /**
+     * Generate the forward-compatible catch-all variant. Annotated with
+     * `#[serde(untagged)]` so serde tries each tagged variant first and falls back
+     * to this variant for unrecognized discriminant values, preserving the raw JSON
+     * payload as `serde_json::Value`.
+     */
+    private generateUnknownVariant(writer: rust.Writer): void {
+        writer.writeLine("    /// Catch-all variant for unrecognized discriminant values.");
+        writer.writeLine("    /// If the server sends a discriminant not recognized by the current SDK");
+        writer.writeLine("    /// version, the raw payload is captured here so callers can still inspect it.");
+        writer.writeLine("    #[serde(untagged)]");
+        writer.writeLine(`    ${UNKNOWN_VARIANT_NAME}(serde_json::Value),`);
     }
 
     private generateUnionAttributes(): rust.Attribute[] {
@@ -166,6 +209,13 @@ export class UnionGenerator {
         // Serde tag attribute for discriminated union
         const discriminantField = getWireValue(this.unionTypeDeclaration.discriminant);
         attributes.push(Attribute.serde.tag(discriminantField));
+
+        if (this.isForwardCompatible()) {
+            // Enum-level #[non_exhaustive] forces callers to include a catch-all
+            // pattern in `match` expressions, so adding new typed variants in the
+            // future is non-breaking.
+            attributes.push(Attribute.nonExhaustive());
+        }
 
         return attributes;
     }
@@ -201,6 +251,12 @@ export class UnionGenerator {
     }
 
     private needsDeriveHashAndEq(): boolean {
+        // The forward-compatible `__Unknown(serde_json::Value)` variant doesn't
+        // support Hash or Eq, so unions with that variant can't derive them.
+        if (this.isForwardCompatible()) {
+            return false;
+        }
+
         // Check if all variant types and base properties can support Hash and Eq derives
 
         const isTypeSupportsHashAndEq = canDeriveHashAndEq(this.unionTypeDeclaration.baseProperties, this.context);
@@ -478,6 +534,19 @@ export class UnionGenerator {
                 });
             });
 
+            // Generate a constructor for the forward-compatible catch-all variant so
+            // callers can wrap a raw JSON payload (the `#[non_exhaustive]` enum attribute
+            // prevents direct construction outside the crate).
+            if (this.isForwardCompatible()) {
+                if (needsNewline) {
+                    writer.newLine();
+                }
+                writer.writeBlock(`pub fn ${UNKNOWN_CONSTRUCTOR_NAME}(value: serde_json::Value) -> Self`, () => {
+                    writer.writeLine(`Self::${UNKNOWN_VARIANT_NAME}(value)`);
+                });
+                needsNewline = true;
+            }
+
             // Generate getter methods for base properties
             if (this.unionTypeDeclaration.baseProperties.length > 0) {
                 this.unionTypeDeclaration.baseProperties.forEach((property) => {
@@ -496,6 +565,15 @@ export class UnionGenerator {
                             const variantName = this.context.case.pascalUnsafe(unionType.discriminantValue);
                             writer.writeLine(`            Self::${variantName} { ${fieldName}, .. } => ${fieldName},`);
                         });
+
+                        if (this.isForwardCompatible()) {
+                            // Base properties aren't typed on the catch-all variant. Callers that
+                            // need to read them on an unknown variant should pattern-match on
+                            // `__Unknown(value)` directly and inspect the raw JSON.
+                            writer.writeLine(
+                                `            Self::${UNKNOWN_VARIANT_NAME}(_) => panic!("${methodName}() called on ${UNKNOWN_VARIANT_NAME} variant; inspect the raw JSON value directly"),`
+                            );
+                        }
 
                         writer.writeLine("        }");
                     });

--- a/generators/rust/sdk/changes/unreleased/forward-compatible-unions.yml
+++ b/generators/rust/sdk/changes/unreleased/forward-compatible-unions.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Discriminated unions are now forward-compatible. Each generated `enum` carries
+    `#[non_exhaustive]` and a final `__Unknown(serde_json::Value)` variant marked
+    `#[serde(untagged)]`. Unknown discriminant values (e.g. variants introduced
+    server-side after this SDK was generated) deserialize into `__Unknown`
+    instead of erroring, preserving the raw JSON payload for inspection and
+    round-trip serialization.
+
+    Forward-compatible unions can no longer derive `Eq`/`Hash` because
+    `serde_json::Value` doesn't implement them. `PartialEq` is still derived.
+  type: feat

--- a/seed/rust-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/rust-sdk/circular-references-advanced/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/circular-references-advanced/src/api/types/ast_container_value.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/types/ast_container_value.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum ContainerValue {
     #[serde(rename = "list")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum ContainerValue {
     #[serde(rename = "optional")]
     #[non_exhaustive]
     Optional { value: Option<Box<FieldValue>> },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl ContainerValue {
@@ -19,5 +26,9 @@ impl ContainerValue {
 
     pub fn optional(value: Option<Box<FieldValue>>) -> Self {
         Self::Optional { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/circular-references-advanced/src/api/types/ast_field_value.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/api/types/ast_field_value.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum FieldValue {
     #[serde(rename = "primitive_value")]
     #[non_exhaustive]
@@ -14,6 +15,12 @@ pub enum FieldValue {
     #[serde(rename = "container_value")]
     #[non_exhaustive]
     ContainerValue { value: Box<ContainerValue> },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl FieldValue {
@@ -27,5 +34,9 @@ impl FieldValue {
 
     pub fn container_value(value: Box<ContainerValue>) -> Self {
         Self::ContainerValue { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/circular-references/.fern/metadata.json
+++ b/seed/rust-sdk/circular-references/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/circular-references/src/api/types/ast_container_value.rs
+++ b/seed/rust-sdk/circular-references/src/api/types/ast_container_value.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum ContainerValue {
     #[serde(rename = "list")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum ContainerValue {
     #[serde(rename = "optional")]
     #[non_exhaustive]
     Optional { value: Option<Box<FieldValue>> },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl ContainerValue {
@@ -19,5 +26,9 @@ impl ContainerValue {
 
     pub fn optional(value: Option<Box<FieldValue>>) -> Self {
         Self::Optional { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/circular-references/src/api/types/ast_field_value.rs
+++ b/seed/rust-sdk/circular-references/src/api/types/ast_field_value.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum FieldValue {
     #[serde(rename = "primitive_value")]
     #[non_exhaustive]
@@ -14,6 +15,12 @@ pub enum FieldValue {
     #[serde(rename = "container_value")]
     #[non_exhaustive]
     ContainerValue { value: Box<ContainerValue> },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl FieldValue {
@@ -27,5 +34,9 @@ impl FieldValue {
 
     pub fn container_value(value: Box<ContainerValue>) -> Self {
         Self::ContainerValue { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/examples/no-custom-config/.fern/metadata.json
+++ b/seed/rust-sdk/examples/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/examples/no-custom-config/src/api/types/commons_types_data.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/types/commons_types_data.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Data {
     #[serde(rename = "string")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum Data {
     #[serde(rename = "base64")]
     #[non_exhaustive]
     Base64 { value: Vec<u8> },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Data {
@@ -19,5 +26,9 @@ impl Data {
 
     pub fn base64(value: Vec<u8>) -> Self {
         Self::Base64 { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/examples/no-custom-config/src/api/types/commons_types_event_info.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/types/commons_types_event_info.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum EventInfo {
     #[serde(rename = "metadata")]
     #[non_exhaustive]
@@ -13,6 +14,12 @@ pub enum EventInfo {
     #[serde(rename = "tag")]
     #[non_exhaustive]
     Tag { value: Tag },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl EventInfo {
@@ -22,5 +29,9 @@ impl EventInfo {
 
     pub fn tag(value: Tag) -> Self {
         Self::Tag { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/examples/no-custom-config/src/api/types/types_exception.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/types/types_exception.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Exception {
     #[serde(rename = "generic")]
     #[non_exhaustive]
@@ -20,6 +21,12 @@ pub enum Exception {
     #[serde(rename = "timeout")]
     #[non_exhaustive]
     Timeout {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Exception {
@@ -37,5 +44,9 @@ impl Exception {
 
     pub fn timeout() -> Self {
         Self::Timeout {}
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/examples/no-custom-config/src/api/types/types_metadata.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/types/types_metadata.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Metadata2 {
     #[serde(rename = "html")]
     #[non_exhaustive]
@@ -18,6 +19,12 @@ pub enum Metadata2 {
         extra: HashMap<String, String>,
         tags: HashSet<String>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Metadata2 {
@@ -29,10 +36,17 @@ impl Metadata2 {
         Self::Markdown { value, extra, tags }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_extra(&self) -> &HashMap<String, String> {
         match self {
             Self::Html { extra, .. } => extra,
             Self::Markdown { extra, .. } => extra,
+            Self::__Unknown(_) => panic!(
+                "get_extra() called on __Unknown variant; inspect the raw JSON value directly"
+            ),
         }
     }
 
@@ -40,6 +54,9 @@ impl Metadata2 {
         match self {
             Self::Html { tags, .. } => tags,
             Self::Markdown { tags, .. } => tags,
+            Self::__Unknown(_) => panic!(
+                "get_tags() called on __Unknown variant; inspect the raw JSON value directly"
+            ),
         }
     }
 }

--- a/seed/rust-sdk/examples/no-custom-config/src/api/types/types_test.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/api/types/types_test.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Test {
     #[serde(rename = "and")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum Test {
     #[serde(rename = "or")]
     #[non_exhaustive]
     Or { value: bool },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Test {
@@ -19,5 +26,9 @@ impl Test {
 
     pub fn or(value: bool) -> Self {
         Self::Or { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/examples/readme-config/.fern/metadata.json
+++ b/seed/rust-sdk/examples/readme-config/.fern/metadata.json
@@ -16,8 +16,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/examples/readme-config/src/api/types/commons_types_data.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/types/commons_types_data.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Data {
     #[serde(rename = "string")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum Data {
     #[serde(rename = "base64")]
     #[non_exhaustive]
     Base64 { value: Vec<u8> },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Data {
@@ -19,5 +26,9 @@ impl Data {
 
     pub fn base64(value: Vec<u8>) -> Self {
         Self::Base64 { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/examples/readme-config/src/api/types/commons_types_event_info.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/types/commons_types_event_info.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum EventInfo {
     #[serde(rename = "metadata")]
     #[non_exhaustive]
@@ -13,6 +14,12 @@ pub enum EventInfo {
     #[serde(rename = "tag")]
     #[non_exhaustive]
     Tag { value: Tag },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl EventInfo {
@@ -22,5 +29,9 @@ impl EventInfo {
 
     pub fn tag(value: Tag) -> Self {
         Self::Tag { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/examples/readme-config/src/api/types/types_exception.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/types/types_exception.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Exception {
     #[serde(rename = "generic")]
     #[non_exhaustive]
@@ -20,6 +21,12 @@ pub enum Exception {
     #[serde(rename = "timeout")]
     #[non_exhaustive]
     Timeout {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Exception {
@@ -37,5 +44,9 @@ impl Exception {
 
     pub fn timeout() -> Self {
         Self::Timeout {}
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/examples/readme-config/src/api/types/types_metadata.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/types/types_metadata.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Metadata2 {
     #[serde(rename = "html")]
     #[non_exhaustive]
@@ -18,6 +19,12 @@ pub enum Metadata2 {
         extra: HashMap<String, String>,
         tags: HashSet<String>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Metadata2 {
@@ -29,10 +36,17 @@ impl Metadata2 {
         Self::Markdown { value, extra, tags }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_extra(&self) -> &HashMap<String, String> {
         match self {
             Self::Html { extra, .. } => extra,
             Self::Markdown { extra, .. } => extra,
+            Self::__Unknown(_) => panic!(
+                "get_extra() called on __Unknown variant; inspect the raw JSON value directly"
+            ),
         }
     }
 
@@ -40,6 +54,9 @@ impl Metadata2 {
         match self {
             Self::Html { tags, .. } => tags,
             Self::Markdown { tags, .. } => tags,
+            Self::__Unknown(_) => panic!(
+                "get_tags() called on __Unknown variant; inspect the raw JSON value directly"
+            ),
         }
     }
 }

--- a/seed/rust-sdk/examples/readme-config/src/api/types/types_test.rs
+++ b/seed/rust-sdk/examples/readme-config/src/api/types/types_test.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Test {
     #[serde(rename = "and")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum Test {
     #[serde(rename = "or")]
     #[non_exhaustive]
     Or { value: bool },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Test {
@@ -19,5 +26,9 @@ impl Test {
 
     pub fn or(value: bool) -> Self {
         Self::Or { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/exhaustive/.fern/metadata.json
+++ b/seed/rust-sdk/exhaustive/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/exhaustive/src/api/types/types_union_animal.rs
+++ b/seed/rust-sdk/exhaustive/src/api/types/types_union_animal.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "animal")]
+#[non_exhaustive]
 pub enum Animal {
     #[serde(rename = "dog")]
     #[non_exhaustive]
@@ -22,6 +23,12 @@ pub enum Animal {
         #[serde(default)]
         likes_to_meow: bool,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Animal {
@@ -37,5 +44,9 @@ impl Animal {
             name,
             likes_to_meow,
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/literal/.fern/metadata.json
+++ b/seed/rust-sdk/literal/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/literal/src/api/types/inlined_discriminated_literal.rs
+++ b/seed/rust-sdk/literal/src/api/types/inlined_discriminated_literal.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum DiscriminatedLiteral {
     #[serde(rename = "customName")]
     #[non_exhaustive]
@@ -18,6 +19,12 @@ pub enum DiscriminatedLiteral {
     #[serde(rename = "literalGeorge")]
     #[non_exhaustive]
     LiteralGeorge { value: bool },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl DiscriminatedLiteral {
@@ -35,5 +42,9 @@ impl DiscriminatedLiteral {
 
     pub fn literal_george(value: bool) -> Self {
         Self::LiteralGeorge { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/mixed-case/.fern/metadata.json
+++ b/seed/rust-sdk/mixed-case/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/mixed-case/src/api/types/service_resource.rs
+++ b/seed/rust-sdk/mixed-case/src/api/types/service_resource.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "resource_type")]
+#[non_exhaustive]
 pub enum Resource {
     #[serde(rename = "user")]
     #[non_exhaustive]
@@ -17,6 +18,12 @@ pub enum Resource {
         name: String,
         status: ResourceStatus,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Resource {
@@ -28,10 +35,17 @@ impl Resource {
         Self::Organization { name, status }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_status(&self) -> &ResourceStatus {
         match self {
             Self::User { status, .. } => status,
             Self::Organization { status, .. } => status,
+            Self::__Unknown(_) => panic!(
+                "get_status() called on __Unknown variant; inspect the raw JSON value directly"
+            ),
         }
     }
 }

--- a/seed/rust-sdk/nullable-optional/.fern/metadata.json
+++ b/seed/rust-sdk/nullable-optional/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_notification_method.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_notification_method.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum NotificationMethod {
     #[serde(rename = "email")]
     #[non_exhaustive]
@@ -42,6 +43,12 @@ pub enum NotificationMethod {
         #[serde(skip_serializing_if = "Option::is_none")]
         badge: Option<i64>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl NotificationMethod {
@@ -97,5 +104,9 @@ impl NotificationMethod {
             body,
             badge: Some(badge),
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_search_result.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_search_result.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum SearchResult {
     #[serde(rename = "user")]
     #[non_exhaustive]
@@ -31,6 +32,12 @@ pub enum SearchResult {
         #[serde(skip_serializing_if = "Option::is_none")]
         tags: Option<Vec<String>>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl SearchResult {
@@ -82,5 +89,9 @@ impl SearchResult {
             author,
             tags: Some(tags),
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/nullable/.fern/metadata.json
+++ b/seed/rust-sdk/nullable/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/nullable/src/api/types/nullable_status.rs
+++ b/seed/rust-sdk/nullable/src/api/types/nullable_status.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Status {
     #[serde(rename = "active")]
     #[non_exhaustive]
@@ -22,6 +23,12 @@ pub enum Status {
         #[serde(with = "crate::core::flexible_datetime::offset::option")]
         value: Option<DateTime<FixedOffset>>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Status {
@@ -35,5 +42,9 @@ impl Status {
 
     pub fn soft_deleted(value: Option<DateTime<FixedOffset>>) -> Self {
         Self::SoftDeleted { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/property-access/.fern/metadata.json
+++ b/seed/rust-sdk/property-access/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/property-access/src/api/types/user_or_admin_discriminated.rs
+++ b/seed/rust-sdk/property-access/src/api/types/user_or_admin_discriminated.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UserOrAdminDiscriminated {
     #[serde(rename = "user")]
     #[non_exhaustive]
@@ -23,6 +24,12 @@ pub enum UserOrAdminDiscriminated {
     #[serde(rename = "empty")]
     #[non_exhaustive]
     Empty {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UserOrAdminDiscriminated {
@@ -38,11 +45,18 @@ impl UserOrAdminDiscriminated {
         Self::Empty {}
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_normal(&self) -> &str {
         match self {
             Self::User { normal, .. } => normal,
             Self::Admin { normal, .. } => normal,
             Self::Empty { normal, .. } => normal,
+            Self::__Unknown(_) => panic!(
+                "get_normal() called on __Unknown variant; inspect the raw JSON value directly"
+            ),
         }
     }
 
@@ -51,6 +65,9 @@ impl UserOrAdminDiscriminated {
             Self::User { foo, .. } => foo,
             Self::Admin { foo, .. } => foo,
             Self::Empty { foo, .. } => foo,
+            Self::__Unknown(_) => {
+                panic!("get_foo() called on __Unknown variant; inspect the raw JSON value directly")
+            }
         }
     }
 }

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/.fern/metadata.json
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/.fern/metadata.json
@@ -8,8 +8,7 @@
     "packageVersion": "0.1.0"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/api/types/completions_stream_event.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/api/types/completions_stream_event.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "event")]
+#[non_exhaustive]
 pub enum StreamEvent {
     #[serde(rename = "completion")]
     #[non_exhaustive]
@@ -16,6 +17,12 @@ pub enum StreamEvent {
         #[serde(flatten)]
         data: ErrorEvent,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl StreamEvent {
@@ -25,5 +32,9 @@ impl StreamEvent {
 
     pub fn error(data: ErrorEvent) -> Self {
         Self::Error { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/api/types/completions_stream_event_context_protocol.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/api/types/completions_stream_event_context_protocol.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "event")]
+#[non_exhaustive]
 pub enum StreamEventContextProtocol {
     #[serde(rename = "completion")]
     #[non_exhaustive]
@@ -25,6 +26,12 @@ pub enum StreamEventContextProtocol {
         #[serde(default)]
         name: String,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl StreamEventContextProtocol {
@@ -38,5 +45,9 @@ impl StreamEventContextProtocol {
 
     pub fn event(event: String, name: String) -> Self {
         Self::Event { event, name }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/api/types/completions_stream_event_discriminant_in_data.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/api/types/completions_stream_event_discriminant_in_data.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum StreamEventDiscriminantInData {
     #[serde(rename = "group.created")]
     #[non_exhaustive]
@@ -20,6 +21,12 @@ pub enum StreamEventDiscriminantInData {
         #[serde(default)]
         group_id: String,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl StreamEventDiscriminantInData {
@@ -29,5 +36,9 @@ impl StreamEventDiscriminantInData {
 
     pub fn group_deleted(offset: String, group_id: String) -> Self {
         Self::GroupDeleted { offset, group_id }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/server-sent-events-openapi/.fern/metadata.json
+++ b/seed/rust-sdk/server-sent-events-openapi/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_data_context_response.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_data_context_response.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "event")]
+#[non_exhaustive]
 pub enum StreamDataContextResponse {
     #[serde(rename = "heartbeat")]
     #[non_exhaustive]
@@ -16,6 +17,12 @@ pub enum StreamDataContextResponse {
         #[serde(flatten)]
         data: DataContextEntityEvent,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl StreamDataContextResponse {
@@ -25,5 +32,9 @@ impl StreamDataContextResponse {
 
     pub fn entity(data: DataContextEntityEvent) -> Self {
         Self::Entity { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_data_context_with_envelope_schema_response.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_data_context_with_envelope_schema_response.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "event")]
+#[non_exhaustive]
 pub enum StreamDataContextWithEnvelopeSchemaResponse {
     #[serde(rename = "heartbeat")]
     #[non_exhaustive]
@@ -30,6 +31,12 @@ pub enum StreamDataContextWithEnvelopeSchemaResponse {
         #[serde(flatten)]
         data: ProtocolObjectEvent,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl StreamDataContextWithEnvelopeSchemaResponse {
@@ -47,5 +54,9 @@ impl StreamDataContextWithEnvelopeSchemaResponse {
 
     pub fn object_data(data: ProtocolObjectEvent) -> Self {
         Self::ObjectData { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_no_context_response.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_no_context_response.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "event")]
+#[non_exhaustive]
 pub enum StreamNoContextResponse {
     #[serde(rename = "heartbeat")]
     #[non_exhaustive]
@@ -16,6 +17,12 @@ pub enum StreamNoContextResponse {
         #[serde(flatten)]
         data: DataContextEntityEvent,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl StreamNoContextResponse {
@@ -25,5 +32,9 @@ impl StreamNoContextResponse {
 
     pub fn entity(data: DataContextEntityEvent) -> Self {
         Self::Entity { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_protocol_collision_response.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_protocol_collision_response.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "event")]
+#[non_exhaustive]
 pub enum StreamProtocolCollisionResponse {
     #[serde(rename = "heartbeat")]
     #[non_exhaustive]
@@ -30,6 +31,12 @@ pub enum StreamProtocolCollisionResponse {
         #[serde(default)]
         data: ObjectPayloadWithEventField,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl StreamProtocolCollisionResponse {
@@ -47,5 +54,9 @@ impl StreamProtocolCollisionResponse {
 
     pub fn object_data(data: ObjectPayloadWithEventField) -> Self {
         Self::ObjectData { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_protocol_no_collision_response.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_protocol_no_collision_response.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "event")]
+#[non_exhaustive]
 pub enum StreamProtocolNoCollisionResponse {
     #[serde(rename = "heartbeat")]
     #[non_exhaustive]
@@ -30,6 +31,12 @@ pub enum StreamProtocolNoCollisionResponse {
         #[serde(flatten)]
         data: ProtocolObjectEvent,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl StreamProtocolNoCollisionResponse {
@@ -47,5 +54,9 @@ impl StreamProtocolNoCollisionResponse {
 
     pub fn object_data(data: ProtocolObjectEvent) -> Self {
         Self::ObjectData { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_protocol_with_flat_schema_response.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_protocol_with_flat_schema_response.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "event")]
+#[non_exhaustive]
 pub enum StreamProtocolWithFlatSchemaResponse {
     #[serde(rename = "heartbeat")]
     #[non_exhaustive]
@@ -16,6 +17,12 @@ pub enum StreamProtocolWithFlatSchemaResponse {
         #[serde(flatten)]
         data: DataContextEntityEvent,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl StreamProtocolWithFlatSchemaResponse {
@@ -25,5 +32,9 @@ impl StreamProtocolWithFlatSchemaResponse {
 
     pub fn entity(data: DataContextEntityEvent) -> Self {
         Self::Entity { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_x_fern_streaming_union_request.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_x_fern_streaming_union_request.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum StreamXFernStreamingUnionRequest {
     #[serde(rename = "message")]
     #[non_exhaustive]
@@ -26,6 +27,12 @@ pub enum StreamXFernStreamingUnionRequest {
         data: UnionStreamCompactVariant,
         stream_response: bool,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl StreamXFernStreamingUnionRequest {
@@ -50,17 +57,16 @@ impl StreamXFernStreamingUnionRequest {
         }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_stream_response(&self) -> &bool {
         match self {
-            Self::Message {
-                stream_response, ..
-            } => stream_response,
-            Self::Interrupt {
-                stream_response, ..
-            } => stream_response,
-            Self::Compact {
-                stream_response, ..
-            } => stream_response,
-        }
+                    Self::Message { stream_response, .. } => stream_response,
+                    Self::Interrupt { stream_response, .. } => stream_response,
+                    Self::Compact { stream_response, .. } => stream_response,
+                    Self::__Unknown(_) => panic!("get_stream_response() called on __Unknown variant; inspect the raw JSON value directly"),
+                }
     }
 }

--- a/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_x_fern_streaming_union_stream_request.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/api/types/stream_x_fern_streaming_union_stream_request.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum StreamXFernStreamingUnionStreamRequest {
     #[serde(rename = "message")]
     #[non_exhaustive]
@@ -26,6 +27,12 @@ pub enum StreamXFernStreamingUnionStreamRequest {
         data: UnionStreamCompactVariant,
         stream_response: bool,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl StreamXFernStreamingUnionStreamRequest {
@@ -50,17 +57,16 @@ impl StreamXFernStreamingUnionStreamRequest {
         }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_stream_response(&self) -> &bool {
         match self {
-            Self::Message {
-                stream_response, ..
-            } => stream_response,
-            Self::Interrupt {
-                stream_response, ..
-            } => stream_response,
-            Self::Compact {
-                stream_response, ..
-            } => stream_response,
-        }
+                    Self::Message { stream_response, .. } => stream_response,
+                    Self::Interrupt { stream_response, .. } => stream_response,
+                    Self::Compact { stream_response, .. } => stream_response,
+                    Self::__Unknown(_) => panic!("get_stream_response() called on __Unknown variant; inspect the raw JSON value directly"),
+                }
     }
 }

--- a/seed/rust-sdk/server-sent-events-openapi/src/api/types/union_stream_request.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/api/types/union_stream_request.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionStreamRequest {
     #[serde(rename = "message")]
     #[non_exhaustive]
@@ -23,6 +24,12 @@ pub enum UnionStreamRequest {
         #[serde(flatten)]
         data: UnionStreamCompactVariant,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionStreamRequest {
@@ -36,5 +43,9 @@ impl UnionStreamRequest {
 
     pub fn compact(data: UnionStreamCompactVariant) -> Self {
         Self::Compact { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/.fern/metadata.json
+++ b/seed/rust-sdk/trace/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/trace/src/api/types/admin_test.rs
+++ b/seed/rust-sdk/trace/src/api/types/admin_test.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Test {
     #[serde(rename = "and")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum Test {
     #[serde(rename = "or")]
     #[non_exhaustive]
     Or { value: bool },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Test {
@@ -19,5 +26,9 @@ impl Test {
 
     pub fn or(value: bool) -> Self {
         Self::Or { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/commons_debug_variable_value.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_debug_variable_value.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum DebugVariableValue {
     #[serde(rename = "integerValue")]
     #[non_exhaustive]
@@ -86,6 +87,12 @@ pub enum DebugVariableValue {
         #[serde(default)]
         stringified_value: String,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl DebugVariableValue {
@@ -158,5 +165,9 @@ impl DebugVariableValue {
             stringified_type: Some(stringified_type),
             stringified_value,
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/commons_variable_type.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_variable_type.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum VariableType {
     #[serde(rename = "integerType")]
     #[non_exhaustive]
@@ -53,6 +54,12 @@ pub enum VariableType {
     #[serde(rename = "doublyLinkedListType")]
     #[non_exhaustive]
     DoublyLinkedListType {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl VariableType {
@@ -110,5 +117,9 @@ impl VariableType {
             value_type,
             is_fixed_length: Some(is_fixed_length),
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/commons_variable_value.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_variable_value.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum VariableValue {
     #[serde(rename = "integerValue")]
     #[non_exhaustive]
@@ -59,6 +60,12 @@ pub enum VariableValue {
     #[serde(rename = "nullValue")]
     #[non_exhaustive]
     NullValue {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl VariableValue {
@@ -104,5 +111,9 @@ impl VariableValue {
 
     pub fn null_value() -> Self {
         Self::NullValue {}
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/playlist_playlist_id_not_found_error_body.rs
+++ b/seed/rust-sdk/trace/src/api/types/playlist_playlist_id_not_found_error_body.rs
@@ -1,15 +1,26 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum PlaylistIdNotFoundErrorBody {
     #[serde(rename = "playlistId")]
     #[non_exhaustive]
     PlaylistId { value: PlaylistId },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl PlaylistIdNotFoundErrorBody {
     pub fn playlist_id(value: PlaylistId) -> Self {
         Self::PlaylistId { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/problem_create_problem_error.rs
+++ b/seed/rust-sdk/trace/src/api/types/problem_create_problem_error.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "_type")]
+#[non_exhaustive]
 pub enum CreateProblemError {
     #[serde(rename = "generic")]
     #[non_exhaustive]
@@ -13,6 +14,12 @@ pub enum CreateProblemError {
         #[serde(default)]
         stacktrace: String,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl CreateProblemError {
@@ -22,5 +29,9 @@ impl CreateProblemError {
             r#type,
             stacktrace,
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/problem_create_problem_response.rs
+++ b/seed/rust-sdk/trace/src/api/types/problem_create_problem_response.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum CreateProblemResponse {
     #[serde(rename = "success")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum CreateProblemResponse {
     #[serde(rename = "error")]
     #[non_exhaustive]
     Error { value: CreateProblemError },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl CreateProblemResponse {
@@ -19,5 +26,9 @@ impl CreateProblemResponse {
 
     pub fn error(value: CreateProblemError) -> Self {
         Self::Error { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/problem_problem_description_board.rs
+++ b/seed/rust-sdk/trace/src/api/types/problem_problem_description_board.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum ProblemDescriptionBoard {
     #[serde(rename = "html")]
     #[non_exhaustive]
@@ -14,6 +15,12 @@ pub enum ProblemDescriptionBoard {
     #[serde(rename = "testCaseId")]
     #[non_exhaustive]
     TestCaseId { value: String },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl ProblemDescriptionBoard {
@@ -27,5 +34,9 @@ impl ProblemDescriptionBoard {
 
     pub fn test_case_id(value: String) -> Self {
         Self::TestCaseId { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_actual_result.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_actual_result.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum ActualResult {
     #[serde(rename = "value")]
     #[non_exhaustive]
@@ -17,6 +18,12 @@ pub enum ActualResult {
     #[serde(rename = "exceptionV2")]
     #[non_exhaustive]
     ExceptionV2 { value: ExceptionV2 },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl ActualResult {
@@ -30,5 +37,9 @@ impl ActualResult {
 
     pub fn exception_v2(value: ExceptionV2) -> Self {
         Self::ExceptionV2 { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_code_execution_update.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_code_execution_update.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum CodeExecutionUpdate {
     #[serde(rename = "buildingExecutor")]
     #[non_exhaustive]
@@ -120,6 +121,12 @@ pub enum CodeExecutionUpdate {
         #[serde(default)]
         submission_id: SubmissionId,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl CodeExecutionUpdate {
@@ -247,5 +254,9 @@ impl CodeExecutionUpdate {
             trace_responses_size,
             test_case_id: Some(test_case_id),
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_error_info.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_error_info.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum ErrorInfo {
     #[serde(rename = "compileError")]
     #[non_exhaustive]
@@ -24,6 +25,12 @@ pub enum ErrorInfo {
         #[serde(default)]
         exception_info: ExceptionInfo,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl ErrorInfo {
@@ -37,5 +44,9 @@ impl ErrorInfo {
 
     pub fn internal_error(exception_info: ExceptionInfo) -> Self {
         Self::InternalError { exception_info }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_exception_v_2.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_exception_v_2.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum ExceptionV2 {
     #[serde(rename = "generic")]
     #[non_exhaustive]
@@ -13,6 +14,12 @@ pub enum ExceptionV2 {
     #[serde(rename = "timeout")]
     #[non_exhaustive]
     Timeout {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl ExceptionV2 {
@@ -22,5 +29,9 @@ impl ExceptionV2 {
 
     pub fn timeout() -> Self {
         Self::Timeout {}
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_invalid_request_cause.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_invalid_request_cause.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum InvalidRequestCause {
     #[serde(rename = "submissionIdNotFound")]
     #[non_exhaustive]
@@ -30,6 +31,12 @@ pub enum InvalidRequestCause {
         #[serde(rename = "actualLanguage")]
         actual_language: Language,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl InvalidRequestCause {
@@ -54,5 +61,9 @@ impl InvalidRequestCause {
             expected_language,
             actual_language,
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_submission_request.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_submission_request.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum SubmissionRequest {
     #[serde(rename = "initializeProblemRequest")]
     #[non_exhaustive]
@@ -61,6 +62,12 @@ pub enum SubmissionRequest {
         #[serde(default)]
         submission_id: SubmissionId,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl SubmissionRequest {
@@ -166,5 +173,9 @@ impl SubmissionRequest {
             submission_files,
             user_id: Some(user_id),
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_submission_response.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_submission_response.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum SubmissionResponse {
     #[serde(rename = "serverInitialized")]
     #[non_exhaustive]
@@ -29,6 +30,12 @@ pub enum SubmissionResponse {
     #[serde(rename = "terminated")]
     #[non_exhaustive]
     Terminated {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl SubmissionResponse {
@@ -54,5 +61,9 @@ impl SubmissionResponse {
 
     pub fn terminated() -> Self {
         Self::Terminated {}
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_submission_status_for_test_case.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_submission_status_for_test_case.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum SubmissionStatusForTestCase {
     #[serde(rename = "graded")]
     #[non_exhaustive]
@@ -22,6 +23,12 @@ pub enum SubmissionStatusForTestCase {
         #[serde(default)]
         trace_responses_size: i64,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl SubmissionStatusForTestCase {
@@ -38,5 +45,9 @@ impl SubmissionStatusForTestCase {
             result,
             trace_responses_size,
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_submission_status_v_2.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_submission_status_v_2.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum SubmissionStatusV2 {
     #[serde(rename = "test")]
     #[non_exhaustive]
@@ -24,6 +25,12 @@ pub enum SubmissionStatusV2 {
         #[serde(default)]
         updates: Vec<WorkspaceSubmissionUpdate>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl SubmissionStatusV2 {
@@ -43,5 +50,9 @@ impl SubmissionStatusV2 {
 
     pub fn workspace(updates: Vec<WorkspaceSubmissionUpdate>) -> Self {
         Self::Workspace { updates }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_submission_type_state.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_submission_type_state.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum SubmissionTypeState {
     #[serde(rename = "test")]
     #[non_exhaustive]
@@ -21,6 +22,12 @@ pub enum SubmissionTypeState {
     #[serde(rename = "workspace")]
     #[non_exhaustive]
     Workspace { status: WorkspaceSubmissionStatus },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl SubmissionTypeState {
@@ -40,5 +47,9 @@ impl SubmissionTypeState {
 
     pub fn workspace(status: WorkspaceSubmissionStatus) -> Self {
         Self::Workspace { status }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_test_case_grade.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_test_case_grade.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum TestCaseGrade {
     #[serde(rename = "hidden")]
     #[non_exhaustive]
@@ -23,6 +24,12 @@ pub enum TestCaseGrade {
         #[serde(default)]
         stdout: String,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl TestCaseGrade {
@@ -65,5 +72,9 @@ impl TestCaseGrade {
             exception: Some(exception),
             stdout,
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_test_submission_status.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_test_submission_status.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum TestSubmissionStatus {
     #[serde(rename = "stopped")]
     #[non_exhaustive]
@@ -20,6 +21,12 @@ pub enum TestSubmissionStatus {
     TestCaseIdToState {
         value: HashMap<String, SubmissionStatusForTestCase>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl TestSubmissionStatus {
@@ -37,5 +44,9 @@ impl TestSubmissionStatus {
 
     pub fn test_case_id_to_state(value: HashMap<String, SubmissionStatusForTestCase>) -> Self {
         Self::TestCaseIdToState { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_test_submission_update_info.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_test_submission_update_info.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum TestSubmissionUpdateInfo {
     #[serde(rename = "running")]
     #[non_exhaustive]
@@ -38,6 +39,12 @@ pub enum TestSubmissionUpdateInfo {
     #[serde(rename = "finished")]
     #[non_exhaustive]
     Finished {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl TestSubmissionUpdateInfo {
@@ -69,5 +76,9 @@ impl TestSubmissionUpdateInfo {
 
     pub fn finished() -> Self {
         Self::Finished {}
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_workspace_submission_status.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_workspace_submission_status.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum WorkspaceSubmissionStatus {
     #[serde(rename = "stopped")]
     #[non_exhaustive]
@@ -28,6 +29,12 @@ pub enum WorkspaceSubmissionStatus {
         #[serde(flatten)]
         data: WorkspaceRunDetails,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl WorkspaceSubmissionStatus {
@@ -49,5 +56,9 @@ impl WorkspaceSubmissionStatus {
 
     pub fn traced(data: WorkspaceRunDetails) -> Self {
         Self::Traced { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_workspace_submission_update_info.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_workspace_submission_update_info.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum WorkspaceSubmissionUpdateInfo {
     #[serde(rename = "running")]
     #[non_exhaustive]
@@ -37,6 +38,12 @@ pub enum WorkspaceSubmissionUpdateInfo {
     #[serde(rename = "finished")]
     #[non_exhaustive]
     Finished {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl WorkspaceSubmissionUpdateInfo {
@@ -68,5 +75,9 @@ impl WorkspaceSubmissionUpdateInfo {
 
     pub fn finished() -> Self {
         Self::Finished {}
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_problem_assert_correctness_check.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_problem_assert_correctness_check.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum AssertCorrectnessCheck {
     #[serde(rename = "deepEquality")]
     #[non_exhaustive]
@@ -20,6 +21,12 @@ pub enum AssertCorrectnessCheck {
         #[serde(default)]
         code: FunctionImplementationForMultipleLanguages,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl AssertCorrectnessCheck {
@@ -37,5 +44,9 @@ impl AssertCorrectnessCheck {
             additional_parameters,
             code,
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_problem_custom_files.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_problem_custom_files.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum CustomFiles {
     #[serde(rename = "basic")]
     #[non_exhaustive]
@@ -21,6 +22,12 @@ pub enum CustomFiles {
     #[serde(rename = "custom")]
     #[non_exhaustive]
     Custom { value: HashMap<Language, Files> },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl CustomFiles {
@@ -40,5 +47,9 @@ impl CustomFiles {
 
     pub fn custom(value: HashMap<Language, Files>) -> Self {
         Self::Custom { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_problem_function_signature.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_problem_function_signature.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum FunctionSignature {
     #[serde(rename = "void")]
     #[non_exhaustive]
@@ -25,6 +26,12 @@ pub enum FunctionSignature {
         #[serde(rename = "actualResultType")]
         actual_result_type: VariableType,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl FunctionSignature {
@@ -44,5 +51,9 @@ impl FunctionSignature {
             parameters,
             actual_result_type,
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_problem_test_case_function.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_problem_test_case_function.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum TestCaseFunction {
     #[serde(rename = "withActualResult")]
     #[non_exhaustive]
@@ -20,6 +21,12 @@ pub enum TestCaseFunction {
         #[serde(default)]
         code: FunctionImplementationForMultipleLanguages,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl TestCaseFunction {
@@ -38,5 +45,9 @@ impl TestCaseFunction {
         code: FunctionImplementationForMultipleLanguages,
     ) -> Self {
         Self::Custom { parameters, code }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_problem_test_case_implementation_description_board.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_problem_test_case_implementation_description_board.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum TestCaseImplementationDescriptionBoard {
     #[serde(rename = "html")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum TestCaseImplementationDescriptionBoard {
     #[serde(rename = "paramId")]
     #[non_exhaustive]
     ParamId { value: ParameterId },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl TestCaseImplementationDescriptionBoard {
@@ -19,5 +26,9 @@ impl TestCaseImplementationDescriptionBoard {
 
     pub fn param_id(value: ParameterId) -> Self {
         Self::ParamId { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_problem_test_case_implementation_reference.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_problem_test_case_implementation_reference.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum TestCaseImplementationReference {
     #[serde(rename = "templateId")]
     #[non_exhaustive]
@@ -13,6 +14,12 @@ pub enum TestCaseImplementationReference {
         #[serde(flatten)]
         data: TestCaseImplementation,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl TestCaseImplementationReference {
@@ -22,5 +29,9 @@ impl TestCaseImplementationReference {
 
     pub fn implementation(data: TestCaseImplementation) -> Self {
         Self::Implementation { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_assert_correctness_check.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_assert_correctness_check.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum AssertCorrectnessCheck2 {
     #[serde(rename = "deepEquality")]
     #[non_exhaustive]
@@ -20,6 +21,12 @@ pub enum AssertCorrectnessCheck2 {
         #[serde(default)]
         code: FunctionImplementationForMultipleLanguages2,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl AssertCorrectnessCheck2 {
@@ -37,5 +44,9 @@ impl AssertCorrectnessCheck2 {
             additional_parameters,
             code,
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_custom_files.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_custom_files.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum CustomFiles2 {
     #[serde(rename = "basic")]
     #[non_exhaustive]
@@ -21,6 +22,12 @@ pub enum CustomFiles2 {
     #[serde(rename = "custom")]
     #[non_exhaustive]
     Custom { value: HashMap<Language, Files2> },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl CustomFiles2 {
@@ -40,5 +47,9 @@ impl CustomFiles2 {
 
     pub fn custom(value: HashMap<Language, Files2>) -> Self {
         Self::Custom { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_function_signature.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_function_signature.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum FunctionSignature2 {
     #[serde(rename = "void")]
     #[non_exhaustive]
@@ -25,6 +26,12 @@ pub enum FunctionSignature2 {
         #[serde(rename = "actualResultType")]
         actual_result_type: VariableType,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl FunctionSignature2 {
@@ -44,5 +51,9 @@ impl FunctionSignature2 {
             parameters,
             actual_result_type,
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_test_case_function.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_test_case_function.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum TestCaseFunction2 {
     #[serde(rename = "withActualResult")]
     #[non_exhaustive]
@@ -20,6 +21,12 @@ pub enum TestCaseFunction2 {
         #[serde(default)]
         code: FunctionImplementationForMultipleLanguages2,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl TestCaseFunction2 {
@@ -38,5 +45,9 @@ impl TestCaseFunction2 {
         code: FunctionImplementationForMultipleLanguages2,
     ) -> Self {
         Self::Custom { parameters, code }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_test_case_implementation_description_board.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_test_case_implementation_description_board.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum TestCaseImplementationDescriptionBoard2 {
     #[serde(rename = "html")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum TestCaseImplementationDescriptionBoard2 {
     #[serde(rename = "paramId")]
     #[non_exhaustive]
     ParamId { value: ParameterId2 },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl TestCaseImplementationDescriptionBoard2 {
@@ -19,5 +26,9 @@ impl TestCaseImplementationDescriptionBoard2 {
 
     pub fn param_id(value: ParameterId2) -> Self {
         Self::ParamId { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_test_case_implementation_reference.rs
+++ b/seed/rust-sdk/trace/src/api/types/v_2_v_3_problem_test_case_implementation_reference.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum TestCaseImplementationReference2 {
     #[serde(rename = "templateId")]
     #[non_exhaustive]
@@ -13,6 +14,12 @@ pub enum TestCaseImplementationReference2 {
         #[serde(flatten)]
         data: TestCaseImplementation2,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl TestCaseImplementationReference2 {
@@ -22,5 +29,9 @@ impl TestCaseImplementationReference2 {
 
     pub fn implementation(data: TestCaseImplementation2) -> Self {
         Self::Implementation { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/rust-sdk/unions-with-local-date/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/bigunion_big_union.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/bigunion_big_union.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum BigUnion {
     #[serde(rename = "normalSweet")]
     #[non_exhaustive]
@@ -466,6 +467,12 @@ pub enum BigUnion {
         #[serde(with = "crate::core::flexible_datetime::offset::option")]
         archived_at: Option<DateTime<FixedOffset>>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl BigUnion {
@@ -875,6 +882,10 @@ impl BigUnion {
         }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_id(&self) -> &str {
         match self {
             Self::NormalSweet { id, .. } => id,
@@ -906,6 +917,9 @@ impl BigUnion {
             Self::PotableBad { id, .. } => id,
             Self::TriangularRepair { id, .. } => id,
             Self::GaseousRoad { id, .. } => id,
+            Self::__Unknown(_) => {
+                panic!("get_id() called on __Unknown variant; inspect the raw JSON value directly")
+            }
         }
     }
 
@@ -940,40 +954,44 @@ impl BigUnion {
             Self::PotableBad { created_at, .. } => created_at,
             Self::TriangularRepair { created_at, .. } => created_at,
             Self::GaseousRoad { created_at, .. } => created_at,
+            Self::__Unknown(_) => panic!(
+                "get_created_at() called on __Unknown variant; inspect the raw JSON value directly"
+            ),
         }
     }
 
     pub fn get_archived_at(&self) -> &Option<DateTime<FixedOffset>> {
         match self {
-            Self::NormalSweet { archived_at, .. } => archived_at,
-            Self::ThankfulFactor { archived_at, .. } => archived_at,
-            Self::JumboEnd { archived_at, .. } => archived_at,
-            Self::HastyPain { archived_at, .. } => archived_at,
-            Self::MistySnow { archived_at, .. } => archived_at,
-            Self::DistinctFailure { archived_at, .. } => archived_at,
-            Self::PracticalPrinciple { archived_at, .. } => archived_at,
-            Self::LimpingStep { archived_at, .. } => archived_at,
-            Self::VibrantExcitement { archived_at, .. } => archived_at,
-            Self::ActiveDiamond { archived_at, .. } => archived_at,
-            Self::PopularLimit { archived_at, .. } => archived_at,
-            Self::FalseMirror { archived_at, .. } => archived_at,
-            Self::PrimaryBlock { archived_at, .. } => archived_at,
-            Self::RotatingRatio { archived_at, .. } => archived_at,
-            Self::ColorfulCover { archived_at, .. } => archived_at,
-            Self::DisloyalValue { archived_at, .. } => archived_at,
-            Self::GruesomeCoach { archived_at, .. } => archived_at,
-            Self::TotalWork { archived_at, .. } => archived_at,
-            Self::HarmoniousPlay { archived_at, .. } => archived_at,
-            Self::UniqueStress { archived_at, .. } => archived_at,
-            Self::UnwillingSmoke { archived_at, .. } => archived_at,
-            Self::FrozenSleep { archived_at, .. } => archived_at,
-            Self::DiligentDeal { archived_at, .. } => archived_at,
-            Self::AttractiveScript { archived_at, .. } => archived_at,
-            Self::HoarseMouse { archived_at, .. } => archived_at,
-            Self::CircularCard { archived_at, .. } => archived_at,
-            Self::PotableBad { archived_at, .. } => archived_at,
-            Self::TriangularRepair { archived_at, .. } => archived_at,
-            Self::GaseousRoad { archived_at, .. } => archived_at,
-        }
+                    Self::NormalSweet { archived_at, .. } => archived_at,
+                    Self::ThankfulFactor { archived_at, .. } => archived_at,
+                    Self::JumboEnd { archived_at, .. } => archived_at,
+                    Self::HastyPain { archived_at, .. } => archived_at,
+                    Self::MistySnow { archived_at, .. } => archived_at,
+                    Self::DistinctFailure { archived_at, .. } => archived_at,
+                    Self::PracticalPrinciple { archived_at, .. } => archived_at,
+                    Self::LimpingStep { archived_at, .. } => archived_at,
+                    Self::VibrantExcitement { archived_at, .. } => archived_at,
+                    Self::ActiveDiamond { archived_at, .. } => archived_at,
+                    Self::PopularLimit { archived_at, .. } => archived_at,
+                    Self::FalseMirror { archived_at, .. } => archived_at,
+                    Self::PrimaryBlock { archived_at, .. } => archived_at,
+                    Self::RotatingRatio { archived_at, .. } => archived_at,
+                    Self::ColorfulCover { archived_at, .. } => archived_at,
+                    Self::DisloyalValue { archived_at, .. } => archived_at,
+                    Self::GruesomeCoach { archived_at, .. } => archived_at,
+                    Self::TotalWork { archived_at, .. } => archived_at,
+                    Self::HarmoniousPlay { archived_at, .. } => archived_at,
+                    Self::UniqueStress { archived_at, .. } => archived_at,
+                    Self::UnwillingSmoke { archived_at, .. } => archived_at,
+                    Self::FrozenSleep { archived_at, .. } => archived_at,
+                    Self::DiligentDeal { archived_at, .. } => archived_at,
+                    Self::AttractiveScript { archived_at, .. } => archived_at,
+                    Self::HoarseMouse { archived_at, .. } => archived_at,
+                    Self::CircularCard { archived_at, .. } => archived_at,
+                    Self::PotableBad { archived_at, .. } => archived_at,
+                    Self::TriangularRepair { archived_at, .. } => archived_at,
+                    Self::GaseousRoad { archived_at, .. } => archived_at,
+                    Self::__Unknown(_) => panic!("get_archived_at() called on __Unknown variant; inspect the raw JSON value directly"),
+                }
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Union {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum Union {
     #[serde(rename = "bar")]
     #[non_exhaustive]
     Bar { bar: Bar },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Union {
@@ -19,5 +26,9 @@ impl Union {
 
     pub fn bar(bar: Bar) -> Self {
         Self::Bar { bar }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_base_properties.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_base_properties.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithBaseProperties {
     #[serde(rename = "integer")]
     #[non_exhaustive]
@@ -18,6 +19,12 @@ pub enum UnionWithBaseProperties {
         data: Foo,
         id: String,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithBaseProperties {
@@ -33,11 +40,18 @@ impl UnionWithBaseProperties {
         Self::Foo { data, id }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_id(&self) -> &str {
         match self {
             Self::Integer { id, .. } => id,
             Self::String { id, .. } => id,
             Self::Foo { id, .. } => id,
+            Self::__Unknown(_) => {
+                panic!("get_id() called on __Unknown variant; inspect the raw JSON value directly")
+            }
         }
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_discriminant.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_discriminant.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "_type")]
+#[non_exhaustive]
 pub enum UnionWithDiscriminant {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum UnionWithDiscriminant {
     #[serde(rename = "bar")]
     #[non_exhaustive]
     Bar { bar: Bar },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithDiscriminant {
@@ -19,5 +26,9 @@ impl UnionWithDiscriminant {
 
     pub fn bar(bar: Bar) -> Self {
         Self::Bar { bar }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_duplicate_primitive.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_duplicate_primitive.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithDuplicatePrimitive {
     #[serde(rename = "integer1")]
     #[non_exhaustive]
@@ -18,6 +19,12 @@ pub enum UnionWithDuplicatePrimitive {
     #[serde(rename = "string2")]
     #[non_exhaustive]
     String2 { value: String },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithDuplicatePrimitive {
@@ -35,5 +42,9 @@ impl UnionWithDuplicatePrimitive {
 
     pub fn string2(value: String) -> Self {
         Self::String2 { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_duplicate_types.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_duplicate_types.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithDuplicateTypes {
     #[serde(rename = "foo1")]
     #[non_exhaustive]
@@ -16,6 +17,12 @@ pub enum UnionWithDuplicateTypes {
         #[serde(flatten)]
         data: Foo,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithDuplicateTypes {
@@ -25,5 +32,9 @@ impl UnionWithDuplicateTypes {
 
     pub fn foo2(data: Foo) -> Self {
         Self::Foo2 { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_literal.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_literal.rs
@@ -1,11 +1,18 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithLiteral {
     #[serde(rename = "fern")]
     #[non_exhaustive]
     Fern { value: String, base: String },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithLiteral {
@@ -13,9 +20,16 @@ impl UnionWithLiteral {
         Self::Fern { value, base }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_base(&self) -> &str {
         match self {
             Self::Fern { base, .. } => base,
+            Self::__Unknown(_) => panic!(
+                "get_base() called on __Unknown variant; inspect the raw JSON value directly"
+            ),
         }
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_multiple_no_properties.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_multiple_no_properties.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithMultipleNoProperties {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -17,6 +18,12 @@ pub enum UnionWithMultipleNoProperties {
     #[serde(rename = "empty2")]
     #[non_exhaustive]
     Empty2 {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithMultipleNoProperties {
@@ -30,5 +37,9 @@ impl UnionWithMultipleNoProperties {
 
     pub fn empty2() -> Self {
         Self::Empty2 {}
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_no_properties.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_no_properties.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithNoProperties {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -13,6 +14,12 @@ pub enum UnionWithNoProperties {
     #[serde(rename = "empty")]
     #[non_exhaustive]
     Empty {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithNoProperties {
@@ -22,5 +29,9 @@ impl UnionWithNoProperties {
 
     pub fn empty() -> Self {
         Self::Empty {}
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_optional_time.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_optional_time.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithOptionalTime {
     #[serde(rename = "date")]
     #[non_exhaustive]
@@ -14,6 +15,12 @@ pub enum UnionWithOptionalTime {
         #[serde(with = "crate::core::flexible_datetime::offset::option")]
         value: Option<DateTime<FixedOffset>>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithOptionalTime {
@@ -23,5 +30,9 @@ impl UnionWithOptionalTime {
 
     pub fn datetime(value: Option<DateTime<FixedOffset>>) -> Self {
         Self::Datetime { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_primitive.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_primitive.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithPrimitive {
     #[serde(rename = "integer")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum UnionWithPrimitive {
     #[serde(rename = "string")]
     #[non_exhaustive]
     r#String { value: String },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithPrimitive {
@@ -19,5 +26,9 @@ impl UnionWithPrimitive {
 
     pub fn string(value: String) -> Self {
         Self::r#String { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_same_number_types.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_same_number_types.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithSameNumberTypes {
     #[serde(rename = "positiveInt")]
     #[non_exhaustive]
@@ -14,6 +15,12 @@ pub enum UnionWithSameNumberTypes {
     #[serde(rename = "anyNumber")]
     #[non_exhaustive]
     AnyNumber { value: f64 },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithSameNumberTypes {
@@ -27,5 +34,9 @@ impl UnionWithSameNumberTypes {
 
     pub fn any_number(value: f64) -> Self {
         Self::AnyNumber { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_same_string_types.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_same_string_types.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithSameStringTypes {
     #[serde(rename = "customFormat")]
     #[non_exhaustive]
@@ -14,6 +15,12 @@ pub enum UnionWithSameStringTypes {
     #[serde(rename = "patternString")]
     #[non_exhaustive]
     PatternString { value: String },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithSameStringTypes {
@@ -27,5 +34,9 @@ impl UnionWithSameStringTypes {
 
     pub fn pattern_string(value: String) -> Self {
         Self::PatternString { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_single_element.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_single_element.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithSingleElement {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -9,10 +10,20 @@ pub enum UnionWithSingleElement {
         #[serde(flatten)]
         data: Foo,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithSingleElement {
     pub fn foo(data: Foo) -> Self {
         Self::Foo { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_sub_types.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_sub_types.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithSubTypes {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -16,6 +17,12 @@ pub enum UnionWithSubTypes {
         #[serde(default)]
         age: i64,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithSubTypes {
@@ -25,5 +32,9 @@ impl UnionWithSubTypes {
 
     pub fn foo_extended(age: i64) -> Self {
         Self::FooExtended { age }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_time.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_with_time.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithTime {
     #[serde(rename = "value")]
     #[non_exhaustive]
@@ -17,6 +18,12 @@ pub enum UnionWithTime {
         #[serde(with = "crate::core::flexible_datetime::offset")]
         value: DateTime<FixedOffset>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithTime {
@@ -30,5 +37,9 @@ impl UnionWithTime {
 
     pub fn datetime(value: DateTime<FixedOffset>) -> Self {
         Self::Datetime { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_without_key.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/types_union_without_key.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithoutKey {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -16,6 +17,12 @@ pub enum UnionWithoutKey {
         #[serde(flatten)]
         data: Bar,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithoutKey {
@@ -25,5 +32,9 @@ impl UnionWithoutKey {
 
     pub fn bar(data: Bar) -> Self {
         Self::Bar { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/api/types/union_shape.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/api/types/union_shape.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Shape {
     #[serde(rename = "circle")]
     #[non_exhaustive]
@@ -20,6 +21,12 @@ pub enum Shape {
         length: f64,
         id: String,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Shape {
@@ -31,10 +38,17 @@ impl Shape {
         Self::Square { length, id }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_id(&self) -> &str {
         match self {
             Self::Circle { id, .. } => id,
             Self::Square { id, .. } => id,
+            Self::__Unknown(_) => {
+                panic!("get_id() called on __Unknown variant; inspect the raw JSON value directly")
+            }
         }
     }
 }

--- a/seed/rust-sdk/unions/.fern/metadata.json
+++ b/seed/rust-sdk/unions/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/unions/src/api/types/bigunion_big_union.rs
+++ b/seed/rust-sdk/unions/src/api/types/bigunion_big_union.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum BigUnion {
     #[serde(rename = "normalSweet")]
     #[non_exhaustive]
@@ -466,6 +467,12 @@ pub enum BigUnion {
         #[serde(with = "crate::core::flexible_datetime::offset::option")]
         archived_at: Option<DateTime<FixedOffset>>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl BigUnion {
@@ -875,6 +882,10 @@ impl BigUnion {
         }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_id(&self) -> &str {
         match self {
             Self::NormalSweet { id, .. } => id,
@@ -906,6 +917,9 @@ impl BigUnion {
             Self::PotableBad { id, .. } => id,
             Self::TriangularRepair { id, .. } => id,
             Self::GaseousRoad { id, .. } => id,
+            Self::__Unknown(_) => {
+                panic!("get_id() called on __Unknown variant; inspect the raw JSON value directly")
+            }
         }
     }
 
@@ -940,40 +954,44 @@ impl BigUnion {
             Self::PotableBad { created_at, .. } => created_at,
             Self::TriangularRepair { created_at, .. } => created_at,
             Self::GaseousRoad { created_at, .. } => created_at,
+            Self::__Unknown(_) => panic!(
+                "get_created_at() called on __Unknown variant; inspect the raw JSON value directly"
+            ),
         }
     }
 
     pub fn get_archived_at(&self) -> &Option<DateTime<FixedOffset>> {
         match self {
-            Self::NormalSweet { archived_at, .. } => archived_at,
-            Self::ThankfulFactor { archived_at, .. } => archived_at,
-            Self::JumboEnd { archived_at, .. } => archived_at,
-            Self::HastyPain { archived_at, .. } => archived_at,
-            Self::MistySnow { archived_at, .. } => archived_at,
-            Self::DistinctFailure { archived_at, .. } => archived_at,
-            Self::PracticalPrinciple { archived_at, .. } => archived_at,
-            Self::LimpingStep { archived_at, .. } => archived_at,
-            Self::VibrantExcitement { archived_at, .. } => archived_at,
-            Self::ActiveDiamond { archived_at, .. } => archived_at,
-            Self::PopularLimit { archived_at, .. } => archived_at,
-            Self::FalseMirror { archived_at, .. } => archived_at,
-            Self::PrimaryBlock { archived_at, .. } => archived_at,
-            Self::RotatingRatio { archived_at, .. } => archived_at,
-            Self::ColorfulCover { archived_at, .. } => archived_at,
-            Self::DisloyalValue { archived_at, .. } => archived_at,
-            Self::GruesomeCoach { archived_at, .. } => archived_at,
-            Self::TotalWork { archived_at, .. } => archived_at,
-            Self::HarmoniousPlay { archived_at, .. } => archived_at,
-            Self::UniqueStress { archived_at, .. } => archived_at,
-            Self::UnwillingSmoke { archived_at, .. } => archived_at,
-            Self::FrozenSleep { archived_at, .. } => archived_at,
-            Self::DiligentDeal { archived_at, .. } => archived_at,
-            Self::AttractiveScript { archived_at, .. } => archived_at,
-            Self::HoarseMouse { archived_at, .. } => archived_at,
-            Self::CircularCard { archived_at, .. } => archived_at,
-            Self::PotableBad { archived_at, .. } => archived_at,
-            Self::TriangularRepair { archived_at, .. } => archived_at,
-            Self::GaseousRoad { archived_at, .. } => archived_at,
-        }
+                    Self::NormalSweet { archived_at, .. } => archived_at,
+                    Self::ThankfulFactor { archived_at, .. } => archived_at,
+                    Self::JumboEnd { archived_at, .. } => archived_at,
+                    Self::HastyPain { archived_at, .. } => archived_at,
+                    Self::MistySnow { archived_at, .. } => archived_at,
+                    Self::DistinctFailure { archived_at, .. } => archived_at,
+                    Self::PracticalPrinciple { archived_at, .. } => archived_at,
+                    Self::LimpingStep { archived_at, .. } => archived_at,
+                    Self::VibrantExcitement { archived_at, .. } => archived_at,
+                    Self::ActiveDiamond { archived_at, .. } => archived_at,
+                    Self::PopularLimit { archived_at, .. } => archived_at,
+                    Self::FalseMirror { archived_at, .. } => archived_at,
+                    Self::PrimaryBlock { archived_at, .. } => archived_at,
+                    Self::RotatingRatio { archived_at, .. } => archived_at,
+                    Self::ColorfulCover { archived_at, .. } => archived_at,
+                    Self::DisloyalValue { archived_at, .. } => archived_at,
+                    Self::GruesomeCoach { archived_at, .. } => archived_at,
+                    Self::TotalWork { archived_at, .. } => archived_at,
+                    Self::HarmoniousPlay { archived_at, .. } => archived_at,
+                    Self::UniqueStress { archived_at, .. } => archived_at,
+                    Self::UnwillingSmoke { archived_at, .. } => archived_at,
+                    Self::FrozenSleep { archived_at, .. } => archived_at,
+                    Self::DiligentDeal { archived_at, .. } => archived_at,
+                    Self::AttractiveScript { archived_at, .. } => archived_at,
+                    Self::HoarseMouse { archived_at, .. } => archived_at,
+                    Self::CircularCard { archived_at, .. } => archived_at,
+                    Self::PotableBad { archived_at, .. } => archived_at,
+                    Self::TriangularRepair { archived_at, .. } => archived_at,
+                    Self::GaseousRoad { archived_at, .. } => archived_at,
+                    Self::__Unknown(_) => panic!("get_archived_at() called on __Unknown variant; inspect the raw JSON value directly"),
+                }
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Union {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum Union {
     #[serde(rename = "bar")]
     #[non_exhaustive]
     Bar { bar: Bar },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Union {
@@ -19,5 +26,9 @@ impl Union {
 
     pub fn bar(bar: Bar) -> Self {
         Self::Bar { bar }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_base_properties.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_base_properties.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithBaseProperties {
     #[serde(rename = "integer")]
     #[non_exhaustive]
@@ -18,6 +19,12 @@ pub enum UnionWithBaseProperties {
         data: Foo,
         id: String,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithBaseProperties {
@@ -33,11 +40,18 @@ impl UnionWithBaseProperties {
         Self::Foo { data, id }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_id(&self) -> &str {
         match self {
             Self::Integer { id, .. } => id,
             Self::String { id, .. } => id,
             Self::Foo { id, .. } => id,
+            Self::__Unknown(_) => {
+                panic!("get_id() called on __Unknown variant; inspect the raw JSON value directly")
+            }
         }
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_discriminant.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_discriminant.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "_type")]
+#[non_exhaustive]
 pub enum UnionWithDiscriminant {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum UnionWithDiscriminant {
     #[serde(rename = "bar")]
     #[non_exhaustive]
     Bar { bar: Bar },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithDiscriminant {
@@ -19,5 +26,9 @@ impl UnionWithDiscriminant {
 
     pub fn bar(bar: Bar) -> Self {
         Self::Bar { bar }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_duplicate_primitive.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_duplicate_primitive.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithDuplicatePrimitive {
     #[serde(rename = "integer1")]
     #[non_exhaustive]
@@ -18,6 +19,12 @@ pub enum UnionWithDuplicatePrimitive {
     #[serde(rename = "string2")]
     #[non_exhaustive]
     String2 { value: String },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithDuplicatePrimitive {
@@ -35,5 +42,9 @@ impl UnionWithDuplicatePrimitive {
 
     pub fn string2(value: String) -> Self {
         Self::String2 { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_duplicate_types.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_duplicate_types.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithDuplicateTypes {
     #[serde(rename = "foo1")]
     #[non_exhaustive]
@@ -16,6 +17,12 @@ pub enum UnionWithDuplicateTypes {
         #[serde(flatten)]
         data: Foo,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithDuplicateTypes {
@@ -25,5 +32,9 @@ impl UnionWithDuplicateTypes {
 
     pub fn foo2(data: Foo) -> Self {
         Self::Foo2 { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_duplicative_discriminants.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_duplicative_discriminants.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithDuplicativeDiscriminants {
     #[serde(rename = "firstItemType")]
     #[non_exhaustive]
@@ -20,6 +21,12 @@ pub enum UnionWithDuplicativeDiscriminants {
         #[serde(default)]
         title: String,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithDuplicativeDiscriminants {
@@ -46,5 +53,9 @@ impl UnionWithDuplicativeDiscriminants {
             r#type: Some(r#type),
             title,
         }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_literal.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_literal.rs
@@ -1,11 +1,18 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithLiteral {
     #[serde(rename = "fern")]
     #[non_exhaustive]
     Fern { value: String, base: String },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithLiteral {
@@ -13,9 +20,16 @@ impl UnionWithLiteral {
         Self::Fern { value, base }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_base(&self) -> &str {
         match self {
             Self::Fern { base, .. } => base,
+            Self::__Unknown(_) => panic!(
+                "get_base() called on __Unknown variant; inspect the raw JSON value directly"
+            ),
         }
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_multiple_no_properties.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_multiple_no_properties.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithMultipleNoProperties {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -17,6 +18,12 @@ pub enum UnionWithMultipleNoProperties {
     #[serde(rename = "empty2")]
     #[non_exhaustive]
     Empty2 {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithMultipleNoProperties {
@@ -30,5 +37,9 @@ impl UnionWithMultipleNoProperties {
 
     pub fn empty2() -> Self {
         Self::Empty2 {}
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_no_properties.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_no_properties.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithNoProperties {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -13,6 +14,12 @@ pub enum UnionWithNoProperties {
     #[serde(rename = "empty")]
     #[non_exhaustive]
     Empty {},
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithNoProperties {
@@ -22,5 +29,9 @@ impl UnionWithNoProperties {
 
     pub fn empty() -> Self {
         Self::Empty {}
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_nullable_reference.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_nullable_reference.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithNullableReference {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum UnionWithNullableReference {
     #[serde(rename = "bar")]
     #[non_exhaustive]
     Bar { value: Option<Bar> },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithNullableReference {
@@ -19,5 +26,9 @@ impl UnionWithNullableReference {
 
     pub fn bar(value: Option<Bar>) -> Self {
         Self::Bar { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_optional_reference.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_optional_reference.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithOptionalReference {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum UnionWithOptionalReference {
     #[serde(rename = "bar")]
     #[non_exhaustive]
     Bar { value: Option<Bar> },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithOptionalReference {
@@ -19,5 +26,9 @@ impl UnionWithOptionalReference {
 
     pub fn bar(value: Option<Bar>) -> Self {
         Self::Bar { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_optional_time.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_optional_time.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithOptionalTime {
     #[serde(rename = "date")]
     #[non_exhaustive]
@@ -14,6 +15,12 @@ pub enum UnionWithOptionalTime {
         #[serde(with = "crate::core::flexible_datetime::offset::option")]
         value: Option<DateTime<FixedOffset>>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithOptionalTime {
@@ -23,5 +30,9 @@ impl UnionWithOptionalTime {
 
     pub fn datetime(value: Option<DateTime<FixedOffset>>) -> Self {
         Self::Datetime { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_primitive.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_primitive.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithPrimitive {
     #[serde(rename = "integer")]
     #[non_exhaustive]
@@ -10,6 +11,12 @@ pub enum UnionWithPrimitive {
     #[serde(rename = "string")]
     #[non_exhaustive]
     r#String { value: String },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithPrimitive {
@@ -19,5 +26,9 @@ impl UnionWithPrimitive {
 
     pub fn string(value: String) -> Self {
         Self::r#String { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_same_number_types.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_same_number_types.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithSameNumberTypes {
     #[serde(rename = "positiveInt")]
     #[non_exhaustive]
@@ -14,6 +15,12 @@ pub enum UnionWithSameNumberTypes {
     #[serde(rename = "anyNumber")]
     #[non_exhaustive]
     AnyNumber { value: f64 },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithSameNumberTypes {
@@ -27,5 +34,9 @@ impl UnionWithSameNumberTypes {
 
     pub fn any_number(value: f64) -> Self {
         Self::AnyNumber { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_same_string_types.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_same_string_types.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithSameStringTypes {
     #[serde(rename = "customFormat")]
     #[non_exhaustive]
@@ -14,6 +15,12 @@ pub enum UnionWithSameStringTypes {
     #[serde(rename = "patternString")]
     #[non_exhaustive]
     PatternString { value: String },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithSameStringTypes {
@@ -27,5 +34,9 @@ impl UnionWithSameStringTypes {
 
     pub fn pattern_string(value: String) -> Self {
         Self::PatternString { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_single_element.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_single_element.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithSingleElement {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -9,10 +10,20 @@ pub enum UnionWithSingleElement {
         #[serde(flatten)]
         data: Foo,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithSingleElement {
     pub fn foo(data: Foo) -> Self {
         Self::Foo { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_sub_types.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_sub_types.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithSubTypes {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -16,6 +17,12 @@ pub enum UnionWithSubTypes {
         #[serde(default)]
         age: i64,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithSubTypes {
@@ -25,5 +32,9 @@ impl UnionWithSubTypes {
 
     pub fn foo_extended(age: i64) -> Self {
         Self::FooExtended { age }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_time.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_time.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithTime {
     #[serde(rename = "value")]
     #[non_exhaustive]
@@ -17,6 +18,12 @@ pub enum UnionWithTime {
         #[serde(with = "crate::core::flexible_datetime::offset")]
         value: DateTime<FixedOffset>,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithTime {
@@ -30,5 +37,9 @@ impl UnionWithTime {
 
     pub fn datetime(value: DateTime<FixedOffset>) -> Self {
         Self::Datetime { value }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_without_key.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_without_key.rs
@@ -1,7 +1,8 @@
 pub use crate::prelude::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum UnionWithoutKey {
     #[serde(rename = "foo")]
     #[non_exhaustive]
@@ -16,6 +17,12 @@ pub enum UnionWithoutKey {
         #[serde(flatten)]
         data: Bar,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl UnionWithoutKey {
@@ -25,5 +32,9 @@ impl UnionWithoutKey {
 
     pub fn bar(data: Bar) -> Self {
         Self::Bar { data }
+    }
+
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
     }
 }

--- a/seed/rust-sdk/unions/src/api/types/union_shape.rs
+++ b/seed/rust-sdk/unions/src/api/types/union_shape.rs
@@ -2,6 +2,7 @@ pub use crate::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Shape {
     #[serde(rename = "circle")]
     #[non_exhaustive]
@@ -20,6 +21,12 @@ pub enum Shape {
         length: f64,
         id: String,
     },
+
+    /// Catch-all variant for unrecognized discriminant values.
+    /// If the server sends a discriminant not recognized by the current SDK
+    /// version, the raw payload is captured here so callers can still inspect it.
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }
 
 impl Shape {
@@ -31,10 +38,17 @@ impl Shape {
         Self::Square { length, id }
     }
 
+    pub fn unknown(value: serde_json::Value) -> Self {
+        Self::__Unknown(value)
+    }
+
     pub fn get_id(&self) -> &str {
         match self {
             Self::Circle { id, .. } => id,
             Self::Square { id, .. } => id,
+            Self::__Unknown(_) => {
+                panic!("get_id() called on __Unknown variant; inspect the raw JSON value directly")
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-10269

Discriminated unions generated by the Rust SDK previously errored on unknown discriminant values — e.g. when the server adds a new variant after the SDK is generated. This adds the same forward-compatibility pattern that the Rust enum generator (and the C#/Java/TypeScript SDKs) already provides for discriminated unions.

Each generated `enum` now carries:
- `#[non_exhaustive]` at the enum level, so future typed variants are non-breaking for `match` callers.
- A trailing `__Unknown(serde_json::Value)` variant annotated `#[serde(untagged)]`. Serde tries each tagged variant first and falls back to `__Unknown` for unrecognized (or missing) discriminants, preserving the raw JSON payload.
- A `pub fn unknown(value: serde_json::Value) -> Self` constructor (since the `#[non_exhaustive]` enum can't be constructed directly outside the crate).

Round-trip is preserved: serializing an `__Unknown` value emits the original JSON, including its discriminant field.

## Changes Made
- `generators/rust/model/src/union/UnionGenerator.ts`: add `__Unknown(serde_json::Value)` catch-all variant with `#[serde(untagged)]`, enum-level `#[non_exhaustive]`, and the `unknown(...)` constructor. Skip `Eq`/`Hash` derives because `serde_json::Value` doesn't implement them; `PartialEq` is still derived. Getter methods for base properties `panic!` on the `__Unknown` variant since base props aren't typed there — callers should pattern-match on `__Unknown(value)` directly.
- Regenerate all union-related snapshots in `generators/rust/model/src/__test__/snapshots/`.
- Regenerate impacted seed outputs across `seed/rust-sdk/` (unions, circular-references, exhaustive, literal, mixed-case, nullable, nullable-optional, property-access, trace, examples, server-sent-events*, unions-with-local-date).
- Add `generators/rust/sdk/changes/unreleased/forward-compatible-unions.yml`.

Sketch of the generated diff (Animal):

```diff
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum Animal {
     #[serde(rename = "dog")]
     Dog { ... },
     ...
+    #[serde(untagged)]
+    __Unknown(serde_json::Value),
 }

 impl Animal {
     pub fn dog(...) -> Self { ... }
     ...
+    pub fn unknown(value: serde_json::Value) -> Self { Self::__Unknown(value) }
 }
```

## Testing
- [x] Unit tests added/updated — `pnpm test` in `generators/rust/model` (16/16 passing) with regenerated snapshots covering `union-types` and `undiscriminated-union-types` fixtures.
- [x] Manual testing completed — ran `pnpm seed test --generator rust-sdk` across 13 affected fixtures (`unions`, `circular-references`, `circular-references-advanced`, `exhaustive`, `literal`, `mixed-case`, `nullable`, `nullable-optional`, `property-access`, `trace`, `unions-with-local-date`, `examples`, `server-sent-event-examples`, `server-sent-events-openapi`); all generated successfully. Side-validated the `#[serde(tag) + #[serde(untagged)]` pattern in a standalone Cargo crate: known discriminants deserialize to typed variants, unknown/missing discriminants fall through to `__Unknown` while preserving the raw JSON for round-trip.

Note: `seed/rust-sdk/unions/types_union_with_duplicative_discriminants.rs` has a preexisting `serde` error (variant field `r#type` collides with the `tag = "type"` discriminant) that is unrelated to this change — `cargo build` on the `unions` fixture fails identically on `main` and on this branch.

Link to Devin session: https://app.devin.ai/sessions/448b28c575dc460297b6618a39f6f2d9
Requested by: @iamnamananand996