### PR TITLE
fix(php): fix multiple PHP generator bugs and remove 13 allowedFailures

### DIFF
--- a/generators/php/base/src/asIs/Client/HttpMethod.Template.php
+++ b/generators/php/base/src/asIs/Client/HttpMethod.Template.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/generators/php/base/src/context/AbstractPhpGeneratorContext.ts
+++ b/generators/php/base/src/context/AbstractPhpGeneratorContext.ts
@@ -427,7 +427,25 @@ export abstract class AbstractPhpGeneratorContext<
     }
 
     public hasToJsonMethod(typeReference: FernIr.TypeReference): boolean {
-        return typeReference.type === "named" && !this.isPrimitive(typeReference) && !this.isEnum(typeReference);
+        return (
+            typeReference.type === "named" &&
+            !this.isPrimitive(typeReference) &&
+            !this.isEnum(typeReference) &&
+            !this.isLiteral(typeReference)
+        );
+    }
+
+    public isLiteral(typeReference: FernIr.TypeReference): boolean {
+        if (typeReference.type === "container" && typeReference.container.type === "literal") {
+            return true;
+        }
+        if (typeReference.type === "named") {
+            const declaration = this.getTypeDeclarationOrThrow(typeReference.typeId);
+            if (declaration.shape.type === "alias") {
+                return this.isLiteral(declaration.shape.aliasOf);
+            }
+        }
+        return false;
     }
 
     public isEnum(typeReference: FernIr.TypeReference): boolean {

--- a/generators/php/codegen/src/ast/ClassReference.ts
+++ b/generators/php/codegen/src/ast/ClassReference.ts
@@ -1,4 +1,5 @@
 import { AstNode } from "./core/AstNode.js";
+import { GLOBAL_NAMESPACE } from "./core/Constant.js";
 import { Writer } from "./core/Writer.js";
 import { Type } from "./Type.js";
 
@@ -32,7 +33,11 @@ export class ClassReference extends AstNode {
 
     public write(writer: Writer): void {
         writer.addReference(this);
-        const refString = this.fullyQualified ? `\\${this.namespace}\\${this.name}` : this.name;
+        const refString = this.fullyQualified
+            ? this.namespace === GLOBAL_NAMESPACE
+                ? `\\${this.name}`
+                : `\\${this.namespace}\\${this.name}`
+            : this.name;
         writer.write(`${refString}`);
     }
 }

--- a/generators/php/model/src/union/UnionGenerator.ts
+++ b/generators/php/model/src/union/UnionGenerator.ts
@@ -299,7 +299,7 @@ export class UnionGenerator extends FileGenerator<PhpFile, ModelCustomConfigSche
             case "samePropertiesAsObject":
                 return php.Type.reference(this.context.phpTypeMapper.convertToClassReference(variant.shape));
             case "singleProperty":
-                return this.context.phpTypeMapper.convert({ reference: variant.shape.type });
+                return this.context.phpTypeMapper.convert({ reference: variant.shape.type, preserveEnums: true });
             case "noProperties":
                 return php.Type.null();
             default:

--- a/generators/php/sdk/changes/unreleased/fix-php-seed-failures.yml
+++ b/generators/php/sdk/changes/unreleased/fix-php-seed-failures.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix multiple PHP generator bugs: add missing HEAD enum case, fix fully-qualified
+    exception class references, use preserveEnums for union return types, fix required
+    parameter ordering after optional parameters, prevent toJson on literal types, cast
+    boolean header values to strings, and fix basic-auth null checks when env vars are set.
+  type: fix

--- a/generators/php/sdk/src/endpoint/AbstractEndpointGenerator.ts
+++ b/generators/php/sdk/src/endpoint/AbstractEndpointGenerator.ts
@@ -29,8 +29,13 @@ export abstract class AbstractEndpointGenerator {
         const { pathParameters, pathParameterReferences } = this.getAllPathParameters({ serviceId, endpoint });
         const request = getEndpointRequest({ context: this.context, endpoint, serviceId, service });
         const requestParameter = request != null ? this.getRequestParameter({ request }) : undefined;
+        // Sort parameters so required params (no initializer) come before optional params (with initializer).
+        // PHP requires this ordering to avoid "required parameter follows optional parameter" errors.
+        const allParams = [...pathParameters, requestParameter].filter((p): p is php.Parameter => p != null);
+        const requiredParams = allParams.filter((p) => p.initializer == null);
+        const optionalParams = allParams.filter((p) => p.initializer != null);
         return {
-            baseParameters: [...pathParameters, requestParameter].filter((p): p is php.Parameter => p != null),
+            baseParameters: [...requiredParams, ...optionalParams],
             pathParameters,
             pathParameterReferences,
             request,

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -387,15 +387,16 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                 if (resolvedBasicAuthSchemes.length > 0) {
                     const isAuthOptional = !this.context.ir.sdkConfig.isAuthMandatory;
                     const needsControlFlow = isAuthOptional || resolvedBasicAuthSchemes.length > 1;
-                    for (let i = 0; i < resolvedBasicAuthSchemes.length; i++) {
-                        const resolved = resolvedBasicAuthSchemes[i];
+                    let hasWrittenIf = false;
+                    for (const resolved of resolvedBasicAuthSchemes) {
                         if (resolved == null) {
                             continue;
                         }
                         const { condition, credentialExpr } = resolved;
                         const hasCondition = needsControlFlow && condition.length > 0;
                         if (hasCondition) {
-                            writer.controlFlow(i === 0 ? "if" : "else if", php.codeblock(condition));
+                            writer.controlFlow(hasWrittenIf ? "else if" : "if", php.codeblock(condition));
+                            hasWrittenIf = true;
                         }
                         writer.writeLine(
                             `$defaultHeaders['Authorization'] = "Basic " . base64_encode(${credentialExpr});`

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -366,9 +366,13 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                     if (param.header != null) {
                         writer.controlFlow("if", php.codeblock(`$${param.name} != null`));
                         writer.write(`$defaultHeaders['${param.header.name}'] = `);
-                        writer.writeNodeStatement(
-                            this.getHeaderValue({ prefix: param.header.prefix, parameterName: param.name })
-                        );
+                        if (param.value.type === "boolean") {
+                            writer.writeTextStatement(`$${param.name} ? 'true' : 'false'`);
+                        } else {
+                            writer.writeNodeStatement(
+                                this.getHeaderValue({ prefix: param.header.prefix, parameterName: param.name })
+                            );
+                        }
                         writer.endControlFlow();
                     }
                 }
@@ -389,13 +393,14 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                             continue;
                         }
                         const { condition, credentialExpr } = resolved;
-                        if (needsControlFlow) {
+                        const hasCondition = needsControlFlow && condition.length > 0;
+                        if (hasCondition) {
                             writer.controlFlow(i === 0 ? "if" : "else if", php.codeblock(condition));
                         }
                         writer.writeLine(
                             `$defaultHeaders['Authorization'] = "Basic " . base64_encode(${credentialExpr});`
                         );
-                        if (needsControlFlow) {
+                        if (hasCondition) {
                             writer.endControlFlow();
                         }
                     }
@@ -685,7 +690,7 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                 }
                 const oauthConfig = scheme.configuration;
                 if (oauthConfig.type === "clientCredentials") {
-                    return [
+                    const params: ConstructorParameter[] = [
                         {
                             name: "clientId",
                             docs: "The client ID for OAuth authentication.",
@@ -709,6 +714,7 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                             environmentVariable: oauthConfig.clientSecretEnvVar
                         }
                     ];
+                    return params;
                 }
                 // Fallback to the default bearer token scheme for other OAuth types
                 const name = "token";
@@ -811,11 +817,13 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
             return undefined;
         }
 
+        // Only add null-check conditions for params without environment variable fallbacks.
+        // Params with env vars are guaranteed non-null after the ??= getFromEnvOrThrow assignment.
         const conditions: string[] = [];
-        if (!usernameOmitted) {
+        if (!usernameOmitted && scheme.usernameEnvVar == null) {
             conditions.push(`$${usernameName} !== null`);
         }
-        if (!passwordOmitted) {
+        if (!passwordOmitted && scheme.passwordEnvVar == null) {
             conditions.push(`$${passwordName} !== null`);
         }
 
@@ -877,7 +885,10 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
 
         writer.write("$this->oauthTokenProvider = new ");
         writer.writeNode(oauthTokenProviderClassReference);
-        writer.writeLine("($clientId ?? '', $clientSecret ?? '', $authClient);");
+        const clientIdFallback = oauth.configuration.clientIdEnvVar != null ? "$clientId" : "$clientId ?? ''";
+        const clientSecretFallback =
+            oauth.configuration.clientSecretEnvVar != null ? "$clientSecret" : "$clientSecret ?? ''";
+        writer.writeLine(`(${clientIdFallback}, ${clientSecretFallback}, $authClient);`);
         writer.writeLine();
     }
 

--- a/seed/php-sdk/any-auth/.fern/metadata.json
+++ b/seed/php-sdk/any-auth/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/any-auth/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/any-auth/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/any-auth/src/SeedClient.php
+++ b/seed/php-sdk/any-auth/src/SeedClient.php
@@ -78,9 +78,7 @@ class SeedClient
             'X-Fern-SDK-Version' => '0.0.1',
             'User-Agent' => 'seed/seed/0.0.1',
         ];
-        if ($username !== null && $password !== null) {
-            $defaultHeaders['Authorization'] = "Basic " . base64_encode($username . ":" . $password);
-        }
+        $defaultHeaders['Authorization'] = "Basic " . base64_encode($username . ":" . $password);
 
         $this->options = $options ?? [];
 

--- a/seed/php-sdk/api-wide-base-path-with-default/.fern/metadata.json
+++ b/seed/php-sdk/api-wide-base-path-with-default/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/api-wide-base-path-with-default/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/api-wide-base-path-with-default/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/api-wide-base-path-with-default/src/Widgets/WidgetsClient.php
+++ b/seed/php-sdk/api-wide-base-path-with-default/src/Widgets/WidgetsClient.php
@@ -49,8 +49,8 @@ class WidgetsClient
     }
 
     /**
-     * @param string $apiVersion
      * @param Widget $request
+     * @param string $apiVersion
      * @param ?array{
      *   baseUrl?: string,
      *   maxRetries?: int,
@@ -63,7 +63,7 @@ class WidgetsClient
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function create(string $apiVersion = 'v1beta', Widget $request, ?array $options = null): ?Widget
+    public function create(Widget $request, string $apiVersion = 'v1beta', ?array $options = null): ?Widget
     {
         $options = array_merge($this->options, $options ?? []);
         try {

--- a/seed/php-sdk/bytes-upload/.fern/metadata.json
+++ b/seed/php-sdk/bytes-upload/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/bytes-upload/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/bytes-upload/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/php-sdk/circular-references-advanced/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/circular-references-advanced/src/Ast/Types/FieldValue.php
+++ b/seed/php-sdk/circular-references-advanced/src/Ast/Types/FieldValue.php
@@ -19,7 +19,7 @@ class FieldValue extends JsonSerializableType
 
     /**
      * @var (
-     *    value-of<PrimitiveValue>
+     *    PrimitiveValue
      *   |ObjectValue
      *   |ContainerValue
      *   |mixed
@@ -36,7 +36,7 @@ class FieldValue extends JsonSerializableType
      *   |'_unknown'
      * ),
      *   value: (
-     *    value-of<PrimitiveValue>
+     *    PrimitiveValue
      *   |ObjectValue
      *   |ContainerValue
      *   |mixed
@@ -51,10 +51,10 @@ class FieldValue extends JsonSerializableType
     }
 
     /**
-     * @param value-of<PrimitiveValue> $primitiveValue
+     * @param PrimitiveValue $primitiveValue
      * @return FieldValue
      */
-    public static function primitiveValue(string $primitiveValue): FieldValue
+    public static function primitiveValue(PrimitiveValue $primitiveValue): FieldValue
     {
         return new FieldValue([
             'type' => 'primitive_value',
@@ -95,9 +95,9 @@ class FieldValue extends JsonSerializableType
     }
 
     /**
-     * @return value-of<PrimitiveValue>
+     * @return PrimitiveValue
      */
-    public function asPrimitiveValue(): string
+    public function asPrimitiveValue(): PrimitiveValue
     {
         if (!($this->value instanceof PrimitiveValue && $this->type === 'primitive_value')) {
             throw new Exception(
@@ -173,7 +173,7 @@ class FieldValue extends JsonSerializableType
 
         switch ($this->type) {
             case 'primitive_value':
-                $value = $this->value;
+                $value = $this->asPrimitiveValue()->jsonSerialize();
                 $result['primitive_value'] = $value;
                 break;
             case 'object_value':
@@ -227,7 +227,12 @@ class FieldValue extends JsonSerializableType
                     );
                 }
 
-                $args['value'] = $data['primitive_value'];
+                if (!(is_array($data['primitive_value']))) {
+                    throw new Exception(
+                        "Expected property 'primitiveValue' in JSON data to be array, instead received " . get_debug_type($data['primitive_value']),
+                    );
+                }
+                $args['value'] = PrimitiveValue::jsonDeserialize($data['primitive_value']);
                 break;
             case 'object_value':
                 $args['value'] = ObjectValue::jsonDeserialize($data);

--- a/seed/php-sdk/circular-references-advanced/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/circular-references-advanced/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/circular-references/.fern/metadata.json
+++ b/seed/php-sdk/circular-references/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/circular-references/src/Ast/Types/FieldValue.php
+++ b/seed/php-sdk/circular-references/src/Ast/Types/FieldValue.php
@@ -19,7 +19,7 @@ class FieldValue extends JsonSerializableType
 
     /**
      * @var (
-     *    value-of<PrimitiveValue>
+     *    PrimitiveValue
      *   |ObjectValue
      *   |ContainerValue
      *   |mixed
@@ -36,7 +36,7 @@ class FieldValue extends JsonSerializableType
      *   |'_unknown'
      * ),
      *   value: (
-     *    value-of<PrimitiveValue>
+     *    PrimitiveValue
      *   |ObjectValue
      *   |ContainerValue
      *   |mixed
@@ -51,10 +51,10 @@ class FieldValue extends JsonSerializableType
     }
 
     /**
-     * @param value-of<PrimitiveValue> $primitiveValue
+     * @param PrimitiveValue $primitiveValue
      * @return FieldValue
      */
-    public static function primitiveValue(string $primitiveValue): FieldValue
+    public static function primitiveValue(PrimitiveValue $primitiveValue): FieldValue
     {
         return new FieldValue([
             'type' => 'primitive_value',
@@ -95,9 +95,9 @@ class FieldValue extends JsonSerializableType
     }
 
     /**
-     * @return value-of<PrimitiveValue>
+     * @return PrimitiveValue
      */
-    public function asPrimitiveValue(): string
+    public function asPrimitiveValue(): PrimitiveValue
     {
         if (!($this->value instanceof PrimitiveValue && $this->type === 'primitive_value')) {
             throw new Exception(
@@ -173,7 +173,7 @@ class FieldValue extends JsonSerializableType
 
         switch ($this->type) {
             case 'primitive_value':
-                $value = $this->value;
+                $value = $this->asPrimitiveValue()->jsonSerialize();
                 $result['primitive_value'] = $value;
                 break;
             case 'object_value':
@@ -227,7 +227,12 @@ class FieldValue extends JsonSerializableType
                     );
                 }
 
-                $args['value'] = $data['primitive_value'];
+                if (!(is_array($data['primitive_value']))) {
+                    throw new Exception(
+                        "Expected property 'primitiveValue' in JSON data to be array, instead received " . get_debug_type($data['primitive_value']),
+                    );
+                }
+                $args['value'] = PrimitiveValue::jsonDeserialize($data['primitive_value']);
                 break;
             case 'object_value':
                 $args['value'] = ObjectValue::jsonDeserialize($data);

--- a/seed/php-sdk/circular-references/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/circular-references/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/endpoint-security-auth/.fern/metadata.json
+++ b/seed/php-sdk/endpoint-security-auth/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/endpoint-security-auth/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/endpoint-security-auth/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/endpoint-security-auth/src/SeedClient.php
+++ b/seed/php-sdk/endpoint-security-auth/src/SeedClient.php
@@ -78,9 +78,7 @@ class SeedClient
             'X-Fern-SDK-Version' => '0.0.1',
             'User-Agent' => 'seed/seed/0.0.1',
         ];
-        if ($username !== null && $password !== null) {
-            $defaultHeaders['Authorization'] = "Basic " . base64_encode($username . ":" . $password);
-        }
+        $defaultHeaders['Authorization'] = "Basic " . base64_encode($username . ":" . $password);
 
         $this->options = $options ?? [];
 

--- a/seed/php-sdk/examples/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/examples/no-custom-config/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/examples/no-custom-config/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/examples/no-custom-config/src/Types/Types/Exception.php
+++ b/seed/php-sdk/examples/no-custom-config/src/Types/Types/Exception.php
@@ -40,16 +40,17 @@ class Exception extends JsonSerializableType
      */
     private function __construct(
         array $values,
-    )
-    {
-        $this->type = $values['type'];$this->value = $values['value'];
+    ) {
+        $this->type = $values['type'];
+        $this->value = $values['value'];
     }
 
     /**
      * @param ExceptionInfo $generic
      * @return Exception
      */
-    public static function generic(ExceptionInfo $generic): Exception {
+    public static function generic(ExceptionInfo $generic): Exception
+    {
         return new Exception([
             'type' => 'generic',
             'value' => $generic,
@@ -59,7 +60,8 @@ class Exception extends JsonSerializableType
     /**
      * @return Exception
      */
-    public static function timeout(): Exception {
+    public static function timeout(): Exception
+    {
         return new Exception([
             'type' => 'timeout',
             'value' => null,
@@ -69,48 +71,53 @@ class Exception extends JsonSerializableType
     /**
      * @return bool
      */
-    public function isGeneric(): bool {
-        return $this->value instanceof ExceptionInfo&& $this->type === 'generic';
+    public function isGeneric(): bool
+    {
+        return $this->value instanceof ExceptionInfo && $this->type === 'generic';
     }
 
     /**
      * @return ExceptionInfo
      */
-    public function asGeneric(): ExceptionInfo {
-        if (!($this->value instanceof ExceptionInfo&& $this->type === 'generic')){
-            throw new \\Exception(
+    public function asGeneric(): ExceptionInfo
+    {
+        if (!($this->value instanceof ExceptionInfo && $this->type === 'generic')) {
+            throw new \Exception(
                 "Expected generic; got " . $this->type . " with value of type " . get_debug_type($this->value),
             );
         }
-        
+
         return $this->value;
     }
 
     /**
      * @return bool
      */
-    public function isTimeout(): bool {
-        return is_null($this->value)&& $this->type === 'timeout';
+    public function isTimeout(): bool
+    {
+        return is_null($this->value) && $this->type === 'timeout';
     }
 
     /**
      * @return string
      */
-    public function __toString(): string {
+    public function __toString(): string
+    {
         return $this->toJson();
     }
 
     /**
      * @return array<mixed>
      */
-    public function jsonSerialize(): array {
+    public function jsonSerialize(): array
+    {
         $result = [];
         $result['type'] = $this->type;
-        
+
         $base = parent::jsonSerialize();
         $result = array_merge($base, $result);
-        
-        switch ($this->type){
+
+        switch ($this->type) {
             case 'generic':
                 $value = $this->asGeneric()->jsonSerialize();
                 $result = array_merge($value, $result);
@@ -120,39 +127,40 @@ class Exception extends JsonSerializableType
                 break;
             case '_unknown':
             default:
-                if (is_null($this->value)){
+                if (is_null($this->value)) {
                     break;
                 }
-                if ($this->value instanceof JsonSerializableType){
+                if ($this->value instanceof JsonSerializableType) {
                     $value = $this->value->jsonSerialize();
                     $result = array_merge($value, $result);
-                } elseif (is_array($this->value)){
+                } elseif (is_array($this->value)) {
                     $result = array_merge($this->value, $result);
                 }
         }
-        
+
         return $result;
     }
 
     /**
      * @param array<string, mixed> $data
      */
-    public static function jsonDeserialize(array $data): static {
+    public static function jsonDeserialize(array $data): static
+    {
         $args = [];
-        if (!array_key_exists('type', $data)){
-            throw new \\Exception(
+        if (!array_key_exists('type', $data)) {
+            throw new \Exception(
                 "JSON data is missing property 'type'",
             );
         }
         $type = $data['type'];
-        if (!(is_string($type))){
-            throw new \\Exception(
+        if (!(is_string($type))) {
+            throw new \Exception(
                 "Expected property 'type' in JSON data to be string, instead received " . get_debug_type($data['type']),
             );
         }
-        
+
         $args['type'] = $type;
-        switch ($type){
+        switch ($type) {
             case 'generic':
                 $args['value'] = ExceptionInfo::jsonDeserialize($data);
                 break;
@@ -164,7 +172,7 @@ class Exception extends JsonSerializableType
                 $args['type'] = '_unknown';
                 $args['value'] = $data;
         }
-        
+
         // @phpstan-ignore-next-line
         return new static($args);
     }

--- a/seed/php-sdk/examples/readme-config/.fern/metadata.json
+++ b/seed/php-sdk/examples/readme-config/.fern/metadata.json
@@ -16,8 +16,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/examples/readme-config/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/examples/readme-config/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/examples/readme-config/src/Types/Types/Exception.php
+++ b/seed/php-sdk/examples/readme-config/src/Types/Types/Exception.php
@@ -40,16 +40,17 @@ class Exception extends JsonSerializableType
      */
     private function __construct(
         array $values,
-    )
-    {
-        $this->type = $values['type'];$this->value = $values['value'];
+    ) {
+        $this->type = $values['type'];
+        $this->value = $values['value'];
     }
 
     /**
      * @param ExceptionInfo $generic
      * @return Exception
      */
-    public static function generic(ExceptionInfo $generic): Exception {
+    public static function generic(ExceptionInfo $generic): Exception
+    {
         return new Exception([
             'type' => 'generic',
             'value' => $generic,
@@ -59,7 +60,8 @@ class Exception extends JsonSerializableType
     /**
      * @return Exception
      */
-    public static function timeout(): Exception {
+    public static function timeout(): Exception
+    {
         return new Exception([
             'type' => 'timeout',
             'value' => null,
@@ -69,48 +71,53 @@ class Exception extends JsonSerializableType
     /**
      * @return bool
      */
-    public function isGeneric(): bool {
-        return $this->value instanceof ExceptionInfo&& $this->type === 'generic';
+    public function isGeneric(): bool
+    {
+        return $this->value instanceof ExceptionInfo && $this->type === 'generic';
     }
 
     /**
      * @return ExceptionInfo
      */
-    public function asGeneric(): ExceptionInfo {
-        if (!($this->value instanceof ExceptionInfo&& $this->type === 'generic')){
-            throw new \\Exception(
+    public function asGeneric(): ExceptionInfo
+    {
+        if (!($this->value instanceof ExceptionInfo && $this->type === 'generic')) {
+            throw new \Exception(
                 "Expected generic; got " . $this->type . " with value of type " . get_debug_type($this->value),
             );
         }
-        
+
         return $this->value;
     }
 
     /**
      * @return bool
      */
-    public function isTimeout(): bool {
-        return is_null($this->value)&& $this->type === 'timeout';
+    public function isTimeout(): bool
+    {
+        return is_null($this->value) && $this->type === 'timeout';
     }
 
     /**
      * @return string
      */
-    public function __toString(): string {
+    public function __toString(): string
+    {
         return $this->toJson();
     }
 
     /**
      * @return array<mixed>
      */
-    public function jsonSerialize(): array {
+    public function jsonSerialize(): array
+    {
         $result = [];
         $result['type'] = $this->type;
-        
+
         $base = parent::jsonSerialize();
         $result = array_merge($base, $result);
-        
-        switch ($this->type){
+
+        switch ($this->type) {
             case 'generic':
                 $value = $this->asGeneric()->jsonSerialize();
                 $result = array_merge($value, $result);
@@ -120,39 +127,40 @@ class Exception extends JsonSerializableType
                 break;
             case '_unknown':
             default:
-                if (is_null($this->value)){
+                if (is_null($this->value)) {
                     break;
                 }
-                if ($this->value instanceof JsonSerializableType){
+                if ($this->value instanceof JsonSerializableType) {
                     $value = $this->value->jsonSerialize();
                     $result = array_merge($value, $result);
-                } elseif (is_array($this->value)){
+                } elseif (is_array($this->value)) {
                     $result = array_merge($this->value, $result);
                 }
         }
-        
+
         return $result;
     }
 
     /**
      * @param array<string, mixed> $data
      */
-    public static function jsonDeserialize(array $data): static {
+    public static function jsonDeserialize(array $data): static
+    {
         $args = [];
-        if (!array_key_exists('type', $data)){
-            throw new \\Exception(
+        if (!array_key_exists('type', $data)) {
+            throw new \Exception(
                 "JSON data is missing property 'type'",
             );
         }
         $type = $data['type'];
-        if (!(is_string($type))){
-            throw new \\Exception(
+        if (!(is_string($type))) {
+            throw new \Exception(
                 "Expected property 'type' in JSON data to be string, instead received " . get_debug_type($data['type']),
             );
         }
-        
+
         $args['type'] = $type;
-        switch ($type){
+        switch ($type) {
             case 'generic':
                 $args['value'] = ExceptionInfo::jsonDeserialize($data);
                 break;
@@ -164,7 +172,7 @@ class Exception extends JsonSerializableType
                 $args['type'] = '_unknown';
                 $args['value'] = $data;
         }
-        
+
         // @phpstan-ignore-next-line
         return new static($args);
     }

--- a/seed/php-sdk/exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/exhaustive/no-custom-config/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/exhaustive/wire-tests/.fern/metadata.json
+++ b/seed/php-sdk/exhaustive/wire-tests/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/exhaustive/wire-tests/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/file-upload/.fern/metadata.json
+++ b/seed/php-sdk/file-upload/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/file-upload/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/file-upload/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/file-upload/src/Service/ServiceClient.php
+++ b/seed/php-sdk/file-upload/src/Service/ServiceClient.php
@@ -762,7 +762,7 @@ class ServiceClient
         $body = new MultipartFormData();
         $body->addPart($request->file->toMultipartFormDataPart('file'));
         if ($request->modelType != null) {
-            $body->add(name: 'model_type', value: $request->modelType->toJson());
+            $body->add(name: 'model_type', value: $request->modelType);
         }
         if ($request->openEnum != null) {
             $body->add(name: 'open_enum', value: $request->openEnum);

--- a/seed/php-sdk/header-auth-environment-variable/.fern/metadata.json
+++ b/seed/php-sdk/header-auth-environment-variable/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/header-auth-environment-variable/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/header-auth-environment-variable/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/http-head/.fern/metadata.json
+++ b/seed/php-sdk/http-head/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/http-head/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/http-head/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/inferred-auth-implicit-reference/.fern/metadata.json
+++ b/seed/php-sdk/inferred-auth-implicit-reference/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/inferred-auth-implicit-reference/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/inferred-auth-implicit/.fern/metadata.json
+++ b/seed/php-sdk/inferred-auth-implicit/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/inferred-auth-implicit/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/inferred-auth-implicit/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/literal/.fern/metadata.json
+++ b/seed/php-sdk/literal/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/literal/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/literal/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/literal/src/SeedClient.php
+++ b/seed/php-sdk/literal/src/SeedClient.php
@@ -81,7 +81,7 @@ class SeedClient
             $defaultHeaders['X-API-Version'] = $version;
         }
         if ($auditLogging != null) {
-            $defaultHeaders['X-API-Enable-Audit-Logging'] = $auditLogging;
+            $defaultHeaders['X-API-Enable-Audit-Logging'] = $auditLogging ? 'true' : 'false';
         }
 
         $this->options = $options ?? [];

--- a/seed/php-sdk/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-custom/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-custom/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/oauth-client-credentials-custom/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-default/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-default/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/oauth-client-credentials-default/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/src/SeedClient.php
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/src/SeedClient.php
@@ -83,7 +83,7 @@ class SeedClient
 
         $authRawClient = new RawClient(['headers' => []]);
         $authClient = new AuthClient($authRawClient);
-        $this->oauthTokenProvider = new OAuthTokenProvider($clientId ?? '', $clientSecret ?? '', $authClient);
+        $this->oauthTokenProvider = new OAuthTokenProvider($clientId, $clientSecret, $authClient);
 
         $this->options['headers'] = array_merge(
             $defaultHeaders,

--- a/seed/php-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/oauth-client-credentials-nested-root/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-reference/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-reference/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/oauth-client-credentials-reference/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/oauth-client-credentials-with-variables/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/oauth-client-credentials/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/oauth-client-credentials/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/pagination-custom/.fern/metadata.json
+++ b/seed/php-sdk/pagination-custom/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/pagination-custom/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/pagination-custom/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/pagination/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/pagination/no-custom-config/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/pagination/no-custom-config/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/pagination/no-custom-config/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/pagination/property-accessors/.fern/metadata.json
+++ b/seed/php-sdk/pagination/property-accessors/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/pagination/property-accessors/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/pagination/property-accessors/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -182,52 +182,29 @@ scripts:
       test:
         - composer test
 allowedFailures:
+  # Dynamic snippet issues (wrong types, missing args, syntax errors in generated snippets).
   - api-wide-base-path-with-default
   - exhaustive:no-custom-config
   - exhaustive:wire-tests
-  - pagination-custom
-  - endpoint-security-auth
-  - inferred-auth-implicit
-  - inferred-auth-implicit-reference
-  # Dynamic snippets need to add support for global headers included in the client constructor.
-  - header-auth-environment-variable
-  # TODO: Add support for bytes upload.
   - bytes-upload
-  # Basic auth wire-tests are enabled in fixtures section.
-  # Generating a union called "Exception" makes our references to Exception throws be escaped incorrectly
+  - variables
+  - oauth-client-credentials-with-variables
+  # Dynamic snippet syntax errors for examples with Exception-named types.
   - examples:no-custom-config
   - examples:readme-config
+  # Union serialization: jsonSerialize/jsonDeserialize called on enum types.
   - trace
   - circular-references
   - circular-references-advanced
-  # Add support for literals and confirm that string literal examples are being generated.
+  # Literal header: ternary condition always true.
   - literal
-  # Add support for OAuth.
-  - oauth-client-credentials
+  # OAuth/InferredAuth custom properties need non-literal property passthrough.
   - oauth-client-credentials-custom
-  - oauth-client-credentials-default
-  - oauth-client-credentials-environment-variables
-  - oauth-client-credentials-nested-root
   - oauth-client-credentials-reference
-  # Pagination example values come through as floats instead of integers (e.g. 1.1 instead of 1).
-  - pagination:no-custom-config
-  - pagination:property-accessors
-  # Fix union dynamic snippets (i.e. BigUnion).
+  - inferred-auth-implicit-reference
+  # Union dynamic snippets (i.e. BigUnion).
   - unions:no-custom-config
   - unions:property-accessors
-  # Java-specific fixture for LocalDate support
   - unions-with-local-date
-  # unknown
-  - file-upload
-  - http-head
-  - oauth-client-credentials-with-variables
-  - variables
-  # Java-specific fixture for staged builder ordering
-  - java-staged-builder-ordering
-  - any-auth
-  - circular-references
-  - file-upload
-  - api-wide-base-path-with-default
-  - oauth-client-credentials-with-variables
 
 

--- a/seed/php-sdk/trace/.fern/metadata.json
+++ b/seed/php-sdk/trace/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/trace/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/trace/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/trace/src/Submission/Types/TestSubmissionStatus.php
+++ b/seed/php-sdk/trace/src/Submission/Types/TestSubmissionStatus.php
@@ -22,7 +22,7 @@ class TestSubmissionStatus extends JsonSerializableType
      * @var (
      *    null
      *   |ErrorInfo
-     *   |value-of<RunningSubmissionState>
+     *   |RunningSubmissionState
      *   |array<string, SubmissionStatusForTestCase>
      *   |mixed
      * ) $value
@@ -41,7 +41,7 @@ class TestSubmissionStatus extends JsonSerializableType
      *   value: (
      *    null
      *   |ErrorInfo
-     *   |value-of<RunningSubmissionState>
+     *   |RunningSubmissionState
      *   |array<string, SubmissionStatusForTestCase>
      *   |mixed
      * ),
@@ -78,10 +78,10 @@ class TestSubmissionStatus extends JsonSerializableType
     }
 
     /**
-     * @param value-of<RunningSubmissionState> $running
+     * @param RunningSubmissionState $running
      * @return TestSubmissionStatus
      */
-    public static function running(string $running): TestSubmissionStatus
+    public static function running(RunningSubmissionState $running): TestSubmissionStatus
     {
         return new TestSubmissionStatus([
             'type' => 'running',
@@ -140,9 +140,9 @@ class TestSubmissionStatus extends JsonSerializableType
     }
 
     /**
-     * @return value-of<RunningSubmissionState>
+     * @return RunningSubmissionState
      */
-    public function asRunning(): string
+    public function asRunning(): RunningSubmissionState
     {
         if (!($this->value instanceof RunningSubmissionState && $this->type === 'running')) {
             throw new Exception(
@@ -203,7 +203,7 @@ class TestSubmissionStatus extends JsonSerializableType
                 $result['errored'] = $value;
                 break;
             case 'running':
-                $value = $this->value;
+                $value = $this->asRunning()->jsonSerialize();
                 $result['running'] = $value;
                 break;
             case 'testCaseIdToState':
@@ -270,7 +270,12 @@ class TestSubmissionStatus extends JsonSerializableType
                     );
                 }
 
-                $args['value'] = $data['running'];
+                if (!(is_array($data['running']))) {
+                    throw new Exception(
+                        "Expected property 'running' in JSON data to be array, instead received " . get_debug_type($data['running']),
+                    );
+                }
+                $args['value'] = RunningSubmissionState::jsonDeserialize($data['running']);
                 break;
             case 'testCaseIdToState':
                 if (!array_key_exists('testCaseIdToState', $data)) {

--- a/seed/php-sdk/trace/src/Submission/Types/TestSubmissionUpdateInfo.php
+++ b/seed/php-sdk/trace/src/Submission/Types/TestSubmissionUpdateInfo.php
@@ -22,7 +22,7 @@ class TestSubmissionUpdateInfo extends JsonSerializableType
 
     /**
      * @var (
-     *    value-of<RunningSubmissionState>
+     *    RunningSubmissionState
      *   |null
      *   |ErrorInfo
      *   |GradedTestCaseUpdate
@@ -44,7 +44,7 @@ class TestSubmissionUpdateInfo extends JsonSerializableType
      *   |'_unknown'
      * ),
      *   value: (
-     *    value-of<RunningSubmissionState>
+     *    RunningSubmissionState
      *   |null
      *   |ErrorInfo
      *   |GradedTestCaseUpdate
@@ -61,10 +61,10 @@ class TestSubmissionUpdateInfo extends JsonSerializableType
     }
 
     /**
-     * @param value-of<RunningSubmissionState> $running
+     * @param RunningSubmissionState $running
      * @return TestSubmissionUpdateInfo
      */
-    public static function running(string $running): TestSubmissionUpdateInfo
+    public static function running(RunningSubmissionState $running): TestSubmissionUpdateInfo
     {
         return new TestSubmissionUpdateInfo([
             'type' => 'running',
@@ -139,9 +139,9 @@ class TestSubmissionUpdateInfo extends JsonSerializableType
     }
 
     /**
-     * @return value-of<RunningSubmissionState>
+     * @return RunningSubmissionState
      */
-    public function asRunning(): string
+    public function asRunning(): RunningSubmissionState
     {
         if (!($this->value instanceof RunningSubmissionState && $this->type === 'running')) {
             throw new Exception(
@@ -255,7 +255,7 @@ class TestSubmissionUpdateInfo extends JsonSerializableType
 
         switch ($this->type) {
             case 'running':
-                $value = $this->value;
+                $value = $this->asRunning()->jsonSerialize();
                 $result['running'] = $value;
                 break;
             case 'stopped':
@@ -319,7 +319,12 @@ class TestSubmissionUpdateInfo extends JsonSerializableType
                     );
                 }
 
-                $args['value'] = $data['running'];
+                if (!(is_array($data['running']))) {
+                    throw new Exception(
+                        "Expected property 'running' in JSON data to be array, instead received " . get_debug_type($data['running']),
+                    );
+                }
+                $args['value'] = RunningSubmissionState::jsonDeserialize($data['running']);
                 break;
             case 'stopped':
                 $args['value'] = null;

--- a/seed/php-sdk/trace/src/Submission/Types/WorkspaceSubmissionStatus.php
+++ b/seed/php-sdk/trace/src/Submission/Types/WorkspaceSubmissionStatus.php
@@ -23,7 +23,7 @@ class WorkspaceSubmissionStatus extends JsonSerializableType
      * @var (
      *    null
      *   |ErrorInfo
-     *   |value-of<RunningSubmissionState>
+     *   |RunningSubmissionState
      *   |WorkspaceRunDetails
      *   |mixed
      * ) $value
@@ -43,7 +43,7 @@ class WorkspaceSubmissionStatus extends JsonSerializableType
      *   value: (
      *    null
      *   |ErrorInfo
-     *   |value-of<RunningSubmissionState>
+     *   |RunningSubmissionState
      *   |WorkspaceRunDetails
      *   |mixed
      * ),
@@ -80,10 +80,10 @@ class WorkspaceSubmissionStatus extends JsonSerializableType
     }
 
     /**
-     * @param value-of<RunningSubmissionState> $running
+     * @param RunningSubmissionState $running
      * @return WorkspaceSubmissionStatus
      */
-    public static function running(string $running): WorkspaceSubmissionStatus
+    public static function running(RunningSubmissionState $running): WorkspaceSubmissionStatus
     {
         return new WorkspaceSubmissionStatus([
             'type' => 'running',
@@ -154,9 +154,9 @@ class WorkspaceSubmissionStatus extends JsonSerializableType
     }
 
     /**
-     * @return value-of<RunningSubmissionState>
+     * @return RunningSubmissionState
      */
-    public function asRunning(): string
+    public function asRunning(): RunningSubmissionState
     {
         if (!($this->value instanceof RunningSubmissionState && $this->type === 'running')) {
             throw new Exception(
@@ -239,7 +239,7 @@ class WorkspaceSubmissionStatus extends JsonSerializableType
                 $result['errored'] = $value;
                 break;
             case 'running':
-                $value = $this->value;
+                $value = $this->asRunning()->jsonSerialize();
                 $result['running'] = $value;
                 break;
             case 'ran':
@@ -310,7 +310,12 @@ class WorkspaceSubmissionStatus extends JsonSerializableType
                     );
                 }
 
-                $args['value'] = $data['running'];
+                if (!(is_array($data['running']))) {
+                    throw new Exception(
+                        "Expected property 'running' in JSON data to be array, instead received " . get_debug_type($data['running']),
+                    );
+                }
+                $args['value'] = RunningSubmissionState::jsonDeserialize($data['running']);
                 break;
             case 'ran':
                 $args['value'] = WorkspaceRunDetails::jsonDeserialize($data);

--- a/seed/php-sdk/trace/src/Submission/Types/WorkspaceSubmissionUpdateInfo.php
+++ b/seed/php-sdk/trace/src/Submission/Types/WorkspaceSubmissionUpdateInfo.php
@@ -23,7 +23,7 @@ class WorkspaceSubmissionUpdateInfo extends JsonSerializableType
 
     /**
      * @var (
-     *    value-of<RunningSubmissionState>
+     *    RunningSubmissionState
      *   |WorkspaceRunDetails
      *   |null
      *   |WorkspaceTracedUpdate
@@ -46,7 +46,7 @@ class WorkspaceSubmissionUpdateInfo extends JsonSerializableType
      *   |'_unknown'
      * ),
      *   value: (
-     *    value-of<RunningSubmissionState>
+     *    RunningSubmissionState
      *   |WorkspaceRunDetails
      *   |null
      *   |WorkspaceTracedUpdate
@@ -63,10 +63,10 @@ class WorkspaceSubmissionUpdateInfo extends JsonSerializableType
     }
 
     /**
-     * @param value-of<RunningSubmissionState> $running
+     * @param RunningSubmissionState $running
      * @return WorkspaceSubmissionUpdateInfo
      */
-    public static function running(string $running): WorkspaceSubmissionUpdateInfo
+    public static function running(RunningSubmissionState $running): WorkspaceSubmissionUpdateInfo
     {
         return new WorkspaceSubmissionUpdateInfo([
             'type' => 'running',
@@ -152,9 +152,9 @@ class WorkspaceSubmissionUpdateInfo extends JsonSerializableType
     }
 
     /**
-     * @return value-of<RunningSubmissionState>
+     * @return RunningSubmissionState
      */
-    public function asRunning(): string
+    public function asRunning(): RunningSubmissionState
     {
         if (!($this->value instanceof RunningSubmissionState && $this->type === 'running')) {
             throw new Exception(
@@ -276,7 +276,7 @@ class WorkspaceSubmissionUpdateInfo extends JsonSerializableType
 
         switch ($this->type) {
             case 'running':
-                $value = $this->value;
+                $value = $this->asRunning()->jsonSerialize();
                 $result['running'] = $value;
                 break;
             case 'ran':
@@ -343,7 +343,12 @@ class WorkspaceSubmissionUpdateInfo extends JsonSerializableType
                     );
                 }
 
-                $args['value'] = $data['running'];
+                if (!(is_array($data['running']))) {
+                    throw new Exception(
+                        "Expected property 'running' in JSON data to be array, instead received " . get_debug_type($data['running']),
+                    );
+                }
+                $args['value'] = RunningSubmissionState::jsonDeserialize($data['running']);
                 break;
             case 'ran':
                 $args['value'] = WorkspaceRunDetails::jsonDeserialize($data);

--- a/seed/php-sdk/trace/src/V2/Problem/Types/CustomFiles.php
+++ b/seed/php-sdk/trace/src/V2/Problem/Types/CustomFiles.php
@@ -20,7 +20,7 @@ class CustomFiles extends JsonSerializableType
     /**
      * @var (
      *    BasicCustomFiles
-     *   |array<value-of<Language>, Files>
+     *   |array<Language, Files>
      *   |mixed
      * ) $value
      */
@@ -35,7 +35,7 @@ class CustomFiles extends JsonSerializableType
      * ),
      *   value: (
      *    BasicCustomFiles
-     *   |array<value-of<Language>, Files>
+     *   |array<Language, Files>
      *   |mixed
      * ),
      * } $values
@@ -60,7 +60,7 @@ class CustomFiles extends JsonSerializableType
     }
 
     /**
-     * @param array<value-of<Language>, Files> $custom
+     * @param array<Language, Files> $custom
      * @return CustomFiles
      */
     public static function custom(array $custom): CustomFiles
@@ -102,7 +102,7 @@ class CustomFiles extends JsonSerializableType
     }
 
     /**
-     * @return array<value-of<Language>, Files>
+     * @return array<Language, Files>
      */
     public function asCustom(): array
     {

--- a/seed/php-sdk/trace/src/V2/V3/Problem/Types/CustomFiles.php
+++ b/seed/php-sdk/trace/src/V2/V3/Problem/Types/CustomFiles.php
@@ -20,7 +20,7 @@ class CustomFiles extends JsonSerializableType
     /**
      * @var (
      *    BasicCustomFiles
-     *   |array<value-of<Language>, Files>
+     *   |array<Language, Files>
      *   |mixed
      * ) $value
      */
@@ -35,7 +35,7 @@ class CustomFiles extends JsonSerializableType
      * ),
      *   value: (
      *    BasicCustomFiles
-     *   |array<value-of<Language>, Files>
+     *   |array<Language, Files>
      *   |mixed
      * ),
      * } $values
@@ -60,7 +60,7 @@ class CustomFiles extends JsonSerializableType
     }
 
     /**
-     * @param array<value-of<Language>, Files> $custom
+     * @param array<Language, Files> $custom
      * @return CustomFiles
      */
     public static function custom(array $custom): CustomFiles
@@ -102,7 +102,7 @@ class CustomFiles extends JsonSerializableType
     }
 
     /**
-     * @return array<value-of<Language>, Files>
+     * @return array<Language, Files>
      */
     public function asCustom(): array
     {

--- a/seed/php-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/php-sdk/unions-with-local-date/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions-with-local-date/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/unions-with-local-date/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/unions/no-custom-config/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions/no-custom-config/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/unions/no-custom-config/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/unions/property-accessors/.fern/metadata.json
+++ b/seed/php-sdk/unions/property-accessors/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions/property-accessors/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/unions/property-accessors/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }

--- a/seed/php-sdk/variables/.fern/metadata.json
+++ b/seed/php-sdk/variables/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/variables/src/Core/Client/HttpMethod.php
+++ b/seed/php-sdk/variables/src/Core/Client/HttpMethod.php
@@ -9,4 +9,5 @@ enum HttpMethod
     case PUT;
     case PATCH;
     case DELETE;
+    case HEAD;
 }


### PR DESCRIPTION
## Description

Fix several PHP SDK generator bugs and remove 13 entries from `seed/php-sdk/seed.yml` `allowedFailures` (32 → 20, including deduplication of 4 repeated entries and removal of 1 invalid fixture).

## Changes Made

**Generator fixes** (6 files):
- `HttpMethod.Template.php`: Add missing `HEAD` enum case — fixes `http-head` fixture
- `ClassReference.ts`: Fix fully-qualified class reference when namespace is `GLOBAL_NAMESPACE` (`""`) — e.g. `\Exception` instead of `\\Exception`
- `UnionGenerator.ts`: Pass `preserveEnums: true` to `phpTypeMapper.convert()` so union `asX()` returns the enum class type instead of `value-of<EnumClass>`
- `AbstractEndpointGenerator.ts`: Sort endpoint parameters so required params (no initializer) come before optional params — fixes PHP "required parameter follows optional" error
- `AbstractPhpGeneratorContext.ts`: Add `isLiteral()` check in `hasToJsonMethod()` to prevent calling `toJson()` on literal string types
- `RootClientGenerator.ts`:
  - Cast boolean literal header values to `'true'`/`'false'` strings
  - Skip null-check conditions for basic-auth params backed by env vars
  - Drop `?? ''` fallback for OAuth `$clientId`/`$clientSecret` when env var guarantees non-null
  - **Fix orphaned `else if`**: Track whether an `if` block was actually written (`hasWrittenIf`) instead of relying on loop index `i === 0` — prevents generating `} else if (...)` with no preceding `if` when the first basic-auth scheme is fully env-var-backed

**Fixtures now passing** (removed from `allowedFailures`):
`http-head`, `file-upload`, `any-auth`, `pagination-custom`, `endpoint-security-auth`, `inferred-auth-implicit`, `header-auth-environment-variable`, `oauth-client-credentials`, `oauth-client-credentials-default`, `oauth-client-credentials-environment-variables`, `oauth-client-credentials-nested-root`, `pagination:no-custom-config`, `pagination:property-accessors`

Also removed invalid entry `java-staged-builder-ordering` (not a PHP fixture).

## Testing

- Ran `pnpm seed test --generator php-sdk --fixture <name>` for every fixture in `allowedFailures`
- Confirmed all 13 removed fixtures pass (generation + PHPStan + test scripts)
- Confirmed remaining 20 entries still fail (dynamic snippet issues, union serialization, OAuth custom properties)
- PHP generator packages compile cleanly via `pnpm turbo run compile --filter @fern-api/php-sdk ...`

Link to Devin session: https://app.devin.ai/sessions/cfede00e80874418a66a835d1356cb4b
Requested by: @iamnamananand996