### PR TITLE
fix(cli): populate publishConfig in IR for github/githubV2 output modes

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-github-publish-config-ir.yml
+++ b/packages/cli/cli/changes/unreleased/fix-github-publish-config-ir.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix `publishConfig` being null in the IR for generators using github output mode with npm/maven/pypi publish info.
+    Previously, the `getPublishConfig` function returned `undefined` for `github` and `githubV2` output modes,
+    preventing generators from receiving the publish configuration needed to emit CI workflows.
+  type: fix

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -24,6 +24,7 @@ import {
 import { cloneRepository, getGithubApiBaseUrl, parseRepository } from "@fern-api/github";
 import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { FernIr, PublishTarget } from "@fern-api/ir-sdk";
+import { FernFiddle } from "@fern-fern/fiddle-sdk";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { getDynamicGeneratorConfig } from "@fern-api/remote-workspace-runner";
 import { CliError, TaskAbortSignal, TaskContext } from "@fern-api/task-context";
@@ -734,12 +735,105 @@ function getPublishConfig({
                 publishTarget: undefined
             });
         },
-        github: () => undefined,
-        githubV2: () => undefined,
+        github: (value) => convertGithubOutputModeToPublishConfig(value),
+        githubV2: (value) => convertGithubV2OutputModeToPublishConfig(value),
         publish: () => undefined,
         publishV2: () => undefined,
         _other: () => undefined
     });
+}
+
+function convertGithubOutputModeToPublishConfig(
+    value: FernFiddle.GithubOutputMode
+): FernIr.PublishingConfig | undefined {
+    const publishTarget = convertGithubPublishInfoToTarget(value.publishInfo);
+    if (publishTarget == null) {
+        return undefined;
+    }
+    return FernIr.PublishingConfig.github({
+        owner: value.owner,
+        repo: value.repo,
+        uri: undefined,
+        token: undefined,
+        mode: value.makePr === true ? "pull-request" : undefined,
+        branch: value.branch,
+        target: publishTarget
+    });
+}
+
+function convertGithubV2OutputModeToPublishConfig(
+    value: FernFiddle.GithubOutputModeV2
+): FernIr.PublishingConfig | undefined {
+    const publishTarget = convertGithubPublishInfoToTarget(value.publishInfo);
+    if (publishTarget == null) {
+        return undefined;
+    }
+    return FernIr.PublishingConfig.github({
+        owner: value.owner,
+        repo: value.repo,
+        uri: undefined,
+        token: undefined,
+        mode: value.type === "pullRequest" ? "pull-request" : undefined,
+        branch: value.branch,
+        target: publishTarget
+    });
+}
+
+function convertGithubPublishInfoToTarget(
+    publishInfo: FernFiddle.GithubPublishInfo | undefined
+): FernIr.PublishTarget | undefined {
+    if (publishInfo == null) {
+        return undefined;
+    }
+    return publishInfo._visit<FernIr.PublishTarget | undefined>({
+        npm: (value) =>
+            FernIr.PublishTarget.npm({
+                version: undefined,
+                packageName: value.packageName,
+                tokenEnvironmentVariable: resolveTokenEnvVar(value.token)
+            }),
+        maven: (value) =>
+            FernIr.PublishTarget.maven({
+                version: undefined,
+                coordinate: value.coordinate,
+                usernameEnvironmentVariable: value.credentials?.username ?? "",
+                passwordEnvironmentVariable: value.credentials?.password ?? "",
+                mavenUrlEnvironmentVariable: value.registryUrl
+            }),
+        pypi: (value) =>
+            FernIr.PublishTarget.pypi({
+                version: undefined,
+                packageName: value.packageName
+            }),
+        postman: (value) =>
+            FernIr.PublishTarget.postman({
+                apiKey: value.apiKey ?? "",
+                workspaceId: value.workspaceId ?? "",
+                collectionId: undefined
+            }),
+        rubygems: () => undefined,
+        nuget: () => undefined,
+        crates: (value) =>
+            FernIr.PublishTarget.crates({
+                version: undefined,
+                packageName: value.packageName
+            }),
+        _other: () => undefined
+    });
+}
+
+function resolveTokenEnvVar(token: string | undefined): string {
+    if (token == null) {
+        return "";
+    }
+    const trimmed = token.trim();
+    if (trimmed === "<USE_OIDC>" || trimmed === "OIDC") {
+        return "<USE_OIDC>";
+    }
+    if (trimmed.startsWith("${") && trimmed.endsWith("}")) {
+        return trimmed.slice(2, -1).trim();
+    }
+    return "";
 }
 
 function getPublishTarget({

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -433,8 +433,8 @@ function getPublishConfig({
 }): FernIr.PublishingConfig | undefined {
     return generatorInvocation.outputMode._visit({
         downloadFiles: () => undefined,
-        github: () => undefined,
-        githubV2: () => undefined,
+        github: (value) => convertGithubOutputModeToPublishConfig(value),
+        githubV2: (value) => convertGithubV2OutputModeToPublishConfig(value),
         publish: () => undefined,
         publishV2: (value) =>
             value._visit({
@@ -461,6 +461,99 @@ function getPublishConfig({
             }),
         _other: () => undefined
     });
+}
+
+function convertGithubOutputModeToPublishConfig(
+    value: FernFiddle.GithubOutputMode
+): FernIr.PublishingConfig | undefined {
+    const publishTarget = convertGithubPublishInfoToTarget(value.publishInfo);
+    if (publishTarget == null) {
+        return undefined;
+    }
+    return FernIr.PublishingConfig.github({
+        owner: value.owner,
+        repo: value.repo,
+        uri: undefined,
+        token: undefined,
+        mode: value.makePr === true ? "pull-request" : undefined,
+        branch: value.branch,
+        target: publishTarget
+    });
+}
+
+function convertGithubV2OutputModeToPublishConfig(
+    value: FernFiddle.GithubOutputModeV2
+): FernIr.PublishingConfig | undefined {
+    const publishTarget = convertGithubPublishInfoToTarget(value.publishInfo);
+    if (publishTarget == null) {
+        return undefined;
+    }
+    return FernIr.PublishingConfig.github({
+        owner: value.owner,
+        repo: value.repo,
+        uri: undefined,
+        token: undefined,
+        mode: value.type === "pullRequest" ? "pull-request" : undefined,
+        branch: value.branch,
+        target: publishTarget
+    });
+}
+
+function convertGithubPublishInfoToTarget(
+    publishInfo: FernFiddle.GithubPublishInfo | undefined
+): FernIr.PublishTarget | undefined {
+    if (publishInfo == null) {
+        return undefined;
+    }
+    return publishInfo._visit<FernIr.PublishTarget | undefined>({
+        npm: (value) =>
+            FernIr.PublishTarget.npm({
+                version: undefined,
+                packageName: value.packageName,
+                tokenEnvironmentVariable: resolveTokenEnvVar(value.token)
+            }),
+        maven: (value) =>
+            FernIr.PublishTarget.maven({
+                version: undefined,
+                coordinate: value.coordinate,
+                usernameEnvironmentVariable: value.credentials?.username ?? "",
+                passwordEnvironmentVariable: value.credentials?.password ?? "",
+                mavenUrlEnvironmentVariable: value.registryUrl
+            }),
+        pypi: (value) =>
+            FernIr.PublishTarget.pypi({
+                version: undefined,
+                packageName: value.packageName
+            }),
+        postman: (value) =>
+            FernIr.PublishTarget.postman({
+                apiKey: value.apiKey ?? "",
+                workspaceId: value.workspaceId ?? "",
+                collectionId: undefined
+            }),
+        rubygems: () => undefined,
+        nuget: () => undefined,
+        crates: (value) =>
+            FernIr.PublishTarget.crates({
+                version: undefined,
+                packageName: value.packageName
+            }),
+        _other: () => undefined
+    });
+}
+
+function resolveTokenEnvVar(token: string | undefined): string {
+    if (token == null) {
+        return "";
+    }
+    const trimmed = token.trim();
+    if (trimmed === "<USE_OIDC>" || trimmed === "OIDC") {
+        return "<USE_OIDC>";
+    }
+    if (trimmed.startsWith("${") && trimmed.endsWith("}")) {
+        return trimmed.slice(2, -1).trim();
+    }
+    return "";
 }
 
 function convertToFdrApiDefinitionSources(


### PR DESCRIPTION
## Description

Fixes `publishConfig` being `null` in the IR when generators use `github` output mode with npm/maven/pypi publish info (e.g. `output: { location: npm }` + `github: { mode: push }`).

## Changes Made

- **`runRemoteGenerationForGenerator.ts`**: `getPublishConfig()` now handles `github` and `githubV2` output modes by extracting `publishInfo` and converting it to `FernIr.PublishingConfig.github(...)` with the appropriate `PublishTarget`.
- **`runLocalGenerationForWorkspace.ts`**: Same fix applied to the local generation path's `getPublishConfig()` fallback `_visit` block (non-self-hosted case).
- Both paths share the same pattern: `convertGithubPublishInfoToTarget` maps `FernFiddle.GithubPublishInfo` variants (npm/maven/pypi/postman/crates) → `FernIr.PublishTarget`.

**Root cause**: The `_visit` handlers for `github` and `githubV2` unconditionally returned `undefined`, so the publish info embedded in the output mode was never propagated to the IR.

## Testing

- [x] Both `@fern-api/remote-workspace-runner` and `@fern-api/local-workspace-runner` compile successfully via `pnpm turbo run compile`
- [x] Manual testing: verified the code path traces correctly from `generators.yml` → `convertGeneratorsConfiguration` → `outputMode.githubV2(push({publishInfo: npm(...)}))` → now correctly resolved in `getPublishConfig()`


Link to Devin session: https://app.devin.ai/sessions/04086b5c5e8445559f28203e1001acac
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->