### PR TITLE
fix(python): guard bare unparameterized dict/list/set in construct_type

### DIFF
--- a/generators/python/core_utilities/shared/unchecked_base_model.py
+++ b/generators/python/core_utilities/shared/unchecked_base_model.py
@@ -358,7 +358,10 @@ def construct_type(
         if not isinstance(object_, typing.Mapping):
             return object_
 
-        key_type, items_type = get_args(type_)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        key_type, items_type = type_args
         key_type = _maybe_resolve_forward_ref(key_type, host)
         items_type = _maybe_resolve_forward_ref(items_type, host)
         d = {
@@ -373,14 +376,20 @@ def construct_type(
         if not isinstance(object_, list):
             return object_
 
-        inner_type = _maybe_resolve_forward_ref(get_args(type_)[0], host)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        inner_type = _maybe_resolve_forward_ref(type_args[0], host)
         return [construct_type(object_=entry, type_=inner_type, host=host) for entry in object_]
 
     if base_type == set:
         if not isinstance(object_, set) and not isinstance(object_, list):
             return object_
 
-        inner_type = _maybe_resolve_forward_ref(get_args(type_)[0], host)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        inner_type = _maybe_resolve_forward_ref(type_args[0], host)
         return {construct_type(object_=entry, type_=inner_type, host=host) for entry in object_}
 
     if is_union(base_type) or is_annotated_union:

--- a/generators/python/sdk/changes/unreleased/fix-bare-container-construct-type.yml
+++ b/generators/python/sdk/changes/unreleased/fix-bare-container-construct-type.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix `construct_type` crash on bare unparameterized `dict`, `list`, and `set` types.
+    Previously, `get_args()` on a bare container returned an empty tuple, causing
+    `ValueError` (dict) or `IndexError` (list/set). Now falls back to returning
+    the object unchanged, matching `Dict[Any, Any]` / `List[Any]` / `Set[Any]` semantics.
+  type: fix

--- a/generators/python/tests/utils/example_models/types/core/unchecked_base_model.py
+++ b/generators/python/tests/utils/example_models/types/core/unchecked_base_model.py
@@ -354,7 +354,10 @@ def construct_type(
         if not isinstance(object_, typing.Mapping):
             return object_
 
-        key_type, items_type = get_args(type_)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        key_type, items_type = type_args
         key_type = _maybe_resolve_forward_ref(key_type, host)
         items_type = _maybe_resolve_forward_ref(items_type, host)
         d = {
@@ -369,14 +372,20 @@ def construct_type(
         if not isinstance(object_, list):
             return object_
 
-        inner_type = _maybe_resolve_forward_ref(get_args(type_)[0], host)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        inner_type = _maybe_resolve_forward_ref(type_args[0], host)
         return [construct_type(object_=entry, type_=inner_type, host=host) for entry in object_]
 
     if base_type == set:
         if not isinstance(object_, set) and not isinstance(object_, list):
             return object_
 
-        inner_type = _maybe_resolve_forward_ref(get_args(type_)[0], host)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        inner_type = _maybe_resolve_forward_ref(type_args[0], host)
         return {construct_type(object_=entry, type_=inner_type, host=host) for entry in object_}
 
     if is_union(base_type) or is_annotated_union:

--- a/generators/python/tests/utils/test_construct_type.py
+++ b/generators/python/tests/utils/test_construct_type.py
@@ -1135,3 +1135,24 @@ def test_empty_details_does_not_greedily_match_figure() -> None:
     # An empty dict should NOT become a FigureDetails (or TextDetails)
     # because the Literal 'type' field is absent
     assert not isinstance(block.details, FigureDetails), "Empty dict should not greedily match FigureDetails"
+
+
+def test_construct_bare_dict() -> None:
+    """Bare `dict` (no type params) should pass through without raising."""
+    input_dict = {"a": 1, "b": "two"}
+    result = construct_type(type_=dict, object_=input_dict)
+    assert result == input_dict
+
+
+def test_construct_bare_list() -> None:
+    """Bare `list` (no type params) should pass through without raising."""
+    input_list = [1, "two", 3.0]
+    result = construct_type(type_=list, object_=input_list)
+    assert result == input_list
+
+
+def test_construct_bare_set() -> None:
+    """Bare `set` (no type params) should pass through without raising."""
+    input_set = {1, 2, 3}
+    result = construct_type(type_=set, object_=input_set)
+    assert result == input_set

--- a/generators/python/tests/utils/typeddict_models/types/core/unchecked_base_model.py
+++ b/generators/python/tests/utils/typeddict_models/types/core/unchecked_base_model.py
@@ -354,7 +354,10 @@ def construct_type(
         if not isinstance(object_, typing.Mapping):
             return object_
 
-        key_type, items_type = get_args(type_)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        key_type, items_type = type_args
         key_type = _maybe_resolve_forward_ref(key_type, host)
         items_type = _maybe_resolve_forward_ref(items_type, host)
         d = {
@@ -369,14 +372,20 @@ def construct_type(
         if not isinstance(object_, list):
             return object_
 
-        inner_type = _maybe_resolve_forward_ref(get_args(type_)[0], host)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        inner_type = _maybe_resolve_forward_ref(type_args[0], host)
         return [construct_type(object_=entry, type_=inner_type, host=host) for entry in object_]
 
     if base_type == set:
         if not isinstance(object_, set) and not isinstance(object_, list):
             return object_
 
-        inner_type = _maybe_resolve_forward_ref(get_args(type_)[0], host)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        inner_type = _maybe_resolve_forward_ref(type_args[0], host)
         return {construct_type(object_=entry, type_=inner_type, host=host) for entry in object_}
 
     if is_union(base_type) or is_annotated_union:

--- a/generators/python/tests/utils/unaliased_models/types/core/unchecked_base_model.py
+++ b/generators/python/tests/utils/unaliased_models/types/core/unchecked_base_model.py
@@ -354,7 +354,10 @@ def construct_type(
         if not isinstance(object_, typing.Mapping):
             return object_
 
-        key_type, items_type = get_args(type_)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        key_type, items_type = type_args
         key_type = _maybe_resolve_forward_ref(key_type, host)
         items_type = _maybe_resolve_forward_ref(items_type, host)
         d = {
@@ -369,14 +372,20 @@ def construct_type(
         if not isinstance(object_, list):
             return object_
 
-        inner_type = _maybe_resolve_forward_ref(get_args(type_)[0], host)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        inner_type = _maybe_resolve_forward_ref(type_args[0], host)
         return [construct_type(object_=entry, type_=inner_type, host=host) for entry in object_]
 
     if base_type == set:
         if not isinstance(object_, set) and not isinstance(object_, list):
             return object_
 
-        inner_type = _maybe_resolve_forward_ref(get_args(type_)[0], host)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        inner_type = _maybe_resolve_forward_ref(type_args[0], host)
         return {construct_type(object_=entry, type_=inner_type, host=host) for entry in object_}
 
     if is_union(base_type) or is_annotated_union:

--- a/generators/python/tests/utils/union_utils/types/core/unchecked_base_model.py
+++ b/generators/python/tests/utils/union_utils/types/core/unchecked_base_model.py
@@ -354,7 +354,10 @@ def construct_type(
         if not isinstance(object_, typing.Mapping):
             return object_
 
-        key_type, items_type = get_args(type_)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        key_type, items_type = type_args
         key_type = _maybe_resolve_forward_ref(key_type, host)
         items_type = _maybe_resolve_forward_ref(items_type, host)
         d = {
@@ -369,14 +372,20 @@ def construct_type(
         if not isinstance(object_, list):
             return object_
 
-        inner_type = _maybe_resolve_forward_ref(get_args(type_)[0], host)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        inner_type = _maybe_resolve_forward_ref(type_args[0], host)
         return [construct_type(object_=entry, type_=inner_type, host=host) for entry in object_]
 
     if base_type == set:
         if not isinstance(object_, set) and not isinstance(object_, list):
             return object_
 
-        inner_type = _maybe_resolve_forward_ref(get_args(type_)[0], host)
+        type_args = get_args(type_)
+        if not type_args:
+            return object_
+        inner_type = _maybe_resolve_forward_ref(type_args[0], host)
         return {construct_type(object_=entry, type_=inner_type, host=host) for entry in object_}
 
     if is_union(base_type) or is_annotated_union:


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-10934

`construct_type` crashes at runtime when a field is annotated with a bare `dict`, `list`, or `set` (no type parameters). `get_args()` returns `()` for these types, causing:
- `dict` branch: `ValueError: not enough values to unpack (expected 2, got 0)`
- `list`/`set` branches: `IndexError: tuple index out of range`

Origin: cohere-ai/cohere-python#774

## Changes Made
- Guard `get_args(type_)` in the `dict`, `list`, and `set` branches of `construct_type` so that empty args cause an early `return object_` (pass-through), matching `Dict[Any, Any]` / `List[Any]` / `Set[Any]` semantics.
- Applied the same fix to the 4 test-copy `unchecked_base_model.py` files under `tests/utils/`.
- Added 3 new tests: `test_construct_bare_dict`, `test_construct_bare_list`, `test_construct_bare_set`.
- Added changelog entry (`fix`).

## Testing
- [x] Unit tests added/updated
- [x] All 29 `test_construct_type.py` tests pass locally
- [x] `pre-commit run -a` passes

Link to Devin session: https://app.devin.ai/sessions/a292ff84abad41ad8d76d81dd7c5022c
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->