### PR TITLE
chore(cli): serve OpenAPI spec locally in v2 generate ETE test

### DIFF
--- a/packages/cli/cli/changes/unreleased/test-ete-local-openapi-server.yml
+++ b/packages/cli/cli/changes/unreleased/test-ete-local-openapi-server.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Replace external petstore3.swagger.io URL with a local OpenAPI server in the v2 generate ETE test to remove a flaky dependency on the public petstore endpoint.
+  type: chore

--- a/packages/cli/ete-tests/src/tests/update-api/update-api.test.ts
+++ b/packages/cli/ete-tests/src/tests/update-api/update-api.test.ts
@@ -11,7 +11,9 @@ const FIXTURES_DIR = path.join(__dirname, "fixtures");
 describe("fern api update", () => {
     it("fern api update", async ({ signal }) => {
         // Start express server that will respond with the OpenAPI spec.
-        const { cleanup } = setupOpenAPIServer();
+        // Port is pinned because the fixture's generators.yml and the test snapshots
+        // reference http://localhost:4567/openapi.json verbatim.
+        const { cleanup } = await setupOpenAPIServer({ port: 4567 });
 
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
@@ -28,7 +30,9 @@ describe("fern api update", () => {
 
     it("fern api update --indent 4", async ({ signal }) => {
         // Start express server that will respond with the OpenAPI spec.
-        const { cleanup } = setupOpenAPIServer();
+        // Port is pinned because the fixture's generators.yml and the test snapshots
+        // reference http://localhost:4567/openapi.json verbatim.
+        const { cleanup } = await setupOpenAPIServer({ port: 4567 });
 
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);

--- a/packages/cli/ete-tests/src/tests/v2/generate.test.ts
+++ b/packages/cli/ete-tests/src/tests/v2/generate.test.ts
@@ -2,6 +2,7 @@ import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-a
 import { describe, expect, it } from "vitest";
 import { createTempFixture } from "../../utils/createTempFixture.js";
 import { cliV2, runCliV2 } from "../../utils/runCliV2.js";
+import { setupOpenAPIServer } from "../../utils/setupOpenAPIServer.js";
 
 const FIXTURES = {
     petstore: "petstore",
@@ -364,6 +365,7 @@ paths:
             }, 120_000);
 
             it("should generate Go SDK from a URL-referenced spec", async () => {
+                const { cleanup: cleanupServer } = setupOpenAPIServer();
                 const fixture = await createTempFixture({});
                 try {
                     const result = await runCliV2({
@@ -371,7 +373,7 @@ paths:
                             "sdk",
                             "generate",
                             "--api",
-                            "https://petstore3.swagger.io/api/v3/openapi.json",
+                            "http://localhost:4567/openapi.json",
                             "--target",
                             "go",
                             "--org",
@@ -389,6 +391,7 @@ paths:
                     expect(await doesPathExist(outputPath)).toBe(true);
                 } finally {
                     await fixture.cleanup();
+                    await cleanupServer();
                 }
             }, 120_000);
         });

--- a/packages/cli/ete-tests/src/tests/v2/generate.test.ts
+++ b/packages/cli/ete-tests/src/tests/v2/generate.test.ts
@@ -365,33 +365,36 @@ paths:
             }, 120_000);
 
             it("should generate Go SDK from a URL-referenced spec", async () => {
-                const { cleanup: cleanupServer } = setupOpenAPIServer();
-                const fixture = await createTempFixture({});
+                const server = await setupOpenAPIServer();
                 try {
-                    const result = await runCliV2({
-                        args: [
-                            "sdk",
-                            "generate",
-                            "--api",
-                            "http://localhost:4567/openapi.json",
-                            "--target",
-                            "go",
-                            "--org",
-                            "test-org",
-                            "--output",
-                            "./out",
-                            "--local"
-                        ],
-                        cwd: fixture.path,
-                        timeout: 120_000
-                    });
-                    expect(result.exitCode).toBe(0);
+                    const fixture = await createTempFixture({});
+                    try {
+                        const result = await runCliV2({
+                            args: [
+                                "sdk",
+                                "generate",
+                                "--api",
+                                server.url,
+                                "--target",
+                                "go",
+                                "--org",
+                                "test-org",
+                                "--output",
+                                "./out",
+                                "--local"
+                            ],
+                            cwd: fixture.path,
+                            timeout: 120_000
+                        });
+                        expect(result.exitCode).toBe(0);
 
-                    const outputPath = join(AbsoluteFilePath.of(fixture.path), RelativeFilePath.of("out"));
-                    expect(await doesPathExist(outputPath)).toBe(true);
+                        const outputPath = join(AbsoluteFilePath.of(fixture.path), RelativeFilePath.of("out"));
+                        expect(await doesPathExist(outputPath)).toBe(true);
+                    } finally {
+                        await fixture.cleanup();
+                    }
                 } finally {
-                    await fixture.cleanup();
-                    await cleanupServer();
+                    await server.cleanup();
                 }
             }, 120_000);
         });

--- a/packages/cli/ete-tests/src/utils/setupOpenAPIServer.ts
+++ b/packages/cli/ete-tests/src/utils/setupOpenAPIServer.ts
@@ -54,7 +54,14 @@ const TEST_OPENAPI_DOCUMENT: OpenAPI.Document = {
     }
 };
 
-export function setupOpenAPIServer(): { server: http.Server; cleanup: () => Promise<void> } {
+export interface OpenAPIServerHandle {
+    server: http.Server;
+    port: number;
+    url: string;
+    cleanup: () => Promise<void>;
+}
+
+export async function setupOpenAPIServer(options: { port?: number } = {}): Promise<OpenAPIServerHandle> {
     const app = express();
 
     // biome-ignore lint/suspicious/noExplicitAny: allow explicit any
@@ -62,7 +69,20 @@ export function setupOpenAPIServer(): { server: http.Server; cleanup: () => Prom
         res.json(TEST_OPENAPI_DOCUMENT);
     });
 
-    const server = app.listen(4567);
+    const requestedPort = options.port ?? 0;
+    const server = await new Promise<http.Server>((resolve, reject) => {
+        const s = app.listen(requestedPort);
+        s.once("listening", () => resolve(s));
+        s.once("error", reject);
+    });
+
+    const address = server.address();
+    if (address == null || typeof address === "string") {
+        throw new Error(`Unexpected server address: ${String(address)}`);
+    }
+    const port = address.port;
+    const url = `http://localhost:${port}/openapi.json`;
+
     const cleanup = async () => {
         return new Promise<void>((resolve, reject) => {
             server.close((err) => {
@@ -74,5 +94,5 @@ export function setupOpenAPIServer(): { server: http.Server; cleanup: () => Prom
             });
         });
     };
-    return { server, cleanup };
+    return { server, port, url, cleanup };
 }


### PR DESCRIPTION
Closes FER-10941

## Summary

- The `should generate Go SDK from a URL-referenced spec` ETE test was hitting `https://petstore3.swagger.io/api/v3/openapi.json`, which has been returning HTTP 504 and flaking the `test-ete` job on `main`.
- Swap the external URL for a localhost server via the existing `setupOpenAPIServer` helper (same one `update-api.test.ts` uses). URL-fetch coverage is preserved; no external dependency.

## Example

Before:

```ts
args: [
    "sdk", "generate",
    "--api", "https://petstore3.swagger.io/api/v3/openapi.json",
    "--target", "go",
    ...
],
```

After:

```ts
const { cleanup: cleanupServer } = setupOpenAPIServer();
// ...
args: [
    "sdk", "generate",
    "--api", "http://localhost:4567/openapi.json",
    "--target", "go",
    ...
],
// ...
finally {
    await fixture.cleanup();
    await cleanupServer();
}
```

## Test plan

- [ ] CI `test-ete` job passes without reaching petstore3.swagger.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)