### PR TITLE
fix(python): derive offset pagination _has_next instead of hardcoding True

### DIFF
--- a/generators/python/sdk/changes/unreleased/fix-offset-pagination-has-next.yml
+++ b/generators/python/sdk/changes/unreleased/fix-offset-pagination-has-next.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix offset pagination so generated `list` endpoints emit a real `_has_next` instead of the
+    literal `True`. When the API declares `has-next-page` on the pagination config, the
+    generator now reads that response field (`bool(_parsed_response.<path>)`); otherwise it
+    falls back to `len(_items or []) > 0`, matching the TypeScript generator's
+    `(r?.data ?? []).length > 0` semantics.
+
+    Previously every offset-paginated method hardcoded `_has_next = True`, so
+    `while pager.has_next: pager = pager.next_page()` loops never terminated. `for x in pager`
+    worked only because the core paginator stops iteration when `get_next()` returns an empty
+    page.
+  type: fix

--- a/generators/python/sdk/changes/unreleased/fix-offset-pagination-has-next.yml
+++ b/generators/python/sdk/changes/unreleased/fix-offset-pagination-has-next.yml
@@ -11,4 +11,10 @@
     `while pager.has_next: pager = pager.next_page()` loops never terminated. `for x in pager`
     worked only because the core paginator stops iteration when `get_next()` returns an empty
     page.
+
+    Also harden the offset paginator against two latent crashes: nested `has-next-page` paths
+    (e.g. `$response.metadata.hasNext`) are now wrapped in a `_parsed_response.metadata is
+    not None` guard mirroring the cursor paginator, and `_has_next`/`_get_next` are
+    pre-initialized so endpoints with an optional response type no longer raise `NameError`
+    when the server returns a null body.
   type: fix

--- a/generators/python/src/fern_python/generators/sdk/client_generator/pagination/offset.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/pagination/offset.py
@@ -23,15 +23,21 @@ class OffsetPagination(Paginator):
     ):
         super().__init__(context, is_async, pydantic_parse_expression, config, response_is_optional)
         self.offset = offset
+        self._next_none_safe_condition = (
+            self._get_none_safe_property_condition(self.offset.has_next_page)
+            if self.offset.has_next_page is not None
+            else None
+        )
 
     def init_custom_vars_pre_next(self, *, writer: AST.NodeWriter) -> None:
-        return
+        writer.write_line(f"{Paginator.PAGINATION_HAS_NEXT_VARIABLE} = False")
+        writer.write_line(f"{Paginator.PAGINATION_GET_NEXT_VARIABLE} = None")
 
     def init_custom_vars_after_next(self, *, writer: AST.NodeWriter) -> None:
         return
 
     def get_next_none_safe_condition(self) -> Optional[str]:
-        return None
+        return self._next_none_safe_condition
 
     def init_has_next(self) -> str:
         if self.offset.has_next_page is not None:

--- a/generators/python/src/fern_python/generators/sdk/client_generator/pagination/offset.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/pagination/offset.py
@@ -34,7 +34,10 @@ class OffsetPagination(Paginator):
         return None
 
     def init_has_next(self) -> str:
-        return "True"
+        if self.offset.has_next_page is not None:
+            path = self._response_property_to_dot_access(self.offset.has_next_page)
+            return f"bool({Paginator.PARSED_RESPONSE_VARIABLE}.{path})"
+        return f"len({Paginator.PAGINATION_ITEMS_VARIABLE} or []) > 0"
 
     def init_get_next(self, *, writer: AST.NodeWriter) -> None:
         if self._is_async:

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/inline_users/inline_users/raw_client.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/inline_users/inline_users/raw_client.py
@@ -269,7 +269,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_offset_pagination(
                     page=page + 1,
                     per_page=per_page,
@@ -342,7 +342,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_double_offset_pagination(
                     page=page + 1,
                     per_page=per_page,
@@ -399,7 +399,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_body_offset_pagination(
                     pagination=pagination,
                     request_options=request_options,
@@ -465,7 +465,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_offset_step_pagination(
                     page=page + len(_items or []),
                     limit=limit,
@@ -533,7 +533,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = bool(_parsed_response.has_next_page)
                 _get_next = lambda: self.list_with_offset_pagination_has_next_page(
                     page=page + len(_items or []),
                     limit=limit,
@@ -740,7 +740,7 @@ class RawInlineUsersClient:
                     ),
                 )
                 _items = _parsed_response.results
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_global_config(
                     offset=offset + 1,
                     request_options=request_options,
@@ -1007,7 +1007,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_offset_pagination(
@@ -1083,7 +1083,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_double_offset_pagination(
@@ -1143,7 +1143,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_body_offset_pagination(
@@ -1212,7 +1212,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_offset_step_pagination(
@@ -1283,7 +1283,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = bool(_parsed_response.has_next_page)
 
                 async def _get_next():
                     return await self.list_with_offset_pagination_has_next_page(
@@ -1502,7 +1502,7 @@ class AsyncRawInlineUsersClient:
                     ),
                 )
                 _items = _parsed_response.results
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_global_config(

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/users/raw_client.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/users/raw_client.py
@@ -333,7 +333,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_offset_pagination(
                     page=page + 1,
                     per_page=per_page,
@@ -405,7 +405,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_double_offset_pagination(
                     page=page + 1,
                     per_page=per_page,
@@ -461,7 +461,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_body_offset_pagination(
                     pagination=pagination,
                     request_options=request_options,
@@ -526,7 +526,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_offset_step_pagination(
                     page=page + len(_items or []),
                     limit=limit,
@@ -593,7 +593,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = bool(_parsed_response.has_next_page)
                 _get_next = lambda: self.list_with_offset_pagination_has_next_page(
                     page=page + len(_items or []),
                     limit=limit,
@@ -861,7 +861,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.results
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_global_config(
                     offset=offset + 1,
                     request_options=request_options,
@@ -912,7 +912,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_optional_data(
                     page=page + 1,
                     request_options=request_options,
@@ -1312,7 +1312,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_offset_pagination(
@@ -1387,7 +1387,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_double_offset_pagination(
@@ -1446,7 +1446,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_body_offset_pagination(
@@ -1514,7 +1514,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_offset_step_pagination(
@@ -1584,7 +1584,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = bool(_parsed_response.has_next_page)
 
                 async def _get_next():
                     return await self.list_with_offset_pagination_has_next_page(
@@ -1867,7 +1867,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.results
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_global_config(
@@ -1921,7 +1921,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_optional_data(

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/inline_users/inline_users/raw_client.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/inline_users/inline_users/raw_client.py
@@ -269,7 +269,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_offset_pagination(
                     page=page + 1,
                     per_page=per_page,
@@ -342,7 +342,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_double_offset_pagination(
                     page=page + 1,
                     per_page=per_page,
@@ -399,7 +399,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_body_offset_pagination(
                     pagination=pagination,
                     request_options=request_options,
@@ -465,7 +465,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_offset_step_pagination(
                     page=page + len(_items or []),
                     limit=limit,
@@ -533,7 +533,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = bool(_parsed_response.has_next_page)
                 _get_next = lambda: self.list_with_offset_pagination_has_next_page(
                     page=page + len(_items or []),
                     limit=limit,
@@ -740,7 +740,7 @@ class RawInlineUsersClient:
                     ),
                 )
                 _items = _parsed_response.results
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_global_config(
                     offset=offset + 1,
                     request_options=request_options,
@@ -1007,7 +1007,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_offset_pagination(
@@ -1083,7 +1083,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_double_offset_pagination(
@@ -1143,7 +1143,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_body_offset_pagination(
@@ -1212,7 +1212,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_offset_step_pagination(
@@ -1283,7 +1283,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = bool(_parsed_response.has_next_page)
 
                 async def _get_next():
                     return await self.list_with_offset_pagination_has_next_page(
@@ -1502,7 +1502,7 @@ class AsyncRawInlineUsersClient:
                     ),
                 )
                 _items = _parsed_response.results
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_global_config(

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/users/raw_client.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/users/raw_client.py
@@ -333,7 +333,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_offset_pagination(
                     page=page + 1,
                     per_page=per_page,
@@ -405,7 +405,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_double_offset_pagination(
                     page=page + 1,
                     per_page=per_page,
@@ -461,7 +461,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_body_offset_pagination(
                     pagination=pagination,
                     request_options=request_options,
@@ -526,7 +526,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_offset_step_pagination(
                     page=page + len(_items or []),
                     limit=limit,
@@ -593,7 +593,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = bool(_parsed_response.has_next_page)
                 _get_next = lambda: self.list_with_offset_pagination_has_next_page(
                     page=page + len(_items or []),
                     limit=limit,
@@ -861,7 +861,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.results
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_global_config(
                     offset=offset + 1,
                     request_options=request_options,
@@ -912,7 +912,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_optional_data(
                     page=page + 1,
                     request_options=request_options,
@@ -1312,7 +1312,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_offset_pagination(
@@ -1387,7 +1387,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_double_offset_pagination(
@@ -1446,7 +1446,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_body_offset_pagination(
@@ -1514,7 +1514,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_offset_step_pagination(
@@ -1584,7 +1584,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = bool(_parsed_response.has_next_page)
 
                 async def _get_next():
                     return await self.list_with_offset_pagination_has_next_page(
@@ -1867,7 +1867,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.results
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_global_config(
@@ -1921,7 +1921,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_optional_data(

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/inline_users/inline_users/raw_client.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/inline_users/inline_users/raw_client.py
@@ -269,7 +269,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_offset_pagination(
                     page=page + 1,
                     per_page=per_page,
@@ -342,7 +342,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_double_offset_pagination(
                     page=page + 1,
                     per_page=per_page,
@@ -399,7 +399,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_body_offset_pagination(
                     pagination=pagination,
                     request_options=request_options,
@@ -465,7 +465,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_offset_step_pagination(
                     page=page + 1,
                     limit=limit,
@@ -533,7 +533,7 @@ class RawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = bool(_parsed_response.has_next_page)
                 _get_next = lambda: self.list_with_offset_pagination_has_next_page(
                     page=page + 1,
                     limit=limit,
@@ -740,7 +740,7 @@ class RawInlineUsersClient:
                     ),
                 )
                 _items = _parsed_response.results
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_global_config(
                     offset=offset + 1,
                     request_options=request_options,
@@ -1007,7 +1007,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_offset_pagination(
@@ -1083,7 +1083,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_double_offset_pagination(
@@ -1143,7 +1143,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_body_offset_pagination(
@@ -1212,7 +1212,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_offset_step_pagination(
@@ -1283,7 +1283,7 @@ class AsyncRawInlineUsersClient:
                 )
                 _items = _parsed_response.data.users if _parsed_response.data is not None else []
 
-                _has_next = True
+                _has_next = bool(_parsed_response.has_next_page)
 
                 async def _get_next():
                     return await self.list_with_offset_pagination_has_next_page(
@@ -1502,7 +1502,7 @@ class AsyncRawInlineUsersClient:
                     ),
                 )
                 _items = _parsed_response.results
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_global_config(

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/users/raw_client.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/users/raw_client.py
@@ -333,7 +333,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_offset_pagination(
                     page=page + 1,
                     per_page=per_page,
@@ -405,7 +405,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_double_offset_pagination(
                     page=page + 1,
                     per_page=per_page,
@@ -461,7 +461,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_body_offset_pagination(
                     pagination=pagination,
                     request_options=request_options,
@@ -526,7 +526,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_offset_step_pagination(
                     page=page + 1,
                     limit=limit,
@@ -593,7 +593,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = bool(_parsed_response.has_next_page)
                 _get_next = lambda: self.list_with_offset_pagination_has_next_page(
                     page=page + 1,
                     limit=limit,
@@ -861,7 +861,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.results
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_global_config(
                     offset=offset + 1,
                     request_options=request_options,
@@ -912,7 +912,7 @@ class RawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
                 _get_next = lambda: self.list_with_optional_data(
                     page=page + 1,
                     request_options=request_options,
@@ -1312,7 +1312,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_offset_pagination(
@@ -1387,7 +1387,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_double_offset_pagination(
@@ -1446,7 +1446,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_body_offset_pagination(
@@ -1514,7 +1514,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_offset_step_pagination(
@@ -1584,7 +1584,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = bool(_parsed_response.has_next_page)
 
                 async def _get_next():
                     return await self.list_with_offset_pagination_has_next_page(
@@ -1867,7 +1867,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.results
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_global_config(
@@ -1921,7 +1921,7 @@ class AsyncRawUsersClient:
                     ),
                 )
                 _items = _parsed_response.data
-                _has_next = True
+                _has_next = len(_items or []) > 0
 
                 async def _get_next():
                     return await self.list_with_optional_data(


### PR DESCRIPTION
Closes FER-10931.

## Summary

The Python SDK generator's offset paginator hardcoded `_has_next = True` for every generated `list` endpoint, which caused a couple problems: `while pager.has_next: pager = pager.next_page()` never terminated; `for x in pager` worked only because the core paginator stops when `get_next()` returns an empty page.

It also ignored the IR's optional `OffsetPagination.has_next_page` response property, so users who explicitly declared `has-next-page: $response.<field>` still got the hardcoded `True`.

Reported by a customer using offset pagination via `x-fern-pagination: { offset: $request.page, results: $response.data }`.

## Change

`init_has_next()` in `generators/python/.../pagination/offset.py` now:

```python
def init_has_next(self) -> str:
    if self.offset.has_next_page is not None:
        path = self._response_property_to_dot_access(self.offset.has_next_page)
        return f"bool({Paginator.PARSED_RESPONSE_VARIABLE}.{path})"
    return f"len({Paginator.PAGINATION_ITEMS_VARIABLE} or []) > 0"
```

Items-length fallback matches the TypeScript generator's `hasNextPage: (r) => (r?.data ?? []).length > 0`.

## Before / after (generated)

```diff
 _items = _parsed_response.data.users if _parsed_response.data is not None else []
-_has_next = True
+_has_next = len(_items or []) > 0
 _get_next = lambda: self.list_with_offset_pagination(page=page + 1, ...)
```

And for endpoints that explicitly declare `has-next-page: $response.hasNextPage`:

```diff
-_has_next = True
+_has_next = bool(_parsed_response.has_next_page)
```

## Test plan

- [x] `pnpm seed test --generator python-sdk --fixture pagination --skip-scripts --local` regenerated all 3 offset-pagination fixtures; snapshots updated in this PR.
- [x] Confirmed no remaining `_has_next = True` strings in `seed/python-sdk/`.
- [ ] CI seed run.