### PR TITLE
fix(rust): import SseStream/ByteStream/QueryBuilder in root client

### DIFF
--- a/generators/rust/sdk/changes/unreleased/fix-root-client-stream-query-imports.yml
+++ b/generators/rust/sdk/changes/unreleased/fix-root-client-stream-query-imports.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix the root client failing to compile when root-level endpoints return
+    Server-Sent Event streams, return binary bodies, or use query parameters.
+    The root client now imports `SseStream`, `ByteStream`, and `QueryBuilder`
+    when those endpoints are present, matching sub-client behavior.
+  type: fix

--- a/generators/rust/sdk/src/generators/RootClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/RootClientGenerator.ts
@@ -201,6 +201,18 @@ export class RootClientGenerator {
         // Add HttpClient and RequestOptions imports if root service has endpoints
         if (this.rootServiceGenerator) {
             crateItems.push("HttpClient", "RequestOptions");
+
+            // Mirror SubClientGenerator: root-level endpoints may also need these
+            // crate-level re-exports for binary, SSE, and query-parameter endpoints.
+            if (this.rootServiceGenerator.hasBinaryEndpoints()) {
+                crateItems.push("ByteStream");
+            }
+            if (this.rootServiceGenerator.hasSseEndpoints()) {
+                crateItems.push("SseStream");
+            }
+            if (this.rootServiceGenerator.hasQueryParameters()) {
+                crateItems.push("QueryBuilder");
+            }
         }
 
         const imports: UseStatement[] = [

--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -514,17 +514,17 @@ export class SubClientGenerator {
         return endpoints.some((endpoint) => endpoint.pagination != null);
     }
 
-    private hasQueryParameters(): boolean {
+    public hasQueryParameters(): boolean {
         const endpoints = this.service?.endpoints || [];
         return endpoints.some((endpoint) => endpoint.queryParameters.length > 0);
     }
 
-    private hasBinaryEndpoints(): boolean {
+    public hasBinaryEndpoints(): boolean {
         const endpoints = this.service?.endpoints || [];
         return endpoints.some((endpoint) => this.isBinaryResponse(endpoint));
     }
 
-    private hasSseEndpoints(): boolean {
+    public hasSseEndpoints(): boolean {
         const endpoints = this.service?.endpoints || [];
         return endpoints.some((endpoint) => this.getResponseStreamType(endpoint) === "sse");
     }

--- a/seed/rust-model/seed.yml
+++ b/seed/rust-model/seed.yml
@@ -57,5 +57,3 @@ fixtures:
     - customConfig:
         generateBuilders: true
       outputFolder: with-builders
-allowedFailures:
-  - server-sent-events-openapi

--- a/seed/rust-sdk/query-param-name-conflict/src/api/resources/mod.rs
+++ b/seed/rust-sdk/query-param-name-conflict/src/api/resources/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides the client implementations for all available services.
 
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ApiClient {

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/api/resources/mod.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/api/resources/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides the client implementations for all available services.
 
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ApiClient {

--- a/seed/rust-sdk/query-parameters-openapi/src/api/resources/mod.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/api/resources/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides the client implementations for all available services.
 
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ApiClient {

--- a/seed/rust-sdk/required-nullable/src/api/resources/mod.rs
+++ b/seed/rust-sdk/required-nullable/src/api/resources/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides the client implementations for all available services.
 
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ApiClient {

--- a/seed/rust-sdk/seed.yml
+++ b/seed/rust-sdk/seed.yml
@@ -164,5 +164,3 @@ fixtures:
         packageLicense: "Apache-2.0"
         packageLicenseFile: "LICENSE.md"
       outputFolder: both-license-options
-allowedFailures:
-  - server-sent-events-openapi

--- a/seed/rust-sdk/server-sent-events-openapi/src/api/resources/mod.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/api/resources/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides the client implementations for all available services.
 
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, RequestOptions, SseStream};
 use reqwest::Method;
 
 pub struct ApiClient {

--- a/seed/rust-sdk/validation/src/api/resources/mod.rs
+++ b/seed/rust-sdk/validation/src/api/resources/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides the client implementations for all available services.
 
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ValidationClient {

--- a/seed/rust-sdk/x-fern-default/src/api/resources/mod.rs
+++ b/seed/rust-sdk/x-fern-default/src/api/resources/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides the client implementations for all available services.
 
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
 use reqwest::Method;
 
 pub struct ApiClient {


### PR DESCRIPTION
## Description
Removes the `allowedFailures` entries from the Rust generator seed configs and fixes the underlying generator bug that required them.

The `server-sent-events-openapi` fixture was listed in `allowedFailures` for both `rust-sdk` and `rust-model`. The root cause: when SSE/binary/query endpoints live on the **root** client (common for OpenAPI specs without subpackages), `RootClientGenerator` emitted code referencing `SseStream<...>`, `ByteStream`, and `QueryBuilder::new()` without importing them, so the crate failed to compile:

```
error[E0425]: cannot find type `SseStream` in this scope
error[E0433]: failed to resolve: use of undeclared type `QueryBuilder`
```

`SubClientGenerator` already adds these crate-level re-exports conditionally; `RootClientGenerator` did not. This PR mirrors that logic.

## Changes Made
- `RootClientGenerator.generateImports()` now pushes `ByteStream` / `SseStream` / `QueryBuilder` into the root `crate` import when the root service has binary, SSE, or query-parameter endpoints respectively.
- Made `hasQueryParameters` / `hasBinaryEndpoints` / `hasSseEndpoints` public on `SubClientGenerator` so the root client can reuse them.
- Removed `allowedFailures: [server-sent-events-openapi]` from `seed/rust-sdk/seed.yml` and `seed/rust-model/seed.yml` (the latter is `disabled: true`).
- Regenerated affected `rust-sdk` seed snapshots — each is a single import-line addition (`server-sent-events-openapi` gets `SseStream`; six query fixtures get `QueryBuilder`).
- Added a `fix` changelog entry under `generators/rust/sdk/changes/unreleased/`.

## Testing
- [x] `pnpm seed test --generator rust-sdk --local` → 135/135 fixtures pass generation.
- [x] `cargo build --all-features` + `cargo test` pass for `server-sent-events-openapi` (100 tests), `query-parameters-openapi` (89), `validation` (87), and the other affected fixtures (`query-param-name-conflict`, `query-parameters-openapi-as-objects`, `required-nullable`, `x-fern-default`) build successfully. Previously these failed with `E0425`/`E0433`.
- [x] Manual testing completed

Note: pre-existing snapshot drift in unrelated fixtures (`allof`, `allof-inline`) was left untouched — it reproduces on `main` without this change and is out of scope.

Link to Devin session: https://app.devin.ai/sessions/6811ca3cbcd34668a3c784b7a64892db
Requested by: @iamnamananand996