### PR TITLE
fix(cli): update irVersion metadata from 66 to 67

### DIFF
--- a/fern-changes-yml.schema.json
+++ b/fern-changes-yml.schema.json
@@ -22,6 +22,11 @@
                 "pre-release": {
                     "$ref": "#/definitions/PreReleaseTag",
                     "description": "Optional pre-release tag. When set, the release version includes this suffix (e.g., 1.2.0-rc.0)."
+                },
+                "irVersion": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Optional IR major version override. When set, the released version entry uses this irVersion instead of inheriting from the previous entry. Use this when bumping the IR major version."
                 }
             },
             "required": [

--- a/packages/cli/cli/changes/unreleased/fix-cli-ir-version-metadata.yml
+++ b/packages/cli/cli/changes/unreleased/fix-cli-ir-version-metadata.yml
@@ -3,3 +3,4 @@
     reports IR 67-compatible generator versions (e.g. CLI generator ≥ 0.2.0)
     when resolving `fern generator upgrade`.
   type: fix
+  irVersion: 67

--- a/packages/cli/cli/changes/unreleased/fix-cli-ir-version-metadata.yml
+++ b/packages/cli/cli/changes/unreleased/fix-cli-ir-version-metadata.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Update CLI irVersion metadata from 66 to 67 so that FDR correctly
+    reports IR 67-compatible generator versions (e.g. CLI generator ≥ 0.2.0)
+    when resolving `fern generator upgrade`.
+  type: fix

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -6,7 +6,7 @@
         `fernapi/fern-cli-generator`.
       type: chore
   createdAt: "2026-06-03"
-  irVersion: 67
+  irVersion: 66
 - version: 5.44.4
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -6,7 +6,7 @@
         `fernapi/fern-cli-generator`.
       type: chore
   createdAt: "2026-06-03"
-  irVersion: 66
+  irVersion: 67
 - version: 5.44.4
   changelogEntry:
     - summary: |

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -18,6 +18,7 @@ interface ChangelogEntry {
     summary: string;
     type: "fix" | "chore" | "feat" | "internal";
     "pre-release"?: string;
+    irVersion?: number;
 }
 
 const VALID_CHANGELOG_TYPES = new Set(["fix", "chore", "feat", "internal"]);
@@ -80,12 +81,22 @@ function validateChangelogEntry(entry: unknown, filename: string, index: number)
         }
     }
 
-    const allowedKeys = new Set(["summary", "type", "pre-release"]);
+    if (obj.irVersion !== undefined) {
+        if (typeof obj.irVersion !== "number" || !Number.isInteger(obj.irVersion) || obj.irVersion < 1) {
+            console.error(
+                `Error in ${filename}, entry ${index + 1}: Invalid "irVersion" field: ${JSON.stringify(obj.irVersion)}. ` +
+                    `Expected a positive integer.`
+            );
+            process.exit(1);
+        }
+    }
+
+    const allowedKeys = new Set(["summary", "type", "pre-release", "irVersion"]);
     for (const key of Object.keys(obj)) {
         if (!allowedKeys.has(key)) {
             console.error(
                 `Error in ${filename}, entry ${index + 1}: Unknown field "${key}". ` +
-                    `Only "summary", "type", and "pre-release" are allowed.`
+                    `Only "summary", "type", "pre-release", and "irVersion" are allowed.`
             );
             process.exit(1);
         }
@@ -140,6 +151,17 @@ function readUnreleasedChanges(unreleasedDir: string): UnreleasedChange[] {
     }
 
     return changes;
+}
+
+function getIrVersionOverride(changes: UnreleasedChange[]): number | undefined {
+    for (const change of changes) {
+        for (const entry of change.entries) {
+            if (entry.irVersion != null) {
+                return entry.irVersion;
+            }
+        }
+    }
+    return undefined;
 }
 
 function getPreReleaseTag(changes: UnreleasedChange[]): string | undefined {
@@ -374,9 +396,14 @@ function prepareRelease(softwareName: string, config: SoftwareConfig): void {
     const currentVersion = getCurrentVersion(versionsFile);
     console.log(`📊 Current version: ${currentVersion}`);
 
-    // Get current IR version
-    const irVersion = getCurrentIrVersion(versionsFile);
-    console.log(`📊 Current IR version: ${irVersion}`);
+    // Get current IR version (changelog override takes precedence)
+    const irVersionFromChangelog = getIrVersionOverride(changes);
+    const irVersion = irVersionFromChangelog ?? getCurrentIrVersion(versionsFile);
+    if (irVersionFromChangelog != null) {
+        console.log(`📊 IR version: ${irVersion} (overridden by changelog entry)`);
+    } else {
+        console.log(`📊 Current IR version: ${irVersion}`);
+    }
 
     // Determine next version
     const nextVersion = determineNextVersion(currentVersion, changes);


### PR DESCRIPTION
## Description

The CLI's `versions.yml` has had `irVersion: 66` for all releases since CLI 5.5.0, even though the IR major version was bumped to 67 back in #15320. The release script (`scripts/release.ts`) copies `irVersion` from the previous entry, so the stale value propagated through ~137 releases.

This causes `fern generator upgrade` to return outdated versions for any generator that requires IR 67 (e.g., CLI generator ≥ 0.2.0). FDR uses `cliVersion` → `irVersion` to filter compatible generator versions, and since it thinks CLI 5.44.5 only supports IR 66, it skips all IR 67 generators.

Verified via direct FDR query:
- `{"generator":"cli","releaseTypes":["GA"],"generatorMajorVersion":0}` → returns **0.6.0** (correct)
- `{"generator":"cli","releaseTypes":["GA"],"generatorMajorVersion":0,"cliVersion":"5.44.5"}` → returns **0.1.0** (wrong — should be 0.6.0)

## Changes Made

- Added `irVersion` as an optional field in changelog entries (`ChangelogEntry` interface, `fern-changes-yml.schema.json`, validation in `release.ts`)
- When present, the release script uses the changelog's `irVersion` instead of copying from the previous versions.yml entry
- Added a CLI changelog entry with `irVersion: 67` to bump the metadata on next release
- No hand-edits to `versions.yml`

## Testing

- Verified FDR query behavior confirming the filtering issue
- Confirmed IR SDK is at 67.3.0 and the CLI outputs IR 67
- Validated the changelog schema and release script changes are consistent


Link to Devin session: https://app.devin.ai/sessions/24526ed457a64a59a25326ba70d86270
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->