### PR TITLE
fix(docs): preserve x-fern-basic labels for runnable endpoints

### DIFF
--- a/packages/cli/docs-resolver/src/__test__/x-fern-basic-auth.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/x-fern-basic-auth.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert";
+
+import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
+import { createMockTaskContext } from "@fern-api/task-context";
+import { loadAPIWorkspace } from "@fern-api/workspace-loader";
+import { AbsoluteFilePath, resolve } from "@fern-api/fs-utils";
+
+import { convertIrToApiDefinition } from "../utils/convertIrToApiDefinition.js";
+
+const context = createMockTaskContext();
+
+it("preserves x-fern-basic auth labels for runnable endpoint API definitions", async () => {
+    const workspaceResult = await loadAPIWorkspace({
+        absolutePathToWorkspace: resolve(
+            AbsoluteFilePath.of(__dirname),
+            "../../../register/src/ir-to-fdr-converter/__test__/fixtures/x-fern-basic-auth"
+        ),
+        context,
+        cliVersion: "0.0.0",
+        workspaceName: "x-fern-basic-auth"
+    });
+
+    expect(workspaceResult.didSucceed).toBe(true);
+    assert(workspaceResult.didSucceed);
+    assert(workspaceResult.workspace instanceof OSSWorkspace);
+
+    const ir = await workspaceResult.workspace.getIntermediateRepresentation({
+        context,
+        audiences: { type: "all" },
+        enableUniqueErrorsPerEndpoint: true,
+        generateV1Examples: false,
+        logWarnings: false
+    });
+
+    const apiDefinition = convertIrToApiDefinition({
+        ir,
+        apiDefinitionId: "x-fern-basic-auth",
+        context
+    });
+
+    const basicAuth = apiDefinition.authSchemes?.["basicAuth"];
+    assert(basicAuth?.type === "basicAuth");
+    expect(basicAuth.usernameName).toBe("project_id");
+    expect(basicAuth.passwordName).toBe("api_token");
+
+    const endpoint = apiDefinition.rootPackage.endpoints.find((endpoint) => endpoint.id === "listPlants");
+    expect(endpoint?.multiAuth).toEqual([{ schemes: ["basicAuth"] }]);
+
+    const endpointBasicAuthId = endpoint?.multiAuth?.[0]?.schemes[0];
+    expect(endpointBasicAuthId).toBe("basicAuth");
+
+    const endpointBasicAuth = apiDefinition.authSchemes?.[endpointBasicAuthId ?? ""];
+    assert(endpointBasicAuth?.type === "basicAuth");
+    expect(endpointBasicAuth.usernameName).toBe("project_id");
+    expect(endpointBasicAuth.passwordName).toBe("api_token");
+});

--- a/packages/cli/register/src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts
@@ -2957,7 +2957,7 @@ describe("OpenAPI v3 Parser Pipeline (--from-openapi flag)", () => {
         // Validate the basic auth scheme structure
         const basicAuthScheme = intermediateRepresentation.auth.schemes[0];
         expect(basicAuthScheme).toBeDefined();
-        expect.assert(basicAuthScheme?.type === "basic");
+        assert(basicAuthScheme?.type === "basic");
 
         // Verify that x-fern-basic custom names are correctly flowing through to the IR
         // The OpenAPI spec has x-fern-basic with username.name="project_id" and password.name="api_token"
@@ -2975,11 +2975,20 @@ describe("OpenAPI v3 Parser Pipeline (--from-openapi flag)", () => {
         expect(fdrAuthSchemes).toBeDefined();
         if (fdrAuthSchemes) {
             const basicAuth = Object.values(fdrAuthSchemes).find((scheme) => scheme.type === "basicAuth");
-            expect.assert(basicAuth?.type === "basicAuth");
+            assert(basicAuth?.type === "basicAuth");
             // Verify custom names from x-fern-basic flow through to FDR
             expect(basicAuth.usernameName).toBe("project_id");
             expect(basicAuth.passwordName).toBe("api_token");
         }
+
+        const endpoint = fdrApiDefinition.rootPackage.endpoints.find((endpoint) => endpoint.id === "listPlants");
+        expect(endpoint?.multiAuth).toEqual([{ schemes: ["basicAuth"] }]);
+        const endpointBasicAuthId = endpoint?.multiAuth?.[0]?.schemes[0];
+        expect(endpointBasicAuthId).toBe("basicAuth");
+        const endpointBasicAuth = fdrAuthSchemes?.[endpointBasicAuthId ?? ""];
+        assert(endpointBasicAuth?.type === "basicAuth");
+        expect(endpointBasicAuth.usernameName).toBe("project_id");
+        expect(endpointBasicAuth.passwordName).toBe("api_token");
 
         // Snapshot the complete output for regression testing
         await expect(fdrApiDefinition).toMatchFileSnapshot("__snapshots__/x-fern-basic-auth-fdr.snap");


### PR DESCRIPTION
﻿## Summary

Adds regression coverage for `x-fern-basic` auth labels on runnable endpoint API definitions.

The existing OpenAPI fixture uses custom basic auth field names:

- `project_id` for the username field
- `api_token` for the password field

This change verifies that those labels are preserved through both:

- OpenAPI/IR to FDR conversion in `@fern-api/register`
- IR to Docs API definition conversion in `@fern-api/docs-resolver`

It also checks that the endpoint `multiAuth` entry points back to the same basic auth scheme, so callers rendering runnable endpoints can resolve the custom labels from `authSchemes`.

## Notes

The runnable endpoint component itself does not appear to live in this package. If the UI still renders `username` / `password`, the remaining fix is likely in the renderer resolving endpoint auth scheme ids into `apiDefinition.authSchemes`.

## Testing

- `tsc --noEmit -p packages/cli/register/tsconfig.json`
- `tsc --noEmit -p packages/cli/docs-resolver/tsconfig.json`
- `git diff --check HEAD`
- `vitest --run src/ir-to-fdr-converter/__test__/openapi-from-flag.test.ts --testNamePattern "x-fern-basic" --config vitest.config.ts --reporter verbose`
- `vitest --run src/__test__/x-fern-basic-auth.test.ts --config vitest.config.ts --reporter verbose`

The Vitest runs used a local Node 20 preload for `navigator`; the repo's DevBox setup pins Node 22.
