### PR TITLE
fix(deps): bump perl-base from sid to fix perl CVEs in generator and seed containers

### DIFF
--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -42,6 +42,19 @@ RUN apt-get update \
   && apt-get -y autoremove \
   && rm -rf /var/lib/apt/lists/*
 
+# Update perl-base to fix CVE-2026-48959, CVE-2026-48961, CVE-2026-9538, CVE-2026-48962, CVE-2026-42497
+RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
+    && echo "URIs: http://deb.debian.org/debian" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Suites: sid" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Components: main" >> /etc/apt/sources.list.d/sid.sources \
+    && echo "Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg" >> /etc/apt/sources.list.d/sid.sources \
+    && echo 'Package: *\nPin: release n=sid\nPin-Priority: 100' > /etc/apt/preferences.d/sid-low \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends -t sid \
+       perl-base perl \
+    && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
+    && rm -rf /var/lib/apt/lists/*
+
 # Upgrade bundled npm to 11.14.1 to pick up patched transitive dependencies
 # (picomatch 4.0.4, minimatch 10.2.5, tar 7.5.13).
 # node:24.16.0 ships npm 11.12.1 which still vendors picomatch 4.0.3 and

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -20,6 +20,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
+       perl-base perl \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack /opt/yarn-*

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -18,6 +18,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
     && apt-get install -y --no-install-recommends -t sid \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
+       perl-base perl \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 # Patch brace-expansion to 5.0.6 (GHSA-jxxr-4gwj-5jf2; node:24.16 vendors 5.0.5).

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -31,6 +31,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
        libexpat1 \
+       perl-base perl \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN node --version

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -56,6 +56,7 @@ RUN echo "Types: deb" > /etc/apt/sources.list.d/sid.sources \
        libkrb5-3 libkrb5support0 libk5crypto3 libgssapi-krb5-2 \
        curl libcurl4t64 libgnutls30t64 \
        libexpat1 \
+       perl-base perl \
     && rm -f /etc/apt/sources.list.d/sid.sources /etc/apt/preferences.d/sid-low \
     && rm -rf /var/lib/apt/lists/*
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \


### PR DESCRIPTION
## Description

Fix perl CVEs flagged by AWS Inspector in the `dev/typescript-sdk-generator`, `dev/python-sdk-generator`, `dev/pydantic-model-v2-generator`, and `dev/ts-seed` containers:

- CVE-2026-48959
- CVE-2026-48961
- CVE-2026-9538
- CVE-2026-48962
- CVE-2026-42497

## Changes Made

- Added `perl-base perl` to the existing Debian sid apt-get install in `generators/typescript/sdk/cli/Dockerfile`, `generators/python-v2/pydantic-model/Dockerfile`, `generators/python-v2/sdk/Dockerfile`, and `generators/python/sdk/Dockerfile`
- Added a new sid-pinning section to `docker/seed/Dockerfile.ts` (which previously had no sid source) to install `perl-base perl` from sid
- Both `perl-base` and `perl` are required together since `git` depends on `perl` which requires a matching `perl-base` version

## Testing

- [ ] CI container builds pass (the Dockerfiles build successfully with the new packages)
- Follows the same pattern used in fern-platform PR https://github.com/fern-api/fern-platform/pull/11537 for the fai/fai-chat containers

Link to Devin session: https://app.devin.ai/sessions/15c635fe2a864fa89cc0fa01790e5453
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->