### PR TITLE
feat: emit referencedFiles per page for ledger shard-side file materialization

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-docs-ledger-file-refs.yml
+++ b/packages/cli/cli/changes/unreleased/fix-docs-ledger-file-refs.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix docs ledger dual-write publishes to store page markdown with stable file path references instead of legacy file IDs.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
@@ -1,8 +1,10 @@
-import type { APIV1Write } from "@fern-api/fdr-sdk";
-import type { FileManifestEntry } from "@fern-api/fdr-sdk/orpc-client";
 import { createHash } from "crypto";
 import { describe, expect, it } from "vitest";
 import { buildLedgerInput } from "../publishDocsLedger.js";
+
+type BuildLedgerInputArgs = Parameters<typeof buildLedgerInput>[0];
+type ApiDefinition = BuildLedgerInputArgs["apiDefinitions"] extends Map<string, infer T> ? T : never;
+type FileManifestEntry = NonNullable<BuildLedgerInputArgs["fileManifest"]>[string];
 
 function sha256(data: string): string {
     return createHash("sha256").update(Buffer.from(data, "utf-8")).digest("hex");
@@ -48,6 +50,28 @@ describe("buildLedgerInput", () => {
             contentLength: Buffer.byteLength(markdown, "utf-8")
         });
         expect(blobs.has(expectedHash)).toBe(true);
+    });
+
+    it("rewrites legacy FileId markdown refs to path refs before hashing page blobs", () => {
+        const fileId = "5ea17f4b-98bd-4d97-a07b-e92a314825d0";
+        const fullPath = "docs/assets/docs/astro-hypervisor.svg";
+        const markdown = `![Diagram](file:${fileId})\n<img src="file:${fileId}" />`;
+        const expectedMarkdown = `![Diagram](file:${fullPath})\n<img src="file:${fullPath}" />`;
+        const { localeEntry, blobs } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition({ pages: { "page-1": { markdown } } }),
+            apiDefinitions: new Map(),
+            fileIdToPath: new Map([[fileId, fullPath]])
+        });
+
+        const expectedHash = sha256(expectedMarkdown);
+        expect(localeEntry.pages["page-1"]).toEqual({
+            hash: expectedHash,
+            contentType: "text/markdown",
+            contentLength: Buffer.byteLength(expectedMarkdown, "utf-8"),
+            referencedFiles: [fullPath]
+        });
+        expect(blobs.get(expectedHash)?.toString("utf-8")).toBe(expectedMarkdown);
+        expect([...blobs.values()].some((buf) => buf.toString("utf-8").includes(fileId))).toBe(false);
     });
 
     it("skips null/undefined pages", () => {
@@ -219,7 +243,7 @@ describe("buildLedgerInput", () => {
         // across publishes and the docs-ledger "no-op republish" fast-path
         // would never fire. The two manifests below have identical entries
         // inserted in opposite orders and MUST produce the same blob hash.
-        const minimalApiDefinition: APIV1Write.ApiDefinition = {
+        const minimalApiDefinition: ApiDefinition = {
             types: {},
             subpackages: {},
             rootPackage: {
@@ -234,11 +258,11 @@ describe("buildLedgerInput", () => {
             globalHeaders: []
         };
 
-        const forward = new Map<string, APIV1Write.ApiDefinition>();
+        const forward = new Map<string, ApiDefinition>();
         forward.set("api-def-a", minimalApiDefinition);
         forward.set("api-def-b", minimalApiDefinition);
 
-        const reverse = new Map<string, APIV1Write.ApiDefinition>();
+        const reverse = new Map<string, ApiDefinition>();
         reverse.set("api-def-b", minimalApiDefinition);
         reverse.set("api-def-a", minimalApiDefinition);
 
@@ -256,7 +280,7 @@ describe("buildLedgerInput", () => {
     });
 
     it("serializes apiManifest as a JSON blob ref when apiDefinitions is non-empty", () => {
-        const minimalApiDefinition: APIV1Write.ApiDefinition = {
+        const minimalApiDefinition: ApiDefinition = {
             types: {},
             subpackages: {},
             rootPackage: {
@@ -271,7 +295,7 @@ describe("buildLedgerInput", () => {
             globalHeaders: []
         };
 
-        const apiDefinitions = new Map<string, APIV1Write.ApiDefinition>();
+        const apiDefinitions = new Map<string, ApiDefinition>();
         apiDefinitions.set("api-def-1", minimalApiDefinition);
 
         const { localeEntry, blobs } = buildLedgerInput({

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/mapDocsDefinitionToLegacyFileIds.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/mapDocsDefinitionToLegacyFileIds.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { mapDocsDefinitionToLegacyFileIds } from "../mapDocsDefinitionToLegacyFileIds.js";
+
+type DocsDefinition = Parameters<typeof mapDocsDefinitionToLegacyFileIds>[0]["docsDefinition"];
+
+describe("mapDocsDefinitionToLegacyFileIds", () => {
+    it("remaps path-canonical page and config file references for V2", () => {
+        const pathToFileId = new Map([
+            ["docs/assets/logo.png", "legacy-logo-id"],
+            ["docs/assets/diagram.svg", "legacy-diagram-id"],
+            ["docs/assets/font.woff2", "legacy-font-id"]
+        ]);
+        const docsDefinition = {
+            pages: {
+                page: {
+                    markdown: '![Diagram](file:docs/assets/diagram.svg)\n<img src="file:docs/assets/logo.png" />',
+                    rawMarkdown: "![Diagram](file:docs/assets/diagram.svg)"
+                }
+            },
+            config: {
+                root: {
+                    type: "root",
+                    child: {
+                        type: "sidebarRoot",
+                        children: [{ type: "page", title: "Page", icon: "file:docs/assets/logo.png" }]
+                    }
+                },
+                colorsV3: {
+                    type: "dark",
+                    accentPrimary: { r: 1, g: 2, b: 3 },
+                    logo: "docs/assets/logo.png",
+                    backgroundImage: "docs/assets/diagram.svg"
+                },
+                metadata: {
+                    "og:image": { type: "fileId", value: "docs/assets/logo.png" },
+                    "twitter:image": { type: "url", value: "https://example.com/image.png" }
+                },
+                typographyV2: {
+                    headingsFont: {
+                        type: "custom",
+                        name: "Headings",
+                        variants: [{ fontFile: "docs/assets/font.woff2", weight: "400" }]
+                    }
+                },
+                js: {
+                    files: [{ fileId: "docs/assets/diagram.svg", strategy: "afterInteractive" }]
+                }
+            }
+        } as unknown as DocsDefinition;
+
+        const remapped = mapDocsDefinitionToLegacyFileIds({ docsDefinition, pathToFileId });
+        const pageId = "page" as keyof typeof remapped.pages;
+
+        expect(remapped.pages[pageId]?.markdown).toContain("file:legacy-diagram-id");
+        expect(remapped.pages[pageId]?.markdown).toContain("file:legacy-logo-id");
+        expect(remapped.pages[pageId]?.rawMarkdown).toBe("![Diagram](file:legacy-diagram-id)");
+        expect(remapped.config.colorsV3).toMatchObject({
+            logo: "legacy-logo-id",
+            backgroundImage: "legacy-diagram-id"
+        });
+        expect(remapped.config.metadata?.["og:image"]).toEqual({ type: "fileId", value: "legacy-logo-id" });
+        expect(remapped.config.metadata?.["twitter:image"]).toEqual({
+            type: "url",
+            value: "https://example.com/image.png"
+        });
+        expect(remapped.config.typographyV2?.headingsFont?.variants[0]?.fontFile).toBe("legacy-font-id");
+        expect(remapped.config.js?.files[0]?.fileId).toBe("legacy-diagram-id");
+        expect(JSON.stringify(remapped.config.root)).toContain("file:legacy-logo-id");
+        expect(docsDefinition.pages[pageId]?.markdown).toContain("file:docs/assets/diagram.svg");
+    });
+
+    it("returns the original definition when no legacy mapping exists", () => {
+        const docsDefinition = {
+            pages: {},
+            config: {}
+        } as DocsDefinition;
+
+        expect(mapDocsDefinitionToLegacyFileIds({ docsDefinition, pathToFileId: undefined })).toBe(docsDefinition);
+        expect(mapDocsDefinitionToLegacyFileIds({ docsDefinition, pathToFileId: new Map() })).toBe(docsDefinition);
+    });
+});

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/mapDocsDefinitionToLegacyFileIds.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/mapDocsDefinitionToLegacyFileIds.ts
@@ -1,0 +1,39 @@
+import type { DocsV1Write } from "@fern-api/fdr-sdk";
+
+type DocsDefinition = DocsV1Write.DocsDefinition;
+
+const FILE_REF_PATTERN = /file:([^\s"'<>)}\]]+)/g;
+
+function remapString(value: string, pathToFileId: Map<string, string>): string {
+    const exactMatch = pathToFileId.get(value);
+    if (exactMatch != null) {
+        return exactMatch;
+    }
+    return value.replace(FILE_REF_PATTERN, (token, path: string) => `file:${pathToFileId.get(path) ?? path}`);
+}
+
+function remapValue(value: unknown, pathToFileId: Map<string, string>): unknown {
+    if (typeof value === "string") {
+        return remapString(value, pathToFileId);
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => remapValue(item, pathToFileId));
+    }
+    if (value != null && typeof value === "object") {
+        return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, remapValue(item, pathToFileId)]));
+    }
+    return value;
+}
+
+export function mapDocsDefinitionToLegacyFileIds({
+    docsDefinition,
+    pathToFileId
+}: {
+    docsDefinition: DocsDefinition;
+    pathToFileId: Map<string, string> | undefined;
+}): DocsDefinition {
+    if (pathToFileId == null || pathToFileId.size === 0) {
+        return docsDefinition;
+    }
+    return remapValue(docsDefinition, pathToFileId) as DocsDefinition;
+}

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -31,6 +31,7 @@ import terminalLink from "terminal-link";
 import { buildTranslatedDocsDefinition } from "./buildTranslatedDocsDefinition.js";
 import { getDocsDeployMode } from "./docsDeployMode.js";
 import { getDynamicGeneratorConfig } from "./getDynamicGeneratorConfig.js";
+import { mapDocsDefinitionToLegacyFileIds } from "./mapDocsDefinitionToLegacyFileIds.js";
 import { measureImageSizes } from "./measureImageSizes.js";
 import { normalizeRepoUrlToHttps } from "./normalizeRepoUrl.js";
 import { publishDocsViaLedger } from "./publishDocsLedger.js";
@@ -283,11 +284,11 @@ export async function publishDocs({
         // into LedgerConfig path strings.
         //
         // Populated by the uploadFiles callback below:
-        //   - ledger mode: identity map (fullPath → fullPath) — the FileId we
-        //     emit IS the sanitizedPath, so the lookup just round-trips it.
-        //   - dual/legacy: keyed by the UUID FileId returned by FDR's
-        //     startDocsRegister/startDocsPreviewRegister response.
+        //   - ledger mode: identity map (fullPath → fullPath)
+        //   - dual/legacy: both the legacy UUID FileId and the canonical
+        //     sanitizedPath resolve to the ledger fullPath.
         const ledgerFileIdToPath = new Map<string, string>();
+        const legacyFilePathToId = new Map<string, string>();
 
         const resolver = new DocsDefinitionResolver({
             domain,
@@ -415,6 +416,22 @@ export async function publishDocs({
                 const hashNonImageTime = performance.now() - hashNonImageStart;
                 context.logger.debug(`Hashed ${filepaths.length} non-image files in ${hashNonImageTime.toFixed(0)}ms`);
 
+                const canonicalizeUploadedFilesForResolver = (uploadedFiles: UploadedFile[]): UploadedFile[] => {
+                    return uploadedFiles.map((uploaded) => {
+                        const sanitizedPath = filesMap.get(uploaded.absoluteFilePath)?.sanitizedPath;
+                        if (sanitizedPath == null) {
+                            return uploaded;
+                        }
+                        legacyFilePathToId.set(sanitizedPath, uploaded.fileId);
+                        ledgerFileIdToPath.set(uploaded.fileId, sanitizedPath);
+                        ledgerFileIdToPath.set(sanitizedPath, sanitizedPath);
+                        return {
+                            ...uploaded,
+                            fileId: sanitizedPath
+                        };
+                    });
+                };
+
                 // ── Ledger-only path ─────────────────────────────────────
                 // In ledger mode we do NOT call fdr.docs.v2.write.startDocsRegister
                 // / startDocsPreviewRegister. The legacy V2 register mints fresh
@@ -511,13 +528,7 @@ export async function publishDocs({
                         docsWorkspace.absoluteFilePath,
                         sanitizedToAbsoluteMap
                     );
-                    for (const uploaded of uploadedFiles) {
-                        const sanitizedPath = filesMap.get(uploaded.absoluteFilePath)?.sanitizedPath;
-                        if (sanitizedPath != null) {
-                            ledgerFileIdToPath.set(uploaded.fileId, sanitizedPath);
-                        }
-                    }
-                    return uploadedFiles;
+                    return canonicalizeUploadedFilesForResolver(uploadedFiles);
                 } else {
                     let startDocsRegisterResponse;
                     try {
@@ -574,13 +585,7 @@ export async function publishDocs({
                         docsWorkspace.absoluteFilePath,
                         sanitizedToAbsoluteMap
                     );
-                    for (const uploaded of uploadedFiles) {
-                        const sanitizedPath = filesMap.get(uploaded.absoluteFilePath)?.sanitizedPath;
-                        if (sanitizedPath != null) {
-                            ledgerFileIdToPath.set(uploaded.fileId, sanitizedPath);
-                        }
-                    }
-                    return uploadedFiles;
+                    return canonicalizeUploadedFilesForResolver(uploadedFiles);
                 }
             },
             registerApi: async ({
@@ -760,9 +765,13 @@ export async function publishDocs({
             context.logger.info("Publishing docs to FDR...");
             const publishStart = performance.now();
             try {
+                const legacyDocsDefinition = mapDocsDefinitionToLegacyFileIds({
+                    docsDefinition,
+                    pathToFileId: legacyFilePathToId
+                });
                 await fdr.docs.v2.write.finishDocsRegister({
                     docsRegistrationId,
-                    docsDefinition,
+                    docsDefinition: legacyDocsDefinition,
                     excludeApis,
                     ...(isBasepathAware && !preview && { basepathAware: true })
                 });
@@ -876,6 +885,10 @@ export async function publishDocs({
                             resolver,
                             context
                         });
+                        const legacyTranslatedDefinition = mapDocsDefinitionToLegacyFileIds({
+                            docsDefinition: translatedDefinition,
+                            pathToFileId: legacyFilePathToId
+                        });
 
                         const pageCount = Object.keys(localePages).length;
                         context.logger.debug(
@@ -899,7 +912,7 @@ export async function publishDocs({
                                 customDomains: preview ? [] : customDomains,
                                 orgId: organization,
                                 locale,
-                                docsDefinition: translatedDefinition
+                                docsDefinition: legacyTranslatedDefinition
                             })
                         });
                         if (!translationResponse.ok) {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -1,7 +1,6 @@
 import { type DocsDefinitionResolver } from "@fern-api/docs-resolver";
 import type { APIV1Write, DocsV1Write } from "@fern-api/fdr-sdk";
 import {
-    createDocsLedgerClient,
     type DocsPublishGitInput,
     type DocsPublishInput,
     type FileManifestEntry,
@@ -12,7 +11,6 @@ import type { TaskContext } from "@fern-api/task-context";
 import { createHash } from "crypto";
 import { readFile } from "fs/promises";
 
-import { buildTranslatedDocsDefinition } from "./buildTranslatedDocsDefinition.js";
 import { mapDocsConfigToLedgerConfig } from "./mapDocsConfigToLedgerConfig.js";
 import { asyncPool } from "./utils/asyncPool.js";
 
@@ -45,6 +43,13 @@ function extractReferencedFiles(markdown: string): string[] {
         }
     }
     return [...paths];
+}
+
+function remapMarkdownFileReferences(markdown: string, fileIdToPath: Map<string, string> | undefined): string {
+    if (fileIdToPath == null || fileIdToPath.size === 0) {
+        return markdown;
+    }
+    return markdown.replace(FILE_REF_PATTERN, (token, fileId: string) => `file:${fileIdToPath.get(fileId) ?? fileId}`);
 }
 
 interface BlobRef {
@@ -126,7 +131,8 @@ export function buildLedgerInput({
         if (page == null) {
             continue;
         }
-        const buf = Buffer.from(page.markdown, "utf-8");
+        const markdown = remapMarkdownFileReferences(page.markdown, fileIdToPath);
+        const buf = Buffer.from(markdown, "utf-8");
         const hash = sha256(buf);
         // Capture the file/image artifacts this page embeds so FDR can
         // materialise the page→file join into the route shards (ADR 0014,
@@ -138,7 +144,7 @@ export function buildLedgerInput({
         // `referencedFiles` is exactly the set the bundle will request for this
         // page — a cheap O(content) scan over markdown already in memory, not a
         // re-parse and not a server-side re-fetch.
-        const referencedFiles = extractReferencedFiles(page.markdown);
+        const referencedFiles = extractReferencedFiles(markdown);
         pages[pageId] = {
             hash,
             contentType: "text/markdown",
@@ -297,6 +303,7 @@ export async function publishDocsViaLedger({
     // entry and translations follow. The server processes all locales
     // through the same pipeline.
 
+    const { createDocsLedgerClient } = await import("@fern-api/fdr-sdk/orpc-client");
     const client = createDocsLedgerClient({ baseUrl: fdrOrigin, token, headers });
 
     const locales: LocaleEntry[] = [baseLocale, ...builtTranslations.map((t) => t.localeEntry)];
@@ -502,6 +509,7 @@ async function buildAllTranslationInputs({
 
     const localeEntries = Object.entries(translationPages);
     context.logger.info(`[ledger] Building ${localeEntries.length} translation locale(s)...`);
+    const { buildTranslatedDocsDefinition } = await import("./buildTranslatedDocsDefinition.js");
 
     return Promise.all(
         localeEntries.map(async ([locale, localePages]): Promise<BuiltTranslation> => {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -26,6 +26,27 @@ function sha256(data: Buffer): string {
     return createHash("sha256").update(data).digest("hex");
 }
 
+/**
+ * Matches `file:<fullPath>` tokens in rewritten page markdown — the same
+ * pattern the docs bundle's MDX serializer uses to discover file references
+ * (`packages/fern-docs/bundle/src/mdx/bundler/serialize.ts`). Keeping the two
+ * in sync guarantees `referencedFiles` is exactly the set the bundle resolves
+ * per page (ADR 0014).
+ */
+const FILE_REF_PATTERN = /file:([^\s"'<>)}\]]+)/g;
+
+/** Deduplicated bare `fullPath`s of every `file:<fullPath>` token in `markdown`. */
+function extractReferencedFiles(markdown: string): string[] {
+    const paths = new Set<string>();
+    for (const match of markdown.matchAll(FILE_REF_PATTERN)) {
+        const fullPath = match[1];
+        if (fullPath != null) {
+            paths.add(fullPath);
+        }
+    }
+    return [...paths];
+}
+
 interface BlobRef {
     hash: string;
     contentType: string;
@@ -107,7 +128,23 @@ export function buildLedgerInput({
         }
         const buf = Buffer.from(page.markdown, "utf-8");
         const hash = sha256(buf);
-        pages[pageId] = { hash, contentType: "text/markdown", contentLength: buf.length };
+        // Capture the file/image artifacts this page embeds so FDR can
+        // materialise the page→file join into the route shards (ADR 0014,
+        // "File metadata on the render path"). The markdown reaching here has
+        // already had image paths rewritten to `file:<sanitizedPath>` tokens by
+        // the resolver's replaceImagePathsAndUrls step, and in ledger mode the
+        // token suffix IS the file's `fullPath`. We scan with the SAME regex
+        // the bundle's MDX serializer uses to discover `file:` references, so
+        // `referencedFiles` is exactly the set the bundle will request for this
+        // page — a cheap O(content) scan over markdown already in memory, not a
+        // re-parse and not a server-side re-fetch.
+        const referencedFiles = extractReferencedFiles(page.markdown);
+        pages[pageId] = {
+            hash,
+            contentType: "text/markdown",
+            contentLength: buf.length,
+            ...(referencedFiles.length > 0 ? { referencedFiles } : {})
+        };
         blobs.set(hash, buf);
     }
 


### PR DESCRIPTION
## Summary

- Emit per-page `referencedFiles[]` in the docs-ledger publish payload so FDR can materialize page → file metadata into route shards.
- Keep resolved docs definitions path-tokenized for the ledger path in dual-write publishes.
- Adapt only the legacy V2 finish / translation payloads back to legacy FileIds, preserving V2 compatibility without storing unstable UUID refs in ledger page blobs.
- Add an unreleased CLI changelog entry for the ledger file-reference fix.

## Dependency / stacking

- Stacked on `feat/docs_ledger`.
- Requires fdr-sdk carrying `PageBlobRef.referencedFiles` from fern-platform ADR-0014.

## Test plan

- [x] `pnpm --dir /home/cbro/fern/fern --filter @fern-api/remote-workspace-runner compile`
- [x] `pnpm --dir /home/cbro/fern/fern exec turbo run test --filter @fern-api/remote-workspace-runner -- src/__test__/buildLedgerInput.test.ts src/__test__/mapDocsDefinitionToLegacyFileIds.test.ts`
- [x] `pnpm --dir /home/cbro/fern/fern --filter @fern-api/remote-workspace-runner test`

Generated with [Devin](https://cli.devin.ai/docs)