### PR TITLE
chore(ruby): remove stale server-sent-events-openapi allowedFailure from seed

### DIFF
--- a/seed/ruby-sdk-v2/seed.yml
+++ b/seed/ruby-sdk-v2/seed.yml
@@ -137,5 +137,3 @@ features:
   additionalProperties: true
   whitelabel: false
   apiReferenceGeneration: false
-allowedFailures:
-  - server-sent-events-openapi


### PR DESCRIPTION
## Description
The Ruby SDK seed config (`seed/ruby-sdk-v2/seed.yml`) listed `server-sent-events-openapi` under `allowedFailures`. That gate was added in #14117 when the Ruby generator could not yet generate this OpenAPI-SSE fixture. The underlying generation/rubocop issues were subsequently fixed (#15469 added the committed Ruby output, #15202 added emitter-level rubocop compliance), but the `allowedFailures` entry was never removed.

The fixture now passes cleanly. The seed runner itself flags this: `1/1 test cases succeeded unexpectedly. Consider removing the following fixtures from allowedFailures: server-sent-events-openapi.` This PR removes the stale entry so the fixture is a required, enforced test. No generator code change is required — regenerating produces output byte-identical to the committed snapshot.

## Changes Made
- Removed the `allowedFailures` block (`server-sent-events-openapi`) from `seed/ruby-sdk-v2/seed.yml`. It was the only entry, so the key is dropped entirely.
- [ ] Updated README.md generator (if applicable)

## Testing
Ran the fixture in both modes; both pass with exit 0 and no "succeeded unexpectedly" warning:
- Local: `pnpm seed test --generator ruby-sdk-v2 --fixture server-sent-events-openapi --local`
- Docker (CI-equivalent, generator image + `ruby:3.3` script containers): `pnpm seed test --generator ruby-sdk-v2 --fixture server-sent-events-openapi`

Both run generation + `bundle install` + `bundle exec rake test`; `bundle exec rubocop` (severity `error`) also passes with no offenses. Regenerated output matches the committed snapshot (only `.fern/metadata.json` differs, as expected for manual/local runs).

- [ ] Unit tests added/updated
- [x] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/77aba60a603842d29fa460beb2dbe692
Requested by: @iamnamananand996