### PR TITLE
fix(openapi): skip inherited props and propagate optionality in discriminated-union base inference

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/inferDiscriminatedUnionBaseProperties.test.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/inferDiscriminatedUnionBaseProperties.test.ts
@@ -1,0 +1,297 @@
+import { Schema, Source } from "@fern-api/openapi-ir";
+import { TaskContext } from "@fern-api/task-context";
+import { OpenAPIV3 } from "openapi-types";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_PARSE_OPENAPI_SETTINGS } from "../options.js";
+import { parse } from "../parse.js";
+
+function mockTaskContext(): TaskContext {
+    return {
+        logger: {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            trace: vi.fn(),
+            log: vi.fn()
+        }
+    } as unknown as TaskContext;
+}
+
+function findRootSchema(ir: ReturnType<typeof parse>, name: string): Schema | undefined {
+    return ir.groupedSchemas.rootSchemas[name];
+}
+
+function commonPropertyKeysOf(schema: Schema | undefined): string[] {
+    if (schema == null || schema.type !== "oneOf") {
+        return [];
+    }
+    if (schema.value.type !== "discriminated") {
+        return [];
+    }
+    return schema.value.commonProperties.map((p) => p.key);
+}
+
+function commonPropertyOptionalityOf(schema: Schema | undefined, key: string): "required" | "optional" | "missing" {
+    if (schema == null || schema.type !== "oneOf" || schema.value.type !== "discriminated") {
+        return "missing";
+    }
+    const prop = schema.value.commonProperties.find((p) => p.key === key);
+    if (prop == null) {
+        return "missing";
+    }
+    return prop.schema.type === "optional" ? "optional" : "required";
+}
+
+describe("infer-discriminated-union-base-properties", () => {
+    it("does NOT infer properties already inherited via a shared allOf $ref parent", () => {
+        const doc: OpenAPIV3.Document = {
+            openapi: "3.0.0",
+            info: { title: "Test API", version: "1.0" },
+            paths: {
+                "/things": {
+                    get: {
+                        operationId: "listThings",
+                        responses: {
+                            "200": {
+                                description: "OK",
+                                content: {
+                                    "application/json": {
+                                        schema: { $ref: "#/components/schemas/MyUnion" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            components: {
+                schemas: {
+                    Common: {
+                        type: "object",
+                        properties: {
+                            sharedField: { type: "string" },
+                            anotherShared: { type: "integer" }
+                        }
+                        // no `required` — both fields are optional in Common
+                    },
+                    VariantA: {
+                        allOf: [
+                            { $ref: "#/components/schemas/Common" },
+                            {
+                                type: "object",
+                                properties: {
+                                    kind: { type: "string", enum: ["a"] },
+                                    ownPropA: { type: "string" }
+                                },
+                                required: ["kind"]
+                            }
+                        ]
+                    },
+                    VariantB: {
+                        allOf: [
+                            { $ref: "#/components/schemas/Common" },
+                            {
+                                type: "object",
+                                properties: {
+                                    kind: { type: "string", enum: ["b"] },
+                                    ownPropB: { type: "string" }
+                                },
+                                required: ["kind"]
+                            }
+                        ]
+                    },
+                    MyUnion: {
+                        type: "object",
+                        oneOf: [{ $ref: "#/components/schemas/VariantA" }, { $ref: "#/components/schemas/VariantB" }],
+                        discriminator: {
+                            propertyName: "kind",
+                            mapping: {
+                                a: "#/components/schemas/VariantA",
+                                b: "#/components/schemas/VariantB"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        const ir = parse({
+            context: mockTaskContext(),
+            documents: [
+                {
+                    type: "openapi",
+                    value: doc,
+                    source: Source.openapi({ file: "test.yml" }),
+                    settings: {
+                        ...DEFAULT_PARSE_OPENAPI_SETTINGS,
+                        shouldInferDiscriminatedUnionBaseProperties: true
+                    }
+                }
+            ]
+        });
+
+        const union = findRootSchema(ir, "MyUnion");
+        const keys = commonPropertyKeysOf(union);
+
+        // `sharedField` and `anotherShared` come from Common, which every variant inherits
+        // via `allOf: $ref`. They should NOT be re-emitted as union commonProperties.
+        expect(keys).not.toContain("sharedField");
+        expect(keys).not.toContain("anotherShared");
+    });
+
+    it("still infers properties that variants declare inline (not inherited from a shared parent)", () => {
+        const doc: OpenAPIV3.Document = {
+            openapi: "3.0.0",
+            info: { title: "Test API", version: "1.0" },
+            paths: {
+                "/things": {
+                    get: {
+                        operationId: "listThings",
+                        responses: {
+                            "200": {
+                                description: "OK",
+                                content: {
+                                    "application/json": {
+                                        schema: { $ref: "#/components/schemas/MyUnion" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            components: {
+                schemas: {
+                    VariantA: {
+                        type: "object",
+                        properties: {
+                            kind: { type: "string", enum: ["a"] },
+                            inlineShared: { type: "string" },
+                            ownPropA: { type: "string" }
+                        },
+                        required: ["kind", "inlineShared"]
+                    },
+                    VariantB: {
+                        type: "object",
+                        properties: {
+                            kind: { type: "string", enum: ["b"] },
+                            inlineShared: { type: "string" },
+                            ownPropB: { type: "string" }
+                        },
+                        required: ["kind", "inlineShared"]
+                    },
+                    MyUnion: {
+                        type: "object",
+                        oneOf: [{ $ref: "#/components/schemas/VariantA" }, { $ref: "#/components/schemas/VariantB" }],
+                        discriminator: {
+                            propertyName: "kind",
+                            mapping: {
+                                a: "#/components/schemas/VariantA",
+                                b: "#/components/schemas/VariantB"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        const ir = parse({
+            context: mockTaskContext(),
+            documents: [
+                {
+                    type: "openapi",
+                    value: doc,
+                    source: Source.openapi({ file: "test.yml" }),
+                    settings: {
+                        ...DEFAULT_PARSE_OPENAPI_SETTINGS,
+                        shouldInferDiscriminatedUnionBaseProperties: true
+                    }
+                }
+            ]
+        });
+
+        const union = findRootSchema(ir, "MyUnion");
+        const keys = commonPropertyKeysOf(union);
+
+        // `inlineShared` is declared inline on each variant and not inherited from a shared parent,
+        // so the inference should still pick it up.
+        expect(keys).toContain("inlineShared");
+    });
+
+    it("lifts an inferred property as optional when any variant declares it optional", () => {
+        const doc: OpenAPIV3.Document = {
+            openapi: "3.0.0",
+            info: { title: "Test API", version: "1.0" },
+            paths: {
+                "/things": {
+                    get: {
+                        operationId: "listThings",
+                        responses: {
+                            "200": {
+                                description: "OK",
+                                content: {
+                                    "application/json": {
+                                        schema: { $ref: "#/components/schemas/MyUnion" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            components: {
+                schemas: {
+                    VariantA: {
+                        type: "object",
+                        properties: {
+                            kind: { type: "string", enum: ["a"] },
+                            sometimesRequired: { type: "string" }
+                        },
+                        // sometimesRequired is OPTIONAL here
+                        required: ["kind"]
+                    },
+                    VariantB: {
+                        type: "object",
+                        properties: {
+                            kind: { type: "string", enum: ["b"] },
+                            sometimesRequired: { type: "string" }
+                        },
+                        // sometimesRequired is REQUIRED here
+                        required: ["kind", "sometimesRequired"]
+                    },
+                    MyUnion: {
+                        type: "object",
+                        oneOf: [{ $ref: "#/components/schemas/VariantA" }, { $ref: "#/components/schemas/VariantB" }],
+                        discriminator: {
+                            propertyName: "kind",
+                            mapping: {
+                                a: "#/components/schemas/VariantA",
+                                b: "#/components/schemas/VariantB"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        const ir = parse({
+            context: mockTaskContext(),
+            documents: [
+                {
+                    type: "openapi",
+                    value: doc,
+                    source: Source.openapi({ file: "test.yml" }),
+                    settings: {
+                        ...DEFAULT_PARSE_OPENAPI_SETTINGS,
+                        shouldInferDiscriminatedUnionBaseProperties: true
+                    }
+                }
+            ]
+        });
+
+        const union = findRootSchema(ir, "MyUnion");
+        // Lifted, but as optional — because at least one variant doesn't require it.
+        expect(commonPropertyOptionalityOf(union, "sometimesRequired")).toBe("optional");
+    });
+});

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertDiscriminatedOneOf.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertDiscriminatedOneOf.ts
@@ -353,6 +353,12 @@ export function wrapDiscriminatedOneOf({
  * all variants. The discriminant property and any properties already declared at the
  * union's top level are excluded. This lets SDKs expose shared fields directly on
  * the union type instead of forcing a cast to a concrete variant.
+ *
+ * Properties that every variant already inherits through a shared `allOf $ref` parent
+ * are also excluded: the parent schema is the single source of truth, and re-emitting
+ * those properties on the union forces some generators (e.g. TypeScript) to declare a
+ * synthesized base interface alongside the real parent, which can collide when the two
+ * disagree on optionality.
  */
 function inferCommonPropertiesFromVariants({
     variants,
@@ -381,12 +387,25 @@ function inferCommonPropertiesFromVariants({
     if (firstVariantProps == null) {
         return [];
     }
+    const inheritedFromSharedParent = getPropertyNamesInheritedFromSharedAllOfRefParents({
+        variants,
+        context,
+        breadcrumbs,
+        source,
+        namespace
+    });
+    const variantRequiredSets = variants.map((variant) =>
+        getAllRequiredPropertyNames({ schema: variant, context, visited: new Set() })
+    );
     const result: CommonPropertyWithExample[] = [];
     for (const [propertyName, firstSchema] of Object.entries(firstVariantProps)) {
         if (propertyName === discriminant) {
             continue;
         }
         if (existingPropertyNames.has(propertyName)) {
+            continue;
+        }
+        if (inheritedFromSharedParent.has(propertyName)) {
             continue;
         }
         let presentInAll = true;
@@ -398,8 +417,159 @@ function inferCommonPropertiesFromVariants({
                 break;
             }
         }
-        if (presentInAll) {
-            result.push({ key: propertyName, schema: firstSchema });
+        if (!presentInAll) {
+            continue;
+        }
+        const requiredInEveryVariant = variantRequiredSets.every((set) => set.has(propertyName));
+        const schemaToLift =
+            requiredInEveryVariant || firstSchema.type === "optional" || firstSchema.type === "nullable"
+                ? firstSchema
+                : SchemaWithExample.optional({
+                      nameOverride: undefined,
+                      generatedName: "",
+                      title: undefined,
+                      value: firstSchema,
+                      description: undefined,
+                      availability: undefined,
+                      namespace: undefined,
+                      groupName: undefined,
+                      inline: undefined
+                  });
+        result.push({ key: propertyName, schema: schemaToLift });
+    }
+    return result;
+}
+
+/**
+ * Returns the set of property names that the given schema (and any schemas reachable via
+ * `allOf`) declares as required. A property is required for the variant if any link in the
+ * `allOf` chain places it in a `required` array; otherwise it's optional. Used by the
+ * inference path to decide whether a lifted common property should be wrapped as optional.
+ */
+function getAllRequiredPropertyNames({
+    schema,
+    context,
+    visited
+}: {
+    schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject;
+    context: SchemaParserContext;
+    visited: Set<string>;
+}): Set<string> {
+    const result = new Set<string>();
+    let resolved: OpenAPIV3.SchemaObject;
+    if (isReferenceObject(schema)) {
+        if (visited.has(schema.$ref)) {
+            return result;
+        }
+        visited.add(schema.$ref);
+        resolved = context.resolveSchemaReference(schema);
+    } else {
+        resolved = schema;
+    }
+    for (const name of resolved.required ?? []) {
+        result.add(name);
+    }
+    for (const allOfElement of resolved.allOf ?? []) {
+        const childRequired = getAllRequiredPropertyNames({ schema: allOfElement, context, visited });
+        for (const name of childRequired) {
+            result.add(name);
+        }
+    }
+    return result;
+}
+
+/**
+ * Walks each variant's `allOf` chain (following `$ref`s transitively) and returns the set
+ * of property names that come from `$ref` parents shared by *every* variant. These are the
+ * properties each variant already inherits from a common ancestor — re-declaring them on
+ * the union would cause the structural duplication described above.
+ */
+function getPropertyNamesInheritedFromSharedAllOfRefParents({
+    variants,
+    context,
+    breadcrumbs,
+    source,
+    namespace
+}: {
+    variants: Array<OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject>;
+    context: SchemaParserContext;
+    breadcrumbs: string[];
+    source: Source;
+    namespace: string | undefined;
+}): Set<string> {
+    if (variants.length === 0) {
+        return new Set();
+    }
+    const refsPerVariant = variants.map((variant) =>
+        collectTransitiveAllOfRefs({ schema: variant, context, visited: new Set() })
+    );
+    const firstSet = refsPerVariant[0];
+    if (firstSet == null || firstSet.size === 0) {
+        return new Set();
+    }
+    const inherited = new Set<string>();
+    for (const [refKey, refObject] of firstSet) {
+        const sharedAcrossAllVariants = refsPerVariant.every((s) => s.has(refKey));
+        if (!sharedAcrossAllVariants) {
+            continue;
+        }
+        const parentProperties = getAllProperties({
+            schema: refObject,
+            context,
+            breadcrumbs,
+            source,
+            namespace
+        });
+        for (const propertyName of Object.keys(parentProperties)) {
+            inherited.add(propertyName);
+        }
+    }
+    return inherited;
+}
+
+/**
+ * Returns a map of `$ref` URI -> the `ReferenceObject` that points to it, for every
+ * `$ref` reachable via `allOf` from the given schema (transitively). Inline `allOf`
+ * elements are recursed into so a deeply-nested `$ref` still surfaces.
+ */
+function collectTransitiveAllOfRefs({
+    schema,
+    context,
+    visited
+}: {
+    schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject;
+    context: SchemaParserContext;
+    visited: Set<string>;
+}): Map<string, OpenAPIV3.ReferenceObject> {
+    const result = new Map<string, OpenAPIV3.ReferenceObject>();
+    let resolved: OpenAPIV3.SchemaObject;
+    if (isReferenceObject(schema)) {
+        if (visited.has(schema.$ref)) {
+            return result;
+        }
+        visited.add(schema.$ref);
+        resolved = context.resolveSchemaReference(schema);
+    } else {
+        resolved = schema;
+    }
+    for (const allOfElement of resolved.allOf ?? []) {
+        if (isReferenceObject(allOfElement)) {
+            if (!result.has(allOfElement.$ref)) {
+                result.set(allOfElement.$ref, allOfElement);
+            }
+            const nested = collectTransitiveAllOfRefs({ schema: allOfElement, context, visited });
+            for (const [k, v] of nested) {
+                if (!result.has(k)) {
+                    result.set(k, v);
+                }
+            }
+        } else {
+            const nested = collectTransitiveAllOfRefs({ schema: allOfElement, context, visited });
+            for (const [k, v] of nested) {
+                if (!result.has(k)) {
+                    result.set(k, v);
+                }
+            }
         }
     }
     return result;

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/oneof-shared-allof-properties.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/oneof-shared-allof-properties.json
@@ -77,21 +77,21 @@
                 "value": {
                   "id": {
                     "value": {
-                      "value": "string",
+                      "value": "id",
                       "type": "string"
                     },
                     "type": "primitive"
                   },
                   "name": {
                     "value": {
-                      "value": "string",
+                      "value": "name",
                       "type": "string"
                     },
                     "type": "primitive"
                   },
                   "display_name": {
                     "value": {
-                      "value": "string",
+                      "value": "display_name",
                       "type": "string"
                     },
                     "type": "primitive"
@@ -204,44 +204,7 @@
       },
       "ConnectionResponse": {
         "value": {
-          "commonProperties": [
-            {
-              "key": "id",
-              "schema": {
-                "description": "The connection's identifier.",
-                "schema": {
-                  "type": "string"
-                },
-                "generatedName": "ConnectionCommonId",
-                "groupName": [],
-                "type": "primitive"
-              }
-            },
-            {
-              "key": "name",
-              "schema": {
-                "description": "The connection's display name.",
-                "schema": {
-                  "type": "string"
-                },
-                "generatedName": "ConnectionCommonName",
-                "groupName": [],
-                "type": "primitive"
-              }
-            },
-            {
-              "key": "display_name",
-              "schema": {
-                "description": "Connection name shown in the login screen.",
-                "schema": {
-                  "type": "string"
-                },
-                "generatedName": "ConnectionCommonDisplayName",
-                "groupName": [],
-                "type": "primitive"
-              }
-            }
-          ],
+          "commonProperties": [],
           "description": "Discriminated union of connection strategies.",
           "discriminantProperty": "strategy",
           "discriminatorContext": "data",

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/oneof-shared-allof-properties.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/oneof-shared-allof-properties.json
@@ -19,9 +19,9 @@
                   },
                   "response": {
                     "body": {
-                      "display_name": "string",
-                      "id": "string",
-                      "name": "string",
+                      "display_name": "display_name",
+                      "id": "id",
+                      "name": "name",
                       "options_auth0": {
                         "tenant": "tenant",
                       },
@@ -77,20 +77,7 @@
           },
           "ConnectionResponse": {
             "availability": undefined,
-            "base-properties": {
-              "display_name": {
-                "docs": "Connection name shown in the login screen.",
-                "type": "string",
-              },
-              "id": {
-                "docs": "The connection's identifier.",
-                "type": "string",
-              },
-              "name": {
-                "docs": "The connection's display name.",
-                "type": "string",
-              },
-            },
+            "base-properties": {},
             "default-variant": undefined,
             "discriminant": {
               "context": "data",
@@ -200,9 +187,9 @@
             id: id
           response:
             body:
-              id: string
-              name: string
-              display_name: string
+              id: id
+              name: name
+              display_name: display_name
               options_auth0:
                 tenant: tenant
               strategy: auth0
@@ -227,16 +214,7 @@ types:
     discriminant:
       value: strategy
       context: data
-    base-properties:
-      id:
-        type: string
-        docs: The connection's identifier.
-      name:
-        type: string
-        docs: The connection's display name.
-      display_name:
-        type: string
-        docs: Connection name shown in the login screen.
+    base-properties: {}
     docs: Discriminated union of connection strategies.
     union:
       auth0: ConnectionResponseAuth0

--- a/packages/cli/cli/changes/unreleased/fix-infer-discriminated-union-base-properties-overlap.yml
+++ b/packages/cli/cli/changes/unreleased/fix-infer-discriminated-union-base-properties-overlap.yml
@@ -1,0 +1,10 @@
+- summary: |
+    Fix OpenAPI parser emitting redundant or wrongly-required base properties for
+    discriminated unions when `infer-discriminated-union-base-properties: true`.
+    The inference now (1) skips properties every variant already inherits via a
+    shared `allOf $ref` parent — the parent schema is the single source of truth —
+    and (2) lifts an inferred property as `optional` if any variant declares it as
+    not-required. Together these prevent generated TypeScript SDKs from synthesizing
+    a `_Base` interface that collides with the real parent on either presence or
+    optionality (`TS2320`).
+  type: fix


### PR DESCRIPTION
Closes FER-10950

## Summary

When `infer-discriminated-union-base-properties: true`, the parser was lifting properties into a union's `commonProperties` that every variant already inherited via a shared `allOf $ref` parent, and was emitting them as required even when the source declared them optional. The TypeScript SDK then synthesized a `_Base` interface that collided with the real parent (TS2320). This PR fixes both in the inference path:

1. **Skip already-inherited props** — Walk each variant's `allOf` chain transitively, intersect the `$ref` parents, and exclude properties those shared parents declare. The parent schema becomes the single source of truth.
2. **Propagate optionality** — If any variant declares an inferred property as not-required (in its own or any `allOf` ancestor's `required` array), the lifted commonProperty is wrapped as `optional<...>`, so generators emit `prop?` matching the parent's optional declaration.

## Example (Auth0)

`api.json`:

```yaml
ConnectionResponseContent:
  discriminator: { propertyName: strategy, mapping: { ad: '...AD', ... } }
  oneOf: [ { $ref: '...AD' }, ... ]   # 55 variants

ConnectionResponseContentAD:
  allOf:
    - { type: object, properties: { strategy: { const: ad } }, required: [strategy] }
    - { $ref: '#/components/schemas/ConnectionPurposes' }      # has `authentication?`
    - { $ref: '#/components/schemas/ConnectionResponseCommon' } # has `id`, `realms?`, ... `name`, `display_name?`, ...

ConnectionResponseCommon:
  allOf: [ { $ref: CreateConnectionCommon } ]
  properties: { id: { ... }, realms: { ... } }
```

**Before** — generated `_Base` re-declared everything the variants already inherit, as required:

```ts
export interface _Base {
    authentication: ConnectionAuthenticationPurpose;  // ConnectionPurposes has it optional
    id: ConnectionId;                                 // ConnectionResponseCommon has it required (✓)
    realms: ConnectionRealms;                         // ConnectionResponseCommon has it optional
    display_name: ConnectionDisplayName;              // CreateConnectionCommon has it optional
    enabled_clients: string[];                        // CreateConnectionCommon has it optional
    is_domain_connection: ConnectionIsDomainConnection;
    metadata: ConnectionsMetadata;
    name: ConnectionName;
}

export interface Ad extends ConnectionResponseContentAd, _Base {  // TS2320
    strategy: "ad";
}
```

**After** — every property reachable through `ConnectionPurposes`, `ConnectionResponseCommon`, or `CreateConnectionCommon` is skipped. The only prop that survives is `authentication`, because the `OIDC` variant declares it inline rather than inheriting it from `ConnectionPurposes` — so it isn't "shared via \$ref" across every variant. But every variant declares it as not-required, so the lifted prop is wrapped optional, matching `ConnectionPurposes.authentication?`:

```ts
export interface _Base {
    authentication?: ConnectionAuthenticationPurpose;
}

export interface Ad extends ConnectionResponseContentAd, _Base {  // ✓
    strategy: "ad";
}
```

## Verification

`tsc -p tsconfig.cjs.json --noEmit` on the regenerated Auth0 SDK:

| Before | After |
|---|---|
| 110 TS2320 errors | **0 TS2320 errors** |

The 4 errors remaining after this fix are unrelated `TS2304 Cannot find name 'HeadersIterator'` in `core/fetcher/Headers.ts` (TS lib typing).

## Test plan

- [x] New parser tests in `inferDiscriminatedUnionBaseProperties.test.ts` cover (1) inheritance-skip, (2) inline-keep, (3) optionality propagation
- [x] `pnpm turbo run test --filter @fern-api/openapi-ir-parser` — 87/87 passing
- [x] `pnpm turbo run test --filter @fern-api/openapi-ir-to-fern-tests` — 297/297 passing (2 snapshots updated to reflect the now-empty `commonProperties` on the `oneof-shared-allof-properties` fixture, which was capturing the previously-buggy lifting)
- [x] Auth0 regen via `pnpm seed run --generator ts-sdk --path /Users/Patrick/configs/auth0-fern-config/fern --local` produces SDK that compiles with 0 TS2320

🤖 Generated with [Claude Code](https://claude.com/claude-code)