### PR TITLE
fix(ruby): emit inherited fields on objects with extends/allOf

### DIFF
--- a/generators/ruby-v2/model/src/object/ObjectGenerator.ts
+++ b/generators/ruby-v2/model/src/object/ObjectGenerator.ts
@@ -29,7 +29,10 @@ export class ObjectGenerator extends FileGenerator<RubyFile, ModelCustomConfigSc
     }
 
     public doGenerate(): RubyFile {
-        const properties = this.objectDeclaration.properties || [];
+        const properties = [
+            ...(this.objectDeclaration.extendedProperties ?? []),
+            ...(this.objectDeclaration.properties ?? [])
+        ];
 
         const statements = generateFields({
             typeDeclaration: this.typeDeclaration,

--- a/generators/ruby-v2/sdk/changes/unreleased/fix-emit-inherited-fields-on-objects.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/fix-emit-inherited-fields-on-objects.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generated model classes now include fields inherited from parent types
+    (Fern `extends` / OpenAPI `allOf`). Previously, derived models — including
+    discriminated union variants — only carried their own declared properties
+    and silently dropped fields contributed by their parents, leaving
+    deserialized responses without `id`, `name`, and other inherited common
+    fields.
+  type: fix

--- a/seed/ruby-sdk-v2/alias-extends/lib/seed/types/child.rb
+++ b/seed/ruby-sdk-v2/alias-extends/lib/seed/types/child.rb
@@ -3,6 +3,8 @@
 module Seed
   module Types
     class Child < Internal::Types::Model
+      field :parent, -> { String }, optional: false, nullable: false
+
       field :child, -> { String }, optional: false, nullable: false
     end
   end

--- a/seed/ruby-sdk-v2/allof/lib/seed/types/rule_response.rb
+++ b/seed/ruby-sdk-v2/allof/lib/seed/types/rule_response.rb
@@ -3,6 +3,14 @@
 module Seed
   module Types
     class RuleResponse < Internal::Types::Model
+      field :created_by, -> { String }, optional: true, nullable: false, api_name: "createdBy"
+
+      field :created_date_time, -> { String }, optional: true, nullable: false, api_name: "createdDateTime"
+
+      field :modified_by, -> { String }, optional: true, nullable: false, api_name: "modifiedBy"
+
+      field :modified_date_time, -> { String }, optional: true, nullable: false, api_name: "modifiedDateTime"
+
       field :id, -> { String }, optional: false, nullable: false
 
       field :name, -> { String }, optional: false, nullable: false

--- a/seed/ruby-sdk-v2/circular-references-extends/lib/seed/common/types/child_type.rb
+++ b/seed/ruby-sdk-v2/circular-references-extends/lib/seed/common/types/child_type.rb
@@ -4,6 +4,8 @@ module Seed
   module Common
     module Types
       class ChildType < Internal::Types::Model
+        field :child_ref, -> { Seed::Common::Types::ChildType }, optional: true, nullable: false
+
         field :child_name, -> { String }, optional: false, nullable: false
       end
     end

--- a/seed/ruby-sdk-v2/circular-references-extends/lib/seed/derived/types/derived_type.rb
+++ b/seed/ruby-sdk-v2/circular-references-extends/lib/seed/derived/types/derived_type.rb
@@ -4,6 +4,8 @@ module Seed
   module Derived
     module Types
       class DerivedType < Internal::Types::Model
+        field :child_ref, -> { Seed::Common::Types::ChildType }, optional: true, nullable: false
+
         field :derived_name, -> { String }, optional: false, nullable: false
       end
     end

--- a/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/types/types/extended_movie.rb
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/lib/seed/types/types/extended_movie.rb
@@ -4,6 +4,26 @@ module Seed
   module Types
     module Types
       class ExtendedMovie < Internal::Types::Model
+        field :id, -> { String }, optional: false, nullable: false
+
+        field :prequel, -> { String }, optional: true, nullable: false
+
+        field :title, -> { String }, optional: false, nullable: false
+
+        field :from, -> { String }, optional: false, nullable: false
+
+        field :rating, -> { Integer }, optional: false, nullable: false
+
+        field :type, -> { String }, optional: false, nullable: false
+
+        field :tag, -> { String }, optional: false, nullable: false
+
+        field :book, -> { String }, optional: true, nullable: false
+
+        field :metadata, -> { Internal::Types::Hash[String, Object] }, optional: false, nullable: false
+
+        field :revenue, -> { Integer }, optional: false, nullable: false
+
         field :cast, -> { Internal::Types::Array[String] }, optional: false, nullable: false
       end
     end

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/types/types/extended_movie.rb
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/lib/seed/types/types/extended_movie.rb
@@ -4,6 +4,26 @@ module Seed
   module Types
     module Types
       class ExtendedMovie < Internal::Types::Model
+        field :id, -> { String }, optional: false, nullable: false
+
+        field :prequel, -> { String }, optional: true, nullable: false
+
+        field :title, -> { String }, optional: false, nullable: false
+
+        field :from, -> { String }, optional: false, nullable: false
+
+        field :rating, -> { Integer }, optional: false, nullable: false
+
+        field :type, -> { String }, optional: false, nullable: false
+
+        field :tag, -> { String }, optional: false, nullable: false
+
+        field :book, -> { String }, optional: true, nullable: false
+
+        field :metadata, -> { Internal::Types::Hash[String, Object] }, optional: false, nullable: false
+
+        field :revenue, -> { Integer }, optional: false, nullable: false
+
         field :cast, -> { Internal::Types::Array[String] }, optional: false, nullable: false
       end
     end

--- a/seed/ruby-sdk-v2/examples/readme-config/lib/seed/types/types/extended_movie.rb
+++ b/seed/ruby-sdk-v2/examples/readme-config/lib/seed/types/types/extended_movie.rb
@@ -4,6 +4,26 @@ module Seed
   module Types
     module Types
       class ExtendedMovie < Internal::Types::Model
+        field :id, -> { String }, optional: false, nullable: false
+
+        field :prequel, -> { String }, optional: true, nullable: false
+
+        field :title, -> { String }, optional: false, nullable: false
+
+        field :from, -> { String }, optional: false, nullable: false
+
+        field :rating, -> { Integer }, optional: false, nullable: false
+
+        field :type, -> { String }, optional: false, nullable: false
+
+        field :tag, -> { String }, optional: false, nullable: false
+
+        field :book, -> { String }, optional: true, nullable: false
+
+        field :metadata, -> { Internal::Types::Hash[String, Object] }, optional: false, nullable: false
+
+        field :revenue, -> { Integer }, optional: false, nullable: false
+
         field :cast, -> { Internal::Types::Array[String] }, optional: false, nullable: false
       end
     end

--- a/seed/ruby-sdk-v2/examples/require-paths/lib/seed/types/types/extended_movie.rb
+++ b/seed/ruby-sdk-v2/examples/require-paths/lib/seed/types/types/extended_movie.rb
@@ -4,6 +4,26 @@ module Seed
   module Types
     module Types
       class ExtendedMovie < Internal::Types::Model
+        field :id, -> { String }, optional: false, nullable: false
+
+        field :prequel, -> { String }, optional: true, nullable: false
+
+        field :title, -> { String }, optional: false, nullable: false
+
+        field :from, -> { String }, optional: false, nullable: false
+
+        field :rating, -> { Integer }, optional: false, nullable: false
+
+        field :type, -> { String }, optional: false, nullable: false
+
+        field :tag, -> { String }, optional: false, nullable: false
+
+        field :book, -> { String }, optional: true, nullable: false
+
+        field :metadata, -> { Internal::Types::Hash[String, Object] }, optional: false, nullable: false
+
+        field :revenue, -> { Integer }, optional: false, nullable: false
+
         field :cast, -> { Internal::Types::Array[String] }, optional: false, nullable: false
       end
     end

--- a/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/types/types/extended_movie.rb
+++ b/seed/ruby-sdk-v2/examples/wire-tests/lib/seed/types/types/extended_movie.rb
@@ -4,6 +4,26 @@ module Seed
   module Types
     module Types
       class ExtendedMovie < Internal::Types::Model
+        field :id, -> { String }, optional: false, nullable: false
+
+        field :prequel, -> { String }, optional: true, nullable: false
+
+        field :title, -> { String }, optional: false, nullable: false
+
+        field :from, -> { String }, optional: false, nullable: false
+
+        field :rating, -> { Integer }, optional: false, nullable: false
+
+        field :type, -> { String }, optional: false, nullable: false
+
+        field :tag, -> { String }, optional: false, nullable: false
+
+        field :book, -> { String }, optional: true, nullable: false
+
+        field :metadata, -> { Internal::Types::Hash[String, Object] }, optional: false, nullable: false
+
+        field :revenue, -> { Integer }, optional: false, nullable: false
+
         field :cast, -> { Internal::Types::Array[String] }, optional: false, nullable: false
       end
     end

--- a/seed/ruby-sdk-v2/extends/lib/seed/types/example_type.rb
+++ b/seed/ruby-sdk-v2/extends/lib/seed/types/example_type.rb
@@ -3,6 +3,8 @@
 module Seed
   module Types
     class ExampleType < Internal::Types::Model
+      field :docs, -> { String }, optional: false, nullable: false
+
       field :name, -> { String }, optional: false, nullable: false
     end
   end

--- a/seed/ruby-sdk-v2/extends/lib/seed/types/json.rb
+++ b/seed/ruby-sdk-v2/extends/lib/seed/types/json.rb
@@ -3,6 +3,8 @@
 module Seed
   module Types
     class JSON_ < Internal::Types::Model
+      field :docs, -> { String }, optional: false, nullable: false
+
       field :raw, -> { String }, optional: false, nullable: false
     end
   end

--- a/seed/ruby-sdk-v2/extends/lib/seed/types/nested_type.rb
+++ b/seed/ruby-sdk-v2/extends/lib/seed/types/nested_type.rb
@@ -3,6 +3,10 @@
 module Seed
   module Types
     class NestedType < Internal::Types::Model
+      field :raw, -> { String }, optional: false, nullable: false
+
+      field :docs, -> { String }, optional: false, nullable: false
+
       field :name, -> { String }, optional: false, nullable: false
     end
   end

--- a/seed/ruby-sdk-v2/nullable-allof-extends/lib/seed/types/root_object.rb
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/lib/seed/types/root_object.rb
@@ -3,6 +3,10 @@
 module Seed
   module Types
     # Object inheriting from a nullable schema via allOf.
-    class RootObject < Internal::Types::Model; end
+    class RootObject < Internal::Types::Model
+      field :normal_field, -> { String }, optional: true, nullable: false, api_name: "normalField"
+
+      field :nullable_field, -> { String }, optional: true, nullable: false, api_name: "nullableField"
+    end
   end
 end

--- a/seed/ruby-sdk-v2/unions/lib/seed/types/types/foo_extended.rb
+++ b/seed/ruby-sdk-v2/unions/lib/seed/types/types/foo_extended.rb
@@ -4,6 +4,8 @@ module Seed
   module Types
     module Types
       class FooExtended < Internal::Types::Model
+        field :name, -> { String }, optional: false, nullable: false
+
         field :age, -> { Integer }, optional: false, nullable: false
       end
     end


### PR DESCRIPTION
Closes FER-10951

## Summary

The ruby-v2 model generator was reading only `objectDeclaration.properties` and ignoring `extendedProperties`, so every derived model — including discriminated union variants — silently dropped fields contributed by parent types. Customers reported this on the auth0 SDK, where `ConnectionResponseContent*` variants exposed only strategy-specific fields and dropped `id`, `name`, `display_name`, `enabled_clients`, etc. from the `ConnectionResponseCommon → CreateConnectionCommon → ConnectionCommon` `allOf` chain.

The fix flattens `extendedProperties` into the field list at emit time, matching the existing pattern used elsewhere in ruby-v2 (`WrappedRequestGenerator.ts:82`). IR already pre-computes the transitive flattened set, so this covers arbitrary-depth `extends`/`allOf` chains.

## Example

`generators/ruby-v2/model/src/object/ObjectGenerator.ts`:

```diff
 public doGenerate(): RubyFile {
-    const properties = this.objectDeclaration.properties || [];
+    const properties = [
+        ...(this.objectDeclaration.extendedProperties ?? []),
+        ...(this.objectDeclaration.properties ?? [])
+    ];
```

Before / after on the auth0 case — variant `ConnectionResponseContentAd extends ConnectionResponseCommon extends CreateConnectionCommon extends ConnectionCommon`:

```diff
 class ConnectionResponseContentAd < Internal::Types::Model
+  field :id, -> { String }, optional: false, nullable: false
+  field :realms, -> { Internal::Types::Array[String] }, optional: true, nullable: false
+  field :name, -> { String }, optional: false, nullable: false
+  field :enabled_clients, -> { Internal::Types::Array[String] }, optional: true, nullable: false
+  field :display_name, -> { String }, optional: true, nullable: false
+  field :is_domain_connection, -> { Internal::Types::Boolean }, optional: true, nullable: false
+  field :metadata, -> { Internal::Types::Hash[String, String] }, optional: true, nullable: false
   field :strategy, -> { String }, optional: false, nullable: false
   field :options, -> { Auth0::Types::ConnectionOptionsAd }, optional: true, nullable: false
   field :provisioning_ticket_url, -> { String }, optional: true, nullable: false
 end
```

Seed fixtures with `extends`/`allOf` all updated to reflect the corrected output. Notably, `nullable-allof-extends/RootObject` was previously emitted as an empty class — it now correctly carries `normalField` and `nullableField`.

## Test plan

- [x] Reproduce the customer issue against `/Users/Patrick/configs/auth0-fern-config/fern` — confirmed variants now expose all inherited fields
- [x] Run `pnpm seed test --generator ruby-sdk-v2 --local --skipScripts` on 17 fixtures covering extends/allOf and non-extends shapes — 22/22 test cases passed
- [x] Verify no surprise impact on non-extends fixtures (only inherited-field additions in changed `.rb` files)
- [x] Confirm unrelated snapshot drift (allof execution_context dedupe, exhaustive dynamic-snippets duplicate `string:`) is pre-existing on main, not introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->