### PR TITLE
feat(cli-generator): generate README.md in generated CLIs

### DIFF
--- a/generators/cli/changes/unreleased/add-readme-generation.yml
+++ b/generators/cli/changes/unreleased/add-readme-generation.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Generate a README.md in every generated CLI project. The README includes
+    installation, authentication, usage, output formats, configuration, and
+    shell completion sections. Customer-authored H2 sections are preserved
+    on regeneration via the existing Fern SDK README merge mechanism.
+  type: feat

--- a/generators/cli/package.json
+++ b/generators/cli/package.json
@@ -36,6 +36,7 @@
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
+    "@fern-api/generator-cli": "workspace:*",
     "@fern-fern/ir-sdk": "67.0.0",
     "@types/node": "catalog:",
     "commander": "^14.0.3",

--- a/generators/cli/src/__test__/copySpecs.test.ts
+++ b/generators/cli/src/__test__/copySpecs.test.ts
@@ -221,13 +221,17 @@ describe("copySpecs", () => {
                     '.auth_basic_scheme_username_only("ApiKeyAuth", ' +
                     'AuthCredentialSource::from_env("CLOSE_API_KEY"))',
                 placement: "binding",
-                authTypeImport: "AuthCredentialSource"
+                authTypeImport: "AuthCredentialSource",
+                envVars: ["CLOSE_API_KEY"],
+                kind: "basic"
             },
             {
                 schemeName: "OAuth2",
                 rustCall: '.auth(BearerAuth::new("OAuth2").env("CLOSE_TOKEN"))',
                 placement: "root",
-                authTypeImport: "BearerAuth"
+                authTypeImport: "BearerAuth",
+                envVars: ["CLOSE_TOKEN"],
+                kind: "bearer"
             }
         ];
         await copySpecs({ outputDir, binaryName: "close", authBindings: bindings, specsDir });
@@ -268,7 +272,9 @@ describe("copySpecs", () => {
                     schemeName: "Bearer",
                     rustCall: '.auth(BearerAuth::new("Bearer").env("ACME_TOKEN"))',
                     placement: "root",
-                    authTypeImport: "BearerAuth"
+                    authTypeImport: "BearerAuth",
+                    envVars: ["ACME_TOKEN"],
+                    kind: "bearer"
                 }
             ],
             specsDir

--- a/generators/cli/src/__test__/emitReadme.test.ts
+++ b/generators/cli/src/__test__/emitReadme.test.ts
@@ -60,10 +60,13 @@ describe("emitReadme", () => {
         expect(readme).toContain("npm install -g @petstore/cli");
         expect(readme).toContain("npx @petstore/cli --help");
         expect(readme).toContain('export PETSTORE_API_TOKEN="<your token>"');
+        expect(readme).toContain(".env");
         expect(readme).toContain("petstore-api --help");
-        expect(readme).toContain("--format json");
-        expect(readme).toContain("--base-url");
+        expect(readme).toContain("--format");
+        expect(readme).toContain("--dry-run");
         expect(readme).toContain("PETSTORE_API_BASE_URL");
+        expect(readme).toContain("PETSTORE_API_CA_BUNDLE");
+        expect(readme).toContain("PETSTORE_API_TIMEOUT_SECS");
         expect(readme).toContain("petstore-api completion <bash|zsh|fish|powershell>");
     });
 
@@ -79,7 +82,7 @@ describe("emitReadme", () => {
         });
 
         expect(readme).toContain("cargo build --release");
-        expect(readme).toContain("target/release/acme");
+        expect(readme).toContain("rustup.rs");
         expect(readme).not.toContain("npm install");
         expect(readme).not.toContain("npx");
     });
@@ -97,7 +100,6 @@ describe("emitReadme", () => {
 
         expect(readme).toContain("This API requires authentication. Run `my-api --help` for details.");
         // The Authentication section should not contain env-var export lines.
-        // (The Configuration section legitimately contains an export for BASE_URL.)
         const authSection = readme.split("## Authentication")[1]?.split("##")[0] ?? "";
         expect(authSection).not.toContain("export ");
     });
@@ -217,8 +219,9 @@ describe("emitReadme", () => {
             "## Installation",
             "## Authentication",
             "## Usage",
+            "## Common flags",
+            "## Environment variables",
             "## Output formats",
-            "## Configuration",
             "## Shell completion"
         ];
 
@@ -228,5 +231,41 @@ describe("emitReadme", () => {
             expect(idx, `${section} should appear in README`).toBeGreaterThan(lastIndex);
             lastIndex = idx;
         }
+    });
+
+    // ── Help output in Usage section ────────────────────────────────
+
+    it("renders a representative --help output in the Usage section", async () => {
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "petstore-api",
+            apiDisplayName: "Petstore",
+            authBindings: [bearerBinding],
+            npmPublishInfo
+        });
+
+        const usageSection = readme.split("## Usage")[1]?.split("## Common flags")[0] ?? "";
+        expect(usageSection).toContain("Petstore");
+        expect(usageSection).toContain("Usage: petstore-api [OPTIONS] <COMMAND>");
+        expect(usageSection).toContain("generate-skills");
+        expect(usageSection).toContain("completion");
+        expect(usageSection).toContain("--dry-run");
+        expect(usageSection).toContain("PETSTORE_API_BASE_URL");
+        expect(usageSection).toContain("PETSTORE_API_TOKEN");
+    });
+
+    // ── .env support mentioned in Authentication ────────────────────
+
+    it("mentions .env file support in Authentication when auth bindings present", async () => {
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "acme",
+            apiDisplayName: "Acme",
+            authBindings: [bearerBinding],
+            npmPublishInfo: undefined
+        });
+
+        const authSection = readme.split("## Authentication")[1]?.split("##")[0] ?? "";
+        expect(authSection).toContain(".env");
     });
 });

--- a/generators/cli/src/__test__/emitReadme.test.ts
+++ b/generators/cli/src/__test__/emitReadme.test.ts
@@ -1,0 +1,232 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { DetectedAuthBinding } from "../detectAuth.js";
+import { emitReadme } from "../emitReadme.js";
+import type { ResolvedNpmPublishInfo } from "../resolveOutputConfig.js";
+
+describe("emitReadme", () => {
+    let tmpDir: string;
+    let outputDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), "emitReadme-"));
+        outputDir = path.join(tmpDir, "out");
+        await mkdir(outputDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    async function emitAndRead(args: Parameters<typeof emitReadme>[0]): Promise<string> {
+        await emitReadme(args);
+        return readFile(path.join(args.outputDir, "README.md"), "utf-8");
+    }
+
+    // ── Fixtures ────────────────────────────────────────────────────
+
+    const npmPublishInfo: ResolvedNpmPublishInfo = {
+        packageName: "@petstore/cli",
+        registryUrl: "https://registry.npmjs.org",
+        tokenEnvironmentVariable: "NPM_TOKEN",
+        useOidc: false
+    };
+
+    const bearerBinding: DetectedAuthBinding = {
+        schemeName: "BearerAuth",
+        rustCall: '.auth(BearerAuth::new("BearerAuth").env("PETSTORE_API_TOKEN"))',
+        placement: "root",
+        authTypeImport: "BearerAuth",
+        envVars: ["PETSTORE_API_TOKEN"],
+        kind: "bearer"
+    };
+
+    // ── npm + bearer auth ───────────────────────────────────────────
+
+    it("generates a complete README with npm install and bearer auth", async () => {
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "petstore-api",
+            apiDisplayName: "Petstore",
+            authBindings: [bearerBinding],
+            npmPublishInfo
+        });
+
+        expect(readme).toContain("# Petstore CLI");
+        expect(readme).toContain("Command-line interface for the Petstore API.");
+        expect(readme).toContain("npm install -g @petstore/cli");
+        expect(readme).toContain("npx @petstore/cli --help");
+        expect(readme).toContain('export PETSTORE_API_TOKEN="<your token>"');
+        expect(readme).toContain("petstore-api --help");
+        expect(readme).toContain("--format json");
+        expect(readme).toContain("--base-url");
+        expect(readme).toContain("PETSTORE_API_BASE_URL");
+        expect(readme).toContain("petstore-api completion <bash|zsh|fish|powershell>");
+    });
+
+    // ── Build from source when npmPublishInfo absent ────────────────
+
+    it("shows build-from-source when npmPublishInfo is absent", async () => {
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "acme",
+            apiDisplayName: "Acme",
+            authBindings: [bearerBinding],
+            npmPublishInfo: undefined
+        });
+
+        expect(readme).toContain("cargo build --release");
+        expect(readme).toContain("target/release/acme");
+        expect(readme).not.toContain("npm install");
+        expect(readme).not.toContain("npx");
+    });
+
+    // ── Generic auth when no supported bindings ─────────────────────
+
+    it("shows generic auth line when there are no supported bindings", async () => {
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "my-api",
+            apiDisplayName: "My API",
+            authBindings: [],
+            npmPublishInfo: undefined
+        });
+
+        expect(readme).toContain("This API requires authentication. Run `my-api --help` for details.");
+        // The Authentication section should not contain env-var export lines.
+        // (The Configuration section legitimately contains an export for BASE_URL.)
+        const authSection = readme.split("## Authentication")[1]?.split("##")[0] ?? "";
+        expect(authSection).not.toContain("export ");
+    });
+
+    // ── apiDisplayName fallback to binaryName ───────────────────────
+
+    it("falls back to binaryName when apiDisplayName is undefined", async () => {
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "my-tool",
+            apiDisplayName: undefined,
+            authBindings: [],
+            npmPublishInfo: undefined
+        });
+
+        expect(readme).toContain("# my-tool CLI");
+        expect(readme).toContain("Command-line interface for the my-tool API.");
+    });
+
+    // ── Multiple auth bindings ──────────────────────────────────────
+
+    it("renders one env-var line per auth binding", async () => {
+        const headerBinding: DetectedAuthBinding = {
+            schemeName: "ApiKey",
+            rustCall: '.auth(ApiKeyAuth::new("ApiKey").env("ACME_API_KEY"))',
+            placement: "root",
+            authTypeImport: "ApiKeyAuth",
+            envVars: ["ACME_API_KEY"],
+            kind: "header"
+        };
+        const basicBinding: DetectedAuthBinding = {
+            schemeName: "Basic",
+            rustCall: '.auth_basic_scheme("Basic", ...)',
+            placement: "binding",
+            authTypeImport: "AuthCredentialSource",
+            envVars: ["ACME_USERNAME", "ACME_PASSWORD"],
+            kind: "basic"
+        };
+
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "acme",
+            apiDisplayName: "Acme",
+            authBindings: [headerBinding, basicBinding],
+            npmPublishInfo: undefined
+        });
+
+        expect(readme).toContain('export ACME_API_KEY="<your api key>"');
+        expect(readme).toContain('export ACME_USERNAME="<your credential>"');
+        expect(readme).toContain('export ACME_PASSWORD="<your credential>"');
+    });
+
+    // ── Merge preserves customer-added sections ─────────────────────
+
+    it("preserves a customer-added section while regenerating generated ones", async () => {
+        const existingReadme = [
+            "# Old Header",
+            "",
+            "## Installation",
+            "",
+            "Old installation content",
+            "",
+            "## Custom Section",
+            "",
+            "This is a custom section added by the user.",
+            "",
+            "## Usage",
+            "",
+            "Old usage content",
+            ""
+        ].join("\n");
+
+        await writeFile(path.join(outputDir, "README.md"), existingReadme);
+
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "acme",
+            apiDisplayName: "Acme",
+            authBindings: [],
+            npmPublishInfo: undefined
+        });
+
+        // Header is regenerated.
+        expect(readme).toContain("# Acme CLI");
+        expect(readme).not.toContain("# Old Header");
+
+        // Generated sections are updated.
+        expect(readme).toContain("## Installation");
+        expect(readme).toContain("cargo build --release");
+        expect(readme).not.toContain("Old installation content");
+
+        // Customer section is preserved.
+        expect(readme).toContain("## Custom Section");
+        expect(readme).toContain("This is a custom section added by the user.");
+
+        // Order: customer section sits between the sections that
+        // originally surrounded it.
+        const installIdx = readme.indexOf("## Installation");
+        const customIdx = readme.indexOf("## Custom Section");
+        const usageIdx = readme.indexOf("## Usage");
+        expect(customIdx).toBeGreaterThan(installIdx);
+        expect(usageIdx).toBeGreaterThan(customIdx);
+    });
+
+    // ── Section order ───────────────────────────────────────────────
+
+    it("emits sections in the specified order", async () => {
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "acme",
+            apiDisplayName: "Acme",
+            authBindings: [bearerBinding],
+            npmPublishInfo
+        });
+
+        const expectedOrder = [
+            "## Installation",
+            "## Authentication",
+            "## Usage",
+            "## Output formats",
+            "## Configuration",
+            "## Shell completion"
+        ];
+
+        let lastIndex = -1;
+        for (const section of expectedOrder) {
+            const idx = readme.indexOf(section);
+            expect(idx, `${section} should appear in README`).toBeGreaterThan(lastIndex);
+            lastIndex = idx;
+        }
+    });
+});

--- a/generators/cli/src/__test__/emitReadme.test.ts
+++ b/generators/cli/src/__test__/emitReadme.test.ts
@@ -59,6 +59,8 @@ describe("emitReadme", () => {
         expect(readme).toContain("Command-line interface for the Petstore API.");
         expect(readme).toContain("npm install -g @petstore/cli");
         expect(readme).toContain("npx @petstore/cli --help");
+        expect(readme).toContain("### Build from source");
+        expect(readme).toContain("cargo build --release");
         expect(readme).toContain('export PETSTORE_API_TOKEN="<your token>"');
         expect(readme).toContain(".env");
         expect(readme).toContain("petstore-api --help");
@@ -85,6 +87,7 @@ describe("emitReadme", () => {
         expect(readme).toContain("rustup.rs");
         expect(readme).not.toContain("npm install");
         expect(readme).not.toContain("npx");
+        expect(readme).not.toContain("### Build from source");
     });
 
     // ── Generic auth when no supported bindings ─────────────────────

--- a/generators/cli/src/detectAuth.ts
+++ b/generators/cli/src/detectAuth.ts
@@ -16,6 +16,10 @@ export interface DetectedAuthBinding {
     placement: "root" | "binding";
     /** Rust type to import from `fern_cli_sdk::auth`, if any. */
     authTypeImport: string | null;
+    /** Resolved environment variable names the user must set for this binding. */
+    envVars: string[];
+    /** Auth kind for documentation purposes. */
+    kind: "bearer" | "header" | "basic";
 }
 
 /**
@@ -62,7 +66,9 @@ function bindingForScheme(scheme: FernIr.AuthScheme, envPrefix: string): Detecte
                 schemeName: bearer.key,
                 rustCall: `.auth(BearerAuth::new("${bearer.key}").env("${env}"))`,
                 placement: "root",
-                authTypeImport: "BearerAuth"
+                authTypeImport: "BearerAuth",
+                envVars: [env],
+                kind: "bearer"
             };
         },
         header: (header) => {
@@ -71,7 +77,9 @@ function bindingForScheme(scheme: FernIr.AuthScheme, envPrefix: string): Detecte
                 schemeName: header.key,
                 rustCall: `.auth(ApiKeyAuth::new("${header.key}").env("${env}"))`,
                 placement: "root",
-                authTypeImport: "ApiKeyAuth"
+                authTypeImport: "ApiKeyAuth",
+                envVars: [env],
+                kind: "header"
             };
         },
         basic: (basic) => {
@@ -88,7 +96,9 @@ function bindingForScheme(scheme: FernIr.AuthScheme, envPrefix: string): Detecte
                     schemeName: basic.key,
                     rustCall: `.auth_provider("${basic.key}", BasicAuthProvider::username_only("${basic.key}", AuthCredentialSource::from_env("${usernameEnv}")))`,
                     placement: "binding",
-                    authTypeImport: "AuthCredentialSource, BasicAuthProvider"
+                    authTypeImport: "AuthCredentialSource, BasicAuthProvider",
+                    envVars: [usernameEnv],
+                    kind: "basic"
                 };
             }
             if (basic.usernameOmit) {
@@ -96,14 +106,18 @@ function bindingForScheme(scheme: FernIr.AuthScheme, envPrefix: string): Detecte
                     schemeName: basic.key,
                     rustCall: `.auth_provider("${basic.key}", BasicAuthProvider::password_only("${basic.key}", AuthCredentialSource::from_env("${passwordEnv}")))`,
                     placement: "binding",
-                    authTypeImport: "AuthCredentialSource, BasicAuthProvider"
+                    authTypeImport: "AuthCredentialSource, BasicAuthProvider",
+                    envVars: [passwordEnv],
+                    kind: "basic"
                 };
             }
             return {
                 schemeName: basic.key,
                 rustCall: `.auth_basic_scheme("${basic.key}", AuthCredentialSource::from_env("${usernameEnv}"), AuthCredentialSource::from_env("${passwordEnv}"))`,
                 placement: "binding",
-                authTypeImport: "AuthCredentialSource"
+                authTypeImport: "AuthCredentialSource",
+                envVars: [usernameEnv, passwordEnv],
+                kind: "basic"
             };
         },
         // The SDK doesn't yet have a runtime provider for OAuth client

--- a/generators/cli/src/emitReadme.ts
+++ b/generators/cli/src/emitReadme.ts
@@ -48,7 +48,8 @@ export async function emitReadme(args: {
 // ---------------------------------------------------------------------------
 
 function generateHeader(displayName: string): string {
-    return lines(`# ${displayName} CLI`, "", `Command-line interface for the ${displayName} API.`, "");
+    const suffix = displayName.toUpperCase().endsWith("API") ? "" : " API";
+    return lines(`# ${displayName} CLI`, "", `Command-line interface for the ${displayName}${suffix}.`, "");
 }
 
 // ---------------------------------------------------------------------------
@@ -97,6 +98,15 @@ function generateInstallation(args: { binaryName: string; npmPublishInfo: Resolv
             "",
             "```bash",
             `npx ${npmPublishInfo.packageName} --help`,
+            "```",
+            "",
+            "### Build from source",
+            "",
+            "If you prefer to build from source, install the [Rust toolchain](https://rustup.rs/) and run:",
+            "",
+            "```bash",
+            "cargo build --release",
+            `./target/release/${binaryName} --help`,
             "```",
             ""
         );

--- a/generators/cli/src/emitReadme.ts
+++ b/generators/cli/src/emitReadme.ts
@@ -33,7 +33,7 @@ export async function emitReadme(args: {
     const displayName = apiDisplayName ?? binaryName;
 
     const header = generateHeader(displayName);
-    const blocks = generateBlocks({ binaryName, authBindings, npmPublishInfo });
+    const blocks = generateBlocks({ binaryName, displayName, authBindings, npmPublishInfo });
 
     const readmePath = path.join(outputDir, "README.md");
     const existing = await readExistingReadme(readmePath);
@@ -63,16 +63,19 @@ function generateHeader(displayName: string): string {
 
 function generateBlocks(args: {
     binaryName: string;
+    displayName: string;
     authBindings: DetectedAuthBinding[];
     npmPublishInfo: ResolvedNpmPublishInfo | undefined;
 }): Block[] {
-    const { binaryName, authBindings, npmPublishInfo } = args;
+    const { binaryName, displayName, authBindings, npmPublishInfo } = args;
+    const envPrefix = toEnvVarPrefix(binaryName);
     return [
         generateInstallation({ binaryName, npmPublishInfo }),
         generateAuthentication({ binaryName, authBindings }),
-        generateUsage(binaryName),
+        generateUsage({ binaryName, displayName, envPrefix, authBindings }),
+        generateCommonFlags(binaryName),
+        generateEnvironmentVariables(envPrefix),
         generateOutputFormats(binaryName),
-        generateConfiguration(binaryName),
         generateShellCompletion(binaryName)
     ];
 }
@@ -101,13 +104,18 @@ function generateInstallation(args: { binaryName: string; npmPublishInfo: Resolv
         content = lines(
             "## Installation",
             "",
-            "Build from source:",
+            "Install the [Rust toolchain](https://rustup.rs/) if you don't have it:",
+            "",
+            "```bash",
+            'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh',
+            "```",
+            "",
+            "Then build from source:",
             "",
             "```bash",
             "cargo build --release",
+            `./target/release/${binaryName} --help`,
             "```",
-            "",
-            `The compiled binary will be available at \`target/release/${binaryName}\`.`,
             ""
         );
     }
@@ -130,7 +138,7 @@ function generateAuthentication(args: { binaryName: string; authBindings: Detect
     const envLines: string[] = [];
     for (const binding of authBindings) {
         for (const envVar of binding.envVars) {
-            envLines.push(`export ${envVar}="<your ${describeAuthKind(binding.kind)}>"`);
+            envLines.push(`export ${envVar}="${placeholderForKind(binding.kind)}"`);
         }
     }
     return new Block({
@@ -143,21 +151,92 @@ function generateAuthentication(args: { binaryName: string; authBindings: Detect
             "```bash",
             ...envLines,
             "```",
+            "",
+            "A `.env` file in the working directory is also supported — the CLI auto-loads it on startup.",
             ""
         )
     });
 }
 
-function generateUsage(binaryName: string): Block {
+function generateUsage(args: {
+    binaryName: string;
+    displayName: string;
+    envPrefix: string;
+    authBindings: DetectedAuthBinding[];
+}): Block {
+    const { binaryName, displayName, envPrefix, authBindings } = args;
+
+    const helpBlock = buildHelpOutput({ binaryName, displayName, envPrefix, authBindings });
+
     return new Block({
         id: "USAGE",
         content: lines(
             "## Usage",
             "",
-            "```bash",
-            `${binaryName} --help                 # list commands and flags`,
-            `${binaryName} --help --format json   # full machine-readable command surface`,
             "```",
+            ...helpBlock,
+            "```",
+            "",
+            "Every API resource appears as a subcommand (e.g. `" +
+                binaryName +
+                " <resource> <method>`). " +
+                "Run `" +
+                binaryName +
+                " <resource> --help` to see available methods.",
+            ""
+        )
+    });
+}
+
+function generateCommonFlags(binaryName: string): Block {
+    return new Block({
+        id: "COMMON_FLAGS",
+        content: lines(
+            "## Common flags",
+            "",
+            "These flags are available on every operation:",
+            "",
+            "| Flag | Description |",
+            "|------|-------------|",
+            "| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |",
+            "| `--json <JSON\\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |",
+            "| `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |",
+            "| `--format <json\\|table\\|yaml\\|csv>` | Output format (default `json`) |",
+            "| `--output <PATH>` | Write binary responses to a file |",
+            "| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |",
+            "| `--page-all` | Auto-paginate and stream results as NDJSON |",
+            "| `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |",
+            "| `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |",
+            "",
+            "### Dry run",
+            "",
+            "The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. " +
+                "This is particularly valuable for AI agent integration — agents can validate their intent " +
+                "before committing to a write operation:",
+            "",
+            "```bash",
+            `${binaryName} <resource> <method> --dry-run`,
+            "```",
+            ""
+        )
+    });
+}
+
+function generateEnvironmentVariables(envPrefix: string): Block {
+    return new Block({
+        id: "ENVIRONMENT_VARIABLES",
+        content: lines(
+            "## Environment variables",
+            "",
+            `| Variable | Description |`,
+            `|----------|-------------|`,
+            `| \`${envPrefix}_BASE_URL\` | Override the API base URL |`,
+            `| \`${envPrefix}_CA_BUNDLE\` | Path to PEM file with extra trust roots (or \`SSL_CERT_FILE\`) |`,
+            `| \`${envPrefix}_INSECURE=1\` | Skip TLS verification (debugging only) |`,
+            `| \`${envPrefix}_PROXY\` | HTTP(S) proxy URL |`,
+            `| \`${envPrefix}_TIMEOUT_SECS\` | Total request timeout in seconds |`,
+            "",
+            "Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.",
             ""
         )
     });
@@ -172,24 +251,11 @@ function generateOutputFormats(binaryName: string): Block {
             "Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.",
             "",
             "```bash",
-            `${binaryName} <command> --format json | jq`,
-            "```",
-            ""
-        )
-    });
-}
-
-function generateConfiguration(binaryName: string): Block {
-    const envPrefix = toEnvVarPrefix(binaryName);
-    return new Block({
-        id: "CONFIGURATION",
-        content: lines(
-            "## Configuration",
+            `# Pipe JSON output through jq`,
+            `${binaryName} <resource> <method> --format json | jq`,
             "",
-            "Override the default base URL with the `--base-url` flag or the environment variable:",
-            "",
-            "```bash",
-            `export ${envPrefix}_BASE_URL="https://api.example.com"`,
+            "# Machine-readable catalog of every operation",
+            `${binaryName} --help --format json | jq 'length'`,
             "```",
             ""
         )
@@ -213,17 +279,88 @@ function generateShellCompletion(binaryName: string): Block {
 }
 
 // ---------------------------------------------------------------------------
+// Help-output builder — renders a representative top-level --help block
+// with the correct binary name, display name, env-var prefix, and auth
+// env vars substituted in.
+// ---------------------------------------------------------------------------
+
+function buildHelpOutput(args: {
+    binaryName: string;
+    displayName: string;
+    envPrefix: string;
+    authBindings: DetectedAuthBinding[];
+}): string[] {
+    const { binaryName, displayName, envPrefix, authBindings } = args;
+
+    const out: string[] = [];
+    out.push(displayName);
+    out.push("");
+    out.push(`Usage: ${binaryName} [OPTIONS] <COMMAND>`);
+    out.push("");
+    out.push("Commands:");
+    out.push("  ...                API resource commands (run --help to list)");
+    out.push("  generate-skills    Generate SKILL.md files for AI agent integration");
+    out.push("  completion         Generate shell completion scripts");
+    out.push("  man                Generate a man page (roff format)");
+    out.push("  help               Print this message or the help of the given subcommand(s)");
+    out.push("");
+    out.push("Options:");
+    out.push("      --dry-run          Validate the request locally without sending it to the API");
+    out.push("      --format <FORMAT>  Output format: json (default), table, yaml, csv");
+    out.push("      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)");
+    out.push("  -q, --quiet            Suppress stdout output on success (errors still go to stderr)");
+    out.push("  -h, --help             Print help");
+    out.push("  -V, --version          Print version");
+    out.push("");
+    out.push("Environment variables:");
+
+    // Auth env vars first
+    for (const binding of authBindings) {
+        for (const envVar of binding.envVars) {
+            out.push(`  ${padEnvVar(envVar)}${describeAuthEnvVar(binding.kind)}`);
+        }
+    }
+
+    out.push(`  ${padEnvVar(`${envPrefix}_BASE_URL`)}Override the API base URL`);
+    out.push(`  ${padEnvVar(`${envPrefix}_CA_BUNDLE`)}Path to PEM file with extra trust roots (or SSL_CERT_FILE)`);
+    out.push(`  ${padEnvVar(`${envPrefix}_INSECURE=1`)}Skip TLS verification (debugging only)`);
+    out.push(`  ${padEnvVar(`${envPrefix}_PROXY`)}HTTP(S) proxy URL`);
+    out.push(`  ${padEnvVar(`${envPrefix}_TIMEOUT_SECS`)}Total request timeout`);
+    out.push("");
+    out.push("Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.");
+
+    return out;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function describeAuthKind(kind: DetectedAuthBinding["kind"]): string {
+const ENV_VAR_COL_WIDTH = 36;
+
+function padEnvVar(envVar: string): string {
+    return envVar.padEnd(ENV_VAR_COL_WIDTH);
+}
+
+function describeAuthEnvVar(kind: DetectedAuthBinding["kind"]): string {
     switch (kind) {
         case "bearer":
-            return "token";
+            return "Bearer token for authentication";
         case "header":
-            return "api key";
+            return "API key for authentication";
         case "basic":
-            return "credential";
+            return "Credential for authentication";
+    }
+}
+
+function placeholderForKind(kind: DetectedAuthBinding["kind"]): string {
+    switch (kind) {
+        case "bearer":
+            return "<your token>";
+        case "header":
+            return "<your api key>";
+        case "basic":
+            return "<your credential>";
     }
 }
 

--- a/generators/cli/src/emitReadme.ts
+++ b/generators/cli/src/emitReadme.ts
@@ -1,0 +1,265 @@
+import { readFile, writeFile } from "fs/promises";
+import path from "path";
+
+import { Block, BlockMerger, ReadmeParser } from "@fern-api/generator-cli/readme";
+
+import type { DetectedAuthBinding } from "./detectAuth.js";
+import { toEnvVarPrefix } from "./identity.js";
+import type { ResolvedNpmPublishInfo } from "./resolveOutputConfig.js";
+
+/**
+ * Emit `README.md` into the generated CLI project.
+ *
+ * Uses the same `ReadmeParser` + `BlockMerger` merge mechanism as Fern
+ * SDK READMEs so that customer-authored H2 sections are preserved on
+ * regeneration. Generated sections are always overwritten; sections
+ * whose id is NOT in the generated set are kept in their original
+ * position.
+ *
+ * Unlike the SDK `ReadmeGenerator` (which renders language-specific
+ * install commands, code-snippet features, and badge shields), the CLI
+ * README documents binary invocation, auth env vars, output formats,
+ * and shell completions — content that has no overlap with the SDK
+ * feature model. We therefore build our own `Block[]` list directly
+ * rather than constructing a `ReadmeConfig` for the SDK generator.
+ */
+export async function emitReadme(args: {
+    outputDir: string;
+    binaryName: string;
+    apiDisplayName: string | undefined;
+    authBindings: DetectedAuthBinding[];
+    npmPublishInfo: ResolvedNpmPublishInfo | undefined;
+}): Promise<void> {
+    const { outputDir, binaryName, apiDisplayName, authBindings, npmPublishInfo } = args;
+    const displayName = apiDisplayName ?? binaryName;
+
+    const header = generateHeader(displayName);
+    const blocks = generateBlocks({ binaryName, authBindings, npmPublishInfo });
+
+    const readmePath = path.join(outputDir, "README.md");
+    const existing = await readExistingReadme(readmePath);
+    const finalBlocks = mergeWithExisting({ existing, generatedBlocks: blocks });
+
+    const content = header + finalBlocks.map((b) => b.content).join("");
+    await writeFile(readmePath, content);
+}
+
+// ---------------------------------------------------------------------------
+// Header
+// ---------------------------------------------------------------------------
+
+function generateHeader(displayName: string): string {
+    return lines(`# ${displayName} CLI`, "", `Command-line interface for the ${displayName} API.`, "");
+}
+
+// ---------------------------------------------------------------------------
+// Block builders — one per generated H2 section.
+//
+// Each follows the same convention as ReadmeGenerator's private helpers:
+// build a content string starting with `## Title\n`, ending with a
+// trailing blank line (`\n`), and wrap it in a `Block` keyed by a
+// SCREAMING_SNAKE_CASE id that ReadmeParser.sectionNameToID would
+// produce from the heading text.
+// ---------------------------------------------------------------------------
+
+function generateBlocks(args: {
+    binaryName: string;
+    authBindings: DetectedAuthBinding[];
+    npmPublishInfo: ResolvedNpmPublishInfo | undefined;
+}): Block[] {
+    const { binaryName, authBindings, npmPublishInfo } = args;
+    return [
+        generateInstallation({ binaryName, npmPublishInfo }),
+        generateAuthentication({ binaryName, authBindings }),
+        generateUsage(binaryName),
+        generateOutputFormats(binaryName),
+        generateConfiguration(binaryName),
+        generateShellCompletion(binaryName)
+    ];
+}
+
+function generateInstallation(args: { binaryName: string; npmPublishInfo: ResolvedNpmPublishInfo | undefined }): Block {
+    const { binaryName, npmPublishInfo } = args;
+    let content: string;
+    if (npmPublishInfo != null) {
+        content = lines(
+            "## Installation",
+            "",
+            "Install the CLI globally via npm:",
+            "",
+            "```bash",
+            `npm install -g ${npmPublishInfo.packageName}`,
+            "```",
+            "",
+            "Or run it directly without installing:",
+            "",
+            "```bash",
+            `npx ${npmPublishInfo.packageName} --help`,
+            "```",
+            ""
+        );
+    } else {
+        content = lines(
+            "## Installation",
+            "",
+            "Build from source:",
+            "",
+            "```bash",
+            "cargo build --release",
+            "```",
+            "",
+            `The compiled binary will be available at \`target/release/${binaryName}\`.`,
+            ""
+        );
+    }
+    return new Block({ id: "INSTALLATION", content });
+}
+
+function generateAuthentication(args: { binaryName: string; authBindings: DetectedAuthBinding[] }): Block {
+    const { binaryName, authBindings } = args;
+    if (authBindings.length === 0) {
+        return new Block({
+            id: "AUTHENTICATION",
+            content: lines(
+                "## Authentication",
+                "",
+                `This API requires authentication. Run \`${binaryName} --help\` for details.`,
+                ""
+            )
+        });
+    }
+    const envLines: string[] = [];
+    for (const binding of authBindings) {
+        for (const envVar of binding.envVars) {
+            envLines.push(`export ${envVar}="<your ${describeAuthKind(binding.kind)}>"`);
+        }
+    }
+    return new Block({
+        id: "AUTHENTICATION",
+        content: lines(
+            "## Authentication",
+            "",
+            "Set the following environment variable(s) before using the CLI:",
+            "",
+            "```bash",
+            ...envLines,
+            "```",
+            ""
+        )
+    });
+}
+
+function generateUsage(binaryName: string): Block {
+    return new Block({
+        id: "USAGE",
+        content: lines(
+            "## Usage",
+            "",
+            "```bash",
+            `${binaryName} --help                 # list commands and flags`,
+            `${binaryName} --help --format json   # full machine-readable command surface`,
+            "```",
+            ""
+        )
+    });
+}
+
+function generateOutputFormats(binaryName: string): Block {
+    return new Block({
+        id: "OUTPUT_FORMATS",
+        content: lines(
+            "## Output formats",
+            "",
+            "Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.",
+            "",
+            "```bash",
+            `${binaryName} <command> --format json | jq`,
+            "```",
+            ""
+        )
+    });
+}
+
+function generateConfiguration(binaryName: string): Block {
+    const envPrefix = toEnvVarPrefix(binaryName);
+    return new Block({
+        id: "CONFIGURATION",
+        content: lines(
+            "## Configuration",
+            "",
+            "Override the default base URL with the `--base-url` flag or the environment variable:",
+            "",
+            "```bash",
+            `export ${envPrefix}_BASE_URL="https://api.example.com"`,
+            "```",
+            ""
+        )
+    });
+}
+
+function generateShellCompletion(binaryName: string): Block {
+    return new Block({
+        id: "SHELL_COMPLETION",
+        content: lines(
+            "## Shell completion",
+            "",
+            "Generate shell completion scripts:",
+            "",
+            "```bash",
+            `${binaryName} completion <bash|zsh|fish|powershell>`,
+            "```",
+            ""
+        )
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function describeAuthKind(kind: DetectedAuthBinding["kind"]): string {
+    switch (kind) {
+        case "bearer":
+            return "token";
+        case "header":
+            return "api key";
+        case "basic":
+            return "credential";
+    }
+}
+
+/**
+ * Join lines with `\n` and append a trailing newline. The trailing
+ * empty-string element in each call-site produces the blank line that
+ * separates adjacent H2 sections when blocks are concatenated.
+ */
+function lines(...parts: string[]): string {
+    return parts.join("\n") + "\n";
+}
+
+async function readExistingReadme(readmePath: string): Promise<string | undefined> {
+    try {
+        return await readFile(readmePath, "utf-8");
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Mirrors `ReadmeGenerator.mergeBlocks()` from `@fern-api/generator-cli`:
+ * parse the existing README into blocks, then merge with the freshly
+ * generated set so customer-authored H2 sections survive regeneration.
+ */
+function mergeWithExisting(args: { existing: string | undefined; generatedBlocks: Block[] }): Block[] {
+    const { existing, generatedBlocks } = args;
+    if (existing == null) {
+        return generatedBlocks;
+    }
+    const parser = new ReadmeParser();
+    const parsed = parser.parse({ content: existing });
+    const merger = new BlockMerger({
+        original: parsed.blocks,
+        updated: generatedBlocks
+    });
+    return merger.merge();
+}

--- a/generators/cli/src/emitReadme.ts
+++ b/generators/cli/src/emitReadme.ts
@@ -1,7 +1,6 @@
+import { Block, BlockMerger, ReadmeParser } from "@fern-api/generator-cli/readme";
 import { readFile, writeFile } from "fs/promises";
 import path from "path";
-
-import { Block, BlockMerger, ReadmeParser } from "@fern-api/generator-cli/readme";
 
 import type { DetectedAuthBinding } from "./detectAuth.js";
 import { toEnvVarPrefix } from "./identity.js";

--- a/generators/cli/src/runPipeline.ts
+++ b/generators/cli/src/runPipeline.ts
@@ -4,6 +4,7 @@ import { copySpecs, hasOpenApiSpecs } from "./copySpecs.js";
 import type { FernCliCustomConfig } from "./customConfig.js";
 import { detectAuthBindings } from "./detectAuth.js";
 import { emitPublishWorkflow } from "./emitPublishWorkflow.js";
+import { emitReadme } from "./emitReadme.js";
 import { deriveBinaryName } from "./identity.js";
 import type { IrSummary } from "./ir.js";
 import { patchCargoToml } from "./patchCargoToml.js";
@@ -67,6 +68,13 @@ export async function runPipeline(args: {
     await patchDistWorkspaceToml({ outputDir });
     await copySpecs({ outputDir, binaryName, authBindings, specsDir });
     await writeGitignore(outputDir);
+    await emitReadme({
+        outputDir,
+        binaryName,
+        apiDisplayName: ir.apiDisplayName,
+        authBindings,
+        npmPublishInfo: outputConfig.npmPublishInfo
+    });
 
     if (outputConfig.npmPublishInfo != null) {
         await emitPublishWorkflow({

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -25,6 +25,12 @@
       "source": "./src/pipeline/index.ts",
       "types": "./lib/pipeline/index.d.ts",
       "default": "./lib/pipeline/index.js"
+    },
+    "./readme": {
+      "development": "./src/readme/index.ts",
+      "source": "./src/readme/index.ts",
+      "types": "./lib/readme/index.d.ts",
+      "default": "./lib/readme/index.js"
     }
   },
   "main": "lib/api.js",

--- a/packages/generator-cli/src/readme/index.ts
+++ b/packages/generator-cli/src/readme/index.ts
@@ -1,2 +1,4 @@
+export { Block } from "./Block.js";
+export { BlockMerger } from "./BlockMerger.js";
 export { ReadmeGenerator } from "./ReadmeGenerator.js";
 export { ReadmeParser } from "./ReadmeParser.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -798,6 +798,9 @@ importers:
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../packages/commons/fs-utils
+      '@fern-api/generator-cli':
+        specifier: workspace:*
+        version: link:../../packages/generator-cli
       '@fern-fern/ir-sdk':
         specifier: 67.0.0
         version: 67.0.0

--- a/seed/cli/imdb/README.md
+++ b/seed/cli/imdb/README.md
@@ -1,0 +1,53 @@
+# api CLI
+
+Command-line interface for the api API.
+
+## Installation
+
+Build from source:
+
+```bash
+cargo build --release
+```
+
+The compiled binary will be available at `target/release/api`.
+
+## Authentication
+
+Set the following environment variable(s) before using the CLI:
+
+```bash
+export API_TOKEN="<your token>"
+```
+
+## Usage
+
+```bash
+api --help                 # list commands and flags
+api --help --format json   # full machine-readable command surface
+```
+
+## Output formats
+
+Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
+
+```bash
+api <command> --format json | jq
+```
+
+## Configuration
+
+Override the default base URL with the `--base-url` flag or the environment variable:
+
+```bash
+export API_BASE_URL="https://api.example.com"
+```
+
+## Shell completion
+
+Generate shell completion scripts:
+
+```bash
+api completion <bash|zsh|fish|powershell>
+```
+

--- a/seed/cli/imdb/README.md
+++ b/seed/cli/imdb/README.md
@@ -4,13 +4,18 @@ Command-line interface for the api API.
 
 ## Installation
 
-Build from source:
+Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
+
+```bash
+curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Then build from source:
 
 ```bash
 cargo build --release
+./target/release/api --help
 ```
-
-The compiled binary will be available at `target/release/api`.
 
 ## Authentication
 
@@ -20,27 +25,89 @@ Set the following environment variable(s) before using the CLI:
 export API_TOKEN="<your token>"
 ```
 
+A `.env` file in the working directory is also supported — the CLI auto-loads it on startup.
+
 ## Usage
 
-```bash
-api --help                 # list commands and flags
-api --help --format json   # full machine-readable command surface
 ```
+api
+
+Usage: api [OPTIONS] <COMMAND>
+
+Commands:
+  ...                API resource commands (run --help to list)
+  generate-skills    Generate SKILL.md files for AI agent integration
+  completion         Generate shell completion scripts
+  man                Generate a man page (roff format)
+  help               Print this message or the help of the given subcommand(s)
+
+Options:
+      --dry-run          Validate the request locally without sending it to the API
+      --format <FORMAT>  Output format: json (default), table, yaml, csv
+      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
+  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
+  -h, --help             Print help
+  -V, --version          Print version
+
+Environment variables:
+  API_TOKEN                           Bearer token for authentication
+  API_BASE_URL                        Override the API base URL
+  API_CA_BUNDLE                       Path to PEM file with extra trust roots (or SSL_CERT_FILE)
+  API_INSECURE=1                      Skip TLS verification (debugging only)
+  API_PROXY                           HTTP(S) proxy URL
+  API_TIMEOUT_SECS                    Total request timeout
+
+Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
+```
+
+Every API resource appears as a subcommand (e.g. `api <resource> <method>`). Run `api <resource> --help` to see available methods.
+
+## Common flags
+
+These flags are available on every operation:
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
+| `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
+| `--output <PATH>` | Write binary responses to a file |
+| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--page-all` | Auto-paginate and stream results as NDJSON |
+| `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
+| `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
+
+### Dry run
+
+The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
+
+```bash
+api <resource> <method> --dry-run
+```
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `API_BASE_URL` | Override the API base URL |
+| `API_CA_BUNDLE` | Path to PEM file with extra trust roots (or `SSL_CERT_FILE`) |
+| `API_INSECURE=1` | Skip TLS verification (debugging only) |
+| `API_PROXY` | HTTP(S) proxy URL |
+| `API_TIMEOUT_SECS` | Total request timeout in seconds |
+
+Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
 ## Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
 ```bash
-api <command> --format json | jq
-```
+# Pipe JSON output through jq
+api <resource> <method> --format json | jq
 
-## Configuration
-
-Override the default base URL with the `--base-url` flag or the environment variable:
-
-```bash
-export API_BASE_URL="https://api.example.com"
+# Machine-readable catalog of every operation
+api --help --format json | jq 'length'
 ```
 
 ## Shell completion

--- a/seed/cli/imdb/README.md
+++ b/seed/cli/imdb/README.md
@@ -1,6 +1,6 @@
 # api CLI
 
-Command-line interface for the api API.
+Command-line interface for the api.
 
 ## Installation
 

--- a/seed/cli/query-parameters-openapi/github-npm/README.md
+++ b/seed/cli/query-parameters-openapi/github-npm/README.md
@@ -1,0 +1,53 @@
+# Query Parameters API CLI
+
+Command-line interface for the Query Parameters API API.
+
+## Installation
+
+Install the CLI globally via npm:
+
+```bash
+npm install -g @fern/query-parameters-openapi
+```
+
+Or run it directly without installing:
+
+```bash
+npx @fern/query-parameters-openapi --help
+```
+
+## Authentication
+
+This API requires authentication. Run `query-parameters-api --help` for details.
+
+## Usage
+
+```bash
+query-parameters-api --help                 # list commands and flags
+query-parameters-api --help --format json   # full machine-readable command surface
+```
+
+## Output formats
+
+Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
+
+```bash
+query-parameters-api <command> --format json | jq
+```
+
+## Configuration
+
+Override the default base URL with the `--base-url` flag or the environment variable:
+
+```bash
+export QUERY_PARAMETERS_API_BASE_URL="https://api.example.com"
+```
+
+## Shell completion
+
+Generate shell completion scripts:
+
+```bash
+query-parameters-api completion <bash|zsh|fish|powershell>
+```
+

--- a/seed/cli/query-parameters-openapi/github-npm/README.md
+++ b/seed/cli/query-parameters-openapi/github-npm/README.md
@@ -22,25 +22,84 @@ This API requires authentication. Run `query-parameters-api --help` for details.
 
 ## Usage
 
-```bash
-query-parameters-api --help                 # list commands and flags
-query-parameters-api --help --format json   # full machine-readable command surface
 ```
+Query Parameters API
+
+Usage: query-parameters-api [OPTIONS] <COMMAND>
+
+Commands:
+  ...                API resource commands (run --help to list)
+  generate-skills    Generate SKILL.md files for AI agent integration
+  completion         Generate shell completion scripts
+  man                Generate a man page (roff format)
+  help               Print this message or the help of the given subcommand(s)
+
+Options:
+      --dry-run          Validate the request locally without sending it to the API
+      --format <FORMAT>  Output format: json (default), table, yaml, csv
+      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
+  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
+  -h, --help             Print help
+  -V, --version          Print version
+
+Environment variables:
+  QUERY_PARAMETERS_API_BASE_URL       Override the API base URL
+  QUERY_PARAMETERS_API_CA_BUNDLE      Path to PEM file with extra trust roots (or SSL_CERT_FILE)
+  QUERY_PARAMETERS_API_INSECURE=1     Skip TLS verification (debugging only)
+  QUERY_PARAMETERS_API_PROXY          HTTP(S) proxy URL
+  QUERY_PARAMETERS_API_TIMEOUT_SECS   Total request timeout
+
+Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
+```
+
+Every API resource appears as a subcommand (e.g. `query-parameters-api <resource> <method>`). Run `query-parameters-api <resource> --help` to see available methods.
+
+## Common flags
+
+These flags are available on every operation:
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
+| `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
+| `--output <PATH>` | Write binary responses to a file |
+| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--page-all` | Auto-paginate and stream results as NDJSON |
+| `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
+| `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
+
+### Dry run
+
+The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
+
+```bash
+query-parameters-api <resource> <method> --dry-run
+```
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `QUERY_PARAMETERS_API_BASE_URL` | Override the API base URL |
+| `QUERY_PARAMETERS_API_CA_BUNDLE` | Path to PEM file with extra trust roots (or `SSL_CERT_FILE`) |
+| `QUERY_PARAMETERS_API_INSECURE=1` | Skip TLS verification (debugging only) |
+| `QUERY_PARAMETERS_API_PROXY` | HTTP(S) proxy URL |
+| `QUERY_PARAMETERS_API_TIMEOUT_SECS` | Total request timeout in seconds |
+
+Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
 ## Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
 ```bash
-query-parameters-api <command> --format json | jq
-```
+# Pipe JSON output through jq
+query-parameters-api <resource> <method> --format json | jq
 
-## Configuration
-
-Override the default base URL with the `--base-url` flag or the environment variable:
-
-```bash
-export QUERY_PARAMETERS_API_BASE_URL="https://api.example.com"
+# Machine-readable catalog of every operation
+query-parameters-api --help --format json | jq 'length'
 ```
 
 ## Shell completion

--- a/seed/cli/query-parameters-openapi/github-npm/README.md
+++ b/seed/cli/query-parameters-openapi/github-npm/README.md
@@ -1,6 +1,6 @@
 # Query Parameters API CLI
 
-Command-line interface for the Query Parameters API API.
+Command-line interface for the Query Parameters API.
 
 ## Installation
 
@@ -14,6 +14,15 @@ Or run it directly without installing:
 
 ```bash
 npx @fern/query-parameters-openapi --help
+```
+
+### Build from source
+
+If you prefer to build from source, install the [Rust toolchain](https://rustup.rs/) and run:
+
+```bash
+cargo build --release
+./target/release/query-parameters-api --help
 ```
 
 ## Authentication

--- a/seed/cli/query-parameters-openapi/no-custom-config/README.md
+++ b/seed/cli/query-parameters-openapi/no-custom-config/README.md
@@ -1,0 +1,49 @@
+# Query Parameters API CLI
+
+Command-line interface for the Query Parameters API API.
+
+## Installation
+
+Build from source:
+
+```bash
+cargo build --release
+```
+
+The compiled binary will be available at `target/release/query-parameters-api`.
+
+## Authentication
+
+This API requires authentication. Run `query-parameters-api --help` for details.
+
+## Usage
+
+```bash
+query-parameters-api --help                 # list commands and flags
+query-parameters-api --help --format json   # full machine-readable command surface
+```
+
+## Output formats
+
+Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
+
+```bash
+query-parameters-api <command> --format json | jq
+```
+
+## Configuration
+
+Override the default base URL with the `--base-url` flag or the environment variable:
+
+```bash
+export QUERY_PARAMETERS_API_BASE_URL="https://api.example.com"
+```
+
+## Shell completion
+
+Generate shell completion scripts:
+
+```bash
+query-parameters-api completion <bash|zsh|fish|powershell>
+```
+

--- a/seed/cli/query-parameters-openapi/no-custom-config/README.md
+++ b/seed/cli/query-parameters-openapi/no-custom-config/README.md
@@ -1,6 +1,6 @@
 # Query Parameters API CLI
 
-Command-line interface for the Query Parameters API API.
+Command-line interface for the Query Parameters API.
 
 ## Installation
 

--- a/seed/cli/query-parameters-openapi/no-custom-config/README.md
+++ b/seed/cli/query-parameters-openapi/no-custom-config/README.md
@@ -4,13 +4,18 @@ Command-line interface for the Query Parameters API API.
 
 ## Installation
 
-Build from source:
+Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
+
+```bash
+curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Then build from source:
 
 ```bash
 cargo build --release
+./target/release/query-parameters-api --help
 ```
-
-The compiled binary will be available at `target/release/query-parameters-api`.
 
 ## Authentication
 
@@ -18,25 +23,84 @@ This API requires authentication. Run `query-parameters-api --help` for details.
 
 ## Usage
 
-```bash
-query-parameters-api --help                 # list commands and flags
-query-parameters-api --help --format json   # full machine-readable command surface
 ```
+Query Parameters API
+
+Usage: query-parameters-api [OPTIONS] <COMMAND>
+
+Commands:
+  ...                API resource commands (run --help to list)
+  generate-skills    Generate SKILL.md files for AI agent integration
+  completion         Generate shell completion scripts
+  man                Generate a man page (roff format)
+  help               Print this message or the help of the given subcommand(s)
+
+Options:
+      --dry-run          Validate the request locally without sending it to the API
+      --format <FORMAT>  Output format: json (default), table, yaml, csv
+      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
+  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
+  -h, --help             Print help
+  -V, --version          Print version
+
+Environment variables:
+  QUERY_PARAMETERS_API_BASE_URL       Override the API base URL
+  QUERY_PARAMETERS_API_CA_BUNDLE      Path to PEM file with extra trust roots (or SSL_CERT_FILE)
+  QUERY_PARAMETERS_API_INSECURE=1     Skip TLS verification (debugging only)
+  QUERY_PARAMETERS_API_PROXY          HTTP(S) proxy URL
+  QUERY_PARAMETERS_API_TIMEOUT_SECS   Total request timeout
+
+Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
+```
+
+Every API resource appears as a subcommand (e.g. `query-parameters-api <resource> <method>`). Run `query-parameters-api <resource> --help` to see available methods.
+
+## Common flags
+
+These flags are available on every operation:
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
+| `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
+| `--output <PATH>` | Write binary responses to a file |
+| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--page-all` | Auto-paginate and stream results as NDJSON |
+| `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
+| `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
+
+### Dry run
+
+The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
+
+```bash
+query-parameters-api <resource> <method> --dry-run
+```
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `QUERY_PARAMETERS_API_BASE_URL` | Override the API base URL |
+| `QUERY_PARAMETERS_API_CA_BUNDLE` | Path to PEM file with extra trust roots (or `SSL_CERT_FILE`) |
+| `QUERY_PARAMETERS_API_INSECURE=1` | Skip TLS verification (debugging only) |
+| `QUERY_PARAMETERS_API_PROXY` | HTTP(S) proxy URL |
+| `QUERY_PARAMETERS_API_TIMEOUT_SECS` | Total request timeout in seconds |
+
+Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
 ## Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
 ```bash
-query-parameters-api <command> --format json | jq
-```
+# Pipe JSON output through jq
+query-parameters-api <resource> <method> --format json | jq
 
-## Configuration
-
-Override the default base URL with the `--base-url` flag or the environment variable:
-
-```bash
-export QUERY_PARAMETERS_API_BASE_URL="https://api.example.com"
+# Machine-readable catalog of every operation
+query-parameters-api --help --format json | jq 'length'
 ```
 
 ## Shell completion


### PR DESCRIPTION
## Description

Emit a `README.md` into every generated CLI project, with enriched content including representative `--help` output, common flags documentation, environment variables, `.env` support, and output format details. On regeneration, customer-authored H2 sections are preserved via the existing `ReadmeParser` + `BlockMerger` merge mechanism from `@fern-api/generator-cli`.

## Changes Made

### New: `generators/cli/src/emitReadme.ts`
Generates a polished README with these sections (in order):
- **Installation** — `npm install -g` primary when `npmPublishInfo` present (with `### Build from source` subsection), Rust toolchain + `cargo build --release` only when absent
- **Authentication** — env-var exports per auth binding + `.env` auto-load documentation
- **Usage** — representative `--help` output with correct `binaryName`, `displayName`, env-var prefix, and auth env vars substituted in
- **Common flags** — table documenting `--dry-run`, `--json`, `--params`, `--format`, `--output`, `--base-url`, `--page-all`, `--page-limit`, `--quiet`, plus a dedicated "Dry run" subsection highlighting agent integration value
- **Environment variables** — table of `{PREFIX}_BASE_URL`, `_CA_BUNDLE`, `_INSECURE`, `_PROXY`, `_TIMEOUT_SECS` plus standard proxy/TLS vars
- **Output formats** — `--format` flag with `jq` piping examples
- **Shell completion** — `completion <bash|zsh|fish|powershell>`

### Extended: `generators/cli/src/detectAuth.ts`
Added `envVars: string[]` and `kind: "bearer" | "header" | "basic"` to `DetectedAuthBinding` so `emitReadme` can render auth details without regex-parsing `rustCall`.

### Wired into pipeline: `generators/cli/src/runPipeline.ts`
`emitReadme(...)` called between `writeGitignore` and `emitPublishWorkflow`, runs on every generation regardless of output mode.

### Tests: `generators/cli/src/__test__/emitReadme.test.ts`
9 test cases covering: npm+bearer (with build-from-source subsection), build-from-source only, no-auth generic line, `apiDisplayName` fallback, multiple bindings, merge preservation, section ordering, `--help` output in Usage, `.env` support in Authentication.

### Bug fix: "API API" redundancy
When `apiDisplayName` already ends with "API" (case-insensitive), the header no longer appends a redundant " API" suffix.

### Seed fixtures regenerated
- `seed/cli/imdb/README.md` — bearer auth, build-from-source
- `seed/cli/query-parameters-openapi/github-npm/README.md` — no auth, npm primary + build-from-source subsection
- `seed/cli/query-parameters-openapi/no-custom-config/README.md` — build-from-source only, no auth

## Testing
- [x] Unit tests added/updated — 103 tests pass (`pnpm turbo run test --filter @fern-api/cli-generator`)
- [x] `pnpm compile` clean
- [x] Biome formatting clean
- [x] Seed fixtures regenerated and committed

Link to Devin session: https://app.devin.ai/sessions/37094f7509b9453a9d5d42c24e912ded
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->