### PR TITLE
feat(cli): prompt for optional description when creating a token interactively

### DIFF
--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -1,5 +1,7 @@
 import { createVenusService } from "@fern-api/core";
 import { CliError } from "@fern-api/task-context";
+import chalk from "chalk";
+import inquirer from "inquirer";
 import type { Argv } from "yargs";
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
@@ -44,12 +46,26 @@ export class CreateTokenCommand {
         }
         const auth0OrgId = orgLookup.body.auth0Id;
 
+        let description = args.description;
+        if (description == null && context.isTTY) {
+            const { desc } = await inquirer.prompt<{ desc: string }>([
+                {
+                    type: "input",
+                    name: "desc",
+                    message: `Description ${chalk.dim("(optional, press Enter to skip)")}:`
+                }
+            ]);
+            if (desc.trim().length > 0) {
+                description = desc.trim();
+            }
+        }
+
         const response = await withSpinner({
             message: `Creating token for organization "${args.org}"`,
             operation: () =>
                 venus.apiKeys.create({
                     organizationId: auth0OrgId,
-                    description: args.description
+                    description
                 })
         });
 

--- a/packages/cli/cli/changes/unreleased/prompt-token-description.yml
+++ b/packages/cli/cli/changes/unreleased/prompt-token-description.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Prompt for an optional description when creating a token interactively via `fern org token create`.
+  type: feat


### PR DESCRIPTION
## Description

When a user runs `fern org token create <org>` in a TTY without the `--description` flag, the CLI now prompts them for an optional description before creating the token. In non-interactive (CI) environments, behavior is unchanged — the token is created without a description unless `--description` is explicitly passed.

## Changes Made

- Added an interactive `inquirer` input prompt in `CreateTokenCommand` that asks for a description when `args.description` is not set and `context.isTTY` is true
- Users can press Enter to skip (empty input = no description)
- The `--description` flag still works as before, bypassing the prompt entirely

## Testing

- [x] Manual testing completed
- Lint passes (`pnpm lint:biome`)

Link to Devin session: https://app.devin.ai/sessions/a2fd2034540b4374a178366b3697f192
Requested by: @dannysheridan