### PR TITLE
fix(internal): handle missing unreleased directory in release workflow

### DIFF
--- a/generators/cli/changes/unreleased/.gitkeep
+++ b/generators/cli/changes/unreleased/.gitkeep
@@ -1,0 +1,2 @@
+# This directory contains unreleased changelog entries
+# Create files here following the format in fern-changes-yml.schema.json

--- a/generators/cli/changes/unreleased/.template.yml
+++ b/generators/cli/changes/unreleased/.template.yml
@@ -1,0 +1,9 @@
+# Template for changelog entries
+# Copy this file and rename it to describe your change (e.g., add-auth-feature.yml)
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Brief description of your change.
+    You can use multiple lines for longer descriptions.
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
+  # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -106,8 +106,8 @@ interface UnreleasedChange {
 
 function readUnreleasedChanges(unreleasedDir: string): UnreleasedChange[] {
     if (!existsSync(unreleasedDir)) {
-        console.error(`❌ Error: Unreleased changes directory not found: ${unreleasedDir}`);
-        process.exit(1);
+        console.log("ℹ️  No unreleased changes directory found. Nothing to release.");
+        process.exit(0);
     }
 
     const files = readdirSync(unreleasedDir).filter(


### PR DESCRIPTION
## Description

Fixes false failures in the **Release Software** GitHub workflow. Every run that actually released software was followed by a red ❌ because `cli-generator`'s `changes/unreleased/` directory didn't exist after its files were moved to a versioned folder.

Example failing run: https://github.com/fern-api/fern/actions/runs/26892939184/job/79323766747  
Error: `❌ Error: Unreleased changes directory not found: …/generators/cli/changes/unreleased`

## Changes Made

- **`scripts/release.ts`**: `readUnreleasedChanges()` now exits 0 (skip) instead of exit 1 (error) when the `unreleased/` directory is missing — matching the existing behavior for an empty directory.
- **`generators/cli/changes/unreleased/.gitkeep`** + **`.template.yml`**: Added so git tracks the directory after releases empty it (matching all other configured software).
- [ ] Updated README.md generator (if applicable) — N/A

## Testing

- Verified all other software packages already have `.gitkeep` in their `unreleased/` directories
- Confirmed the error in the failing job log matches exactly this code path
- Lint passes (`biome check scripts/release.ts`)

Link to Devin session: https://app.devin.ai/sessions/61f7ed6be17d4fce9242cbcc055d7b04
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->