### PR TITLE
fix(cli-generator): remove accidental _cli-sdk submodule gitlink

### DIFF
--- a/.github/workflows/sync-cli-sdk.yml
+++ b/.github/workflows/sync-cli-sdk.yml
@@ -68,6 +68,10 @@ jobs:
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725  # v8
         with:
           token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
+          # Scope staging to the synced path only. Without this the action runs
+          # `git add -A` across the whole tree and captures the transient
+          # `_cli-sdk` clone as a submodule gitlink (mode 160000).
+          add-paths: generators/cli/sdk/
           commit-message: "chore(cli-generator): sync cli-sdk@${{ steps.provenance.outputs.short }}"
           title: "chore(cli-generator): sync cli-sdk@${{ steps.provenance.outputs.short }}"
           body: |

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ seed/**/Library/Caches/
 
 # Devbox gradle properties
 /gradle.properties
+
+# Transient cli-sdk checkout used by .github/workflows/sync-cli-sdk.yml.
+# It is a nested git clone; never let `git add -A` capture it as a gitlink.
+/_cli-sdk/


### PR DESCRIPTION
## What

Removes an accidental **submodule gitlink** at the repo root and prevents it from coming back.

## Root cause

PR #16187 (`chore(cli-generator): sync cli-sdk@9c1f38f`, commit 6688ff1) committed `_cli-sdk` as a `mode 160000` gitlink pointing at cli-sdk commit `9c1f38f` — a phantom submodule with **no `.gitmodules`** entry.

- `.github/workflows/sync-cli-sdk.yml` checks out `fern-api/cli-sdk` into `_cli-sdk` at the repo root (it carries its own nested `.git`).
- The sync script only writes into `generators/cli/sdk/`, and the workflow's "Check for changes" step correctly scopes its `git add` to that path.
- But `peter-evans/create-pull-request` re-stages the **entire** working tree with `git add -A`, which captured the `_cli-sdk` clone as a gitlink.

Because there's no submodule mapping, `git submodule status` fails fatally (`no submodule mapping found in .gitmodules for path '_cli-sdk'`), breaking clean checkouts and downstream CI (Update Seed, Release Software, etc.).

## Fix

1. **Remove** the stray `_cli-sdk` gitlink (`delete mode 160000`).
2. **`.gitignore`**: add `/_cli-sdk/` — robust layer; any `git add -A` in CI now skips the transient clone.
3. **`sync-cli-sdk.yml`**: add `add-paths: generators/cli/sdk/` to the `create-pull-request` step so it can only ever stage the synced path.

Layers 2 and 3 are defense-in-depth: either alone prevents recurrence; together the repo is protected and the workflow is explicit.

## Notes

- No `.gitmodules` exists (verified) — the deletion fully removes the submodule, nothing else to clean up.
- No CLI/IR semver impact; this is repo-hygiene + CI.
