### PR TITLE
feat(cli): use npm@latest publish with backport tag detection in generated workflow

### DIFF
--- a/generators/cli/changes/unreleased/use-npm-latest-publish-with-backport.yml
+++ b/generators/cli/changes/unreleased/use-npm-latest-publish-with-backport.yml
@@ -1,6 +1,10 @@
 # yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
 
 - summary: |
-    Generated publish workflow now uses `npx -y npm@latest publish` to ensure
-    OIDC support and adds backport tag detection for older-than-latest releases.
+    Generated publish workflow improvements: uses `npx -y npm@latest publish`
+    for OIDC support, adds backport tag detection for older-than-latest releases,
+    switches Linux targets from glibc to musl for fully static binaries,
+    builds aarch64-linux natively on `ubuntu-24.04-arm` instead of cross-compiling,
+    conditionally uses `--no-default-features --features rustls` for musl targets,
+    and bumps `actions/checkout` and `actions/setup-node` to v6.
   type: feat

--- a/generators/cli/changes/unreleased/use-npm-latest-publish-with-backport.yml
+++ b/generators/cli/changes/unreleased/use-npm-latest-publish-with-backport.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Generated publish workflow now uses `npx -y npm@latest publish` to ensure
+    OIDC support and adds backport tag detection for older-than-latest releases.
+  type: feat

--- a/generators/cli/src/__test__/emitPublishWorkflow.test.ts
+++ b/generators/cli/src/__test__/emitPublishWorkflow.test.ts
@@ -57,7 +57,7 @@ describe("emitPublishWorkflow", () => {
 
         expect(yaml).toContain("dist-tags.latest");
         expect(yaml).toContain("--tag backport");
-        expect(yaml).toContain("npx -y semver");
+        expect(yaml).toContain("npx -y semver@7.8.1");
     });
 
     it("uses a custom token variable name in the secret reference", async () => {

--- a/generators/cli/src/__test__/emitPublishWorkflow.test.ts
+++ b/generators/cli/src/__test__/emitPublishWorkflow.test.ts
@@ -118,7 +118,7 @@ describe("emitPublishWorkflow", () => {
 
         expect(yaml).toContain('BINARY_NAME="my-tool"');
         expect(yaml).toContain("@acme/cli");
-        expect(yaml).toContain("x86_64-unknown-linux-gnu");
+        expect(yaml).toContain("x86_64-unknown-linux-musl");
         expect(yaml).toContain("aarch64-apple-darwin");
     });
 
@@ -135,6 +135,32 @@ describe("emitPublishWorkflow", () => {
         const yaml = await emitAndRead(baseInfo);
 
         expect(yaml).toContain("contains(github.ref, 'refs/tags/')");
+    });
+
+    it("uses actions/checkout@v6 and actions/setup-node@v6", async () => {
+        const yaml = await emitAndRead(baseInfo);
+
+        expect(yaml).toContain("actions/checkout@v6");
+        expect(yaml).not.toContain("actions/checkout@v4");
+        expect(yaml).toContain("actions/setup-node@v6");
+        expect(yaml).not.toContain("actions/setup-node@v4");
+    });
+
+    it("uses musl targets for Linux with native ARM runner", async () => {
+        const yaml = await emitAndRead(baseInfo);
+
+        expect(yaml).toContain("x86_64-unknown-linux-musl");
+        expect(yaml).toContain("aarch64-unknown-linux-musl");
+        expect(yaml).not.toContain("unknown-linux-gnu");
+        expect(yaml).toContain("ubuntu-24.04-arm");
+    });
+
+    it("installs musl-tools and conditionally builds with rustls for musl targets", async () => {
+        const yaml = await emitAndRead(baseInfo);
+
+        expect(yaml).toContain("musl-tools");
+        expect(yaml).toContain("--no-default-features --features rustls");
+        expect(yaml).not.toContain("gcc-aarch64-linux-gnu");
     });
 
     it("both publish steps define a publish() helper and backport logic", async () => {

--- a/generators/cli/src/__test__/emitPublishWorkflow.test.ts
+++ b/generators/cli/src/__test__/emitPublishWorkflow.test.ts
@@ -45,6 +45,21 @@ describe("emitPublishWorkflow", () => {
         expect(yaml).not.toContain("id-token: write");
     });
 
+    it("uses npx npm@latest publish wrapper instead of bare npm publish", async () => {
+        const yaml = await emitAndRead(baseInfo);
+
+        expect(yaml).toContain('npx -y npm@latest publish "$@"');
+        expect(yaml).not.toMatch(/^\s+npm publish/m);
+    });
+
+    it("includes backport detection for stable releases", async () => {
+        const yaml = await emitAndRead(baseInfo);
+
+        expect(yaml).toContain("dist-tags.latest");
+        expect(yaml).toContain("--tag backport");
+        expect(yaml).toContain("npx -y semver");
+    });
+
     it("uses a custom token variable name in the secret reference", async () => {
         const yaml = await emitAndRead({
             ...baseInfo,
@@ -120,5 +135,18 @@ describe("emitPublishWorkflow", () => {
         const yaml = await emitAndRead(baseInfo);
 
         expect(yaml).toContain("contains(github.ref, 'refs/tags/')");
+    });
+
+    it("both publish steps define a publish() helper and backport logic", async () => {
+        const yaml = await emitAndRead(baseInfo);
+
+        // There should be two publish() helper definitions — one per publish step
+        const publishHelperMatches = yaml.match(/publish\(\)\s*\{/g);
+        expect(publishHelperMatches).toHaveLength(2);
+
+        // Both platform and launcher steps should have backport logic
+        // Each step has 2 occurrences: the echo message + the publish call
+        const backportMatches = yaml.match(/--tag backport/g);
+        expect(backportMatches).toHaveLength(4);
     });
 });

--- a/generators/cli/src/__test__/runPipeline.test.ts
+++ b/generators/cli/src/__test__/runPipeline.test.ts
@@ -312,7 +312,7 @@ describe("runPipeline", () => {
         expect(ciYml).toContain("NPM_TOKEN");
         expect(ciYml).toContain("@acme/cli");
         expect(ciYml).toContain("npm@latest publish");
-        expect(ciYml).toContain("x86_64-unknown-linux-gnu");
+        expect(ciYml).toContain("x86_64-unknown-linux-musl");
         expect(ciYml).toContain("aarch64-apple-darwin");
     });
 });

--- a/generators/cli/src/__test__/runPipeline.test.ts
+++ b/generators/cli/src/__test__/runPipeline.test.ts
@@ -311,7 +311,7 @@ describe("runPipeline", () => {
         expect(ciYml).toContain("contains(github.ref, 'refs/tags/')");
         expect(ciYml).toContain("NPM_TOKEN");
         expect(ciYml).toContain("@acme/cli");
-        expect(ciYml).toContain("npm publish");
+        expect(ciYml).toContain("npm@latest publish");
         expect(ciYml).toContain("x86_64-unknown-linux-gnu");
         expect(ciYml).toContain("aarch64-apple-darwin");
     });

--- a/generators/cli/src/emitPublishWorkflow.ts
+++ b/generators/cli/src/emitPublishWorkflow.ts
@@ -12,8 +12,8 @@ const TARGETS: ReadonlyArray<{
     runner: string;
     npmPlatformSuffix: string;
 }> = [
-    { rustTarget: "x86_64-unknown-linux-gnu", runner: "ubuntu-latest", npmPlatformSuffix: "linux-x64" },
-    { rustTarget: "aarch64-unknown-linux-gnu", runner: "ubuntu-latest", npmPlatformSuffix: "linux-arm64" },
+    { rustTarget: "x86_64-unknown-linux-musl", runner: "ubuntu-latest", npmPlatformSuffix: "linux-x64" },
+    { rustTarget: "aarch64-unknown-linux-musl", runner: "ubuntu-24.04-arm", npmPlatformSuffix: "linux-arm64" },
     { rustTarget: "x86_64-apple-darwin", runner: "macos-latest", npmPlatformSuffix: "darwin-x64" },
     { rustTarget: "aarch64-apple-darwin", runner: "macos-latest", npmPlatformSuffix: "darwin-arm64" },
     { rustTarget: "x86_64-pc-windows-msvc", runner: "windows-latest", npmPlatformSuffix: "win32-x64" }
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -142,7 +142,7 @@ jobs:
 ${matrixIncludes}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -150,19 +150,25 @@ ${matrixIncludes}
           target: \${{ matrix.rust-target }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           registry-url: "${npmPublishInfo.registryUrl}"
 
-      - name: Install cross-compilation tools
-        if: matrix.rust-target == 'aarch64-unknown-linux-gnu'
+      - name: Install musl build tools
+        if: contains(matrix.rust-target, '-linux-musl')
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          sudo apt-get install -y musl-tools
 
       - name: Build release binary
-        run: cargo build --release --locked --target \${{ matrix.rust-target }}
+        shell: bash
+        run: |
+          if [[ "\${{ matrix.rust-target }}" == *-linux-musl ]]; then
+            cargo build --release --locked --target \${{ matrix.rust-target }} \\
+              --no-default-features --features rustls
+          else
+            cargo build --release --locked --target \${{ matrix.rust-target }}
+          fi
 
       - name: Package and publish npm platform package${tokenEnvBlock}
         shell: bash
@@ -224,10 +230,10 @@ ${matrixIncludes}
     runs-on: ubuntu-latest${oidcPermissions}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           registry-url: "${npmPublishInfo.registryUrl}"
 

--- a/generators/cli/src/emitPublishWorkflow.ts
+++ b/generators/cli/src/emitPublishWorkflow.ts
@@ -216,7 +216,7 @@ ${matrixIncludes}
             PKG_NAME=\$(node -p "require('./package.json').name")
             PKG_VERSION=\$(node -p "require('./package.json').version")
             CURRENT_LATEST=\$(npm view "\${PKG_NAME}" dist-tags.latest 2>/dev/null || echo "0.0.0")
-            if npx -y semver "\${PKG_VERSION}" -r "<\${CURRENT_LATEST}" > /dev/null 2>&1; then
+            if npx -y semver@7.8.1 "\${PKG_VERSION}" -r "<\${CURRENT_LATEST}" > /dev/null 2>&1; then
               echo "Publishing \${PKG_VERSION} with --tag backport (current latest is \${CURRENT_LATEST})"
               publish --access public --tag backport
             else
@@ -316,7 +316,7 @@ ${launcherPlatformEntries}
             PKG_NAME=\$(node -p "require('./package.json').name")
             PKG_VERSION=\$(node -p "require('./package.json').version")
             CURRENT_LATEST=\$(npm view "\${PKG_NAME}" dist-tags.latest 2>/dev/null || echo "0.0.0")
-            if npx -y semver "\${PKG_VERSION}" -r "<\${CURRENT_LATEST}" > /dev/null 2>&1; then
+            if npx -y semver@7.8.1 "\${PKG_VERSION}" -r "<\${CURRENT_LATEST}" > /dev/null 2>&1; then
               echo "Publishing \${PKG_VERSION} with --tag backport (current latest is \${CURRENT_LATEST})"
               publish --access public --tag backport
             else

--- a/generators/cli/src/emitPublishWorkflow.ts
+++ b/generators/cli/src/emitPublishWorkflow.ts
@@ -28,7 +28,7 @@ const TARGETS: ReadonlyArray<{
  *   - **publish** job runs only on tag pushes, builds cross-platform
  *     binaries, packages each as an embedded-binary npm platform
  *     package, assembles a thin launcher package, and publishes all
- *     to npm via `secrets.NPM_TOKEN`.
+ *     to npm via OIDC or `secrets.NPM_TOKEN`.
  *
  * The embedded-binary packaging model (the esbuild/swc pattern) means
  * the binary bytes live *inside* the npm tarball. This decouples
@@ -195,16 +195,27 @@ ${matrixIncludes}
           PKGJSON
 
           cd "\${PKG_DIR}"
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "\$@"
+          }
           # Pre-release detection — require the semver "-" separator so a
           # release tag like v1.0.0 for a package whose version string
           # happens to contain "alpha"/"beta" as a substring isn't
           # mis-tagged on npm.
           if [[ "\${VERSION}" == *-alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ "\${VERSION}" == *-beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            PKG_NAME=\$(node -p "require('./package.json').name")
+            PKG_VERSION=\$(node -p "require('./package.json').version")
+            CURRENT_LATEST=\$(npm view "\${PKG_NAME}" dist-tags.latest 2>/dev/null || echo "0.0.0")
+            if npx -y semver "\${PKG_VERSION}" -r "<\${CURRENT_LATEST}" > /dev/null 2>&1; then
+              echo "Publishing \${PKG_VERSION} with --tag backport (current latest is \${CURRENT_LATEST})"
+              publish --access public --tag backport
+            else
+              publish --access public
+            fi
           fi
 
   publish-launcher:
@@ -284,16 +295,27 @@ ${launcherPlatformEntries}
           LAUNCHER
 
           cd "\${PKG_DIR}"
+          publish() {  # use latest npm to ensure OIDC support
+            npx -y npm@latest publish "\$@"
+          }
           # Pre-release detection — require the semver "-" separator so a
           # release tag like v1.0.0 for a package whose version string
           # happens to contain "alpha"/"beta" as a substring isn't
           # mis-tagged on npm.
           if [[ "\${VERSION}" == *-alpha* ]]; then
-            npm publish --access public --tag alpha
+            publish --access public --tag alpha
           elif [[ "\${VERSION}" == *-beta* ]]; then
-            npm publish --access public --tag beta
+            publish --access public --tag beta
           else
-            npm publish --access public
+            PKG_NAME=\$(node -p "require('./package.json').name")
+            PKG_VERSION=\$(node -p "require('./package.json').version")
+            CURRENT_LATEST=\$(npm view "\${PKG_NAME}" dist-tags.latest 2>/dev/null || echo "0.0.0")
+            if npx -y semver "\${PKG_VERSION}" -r "<\${CURRENT_LATEST}" > /dev/null 2>&1; then
+              echo "Publishing \${PKG_VERSION} with --tag backport (current latest is \${CURRENT_LATEST})"
+              publish --access public --tag backport
+            else
+              publish --access public
+            fi
           fi
 `;
 }


### PR DESCRIPTION
## Description

Overhauls the CLI generator's emitted `.github/workflows/ci.yml` to match the manual fixes needed for actual publishing to work. Integrates all changes from the hand-patched diff into the generator template so future `fern generate` runs produce a correct workflow out of the box.

## Changes Made

- **`npx -y npm@latest publish`**: Both publish steps (platform packages + launcher) now use a `publish()` shell helper wrapping `npx -y npm@latest publish "$@"` — ensures the latest npm with full OIDC support
- **Backport tag detection**: Stable releases check `dist-tags.latest` on npm; if the version being published is older, it publishes with `--tag backport` instead of overwriting `latest`
- **Linux: glibc → musl**: `x86_64-unknown-linux-gnu` → `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-gnu` → `aarch64-unknown-linux-musl` — produces fully static binaries with no runtime glibc/OpenSSL dependency
- **Native ARM builds**: `aarch64` runner changed from `ubuntu-latest` (cross-compile) to `ubuntu-24.04-arm` (native build)
- **musl-tools + rustls**: Cross-compilation step replaced with `musl-tools` install; musl targets build with `--no-default-features --features rustls` for static TLS
- **Action version bumps**: `actions/checkout@v4` → `@v6`, `actions/setup-node@v4` → `@v6`

## Testing

- [x] Unit tests added/updated (100/100 passing — 3 new tests for musl, action versions, rustls)
- [x] `pnpm format` clean

Link to Devin session: https://app.devin.ai/sessions/d1c69f81d9e6467eab851847dfec29ea
Requested by: @jsklan