### PR TITLE
fix(cli-generator): stop syncing tests and drop --tests from sync build

### DIFF
--- a/.github/workflows/sync-cli-sdk.yml
+++ b/.github/workflows/sync-cli-sdk.yml
@@ -40,7 +40,7 @@ jobs:
         run: bash generators/cli/scripts/sync-sdk.sh _cli-sdk
 
       - name: Verify projected SDK builds
-        run: cargo build --locked --all-features --tests
+        run: cargo build --locked --all-features
         working-directory: generators/cli/sdk
 
       - name: Check for changes

--- a/generators/cli/scripts/sync-sdk.sh
+++ b/generators/cli/scripts/sync-sdk.sh
@@ -34,45 +34,30 @@ SYNC_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 echo "==> Syncing cli-sdk@${CLI_SDK_SHORT} (${CLI_SDK_SHA}) into generators/cli/sdk/"
 
 # ---------------------------------------------------------------------------
-# 1. Rsync source files with SDK_IGNORE rules (mirrors build.mjs SDK_IGNORE)
+# 1. Rsync source files + openapi-fixture dev binary
 # ---------------------------------------------------------------------------
-echo "--- Syncing src/, tests/, cli/openapi-fixture/ ..."
+echo "--- Syncing src/, cli/openapi-fixture/ ..."
 
 rsync -a --delete \
   --exclude='.DS_Store' \
-  --exclude='target/' \
-  --exclude='.gitignore' \
-  --exclude='docs/' \
-  --exclude='tests/overlay_fixture.rs' \
-  --exclude='tests/fixtures/' \
-  --exclude='cli/openapi-fixture/' \
-  --exclude='.github/' \
-  --exclude='build.rs' \
-  --exclude='tests/common/' \
-  --exclude='tests/auth_routing_wire.rs' \
-  --exclude='tests/extension_surface_behavior.rs' \
-  --exclude='tests/lib_api.rs' \
-  --exclude='tests/tls_env_vars.rs' \
-  --exclude='changes/' \
   "$CLI_SDK_DIR/src/" "$SDK_DIR/src/"
 
-# Sync tests (only the ones not in SDK_IGNORE)
-mkdir -p "$SDK_DIR/tests"
-rsync -a --delete \
-  --exclude='.DS_Store' \
-  --exclude='overlay_fixture.rs' \
-  --exclude='fixtures/' \
-  --exclude='common/' \
-  --exclude='auth_routing_wire.rs' \
-  --exclude='extension_surface_behavior.rs' \
-  --exclude='lib_api.rs' \
-  --exclude='tls_env_vars.rs' \
-  "$CLI_SDK_DIR/tests/" "$SDK_DIR/tests/"
+# Tests are NOT synced. cli-sdk's own CI validates test compilation;
+# the vendored SDK only needs the library + openapi-fixture binary to
+# compile. Many test files reference non-synced CLI binaries/specs
+# (smoke tests, parser.rs #[cfg(test)] include_str! calls) and would
+# fail to compile in the projected single-package layout.
 
 # Sync cli/openapi-fixture/ (the dev fixture used by seed)
 mkdir -p "$SDK_DIR/cli/openapi-fixture"
 rsync -a --delete \
   "$CLI_SDK_DIR/cli/openapi-fixture/" "$SDK_DIR/cli/openapi-fixture/"
+
+# Remove stale tests/ directory if present from a prior sync revision
+if [[ -d "$SDK_DIR/tests" ]]; then
+  echo "--- Removing stale tests/ directory ..."
+  rm -rf "$SDK_DIR/tests"
+fi
 
 # ---------------------------------------------------------------------------
 # 2. Project Cargo.toml (not a naive copy — workspace → single-package)


### PR DESCRIPTION
## Description

Fixes the `sync-cli-sdk` workflow that's been failing after #16173 merged. The `SYNC_DATE` fix was necessary but the build step (`cargo build --locked --all-features --tests`) still fails because:

1. `src/openapi/parser.rs` has `#[cfg(test)]` blocks with `include_str!` calls referencing CLI directories (`cli/bigcommerce/`, `cli/box/`, `cli/devin/`, etc.) that are **not** synced — only `cli/openapi-fixture/` is.
2. Smoke test files (`square_smoke.rs`, `sarvam_smoke.rs`, `icepanel_smoke.rs`, etc.) reference `CARGO_BIN_EXE_<binary>` for binaries not in the projected `Cargo.toml`.

## Changes Made

- **`sync-sdk.sh`**: Remove the `tests/` rsync entirely — cli-sdk's own CI validates test compilation; the vendored SDK only needs `lib` + `openapi-fixture` to compile. Added cleanup for stale `tests/` from prior sync revisions. Simplified `src/` rsync (the old `--exclude` flags for `tests/` and `cli/` paths were relative to `src/` and therefore dead).
- **`sync-cli-sdk.yml`**: Drop `--tests` from `cargo build` — this matches what users actually build and avoids the `parser.rs` `#[cfg(test)]` `include_str!` issue.

## Testing

- Ran `sync-sdk.sh` locally against a fresh cli-sdk clone — sync completed cleanly
- Ran `cargo build --locked --all-features` (without `--tests`) against the synced SDK — library, `openapi-fixture`, and `strip-schema` all compile successfully
- Verified `tests/` directory is properly removed after sync

Link to Devin session: https://app.devin.ai/sessions/68b2bc999af64e5f8e89e61608f693a6
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->