### PR TITLE
feat(cli-generator): add GitHub tagged release creation in release mode

### DIFF
--- a/generators/cli/changes/unreleased/add-github-release.yml
+++ b/generators/cli/changes/unreleased/add-github-release.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Add GitHub tagged release creation when running in release mode.
+    After generating CLI output and pushing to GitHub, the generator
+    now creates a tagged release via the GitHub API.
+  type: feat

--- a/generators/cli/src/cli.ts
+++ b/generators/cli/src/cli.ts
@@ -8,6 +8,7 @@ import {
     shouldReportToSentry,
     shouldTrackLocalVariablesInSentry
 } from "@fern-api/base-generator";
+import { githubPush, githubRelease } from "@fern-api/generator-cli";
 import { getCustomConfig } from "./customConfig.js";
 import { readIrSummary } from "./ir.js";
 import { resolveOutputConfig } from "./resolveOutputConfig.js";
@@ -57,6 +58,23 @@ async function generate(configPath: string): Promise<void> {
             if (outcome.status === "skipped") {
                 // biome-ignore lint/suspicious/noConsole: generator CLI output
                 console.log("No OpenAPI specs mounted — skipping CLI generation.");
+            }
+
+            // Push to GitHub and create a tagged release when running in
+            // github mode with an installation token (remote generation).
+            // Local generation without a token delegates to the
+            // PostGenerationPipeline instead.
+            if (outcome.status === "generated" && config.output.mode.type === "github") {
+                const { repoUrl, installationToken, version } = config.output.mode;
+                if (installationToken != null) {
+                    const githubConfig = {
+                        sourceDirectory: config.output.path,
+                        uri: repoUrl,
+                        token: installationToken
+                    };
+                    await githubPush({ githubConfig });
+                    await githubRelease({ githubConfig, version });
+                }
             }
 
             await generatorLoggingClient.sendUpdate(GeneratorUpdate.exitStatusUpdate(ExitStatusUpdate.successful({})));

--- a/packages/generator-cli/src/api/github-release.ts
+++ b/packages/generator-cli/src/api/github-release.ts
@@ -3,10 +3,12 @@ import { GitHub } from "../github/GitHub.js";
 
 export interface GithubReleaseParams {
     githubConfig: FernGeneratorCli.GitHubConfig;
+    version: string;
+    body?: string;
 }
 
-export async function githubRelease(params: GithubReleaseParams) {
-    const { githubConfig } = params;
+export async function githubRelease(params: GithubReleaseParams): Promise<void> {
+    const { githubConfig, version, body } = params;
     const github = new GitHub({ githubConfig });
-    await github.release();
+    await github.release({ version, body });
 }

--- a/packages/generator-cli/src/cli.ts
+++ b/packages/generator-cli/src/cli.ts
@@ -146,22 +146,35 @@ void yargs(hideBin(process.argv))
                 "release",
                 "Create a release on GitHub",
                 (subYargs) => {
-                    return subYargs.option("config", {
-                        string: true,
-                        required: true,
-                        description: "Path to configuration file"
-                    });
+                    return subYargs
+                        .option("config", {
+                            string: true,
+                            required: true,
+                            description: "Path to configuration file"
+                        })
+                        .option("version", {
+                            string: true,
+                            required: true,
+                            description: "The version tag for the release"
+                        })
+                        .option("body", {
+                            string: true,
+                            required: false,
+                            description: "Optional release body / changelog"
+                        });
                 },
                 async (argv) => {
-                    if (argv.config == null) {
-                        process.stderr.write("missing required arguments; please specify the --config flag\n");
+                    if (argv.config == null || argv.version == null) {
+                        process.stderr.write(
+                            "missing required arguments; please specify --config and --version flags\n"
+                        );
                         process.exit(1);
                     }
                     const wd = cwd();
                     const githubConfig = await loadGitHubConfig({
                         absolutePathToConfig: resolve(wd, argv.config)
                     });
-                    await githubRelease({ githubConfig });
+                    await githubRelease({ githubConfig, version: argv.version, body: argv.body });
                     process.exit(0);
                 }
             )

--- a/packages/generator-cli/src/github/GitHub.ts
+++ b/packages/generator-cli/src/github/GitHub.ts
@@ -155,16 +155,30 @@ export class GitHub {
             });
             const headSha = refData.object.sha;
 
-            await octokit.repos.createRelease({
-                owner,
-                repo,
-                tag_name: version,
-                target_commitish: headSha,
-                name: version,
-                body,
-                draft: false,
-                prerelease: false
-            });
+            try {
+                await octokit.repos.createRelease({
+                    owner,
+                    repo,
+                    tag_name: version,
+                    target_commitish: headSha,
+                    name: version,
+                    body,
+                    draft: false,
+                    prerelease: false
+                });
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } catch (e: any) {
+                if (
+                    typeof e?.status === "number" &&
+                    e.status === 422 &&
+                    typeof e?.message === "string" &&
+                    e.message.includes("already_exists")
+                ) {
+                    console.error(`A release for tag ${version} already exists`);
+                } else {
+                    throw e;
+                }
+            }
         } catch (error) {
             console.error("Error during GitHub release:", error);
             throw error;

--- a/packages/generator-cli/src/github/GitHub.ts
+++ b/packages/generator-cli/src/github/GitHub.ts
@@ -133,8 +133,42 @@ export class GitHub {
         }
     }
 
-    public async release(): Promise<void> {
-        console.log("TODO: Implement release");
+    public async release({ version, body }: { version: string; body?: string }): Promise<void> {
+        try {
+            const { owner, repo } = parseRepository(this.githubConfig.uri);
+            const apiBaseUrl = getGithubApiBaseUrl(this.githubConfig.uri);
+            const octokit = new Octokit({
+                auth: this.githubConfig.token,
+                ...(apiBaseUrl != null ? { baseUrl: apiBaseUrl } : {})
+            });
+
+            // Resolve the target branch to get its HEAD SHA without cloning.
+            let branch = this.githubConfig.branch;
+            if (branch == null) {
+                const { data: repoData } = await octokit.repos.get({ owner, repo });
+                branch = repoData.default_branch;
+            }
+            const { data: refData } = await octokit.git.getRef({
+                owner,
+                repo,
+                ref: `heads/${branch}`
+            });
+            const headSha = refData.object.sha;
+
+            await octokit.repos.createRelease({
+                owner,
+                repo,
+                tag_name: version,
+                target_commitish: headSha,
+                name: version,
+                body,
+                draft: false,
+                prerelease: false
+            });
+        } catch (error) {
+            console.error("Error during GitHub release:", error);
+            throw error;
+        }
     }
 
     private async getFernignoreFiles(repository: ClonedRepository): Promise<string[]> {

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Implement `GitHub.release()` to create tagged releases via the
+        GitHub API. The `githubRelease` API function now accepts `version`
+        and optional `body` parameters. Previously the release command was
+        a no-op stub.
+      type: feat
+  createdAt: "2026-06-03"
+  version: 0.9.36
+
+- changelogEntry:
+    - summary: |
         Disable minimatch negation on `.fernignore` patterns so a stray `!pattern` doesn't silently invert the match and discard generator output.
       type: fix
   createdAt: "2026-05-21"


### PR DESCRIPTION
## Description

The CLI generator generates output successfully in release mode but does not create a tagged GitHub release in the output repo. This PR implements that missing feature, matching the behavior of the TypeScript SDK generator.

## Changes Made

### `packages/generator-cli/src/github/GitHub.ts`
- Implement `GitHub.release()` — previously a TODO stub. Uses Octokit to resolve the target branch HEAD via API (no clone needed) and calls `octokit.repos.createRelease()`.
- Idempotent on retries: catches 422 `already_exists` errors (matching the `pr()` pattern).

### `packages/generator-cli/src/api/github-release.ts`
- Add required `version` and optional `body` params to `GithubReleaseParams`. Pass through to `GitHub.release()`.

### `packages/generator-cli/src/cli.ts`
- Update the `github release` CLI subcommand to accept `--version` (required) and `--body` (optional) flags.

### `generators/cli/src/cli.ts`
- After successful `runPipeline()`, when output mode is `github` with an `installationToken` (remote generation), call `githubPush()` then `githubRelease()` to push generated output and create a tagged release.
- Local generation (no token) continues to delegate to `PostGenerationPipeline`.

### Versioning
- `generator-cli` bumped to `0.9.36` in `versions.yml`
- CLI generator changelog entry added under `generators/cli/changes/unreleased/`

## Testing
- [x] `pnpm turbo run compile --filter @fern-api/cli-generator` passes
- [x] `pnpm turbo run compile --filter @fern-api/generator-cli --force` passes
- [x] `pnpm lint:biome` and `pnpm format` pass
- [x] All CI checks pass

Link to Devin session: https://app.devin.ai/sessions/9b3ed3e9d76c4a28975e3a1db08ef189
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->