### PR TITLE
fix(cli-generator): define SYNC_DATE in sync-sdk.sh

### DIFF
--- a/generators/cli/scripts/sync-sdk.sh
+++ b/generators/cli/scripts/sync-sdk.sh
@@ -29,6 +29,7 @@ fi
 
 CLI_SDK_SHA="$(git -C "$CLI_SDK_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")"
 CLI_SDK_SHORT="$(git -C "$CLI_SDK_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+SYNC_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
 echo "==> Syncing cli-sdk@${CLI_SDK_SHORT} (${CLI_SDK_SHA}) into generators/cli/sdk/"
 


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-10795

Follow-on fix for #16149. The `sync-cli-sdk` workflow fails because `SYNC_DATE` is referenced in the summary output of `sync-sdk.sh` (line 198) but never defined. Since the script runs with `set -u` (`set -euo pipefail`), bash treats the unbound variable as a fatal error.

Failing run: https://github.com/fern-api/fern/actions/runs/26783324251/job/78953024135

## Changes Made
- Added `SYNC_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"` alongside the other git-derived variables at the top of the script

## Testing
- [x] Verified the variable is used only in the summary echo on line 199 — no other consumers
- [x] Confirmed this is the sole cause of the `exit code 1` in the failing action

Link to Devin session: https://app.devin.ai/sessions/7d7dcf80049f4c1b85e7328727bb95ff
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->