### PR TITLE
feat(ruby): add client-level max_retries constructor parameter

### DIFF
--- a/generators/ruby-v2/sdk/changes/unreleased/add-client-level-max-retries.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/add-client-level-max-retries.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Add a `max_retries:` keyword argument to the generated root `Client`
+    constructor. Consumers can now configure the default retry count once
+    at client construction (e.g. `Client.new(max_retries: 5)`) instead of
+    relying on the generation-time `maxRetries` setting in `generators.yml`.
+    The constructor default still respects the configured value (or `2`
+    when unset), so existing behavior is preserved.
+  type: feat

--- a/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
@@ -73,6 +73,7 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
     private getInitializeMethod(): ruby.Method {
         const parameters: ruby.KeywordParameter[] = [];
         const isMultiUrl = this.context.isMultipleBaseUrlsEnvironment();
+        const defaultMaxRetries = this.context.customConfig.maxRetries ?? 2;
 
         const baseUrlParameter = ruby.parameters.keyword({
             name: "base_url",
@@ -98,6 +99,14 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
 
         const globalHeaderParameters = this.getGlobalHeaderParameters();
         parameters.push(...globalHeaderParameters);
+
+        const maxRetriesParameter = ruby.parameters.keyword({
+            name: "max_retries",
+            type: ruby.Type.integer(),
+            initializer: ruby.TypeLiteral.integer(defaultMaxRetries),
+            docs: "The default maximum number of retries for failed requests."
+        });
+        parameters.push(maxRetriesParameter);
 
         // Sort parameters: required (no initializer) before optional (with initializer)
         const sortedParameters = [...parameters].sort((a, b) => {
@@ -235,10 +244,11 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
                     writer.writeNode(this.getRawClientHeaders());
                 }
                 if (inferredAuth != null) {
-                    writer.writeLine(`.merge(@auth_provider.auth_headers)`);
+                    writer.writeLine(`.merge(@auth_provider.auth_headers),`);
                 } else {
-                    writer.newLine();
+                    writer.writeLine(",");
                 }
+                writer.writeLine(`max_retries: max_retries`);
                 writer.dedent();
                 writer.writeLine(`)`);
             })

--- a/seed/ruby-sdk-v2/accept-header/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/accept-header/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_accept-header/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/alias-extends/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/alias-extends/lib/seed/client.rb
@@ -33,15 +33,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_alias-extends/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/alias/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/alias/lib/seed/client.rb
@@ -33,15 +33,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_alias/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/allof-inline/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/allof-inline/lib/seed/client.rb
@@ -161,15 +161,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url || Seed::Environment::DEFAULT,
         headers: {
           "User-Agent" => "fern_allof-inline/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/allof/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/allof/lib/seed/client.rb
@@ -161,15 +161,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url || Seed::Environment::DEFAULT,
         headers: {
           "User-Agent" => "fern_allof/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/any-auth/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/any-auth/lib/seed/client.rb
@@ -9,9 +9,10 @@ module Seed
     # @param api_key [String]
     # @param username [String]
     # @param password [String]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(client_id:, client_secret:, base_url: nil, token: ENV.fetch("MY_TOKEN", nil), api_key: ENV.fetch("MY_API_KEY", nil), username: ENV.fetch("MY_USERNAME", nil), password: ENV.fetch("MY_PASSWORD", nil))
+    def initialize(client_id:, client_secret:, base_url: nil, token: ENV.fetch("MY_TOKEN", nil), api_key: ENV.fetch("MY_API_KEY", nil), username: ENV.fetch("MY_USERNAME", nil), password: ENV.fetch("MY_PASSWORD", nil), max_retries: 2)
       # Create an unauthenticated client for the auth endpoint
       auth_raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
@@ -40,7 +41,8 @@ module Seed
       headers["Authorization"] = "Basic #{Base64.strict_encode64("#{username}:#{password}")}" if !username.nil? && !password.nil?
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
-        headers: headers.merge(@auth_provider.auth_headers)
+        headers: headers.merge(@auth_provider.auth_headers),
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/api-wide-base-path-with-default/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path-with-default/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_api-wide-base-path-with-default/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/api-wide-base-path/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_api-wide-base-path/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/audiences/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/audiences/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_audiences/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/lib/seed/client.rb
@@ -5,9 +5,10 @@ module Seed
     # @param base_url [String, nil]
     # @param username [String]
     # @param access_token [String]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil, username: ENV.fetch("USERNAME", nil), access_token: ENV.fetch("PASSWORD", nil))
+    def initialize(base_url: nil, username: ENV.fetch("USERNAME", nil), access_token: ENV.fetch("PASSWORD", nil), max_retries: 2)
       headers = {
         "User-Agent" => "fern_basic-auth-environment-variables/0.0.1",
         "X-Fern-Language" => "Ruby"
@@ -15,7 +16,8 @@ module Seed
       headers["Authorization"] = "Basic #{Base64.strict_encode64("#{username}:#{access_token}")}"
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
-        headers: headers
+        headers: headers,
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/lib/seed/client.rb
@@ -4,9 +4,10 @@ module Seed
   class Client
     # @param username [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(username:, base_url: nil)
+    def initialize(username:, base_url: nil, max_retries: 2)
       headers = {
         "User-Agent" => "fern_basic-auth-pw-omitted/0.0.1",
         "X-Fern-Language" => "Ruby"
@@ -14,7 +15,8 @@ module Seed
       headers["Authorization"] = "Basic #{Base64.strict_encode64("#{username}:")}"
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
-        headers: headers
+        headers: headers,
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/basic-auth/wire-tests/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/basic-auth/wire-tests/lib/seed/client.rb
@@ -5,9 +5,10 @@ module Seed
     # @param username [String]
     # @param password [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(username:, password:, base_url: nil)
+    def initialize(username:, password:, base_url: nil, max_retries: 2)
       headers = {
         "User-Agent" => "fern_basic-auth/0.0.1",
         "X-Fern-Language" => "Ruby"
@@ -15,7 +16,8 @@ module Seed
       headers["Authorization"] = "Basic #{Base64.strict_encode64("#{username}:#{password}")}"
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
-        headers: headers
+        headers: headers,
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param base_url [String, nil]
     # @param token [String]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil, token: ENV.fetch("COURIER_API_KEY", nil))
+    def initialize(base_url: nil, token: ENV.fetch("COURIER_API_KEY", nil), max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_bearer-token-environment-variable/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/bytes-download/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/bytes-download/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_bytes-download/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/bytes-upload/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/bytes-upload/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_bytes-upload/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/circular-references-advanced/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/circular-references-advanced/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_circular-references-advanced/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/circular-references-extends/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/circular-references-extends/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_circular-references-extends/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/circular-references/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/circular-references/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_circular-references/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/cli-multi-spec-namespaced/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/cli-multi-spec-namespaced/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url || Seed::Environment::DEFAULT,
         headers: {
           "User-Agent" => "fern_cli-multi-spec-namespaced/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/cli-multi-spec/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/cli-multi-spec/lib/seed/client.rb
@@ -123,15 +123,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url || Seed::Environment::DEFAULT,
         headers: {
           "User-Agent" => "fern_cli-multi-spec/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/client-side-params/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/client-side-params/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_client-side-params/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/content-type/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/content-type/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_content-type/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/cross-package-type-names/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_cross-package-type-names/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/dollar-string-examples/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/dollar-string-examples/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_dollar-string-examples/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/empty-clients/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/empty-clients/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_empty-clients/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/endpoint-security-auth/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/endpoint-security-auth/lib/seed/client.rb
@@ -9,9 +9,10 @@ module Seed
     # @param api_key [String]
     # @param username [String]
     # @param password [String]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(client_id:, client_secret:, base_url: nil, token: ENV.fetch("MY_TOKEN", nil), api_key: ENV.fetch("MY_API_KEY", nil), username: ENV.fetch("MY_USERNAME", nil), password: ENV.fetch("MY_PASSWORD", nil))
+    def initialize(client_id:, client_secret:, base_url: nil, token: ENV.fetch("MY_TOKEN", nil), api_key: ENV.fetch("MY_API_KEY", nil), username: ENV.fetch("MY_USERNAME", nil), password: ENV.fetch("MY_PASSWORD", nil), max_retries: 2)
       # Create an unauthenticated client for the auth endpoint
       auth_raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
@@ -40,7 +41,8 @@ module Seed
       headers["Authorization"] = "Basic #{Base64.strict_encode64("#{username}:#{password}")}" if !username.nil? && !password.nil?
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
-        headers: headers.merge(@auth_provider.auth_headers)
+        headers: headers.merge(@auth_provider.auth_headers),
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/enum/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/enum/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_enum/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/error-property/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/error-property/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_error-property/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/errors/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/errors/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_errors/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/client.rb
@@ -66,16 +66,18 @@ module Seed
 
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_examples/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/client.rb
@@ -66,14 +66,16 @@ module Seed
 
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/examples/readme-config/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/lib/seed/client.rb
@@ -66,16 +66,18 @@ module Seed
 
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_examples/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/examples/require-paths/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/examples/require-paths/lib/seed/client.rb
@@ -66,16 +66,18 @@ module Seed
 
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_examples/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/client.rb
@@ -66,16 +66,18 @@ module Seed
 
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_examples/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class MyClient
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 5)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_exhaustive/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/extends/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/extends/lib/seed/client.rb
@@ -33,15 +33,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_extends/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/extra-properties/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/extra-properties/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_extra-properties/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/file-download/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/file-download/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_file-download/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/file-upload-openapi/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/file-upload-openapi/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_file-upload-openapi/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/file-upload/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/file-upload/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_file-upload/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/folders/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/folders/lib/seed/client.rb
@@ -31,15 +31,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_folders/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param base_url [String, nil]
     # @param header_token_auth [String]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil, header_token_auth: ENV.fetch("HEADER_TOKEN_ENV_VAR", nil))
+    def initialize(base_url: nil, header_token_auth: ENV.fetch("HEADER_TOKEN_ENV_VAR", nil), max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_header-auth-environment-variable/0.0.1",
           "X-Fern-Language" => "Ruby",
           "x-api-key" => "test_prefix #{header_token_auth}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/header-auth/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/header-auth/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param header_token_auth [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(header_token_auth:, base_url: nil)
+    def initialize(header_token_auth:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_header-auth/0.0.1",
           "X-Fern-Language" => "Ruby",
           "x-api-key" => "test_prefix #{header_token_auth}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/http-head/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/http-head/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_http-head/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/idempotency-headers/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/idempotency-headers/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_idempotency-headers/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/imdb/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_imdb/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/client.rb
@@ -7,9 +7,10 @@ module Seed
     # @param x_api_key [String]
     # @param base_url [String, nil]
     # @param scope [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(client_id:, client_secret:, x_api_key:, base_url: nil, scope: nil)
+    def initialize(client_id:, client_secret:, x_api_key:, base_url: nil, scope: nil, max_retries: 2)
       # Create an unauthenticated client for the auth endpoint
       auth_raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
@@ -36,7 +37,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_inferred-auth-explicit/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers)
+        }.merge(@auth_provider.auth_headers),
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/lib/seed/client.rb
@@ -4,9 +4,10 @@ module Seed
   class Client
     # @param api_key [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(api_key:, base_url: nil)
+    def initialize(api_key:, base_url: nil, max_retries: 2)
       # Create an unauthenticated client for the auth endpoint
       auth_raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
@@ -30,7 +31,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_inferred-auth-implicit-api-key/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers)
+        }.merge(@auth_provider.auth_headers),
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/lib/seed/client.rb
@@ -7,9 +7,10 @@ module Seed
     # @param x_api_key [String]
     # @param base_url [String, nil]
     # @param scope [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(client_id:, client_secret:, x_api_key:, base_url: nil, scope: nil)
+    def initialize(client_id:, client_secret:, x_api_key:, base_url: nil, scope: nil, max_retries: 2)
       # Create an unauthenticated client for the auth endpoint
       auth_raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
@@ -36,7 +37,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_inferred-auth-implicit-no-expiry/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers)
+        }.merge(@auth_provider.auth_headers),
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-reference/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-reference/lib/seed/client.rb
@@ -3,9 +3,10 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       # Create an unauthenticated client for the auth endpoint
       auth_raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
@@ -28,7 +29,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_inferred-auth-implicit-reference/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers)
+        }.merge(@auth_provider.auth_headers),
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/lib/seed/client.rb
@@ -7,9 +7,10 @@ module Seed
     # @param x_api_key [String]
     # @param base_url [String, nil]
     # @param scope [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(client_id:, client_secret:, x_api_key:, base_url: nil, scope: nil)
+    def initialize(client_id:, client_secret:, x_api_key:, base_url: nil, scope: nil, max_retries: 2)
       # Create an unauthenticated client for the auth endpoint
       auth_raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
@@ -36,7 +37,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_inferred-auth-implicit/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers)
+        }.merge(@auth_provider.auth_headers),
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/license/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/license/lib/seed/client.rb
@@ -31,15 +31,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_license/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/literal-user-agent/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/literal-user-agent/lib/seed/client.rb
@@ -31,14 +31,16 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/literal/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/literal/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_literal/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/literals-unions/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/literals-unions/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_literals-unions/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/mixed-case/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/mixed-case/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_mixed-case/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/mixed-file-directory/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_mixed-file-directory/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/multi-line-docs/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/multi-line-docs/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_multi-line-docs/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/lib/seed/client.rb
@@ -5,9 +5,10 @@ module Seed
     # @param token [String]
     # @param base_url [String, nil]
     # @param environment [Hash[Symbol, String], nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil, environment: nil)
+    def initialize(token:, base_url: nil, environment: nil, max_retries: 2)
       @base_url = base_url
       @environment = environment
 
@@ -17,7 +18,8 @@ module Seed
           "User-Agent" => "fern_multi-url-environment-no-default/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/multi-url-environment-reference/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment-reference/lib/seed/client.rb
@@ -5,9 +5,10 @@ module Seed
     # @param token [String]
     # @param base_url [String, nil]
     # @param environment [Hash[Symbol, String], nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil, environment: Seed::Environment::PRODUCTION)
+    def initialize(token:, base_url: nil, environment: Seed::Environment::PRODUCTION, max_retries: 2)
       @base_url = base_url
       @environment = environment
 
@@ -17,7 +18,8 @@ module Seed
           "User-Agent" => "fern_multi-url-environment-reference/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/multi-url-environment/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/multi-url-environment/lib/seed/client.rb
@@ -5,9 +5,10 @@ module Seed
     # @param token [String]
     # @param base_url [String, nil]
     # @param environment [Hash[Symbol, String], nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil, environment: Seed::Environment::PRODUCTION)
+    def initialize(token:, base_url: nil, environment: Seed::Environment::PRODUCTION, max_retries: 2)
       @base_url = base_url
       @environment = environment
 
@@ -17,7 +18,8 @@ module Seed
           "User-Agent" => "fern_multi-url-environment/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/multiple-request-bodies/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/lib/seed/client.rb
@@ -66,16 +66,18 @@ module Seed
 
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url || Seed::Environment::DEFAULT,
         headers: {
           "User-Agent" => "fern_multiple-request-bodies/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/no-content-response/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/no-content-response/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_no-content-response/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/no-environment/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/no-environment/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_no-environment/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/no-retries/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/no-retries/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_no-retries/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/null-type/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/null-type/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_null-type/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/nullable-allof-extends/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/lib/seed/client.rb
@@ -69,15 +69,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url || Seed::Environment::DEFAULT,
         headers: {
           "User-Agent" => "fern_nullable-allof-extends/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/nullable-optional/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/nullable-optional/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_nullable-optional/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/nullable-request-body/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/nullable-request-body/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_nullable-request-body/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/nullable/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/nullable/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_nullable/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-custom/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-default/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-environment-variables/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-mandatory-auth/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-nested-root/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-openapi/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-openapi/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-openapi/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-reference/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-reference/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-reference/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_oauth-client-credentials-with-variables/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_oauth-client-credentials/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/object/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/object/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_object/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/objects-with-imports/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/objects-with-imports/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_objects-with-imports/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/openapi-request-body-ref/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/openapi-request-body-ref/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_openapi-request-body-ref/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/optional/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/optional/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_optional/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/package-yml/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/package-yml/lib/seed/client.rb
@@ -34,15 +34,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_package-yml/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/pagination-custom/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/pagination-custom/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_pagination-custom/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/pagination-uri-path/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/pagination-uri-path/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_pagination-uri-path/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/pagination/no-custom-config/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/pagination/no-custom-config/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_pagination/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/pagination/page-index-semantics/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/pagination/page-index-semantics/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_pagination/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/path-parameters/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/path-parameters/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_path-parameters/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/plain-text/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/plain-text/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_plain-text/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/property-access/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/property-access/lib/seed/client.rb
@@ -35,15 +35,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_property-access/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/public-object/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/public-object/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_public-object/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/query-param-name-conflict/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/query-param-name-conflict/lib/seed/client.rb
@@ -50,15 +50,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_query-param-name-conflict/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/lib/seed/client.rb
@@ -73,15 +73,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_query-parameters-openapi-as-objects/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/query-parameters-openapi/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/lib/seed/client.rb
@@ -73,15 +73,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_query-parameters-openapi/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/query-parameters/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/query-parameters/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_query-parameters/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/request-parameters/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/request-parameters/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_request-parameters/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/required-nullable/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/required-nullable/lib/seed/client.rb
@@ -87,15 +87,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_required-nullable/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/reserved-keywords/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/reserved-keywords/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_reserved-keywords/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/response-property/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/response-property/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_response-property/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_ruby-reserved-word-properties/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/lib/seed/client.rb
@@ -109,15 +109,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_schemaless-request-body-examples/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_server-sent-event-examples/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/server-sent-events-openapi/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/server-sent-events-openapi/lib/seed/client.rb
@@ -628,15 +628,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_server-sent-events-openapi/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/server-sent-events-resumable/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/server-sent-events-resumable/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_server-sent-events-resumable/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/server-sent-events/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/server-sent-events/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_server-sent-events/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/server-url-templating/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/server-url-templating/lib/seed/client.rb
@@ -96,9 +96,10 @@ module Seed
 
     # @param base_url [String, nil]
     # @param environment [Hash[Symbol, String], nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil, environment: Seed::Environment::REGIONAL_API_SERVER)
+    def initialize(base_url: nil, environment: Seed::Environment::REGIONAL_API_SERVER, max_retries: 2)
       @base_url = base_url
       @environment = environment
 
@@ -107,7 +108,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_server-url-templating/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/simple-api/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/simple-api/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_simple-api/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/simple-fhir/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/simple-fhir/lib/seed/client.rb
@@ -35,15 +35,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_simple-fhir/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-default/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url || Seed::Environment::PRODUCTION,
         headers: {
           "User-Agent" => "fern_single-url-environment-default/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_single-url-environment-no-default/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/streaming-parameter/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/streaming-parameter/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_streaming-parameter/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/streaming/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/streaming/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_streaming/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/trace/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/trace/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param token [String]
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil)
+    def initialize(token:, base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url || Seed::Environment::PROD,
         headers: {
           "User-Agent" => "fern_trace/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/lib/seed/client.rb
@@ -63,15 +63,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_undiscriminated-union-with-response-property/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/undiscriminated-unions/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_undiscriminated-unions/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/union-query-parameters/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/union-query-parameters/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_union-query-parameters/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/unions-with-local-date/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_unions-with-local-date/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/unions/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/unions/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_unions/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/unknown/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/unknown/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_unknown/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/url-form-encoded/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/url-form-encoded/lib/seed/client.rb
@@ -67,15 +67,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_url-form-encoded/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/validation/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/validation/lib/seed/client.rb
@@ -75,15 +75,17 @@ module Seed
     end
 
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_validation/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/variables/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/variables/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_variables/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/version-no-default/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/version-no-default/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_version-no-default/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/version/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/version/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_version/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/webhook-audience/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/webhook-audience/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_webhook-audience/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/webhooks/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/webhooks/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_webhooks/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/websocket-bearer-auth/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/websocket-bearer-auth/lib/seed/client.rb
@@ -4,16 +4,18 @@ module Seed
   class Client
     # @param base_url [String, nil]
     # @param token [String]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil, token: ENV.fetch("SEED_API_KEY", nil))
+    def initialize(base_url: nil, token: ENV.fetch("SEED_API_KEY", nil), max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_websocket-bearer-auth/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/lib/seed/client.rb
@@ -7,9 +7,10 @@ module Seed
     # @param x_api_key [String]
     # @param base_url [String, nil]
     # @param scope [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(client_id:, client_secret:, x_api_key:, base_url: nil, scope: nil)
+    def initialize(client_id:, client_secret:, x_api_key:, base_url: nil, scope: nil, max_retries: 2)
       # Create an unauthenticated client for the auth endpoint
       auth_raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
@@ -36,7 +37,8 @@ module Seed
         headers: {
           "User-Agent" => "fern_websocket-inferred-auth/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }.merge(@auth_provider.auth_headers)
+        }.merge(@auth_provider.auth_headers),
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/websocket-multi-url/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/websocket-multi-url/lib/seed/client.rb
@@ -5,9 +5,10 @@ module Seed
     # @param token [String]
     # @param base_url [String, nil]
     # @param environment [Hash[Symbol, String], nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(token:, base_url: nil, environment: Seed::Environment::PRODUCTION)
+    def initialize(token:, base_url: nil, environment: Seed::Environment::PRODUCTION, max_retries: 2)
       @base_url = base_url
       @environment = environment
 
@@ -17,7 +18,8 @@ module Seed
           "User-Agent" => "fern_websocket-multi-url/0.0.1",
           "X-Fern-Language" => "Ruby",
           Authorization: "Bearer #{token}"
-        }
+        },
+        max_retries: max_retries
       )
     end
   end

--- a/seed/ruby-sdk-v2/websocket/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/websocket/lib/seed/client.rb
@@ -3,15 +3,17 @@
 module Seed
   class Client
     # @param base_url [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil)
+    def initialize(base_url: nil, max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_websocket/0.0.1",
           "X-Fern-Language" => "Ruby"
-        }
+        },
+        max_retries: max_retries
       )
     end
 

--- a/seed/ruby-sdk-v2/x-fern-default/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/x-fern-default/lib/seed/client.rb
@@ -41,16 +41,18 @@ module Seed
 
     # @param base_url [String, nil]
     # @param api_version [String, nil]
+    # @param max_retries [Integer]
     #
     # @return [void]
-    def initialize(base_url: nil, api_version: "2024-02-08")
+    def initialize(base_url: nil, api_version: "2024-02-08", max_retries: 2)
       @raw_client = Seed::Internal::Http::RawClient.new(
         base_url: base_url,
         headers: {
           "User-Agent" => "fern_x-fern-default/0.0.1",
           "X-Fern-Language" => "Ruby",
           "X-API-Version" => api_version.to_s
-        }
+        },
+        max_retries: max_retries
       )
     end
   end


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-10182](https://linear.app/buildwithfern/issue/FER-10182/ruby-client-level-retry-options)

Adds a `max_retries:` keyword argument to the root `Client` constructor generated by the Ruby-v2 SDK generator. Consumers can now configure the default retry count once at client construction (e.g. `Client.new(max_retries: 5)`) instead of relying on the generation-time `maxRetries` setting in `generators.yml` (which only the SDK author can change).

Mirrors the existing Python implementation ([FER-10180](https://linear.app/buildwithfern/issue/FER-10180), commit b7d4e679b68) and matches the README snippet that already documents this option (`generators/ruby-v2/sdk/src/readme/ReadmeSnippetBuilder.ts`).

```ruby
# Before — consumer can't override retries at runtime
client = MyApi::Client.new(token: "...")

# After — consumer can override the default retry count
client = MyApi::Client.new(token: "...", max_retries: 5)
```

The constructor default still respects the configured `customConfig.maxRetries` (falling back to `2` when unset), so existing behavior is preserved for SDK authors who already pinned a value in `generators.yml`. The argument is threaded through to `RawClient.new(...)`, whose retry logic was already in place.

## Changes Made
- `generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts`: add `max_retries` keyword parameter (typed `Integer`, default = `customConfig.maxRetries ?? 2`) and pass it through to `RawClient.new(...)` after the existing `headers:` argument.
- `generators/ruby-v2/sdk/changes/unreleased/add-client-level-max-retries.yml`: `feat` changelog entry.
- `seed/ruby-sdk-v2/**/lib/**/client.rb`: regenerated snapshots (132 fixtures) — all now expose `max_retries:` on the root `Client.initialize` and forward it to `RawClient`.
- [ ] Updated README.md generator (if applicable) — N/A, the existing README snippet already documents this option.

## Testing
- [x] Unit tests added/updated — existing ruby-v2 unit suites still pass (`pnpm turbo run test --filter='@fern-api/ruby-*'` → 104 ast + 33 dynamic-snippets + 6 sdk tests passed; existing `maxRetries.test.ts` config schema tests unchanged).
- [x] Manual testing completed — ran `pnpm seed test --generator ruby-sdk-v2 --skip-scripts` across all 132 fixtures, all green. Spot-checked generated output for several fixture shapes:
    - `seed/ruby-sdk-v2/no-environment/lib/seed/client.rb`: `def initialize(token:, base_url: nil, max_retries: 2)` → forwards `max_retries: max_retries` to `RawClient.new`.
    - `seed/ruby-sdk-v2/multi-url-environment/lib/seed/client.rb`: parameter placed after `environment:`, still forwarded correctly with the multi-URL `base_url:` resolution.
    - `seed/ruby-sdk-v2/basic-auth/wire-tests/lib/seed/client.rb`: `headers` are built into a local variable then passed alongside `max_retries: max_retries`.
    - `seed/ruby-sdk-v2/inferred-auth-explicit/lib/seed/client.rb`: `@raw_client = ...new(... .merge(@auth_provider.auth_headers), max_retries: max_retries)` — `.merge(...)` line gets the trailing comma so `max_retries:` follows on its own line. The internal `auth_raw_client` is intentionally left untouched (internal-only).


Link to Devin session: https://app.devin.ai/sessions/82a9f76b68ad40efbc9aaebca894e8fb
Requested by: @iamnamananand996