### PR TITLE
fix(typescript): use IterableIterator<T> in generated Headers.ts shim

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/fix-headers-iterator-type.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-headers-iterator-type.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix TS2304 compilation errors in generated `core/fetcher/Headers.ts` on TypeScript < 5.6.
+    The shim now annotates `entries()`, `keys()`, `values()`, and `[Symbol.iterator]()` with
+    `IterableIterator<T>` instead of `HeadersIterator<T>` (which only exists in the DOM lib
+    starting in TypeScript 5.6). Compiles cleanly on TypeScript 5.5.x and 5.6+.
+  type: fix

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/Headers.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/Headers.ts
@@ -1,93 +1,100 @@
 let Headers: typeof globalThis.Headers;
 
 if (typeof globalThis.Headers !== "undefined") {
-    Headers = globalThis.Headers;
+	Headers = globalThis.Headers;
 } else {
-    Headers = class Headers implements Headers {
-        private headers: Map<string, string[]>;
+	Headers = class Headers implements Headers {
+		private headers: Map<string, string[]>;
 
-        constructor(init?: HeadersInit) {
-            this.headers = new Map();
+		constructor(init?: HeadersInit) {
+			this.headers = new Map();
 
-            if (init) {
-                if (init instanceof Headers) {
-                    init.forEach((value, key) => this.append(key, value));
-                } else if (Array.isArray(init)) {
-                    for (const [key, value] of init) {
-                        if (typeof key === "string" && typeof value === "string") {
-                            this.append(key, value);
-                        } else {
-                            throw new TypeError("Each header entry must be a [string, string] tuple");
-                        }
-                    }
-                } else {
-                    for (const [key, value] of Object.entries(init)) {
-                        if (typeof value === "string") {
-                            this.append(key, value);
-                        } else {
-                            throw new TypeError("Header values must be strings");
-                        }
-                    }
-                }
-            }
-        }
+			if (init) {
+				if (init instanceof Headers) {
+					init.forEach((value, key) => this.append(key, value));
+				} else if (Array.isArray(init)) {
+					for (const [key, value] of init) {
+						if (typeof key === "string" && typeof value === "string") {
+							this.append(key, value);
+						} else {
+							throw new TypeError(
+								"Each header entry must be a [string, string] tuple",
+							);
+						}
+					}
+				} else {
+					for (const [key, value] of Object.entries(init)) {
+						if (typeof value === "string") {
+							this.append(key, value);
+						} else {
+							throw new TypeError("Header values must be strings");
+						}
+					}
+				}
+			}
+		}
 
-        append(name: string, value: string): void {
-            const key = name.toLowerCase();
-            const existing = this.headers.get(key) || [];
-            this.headers.set(key, [...existing, value]);
-        }
+		append(name: string, value: string): void {
+			const key = name.toLowerCase();
+			const existing = this.headers.get(key) || [];
+			this.headers.set(key, [...existing, value]);
+		}
 
-        delete(name: string): void {
-            const key = name.toLowerCase();
-            this.headers.delete(key);
-        }
+		delete(name: string): void {
+			const key = name.toLowerCase();
+			this.headers.delete(key);
+		}
 
-        get(name: string): string | null {
-            const key = name.toLowerCase();
-            const values = this.headers.get(key);
-            return values ? values.join(", ") : null;
-        }
+		get(name: string): string | null {
+			const key = name.toLowerCase();
+			const values = this.headers.get(key);
+			return values ? values.join(", ") : null;
+		}
 
-        has(name: string): boolean {
-            const key = name.toLowerCase();
-            return this.headers.has(key);
-        }
+		has(name: string): boolean {
+			const key = name.toLowerCase();
+			return this.headers.has(key);
+		}
 
-        set(name: string, value: string): void {
-            const key = name.toLowerCase();
-            this.headers.set(key, [value]);
-        }
+		set(name: string, value: string): void {
+			const key = name.toLowerCase();
+			this.headers.set(key, [value]);
+		}
 
-        forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: unknown): void {
-            const boundCallback = thisArg ? callbackfn.bind(thisArg) : callbackfn;
-            this.headers.forEach((values, key) => boundCallback(values.join(", "), key, this));
-        }
+		forEach(
+			callbackfn: (value: string, key: string, parent: Headers) => void,
+			thisArg?: unknown,
+		): void {
+			const boundCallback = thisArg ? callbackfn.bind(thisArg) : callbackfn;
+			this.headers.forEach((values, key) =>
+				boundCallback(values.join(", "), key, this),
+			);
+		}
 
-        getSetCookie(): string[] {
-            return this.headers.get("set-cookie") || [];
-        }
+		getSetCookie(): string[] {
+			return this.headers.get("set-cookie") || [];
+		}
 
-        *entries(): HeadersIterator<[string, string]> {
-            for (const [key, values] of this.headers.entries()) {
-                yield [key, values.join(", ")];
-            }
-        }
+		*entries(): IterableIterator<[string, string]> {
+			for (const [key, values] of this.headers.entries()) {
+				yield [key, values.join(", ")];
+			}
+		}
 
-        *keys(): HeadersIterator<string> {
-            yield* this.headers.keys();
-        }
+		*keys(): IterableIterator<string> {
+			yield* this.headers.keys();
+		}
 
-        *values(): HeadersIterator<string> {
-            for (const values of this.headers.values()) {
-                yield values.join(", ");
-            }
-        }
+		*values(): IterableIterator<string> {
+			for (const values of this.headers.values()) {
+				yield values.join(", ");
+			}
+		}
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
-            return this.entries();
-        }
-    };
+		[Symbol.iterator](): IterableIterator<[string, string]> {
+			return this.entries();
+		}
+	};
 }
 
 export { Headers };

--- a/seed/ts-sdk/accept-header/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/accept-header/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/alias-extends/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/alias-extends/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/alias/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/alias/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/allof-inline/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/allof-inline/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/allof/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/allof/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/any-auth/always-send-auth/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/any-auth/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/api-wide-base-path-with-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/api-wide-base-path-with-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/api-wide-base-path/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/basic-auth-pw-omitted/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/basic-auth/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/basic-auth/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/bytes-download/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/bytes-download/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/bytes-upload/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/circular-references-advanced/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/circular-references-extends/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/circular-references-extends/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/circular-references/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/circular-references/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/cli-multi-spec-namespaced/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/cli-multi-spec-namespaced/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/cli-multi-spec/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/cli-multi-spec/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/client-side-params/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/client-side-params/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/content-type/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/content-type/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/dollar-string-examples/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/dollar-string-examples/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/empty-clients/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/empty-clients/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/endpoint-security-auth/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/enum/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/enum/serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/enum/serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/error-property/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/error-property/union-utils/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/errors/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/errors/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/local-files/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/output-src-only/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/use-jest/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/extends/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/extends/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/extra-properties/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/extra-properties/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-download/stream-wrapper/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload-openapi/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload-openapi/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload/inline/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload/serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload/use-jest/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload/use-jest/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/folders/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/folders/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/header-auth-environment-variable/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/header-auth/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/header-auth/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/http-head/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/http-head/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/idempotency-headers/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/license/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/license/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/literal-user-agent/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/literal-user-agent/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/literal/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/literal/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/literals-unions/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/literals-unions/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/mixed-file-directory/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/multi-line-docs/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/multi-url-environment-reference/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/multi-url-environment/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/multiple-request-bodies/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/no-content-response/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/no-content-response/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/no-environment/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/no-environment/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/no-retries/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/no-retries/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/null-type/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/null-type/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/nullable-allof-extends/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/nullable-allof-extends/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/nullable-optional/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/nullable-optional/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/nullable-request-body/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/nullable-request-body/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/nullable/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/nullable/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/object/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/object/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/objects-with-imports/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/optional/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/optional/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/package-yml/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/package-yml/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/pagination-custom/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/pagination-uri-path/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/pagination/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/pagination/page-index-semantics/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/plain-text/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/plain-text/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/property-access/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/public-object/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/public-object/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-param-name-conflict/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-param-name-conflict/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters-openapi/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters-openapi/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/query-parameters/serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/query-parameters/serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/required-nullable/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/required-nullable/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/reserved-keywords/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/response-property/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/response-property/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/schemaless-request-body-examples/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/schemaless-request-body-examples/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/server-sent-events-resumable/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/server-sent-events/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/server-url-templating/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/server-url-templating/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/bundle/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/custom-package-json/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/jsr/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/legacy-exports/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/naming-shorthand/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/naming/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/naming/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/fetcher/Headers.ts
@@ -1,93 +1,100 @@
 let Headers: typeof globalThis.Headers;
 
 if (typeof globalThis.Headers !== "undefined") {
-    Headers = globalThis.Headers;
+	Headers = globalThis.Headers;
 } else {
-    Headers = class Headers implements Headers {
-        private headers: Map<string, string[]>;
+	Headers = class Headers implements Headers {
+		private headers: Map<string, string[]>;
 
-        constructor(init?: HeadersInit) {
-            this.headers = new Map();
+		constructor(init?: HeadersInit) {
+			this.headers = new Map();
 
-            if (init) {
-                if (init instanceof Headers) {
-                    init.forEach((value, key) => this.append(key, value));
-                } else if (Array.isArray(init)) {
-                    for (const [key, value] of init) {
-                        if (typeof key === "string" && typeof value === "string") {
-                            this.append(key, value);
-                        } else {
-                            throw new TypeError("Each header entry must be a [string, string] tuple");
-                        }
-                    }
-                } else {
-                    for (const [key, value] of Object.entries(init)) {
-                        if (typeof value === "string") {
-                            this.append(key, value);
-                        } else {
-                            throw new TypeError("Header values must be strings");
-                        }
-                    }
-                }
-            }
-        }
+			if (init) {
+				if (init instanceof Headers) {
+					init.forEach((value, key) => this.append(key, value));
+				} else if (Array.isArray(init)) {
+					for (const [key, value] of init) {
+						if (typeof key === "string" && typeof value === "string") {
+							this.append(key, value);
+						} else {
+							throw new TypeError(
+								"Each header entry must be a [string, string] tuple",
+							);
+						}
+					}
+				} else {
+					for (const [key, value] of Object.entries(init)) {
+						if (typeof value === "string") {
+							this.append(key, value);
+						} else {
+							throw new TypeError("Header values must be strings");
+						}
+					}
+				}
+			}
+		}
 
-        append(name: string, value: string): void {
-            const key = name.toLowerCase();
-            const existing = this.headers.get(key) || [];
-            this.headers.set(key, [...existing, value]);
-        }
+		append(name: string, value: string): void {
+			const key = name.toLowerCase();
+			const existing = this.headers.get(key) || [];
+			this.headers.set(key, [...existing, value]);
+		}
 
-        delete(name: string): void {
-            const key = name.toLowerCase();
-            this.headers.delete(key);
-        }
+		delete(name: string): void {
+			const key = name.toLowerCase();
+			this.headers.delete(key);
+		}
 
-        get(name: string): string | null {
-            const key = name.toLowerCase();
-            const values = this.headers.get(key);
-            return values ? values.join(", ") : null;
-        }
+		get(name: string): string | null {
+			const key = name.toLowerCase();
+			const values = this.headers.get(key);
+			return values ? values.join(", ") : null;
+		}
 
-        has(name: string): boolean {
-            const key = name.toLowerCase();
-            return this.headers.has(key);
-        }
+		has(name: string): boolean {
+			const key = name.toLowerCase();
+			return this.headers.has(key);
+		}
 
-        set(name: string, value: string): void {
-            const key = name.toLowerCase();
-            this.headers.set(key, [value]);
-        }
+		set(name: string, value: string): void {
+			const key = name.toLowerCase();
+			this.headers.set(key, [value]);
+		}
 
-        forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: unknown): void {
-            const boundCallback = thisArg ? callbackfn.bind(thisArg) : callbackfn;
-            this.headers.forEach((values, key) => boundCallback(values.join(", "), key, this));
-        }
+		forEach(
+			callbackfn: (value: string, key: string, parent: Headers) => void,
+			thisArg?: unknown,
+		): void {
+			const boundCallback = thisArg ? callbackfn.bind(thisArg) : callbackfn;
+			this.headers.forEach((values, key) =>
+				boundCallback(values.join(", "), key, this),
+			);
+		}
 
-        getSetCookie(): string[] {
-            return this.headers.get("set-cookie") || [];
-        }
+		getSetCookie(): string[] {
+			return this.headers.get("set-cookie") || [];
+		}
 
-        *entries(): HeadersIterator<[string, string]> {
-            for (const [key, values] of this.headers.entries()) {
-                yield [key, values.join(", ")];
-            }
-        }
+		*entries(): IterableIterator<[string, string]> {
+			for (const [key, values] of this.headers.entries()) {
+				yield [key, values.join(", ")];
+			}
+		}
 
-        *keys(): HeadersIterator<string> {
-            yield* this.headers.keys();
-        }
+		*keys(): IterableIterator<string> {
+			yield* this.headers.keys();
+		}
 
-        *values(): HeadersIterator<string> {
-            for (const values of this.headers.values()) {
-                yield values.join(", ");
-            }
-        }
+		*values(): IterableIterator<string> {
+			for (const values of this.headers.values()) {
+				yield values.join(", ");
+			}
+		}
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
-            return this.entries();
-        }
-    };
+		[Symbol.iterator](): IterableIterator<[string, string]> {
+			return this.entries();
+		}
+	};
 }
 
 export { Headers };

--- a/seed/ts-sdk/simple-api/no-scripts/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/core/fetcher/Headers.ts
@@ -1,93 +1,100 @@
 let Headers: typeof globalThis.Headers;
 
 if (typeof globalThis.Headers !== "undefined") {
-    Headers = globalThis.Headers;
+	Headers = globalThis.Headers;
 } else {
-    Headers = class Headers implements Headers {
-        private headers: Map<string, string[]>;
+	Headers = class Headers implements Headers {
+		private headers: Map<string, string[]>;
 
-        constructor(init?: HeadersInit) {
-            this.headers = new Map();
+		constructor(init?: HeadersInit) {
+			this.headers = new Map();
 
-            if (init) {
-                if (init instanceof Headers) {
-                    init.forEach((value, key) => this.append(key, value));
-                } else if (Array.isArray(init)) {
-                    for (const [key, value] of init) {
-                        if (typeof key === "string" && typeof value === "string") {
-                            this.append(key, value);
-                        } else {
-                            throw new TypeError("Each header entry must be a [string, string] tuple");
-                        }
-                    }
-                } else {
-                    for (const [key, value] of Object.entries(init)) {
-                        if (typeof value === "string") {
-                            this.append(key, value);
-                        } else {
-                            throw new TypeError("Header values must be strings");
-                        }
-                    }
-                }
-            }
-        }
+			if (init) {
+				if (init instanceof Headers) {
+					init.forEach((value, key) => this.append(key, value));
+				} else if (Array.isArray(init)) {
+					for (const [key, value] of init) {
+						if (typeof key === "string" && typeof value === "string") {
+							this.append(key, value);
+						} else {
+							throw new TypeError(
+								"Each header entry must be a [string, string] tuple",
+							);
+						}
+					}
+				} else {
+					for (const [key, value] of Object.entries(init)) {
+						if (typeof value === "string") {
+							this.append(key, value);
+						} else {
+							throw new TypeError("Header values must be strings");
+						}
+					}
+				}
+			}
+		}
 
-        append(name: string, value: string): void {
-            const key = name.toLowerCase();
-            const existing = this.headers.get(key) || [];
-            this.headers.set(key, [...existing, value]);
-        }
+		append(name: string, value: string): void {
+			const key = name.toLowerCase();
+			const existing = this.headers.get(key) || [];
+			this.headers.set(key, [...existing, value]);
+		}
 
-        delete(name: string): void {
-            const key = name.toLowerCase();
-            this.headers.delete(key);
-        }
+		delete(name: string): void {
+			const key = name.toLowerCase();
+			this.headers.delete(key);
+		}
 
-        get(name: string): string | null {
-            const key = name.toLowerCase();
-            const values = this.headers.get(key);
-            return values ? values.join(", ") : null;
-        }
+		get(name: string): string | null {
+			const key = name.toLowerCase();
+			const values = this.headers.get(key);
+			return values ? values.join(", ") : null;
+		}
 
-        has(name: string): boolean {
-            const key = name.toLowerCase();
-            return this.headers.has(key);
-        }
+		has(name: string): boolean {
+			const key = name.toLowerCase();
+			return this.headers.has(key);
+		}
 
-        set(name: string, value: string): void {
-            const key = name.toLowerCase();
-            this.headers.set(key, [value]);
-        }
+		set(name: string, value: string): void {
+			const key = name.toLowerCase();
+			this.headers.set(key, [value]);
+		}
 
-        forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: unknown): void {
-            const boundCallback = thisArg ? callbackfn.bind(thisArg) : callbackfn;
-            this.headers.forEach((values, key) => boundCallback(values.join(", "), key, this));
-        }
+		forEach(
+			callbackfn: (value: string, key: string, parent: Headers) => void,
+			thisArg?: unknown,
+		): void {
+			const boundCallback = thisArg ? callbackfn.bind(thisArg) : callbackfn;
+			this.headers.forEach((values, key) =>
+				boundCallback(values.join(", "), key, this),
+			);
+		}
 
-        getSetCookie(): string[] {
-            return this.headers.get("set-cookie") || [];
-        }
+		getSetCookie(): string[] {
+			return this.headers.get("set-cookie") || [];
+		}
 
-        *entries(): HeadersIterator<[string, string]> {
-            for (const [key, values] of this.headers.entries()) {
-                yield [key, values.join(", ")];
-            }
-        }
+		*entries(): IterableIterator<[string, string]> {
+			for (const [key, values] of this.headers.entries()) {
+				yield [key, values.join(", ")];
+			}
+		}
 
-        *keys(): HeadersIterator<string> {
-            yield* this.headers.keys();
-        }
+		*keys(): IterableIterator<string> {
+			yield* this.headers.keys();
+		}
 
-        *values(): HeadersIterator<string> {
-            for (const values of this.headers.values()) {
-                yield values.join(", ");
-            }
-        }
+		*values(): IterableIterator<string> {
+			for (const values of this.headers.values()) {
+				yield values.join(", ");
+			}
+		}
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
-            return this.entries();
-        }
-    };
+		[Symbol.iterator](): IterableIterator<[string, string]> {
+			return this.entries();
+		}
+	};
 }
 
 export { Headers };

--- a/seed/ts-sdk/simple-api/oidc-token/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/use-oxc/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/use-oxlint/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/use-prettier/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-api/use-yarn/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/simple-fhir/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/single-url-environment-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/streaming-parameter/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/streaming/serde-layer/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/streaming/wrapper/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/trace/exhaustive/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/trace/serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/trace/serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/ts-express-casing/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/ts-extra-properties/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/ts-extra-properties/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/union-query-parameters/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/union-query-parameters/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/unions-with-local-date/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/unions/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/unions/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/unions/serde-layer/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/unions/serde-layer/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/url-form-encoded/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/url-form-encoded/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/validation/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/validation/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/variables/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/variables/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/version-no-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/version-no-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/version/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/version/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/webhook-audience/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/webhook-audience/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/webhooks/no-custom-config/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/webhooks/no-custom-config/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/websocket-multi-url/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/websocket-multi-url/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/websocket/no-serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/websocket/serde/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };

--- a/seed/ts-sdk/x-fern-default/src/core/fetcher/Headers.ts
+++ b/seed/ts-sdk/x-fern-default/src/core/fetcher/Headers.ts
@@ -68,23 +68,23 @@ if (typeof globalThis.Headers !== "undefined") {
             return this.headers.get("set-cookie") || [];
         }
 
-        *entries(): HeadersIterator<[string, string]> {
+        *entries(): IterableIterator<[string, string]> {
             for (const [key, values] of this.headers.entries()) {
                 yield [key, values.join(", ")];
             }
         }
 
-        *keys(): HeadersIterator<string> {
+        *keys(): IterableIterator<string> {
             yield* this.headers.keys();
         }
 
-        *values(): HeadersIterator<string> {
+        *values(): IterableIterator<string> {
             for (const values of this.headers.values()) {
                 yield values.join(", ");
             }
         }
 
-        [Symbol.iterator](): HeadersIterator<[string, string]> {
+        [Symbol.iterator](): IterableIterator<[string, string]> {
             return this.entries();
         }
     };


### PR DESCRIPTION
Closes FER-10963

## Summary

- The generated `core/fetcher/Headers.ts` shim annotates `entries()`, `keys()`, `values()`, and `[Symbol.iterator]()` with `HeadersIterator<T>`, which only exists in the TypeScript DOM lib starting in **5.6**. Under TS < 5.6, generated SDKs fail to compile with 4× `TS2304: Cannot find name 'HeadersIterator'`.
- Surfaced during validation of FER-10950 against the Auth0 SDK (validator pins TS 5.5.4).
- Switch the four annotations to `IterableIterator<T>`. Same semantics, compiles cleanly on TS 4.x → 5.x.

## Why this specific fix

I tested four candidate fixes against an isolated tsc compile of the Headers.ts shim:

| Candidate | TS 5.5.4 | TS 5.9.3 |
|---|---|---|
| Original (`HeadersIterator<T>`) | TS2304 | ✅ |
| **A: `IterableIterator<T>`** | ✅ | ✅ |
| B: drop return type | ✅ | TS2322 (`Generator<T, void, …>` vs `BuiltinIteratorReturn=undefined`) |
| C: drop `implements Headers` | ✅ | ✅ |

A is minimal — exactly four type-annotation swaps. The 5.6+ DOM lib defines both `HeadersIterator<T>` and `IterableIterator<T>` as extending the same `IteratorObject<T, BuiltinIteratorReturn, unknown>` base, so an `IterableIterator<T>` return is structurally compatible with `Headers.entries(): HeadersIterator<T>` in `class Headers implements Headers`.

## Before / after

```diff
- *entries(): HeadersIterator<[string, string]> { … }
- *keys(): HeadersIterator<string> { … }
- *values(): HeadersIterator<string> { … }
- [Symbol.iterator](): HeadersIterator<[string, string]> { … }
+ *entries(): IterableIterator<[string, string]> { … }
+ *keys(): IterableIterator<string> { … }
+ *values(): IterableIterator<string> { … }
+ [Symbol.iterator](): IterableIterator<[string, string]> { … }
```

## Test plan

- [x] Regenerate Auth0 SDK from local generator → `tsc -p tsconfig.{cjs,esm,}.json --noEmit` under **TS 5.5.4**: 0 errors (was 4× TS2304)
- [x] Same regenerated SDK → `tsc -p tsconfig.cjs.json --noEmit` under **TS 5.9.3**: 0 errors (no regression)
- [x] `pnpm seed test --generator ts-sdk --local` against `no-retries`, `bytes-upload`, `server-sent-event-examples`, and all 22 `exhaustive` variants: 22/24 ✅ (2 failures are pre-existing expected failures unrelated to this change — both fail at generation, not validator/tsc)
- [x] Seed snapshots for all 217 ts-sdk fixtures updated to reflect the new emission (single md5 across all 217, matching a fresh regeneration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)