### PR TITLE
fix(python): respect optional response-property types and oauth request-properties mapping

### DIFF
--- a/generators/python/sdk/changes/unreleased/fix-response-property-and-oauth-request-properties.yml
+++ b/generators/python/sdk/changes/unreleased/fix-response-property-and-oauth-request-properties.yml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix the typing of endpoints that extract a property from an optional response body. The
+    `HttpResponse`/`AsyncHttpResponse` generic (and the corresponding client return type) is now
+    wrapped in `Optional` when the underlying response body resolves to an optional type, so an
+    empty response (`data=None`) no longer fails type checking.
+  type: fix
+
+- summary: |
+    Fix the generated OAuth token provider to respect the auth scheme's `request-properties`
+    mapping. The token endpoint is now invoked using the actual request parameter names
+    (e.g. `username`/`password` or custom names) instead of always hard-coding
+    `client_id`/`client_secret`.
+  type: fix

--- a/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_function_generator.py
@@ -1288,15 +1288,14 @@ class EndpointFunctionGenerator:
         )
 
     def _get_nested_json_response_type(self, response: ir_types.JsonResponseBodyWithProperty) -> AST.TypeHint:
-        response_type = self._context.pydantic_generator_context.get_type_hint_for_type_reference(
-            response.response_body_type
-        )
         property_type = self._context.pydantic_generator_context.get_type_hint_for_type_reference(
             response.response_property.value_type
             if response.response_property is not None
             else response.response_body_type
         )
-        if response_type.is_optional:
+        # When the response body resolves to an optional type (including named aliases such as
+        # optional<...>), an empty response yields data=None, so the property type must be optional.
+        if self._context.resolved_schema_is_optional_or_unknown(response.response_body_type):
             return AST.TypeHint.optional(property_type)
         return property_type
 

--- a/generators/python/src/fern_python/generators/sdk/client_generator/oauth_token_provider_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/oauth_token_provider_generator.py
@@ -533,6 +533,7 @@ class OAuthTokenProviderGenerator:
         self, client_credentials: ir_types.OAuthClientCredentials
     ) -> AST.FunctionInvocation:
         # TODO(amckinney): Support non-in-lined request types.
+
         # The token endpoint's parameter names come from the configured request-properties
         # mapping (e.g. client-id -> $request.cid), which may differ from "client_id"/"client_secret".
         token_request_properties = client_credentials.token_endpoint.request_properties

--- a/generators/python/src/fern_python/generators/sdk/client_generator/oauth_token_provider_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/oauth_token_provider_generator.py
@@ -533,13 +533,16 @@ class OAuthTokenProviderGenerator:
         self, client_credentials: ir_types.OAuthClientCredentials
     ) -> AST.FunctionInvocation:
         # TODO(amckinney): Support non-in-lined request types.
+        # The token endpoint's parameter names come from the configured request-properties
+        # mapping (e.g. client-id -> $request.cid), which may differ from "client_id"/"client_secret".
+        token_request_properties = client_credentials.token_endpoint.request_properties
         kwargs = [
             (
-                "client_id",
+                self._get_request_property_parameter_name(token_request_properties.client_id),
                 AST.Expression(f"self.{self._get_client_id_member_name()}"),
             ),
             (
-                "client_secret",
+                self._get_request_property_parameter_name(token_request_properties.client_secret),
                 AST.Expression(f"self.{self._get_client_secret_member_name()}"),
             ),
         ]
@@ -561,7 +564,9 @@ class OAuthTokenProviderGenerator:
         )
         kwargs.append(
             (
-                "refresh_token",
+                self._get_request_property_parameter_name(
+                    client_credentials.refresh_endpoint.request_properties.refresh_token
+                ),
                 AST.Expression(f"self.{self._get_refresh_token_member_name()}"),
             ),
         )
@@ -572,6 +577,18 @@ class OAuthTokenProviderGenerator:
                 ),
             ),
             kwargs=kwargs,
+        )
+
+    def _get_request_property_parameter_name(self, request_property: ir_types.RequestProperty) -> str:
+        # Resolve the actual generated parameter name (snake_case, Python-safe) for a request
+        # property, which is derived from the underlying query parameter or body property wire value.
+        return request_property.property.visit(
+            query=lambda query_parameter: resolve_name(
+                get_name_from_wire_value(query_parameter.name)
+            ).snake_case.safe_name,
+            body=lambda object_property: resolve_name(
+                get_name_from_wire_value(object_property.name)
+            ).snake_case.safe_name,
         )
 
     def _get_expires_at_function_declaration(self) -> AST.FunctionDeclaration:

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/oauth_token_provider.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/oauth_token_provider.py
@@ -32,7 +32,7 @@ class OAuthTokenProvider:
 
     def _refresh(self) -> str:
         token_response = self._auth_client.get_token_with_client_credentials(
-            client_id=self._client_id, client_secret=self._client_secret
+            cid=self._client_id, csr=self._client_secret
         )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(
@@ -65,7 +65,7 @@ class AsyncOAuthTokenProvider:
 
     async def _refresh(self) -> str:
         token_response = await self._auth_client.get_token_with_client_credentials(
-            client_id=self._client_id, client_secret=self._client_secret
+            cid=self._client_id, csr=self._client_secret
         )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/oauth_token_provider.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/oauth_token_provider.py
@@ -32,7 +32,7 @@ class OAuthTokenProvider:
             return self._refresh()
 
     def _refresh(self) -> str:
-        token_response = self._auth_client.get_token(client_id=self._client_id, client_secret=self._client_secret)
+        token_response = self._auth_client.get_token(username=self._client_id, password=self._client_secret)
         self._access_token = token_response.access_token
         if token_response.refresh_token is None:
             raise RuntimeError("Access token not present in OAuth response")
@@ -67,7 +67,7 @@ class AsyncOAuthTokenProvider:
             return await self._refresh()
 
     async def _refresh(self) -> str:
-        token_response = await self._auth_client.get_token(client_id=self._client_id, client_secret=self._client_secret)
+        token_response = await self._auth_client.get_token(username=self._client_id, password=self._client_secret)
         self._access_token = token_response.access_token
         if token_response.refresh_token is None:
             raise RuntimeError("Access token not present in OAuth response")

--- a/seed/python-sdk/response-property/src/seed/service/client.py
+++ b/seed/python-sdk/response-property/src/seed/service/client.py
@@ -165,7 +165,9 @@ class ServiceClient:
         _response = self._raw_client.get_optional_movie(request=request, request_options=request_options)
         return _response.data
 
-    def get_optional_movie_docs(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
+    def get_optional_movie_docs(
+        self, *, request: str, request_options: typing.Optional[RequestOptions] = None
+    ) -> typing.Optional[str]:
         """
         Parameters
         ----------
@@ -176,7 +178,7 @@ class ServiceClient:
 
         Returns
         -------
-        str
+        typing.Optional[str]
 
         Examples
         --------
@@ -192,7 +194,9 @@ class ServiceClient:
         _response = self._raw_client.get_optional_movie_docs(request=request, request_options=request_options)
         return _response.data
 
-    def get_optional_movie_name(self, *, request: str, request_options: typing.Optional[RequestOptions] = None) -> str:
+    def get_optional_movie_name(
+        self, *, request: str, request_options: typing.Optional[RequestOptions] = None
+    ) -> typing.Optional[str]:
         """
         Parameters
         ----------
@@ -203,7 +207,7 @@ class ServiceClient:
 
         Returns
         -------
-        str
+        typing.Optional[str]
 
         Examples
         --------
@@ -416,7 +420,7 @@ class AsyncServiceClient:
 
     async def get_optional_movie_docs(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
-    ) -> str:
+    ) -> typing.Optional[str]:
         """
         Parameters
         ----------
@@ -427,7 +431,7 @@ class AsyncServiceClient:
 
         Returns
         -------
-        str
+        typing.Optional[str]
 
         Examples
         --------
@@ -453,7 +457,7 @@ class AsyncServiceClient:
 
     async def get_optional_movie_name(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
-    ) -> str:
+    ) -> typing.Optional[str]:
         """
         Parameters
         ----------
@@ -464,7 +468,7 @@ class AsyncServiceClient:
 
         Returns
         -------
-        str
+        typing.Optional[str]
 
         Examples
         --------

--- a/seed/python-sdk/response-property/src/seed/service/raw_client.py
+++ b/seed/python-sdk/response-property/src/seed/service/raw_client.py
@@ -238,7 +238,7 @@ class RawServiceClient:
 
     def get_optional_movie_docs(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
-    ) -> HttpResponse[str]:
+    ) -> HttpResponse[typing.Optional[str]]:
         """
         Parameters
         ----------
@@ -249,7 +249,7 @@ class RawServiceClient:
 
         Returns
         -------
-        HttpResponse[str]
+        HttpResponse[typing.Optional[str]]
         """
         _response = self._client_wrapper.httpx_client.request(
             "movie",
@@ -282,7 +282,7 @@ class RawServiceClient:
 
     def get_optional_movie_name(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
-    ) -> HttpResponse[str]:
+    ) -> HttpResponse[typing.Optional[str]]:
         """
         Parameters
         ----------
@@ -293,7 +293,7 @@ class RawServiceClient:
 
         Returns
         -------
-        HttpResponse[str]
+        HttpResponse[typing.Optional[str]]
         """
         _response = self._client_wrapper.httpx_client.request(
             "movie",
@@ -543,7 +543,7 @@ class AsyncRawServiceClient:
 
     async def get_optional_movie_docs(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
-    ) -> AsyncHttpResponse[str]:
+    ) -> AsyncHttpResponse[typing.Optional[str]]:
         """
         Parameters
         ----------
@@ -554,7 +554,7 @@ class AsyncRawServiceClient:
 
         Returns
         -------
-        AsyncHttpResponse[str]
+        AsyncHttpResponse[typing.Optional[str]]
         """
         _response = await self._client_wrapper.httpx_client.request(
             "movie",
@@ -587,7 +587,7 @@ class AsyncRawServiceClient:
 
     async def get_optional_movie_name(
         self, *, request: str, request_options: typing.Optional[RequestOptions] = None
-    ) -> AsyncHttpResponse[str]:
+    ) -> AsyncHttpResponse[typing.Optional[str]]:
         """
         Parameters
         ----------
@@ -598,7 +598,7 @@ class AsyncRawServiceClient:
 
         Returns
         -------
-        AsyncHttpResponse[str]
+        AsyncHttpResponse[typing.Optional[str]]
         """
         _response = await self._client_wrapper.httpx_client.request(
             "movie",

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -501,8 +501,6 @@ allowedFailures:
   - examples:legacy-wire-tests
   - exhaustive:deps_with_min_python_version
   - oauth-client-credentials-custom
-  - oauth-client-credentials-openapi
-  - response-property
   - streaming-parameter
   - trace
   - unions:union-naming-v1-wire-tests


### PR DESCRIPTION
## Description
Fixes two allowed-failure fixtures in the Python SDK generator by addressing the generator root causes (not the generated output).

**1. `response-property`** — When a `response: { property: ... }` endpoint resolves to an optional body (e.g. a named alias to `optional<...>` such as `OptionalWithDocs`), the raw client emits `HttpResponse(response=_response, data=None)` for empty responses, but the generic was `HttpResponse[str]`, so mypy flagged `data=None`. The generator used `response_type.is_optional` on the body's type hint, which is `False` for a named alias even though the alias resolves to optional. Now it uses `resolved_schema_is_optional_or_unknown(response.response_body_type)`, so the property type is wrapped in `Optional` whenever the underlying body resolves to optional.

**2. `oauth-client-credentials-openapi`** — The generated OAuth token provider hard-coded `client_id`/`client_secret` kwargs when calling the token endpoint, but the endpoint params come from the auth scheme's `request-properties` mapping (e.g. `username`/`password` for the OpenAPI spec). The provider now resolves the actual generated parameter name from the `request-properties` mapping for `client_id`, `client_secret`, and `refresh_token`.

`oauth-client-credentials-custom` is **left in `allowedFailures`** — see note below.

## Changes Made
- `endpoint_function_generator.py`: `_get_nested_json_response_type` wraps the property type in `Optional` based on the resolved schema, not the rendered type hint.
- `oauth_token_provider_generator.py`: token/refresh invocations use parameter names resolved from the `request-properties` mapping instead of hard-coded `client_id`/`client_secret`/`refresh_token`.
- Regenerated `response-property`, `oauth-client-credentials-openapi`, and `oauth-client-credentials-custom` snapshots (all other oauth/response-property fixtures regenerate with no diff).
- Removed `response-property` and `oauth-client-credentials-openapi` from `seed/python-sdk/seed.yml` `allowedFailures`.
- Added changelog entries under `generators/python/sdk/changes/unreleased/`.

### Note on `oauth-client-credentials-custom`
The mapping fix is applied here too (now calls `get_token_with_client_credentials(cid=..., csr=...)` instead of `client_id=`/`client_secret=`), which removes the original 4 "unexpected keyword argument" mypy errors. However, this fixture's token endpoint additionally requires `scp` (the `scopes` mapping) and `entity_id` (a non-literal `customProperties` entry), which have **no value source** in the OAuth token provider abstraction. mypy was previously masking these as soon as the unexpected-kwarg errors are resolved, so the fixture now fails with `Missing named argument "scp"`/`"entity_id"` instead. This is a deeper feature gap (the token provider would need to source/forward scopes and arbitrary custom properties) and is also unsupported in the TypeScript and Java generators (Go only "passes" because Go does not enforce required struct fields). Left in `allowedFailures` pending a decision on how to model custom/scope property values.

## Testing
- [x] Full `poetry run mypy .` passes on regenerated `response-property` (52 files) and `oauth-client-credentials-openapi` (50 files).
- [x] `mypy` + `pre-commit run` pass on the changed generator source.
- [x] All oauth + response-property fixtures regenerate via seed; only the three intended snapshots change.
- [ ] Unit tests added/updated

Link to Devin session: https://app.devin.ai/sessions/aa201fe3b32348b59c79ab37d86a80b3
Requested by: @iamnamananand996