### PR TITLE
fix(deps): upgrade vitest to ^4.1.1 in ts-seed container to fix CVE-2026-47429

### DIFF
--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -88,7 +88,7 @@ RUN pnpm add -g typescript@~5.7.2 \
   @types/node@^18.19.70 \
   webpack@^5.97.1 \
   msw@2.11.2 \
-  vitest@^3.2.4
+  vitest@^4.1.1
 
 # Replace the prebuilt @oxlint-tsgolint/linux-* binary with the locally
 # rebuilt one (go1.26.3). pnpm installs the platform-specific binary at


### PR DESCRIPTION
## Description

Upgrades vitest from `^3.2.4` to `^4.1.1` in the ts-seed container (`docker/seed/Dockerfile.ts`) to fix [CVE-2026-47429](https://github.com/advisories/GHSA-5xrq-8626-4rwp) (CVSS 9.8 Critical).

CVE-2026-47429 is a missing-authorization flaw in the Vitest UI/API server that allows remote file read and code execution when the server is exposed to the network. Fixed in vitest 4.1.0.

## Changes Made

- Bumped `vitest@^3.2.4` → `vitest@^4.1.1` in `docker/seed/Dockerfile.ts`

## Other containers checked

| Container | vitest? | Status |
|---|---|---|
| `generators/typescript/sdk/cli/Dockerfile` | `vitest@^4.1.1` | Already patched |
| All other seed Dockerfiles (cli, csharp, go, java, php, python) | No vitest | Not affected |
| All other generator Dockerfiles | No vitest | Not affected |

## Testing

- [x] Verified no other seed or generator Dockerfiles reference vitest
- [ ] CI build validates the Dockerfile

Link to Devin session: https://app.devin.ai/sessions/3dfa8808a87b4cfaa14ba0c9dab1d998
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->