### PR TITLE
chore(cli-generator): rename Docker image from fernapi/fern-cli to fernapi/fern-cli-generator

### DIFF
--- a/generators/cli/package.json
+++ b/generators/cli/package.json
@@ -27,8 +27,8 @@
     "compile": "tsc",
     "compile:debug": "tsc --sourceMap",
     "dist:cli": "node build.mjs",
-    "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-cli:latest .",
-    "dockerTagVersion": "turbo run dist:cli --filter . && docker build -f ./Dockerfile -t fernapi/fern-cli:${0} .",
+    "dockerTagLatest": "docker build -f ./Dockerfile -t fernapi/fern-cli-generator:latest .",
+    "dockerTagVersion": "turbo run dist:cli --filter . && docker build -f ./Dockerfile -t fernapi/fern-cli-generator:${0} .",
     "test": "vitest --passWithNoTests --run"
   },
   "devDependencies": {

--- a/generators/cli/sdk/docs/DESIGN.md
+++ b/generators/cli/sdk/docs/DESIGN.md
@@ -429,7 +429,7 @@ The current prototype embeds a single spec at compile time. The full vision (out
 groups:
   cli:
     generators:
-      - name: fernapi/fern-cli
+      - name: fernapi/fern-cli-generator
         version: 0.1.0
         config:
           cli-name: acme

--- a/packages/cli/cli-v2/src/sdk/config/converter/constants.ts
+++ b/packages/cli/cli-v2/src/sdk/config/converter/constants.ts
@@ -66,7 +66,7 @@ export const DOCKER_IMAGE_TO_GENERATOR_ID: Record<string, string> = {
     "fernapi/fern-swift-model": "swift-model",
     "fernapi/fern-postman": "postman",
     "fernapi/fern-openapi": "openapi",
-    "fernapi/fern-cli": "cli"
+    "fernapi/fern-cli-generator": "cli"
 };
 
 /**

--- a/packages/cli/cli/changes/5.25.0/add-cli-generator.yml
+++ b/packages/cli/cli/changes/5.25.0/add-cli-generator.yml
@@ -1,5 +1,5 @@
 - summary: |
-    Register the new `fernapi/fern-cli` generator in the CLI configuration.
+    Register the new `fernapi/fern-cli-generator` generator in the CLI configuration.
   type: feat
 - summary: |
     Pass raw API spec files (OAS, overrides, overlays, protobuf, etc.) to generators via Docker mount.

--- a/packages/cli/cli/changes/5.37.0/cli-generator-support.yml
+++ b/packages/cli/cli/changes/5.37.0/cli-generator-support.yml
@@ -7,7 +7,7 @@
     and `GraphQLSpec.namespace`). Enables generators that opt into
     `generatorWantsSpecs` to route multi-spec workspaces by their
     workspace-declared namespace instead of inferring one from the
-    runner-assigned filename. The new `fernapi/fern-cli` generator
+    runner-assigned filename. The new `fernapi/fern-cli-generator` generator
     uses this to emit `.spec_under("<ns>", ...)` in the generated
     `main.rs` when the user namespaces their specs.
   type: feat

--- a/packages/cli/cli/changes/unreleased/rename-cli-generator-image.yml
+++ b/packages/cli/cli/changes/unreleased/rename-cli-generator-image.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Rename the CLI generator Docker image from `fernapi/fern-cli` to
+    `fernapi/fern-cli-generator`.
+  type: chore

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -239,7 +239,7 @@
         and `GraphQLSpec.namespace`). Enables generators that opt into
         `generatorWantsSpecs` to route multi-spec workspaces by their
         workspace-declared namespace instead of inferring one from the
-        runner-assigned filename. The new `fernapi/fern-cli` generator
+        runner-assigned filename. The new `fernapi/fern-cli-generator` generator
         uses this to emit `.spec_under("<ns>", ...)` in the generated
         `main.rs` when the user namespaces their specs.
       type: feat
@@ -703,7 +703,7 @@
 - version: 5.25.0
   changelogEntry:
     - summary: |
-        Register the new `fernapi/fern-cli` generator in the CLI configuration.
+        Register the new `fernapi/fern-cli-generator` generator in the CLI configuration.
       type: feat
   createdAt: "2026-05-14"
   irVersion: 66

--- a/packages/cli/configuration-loader/src/generators-yml/GeneratorName.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/GeneratorName.ts
@@ -26,7 +26,7 @@ export const GeneratorName = {
     STOPLIGHT: "fernapi/fern-stoplight",
     POSTMAN: "fernapi/fern-postman",
     OPENAPI_PYTHON_CLIENT: "fernapi/openapi-python-client",
-    CLI: "fernapi/fern-cli"
+    CLI: "fernapi/fern-cli-generator"
 } as const;
 
 export type GeneratorName = (typeof GeneratorName)[keyof typeof GeneratorName];

--- a/packages/cli/generation/ir-migrations/src/generatorVersionMap.ts
+++ b/packages/cli/generation/ir-migrations/src/generatorVersionMap.ts
@@ -5,7 +5,7 @@
 import { MINIMUM_SUPPORTED_IR_VERSION } from "./constants.js";
 
 export const GENERATOR_MINIMUM_VERSIONS: Record<string, string> = {
-    "fernapi/fern-cli": "0.0.1",
+    "fernapi/fern-cli-generator": "0.0.1",
     "fernapi/fern-csharp-model": "0.0.2",
     "fernapi/fern-csharp-sdk": "0.5.0",
     "fernapi/fern-express": "0.17.3",

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/LocalTaskHandler.snippetCopy.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/LocalTaskHandler.snippetCopy.test.ts
@@ -7,7 +7,7 @@ import { copySnippetJsonIfNonEmpty } from "../LocalTaskHandler.js";
 
 /**
  * Unit coverage for the empty-stub skip behavior introduced when the
- * `fernapi/fern-cli` generator started shipping outputs without
+ * `fernapi/fern-cli-generator` generator started shipping outputs without
  * per-endpoint snippets. `runGenerator` pre-creates an empty
  * `snippet.json` in the workspace tmp dir; if we blindly copy it into
  * the user's output every generator without a snippet emission leaves a

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/rawSpecs.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/rawSpecs.test.ts
@@ -882,7 +882,7 @@ describe("filterSpec", () => {
 /**
  * Coverage for the per-entry `namespace` field added to
  * `RawSpecsManifestEntry`. Downstream generators (initially
- * `fernapi/fern-cli`) rely on this field to route multi-spec
+ * `fernapi/fern-cli-generator`) rely on this field to route multi-spec
  * workspaces by their `generators.yml`-declared namespace rather than
  * inferring one from the runner-assigned filename.
  */

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/constants.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/constants.ts
@@ -37,7 +37,7 @@ export const DEFAULT_NODE_DEBUG_PORT = "9229";
  * Generators that receive pre-processed raw API spec files mounted into their
  * Docker container. Add new generator names here as they opt in.
  */
-const GENERATORS_WANTING_SPECS: ReadonlySet<string> = new Set(["fernapi/fern-cli"]);
+const GENERATORS_WANTING_SPECS: ReadonlySet<string> = new Set(["fernapi/fern-cli-generator"]);
 
 export function generatorWantsSpecs(generatorName: string): boolean {
     return GENERATORS_WANTING_SPECS.has(generatorName);

--- a/seed/cli/seed.yml
+++ b/seed/cli/seed.yml
@@ -1,6 +1,6 @@
 irVersion: v67
 displayName: CLI
-image: fernapi/fern-cli
+image: fernapi/fern-cli-generator
 changelogLocation: ../../generators/cli/versions.yml
 
 buildScripts:
@@ -16,12 +16,12 @@ publish:
     - pnpm turbo run dist:cli --filter @fern-api/cli-generator
   docker:
     file: ./generators/cli/Dockerfile
-    image: fernapi/fern-cli
+    image: fernapi/fern-cli-generator
     context: ./generators/cli
 
 test:
   docker:
-    image: fernapi/fern-cli:latest
+    image: fernapi/fern-cli-generator:latest
     command: pnpm turbo run dockerTagLatest --filter @fern-api/cli-generator
   local:
     workingDirectory: generators/cli

--- a/test-definitions/fern/apis/cli-multi-spec-namespaced/generators.yml
+++ b/test-definitions/fern/apis/cli-multi-spec-namespaced/generators.yml
@@ -13,6 +13,6 @@ api:
 groups:
   cli:
     generators:
-      - name: fernapi/fern-cli
+      - name: fernapi/fern-cli-generator
         version: latest
         ir-version: latest

--- a/test-definitions/fern/apis/cli-multi-spec/generators.yml
+++ b/test-definitions/fern/apis/cli-multi-spec/generators.yml
@@ -10,6 +10,6 @@ api:
 groups:
   cli:
     generators:
-      - name: fernapi/fern-cli
+      - name: fernapi/fern-cli-generator
         version: latest
         ir-version: latest


### PR DESCRIPTION
## Description

Renames the CLI generator Docker image target from `fernapi/fern-cli` to `fernapi/fern-cli-generator` across all references in the repo.

## Changes Made

- `GeneratorName.CLI` → `"fernapi/fern-cli-generator"`
- `GENERATORS_WANTING_SPECS` set updated
- `DOCKER_IMAGE_TO_GENERATOR_ID` and `generatorVersionMap` entries updated
- Docker build scripts in `generators/cli/package.json` updated
- Seed config (`seed/cli/seed.yml`) image references updated
- Test-definition `generators.yml` fixtures updated
- Comments in test files, `DESIGN.md`, and historical changelogs updated

15 files changed, all mechanical `fernapi/fern-cli` → `fernapi/fern-cli-generator` renames.

## Testing

- [x] `pnpm format` passes
- [ ] CI


Link to Devin session: https://app.devin.ai/sessions/e2db6b5d65df47e09a3c59cdc4d34ae0
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->