### PR TITLE
chore(docs): add Built with Fern shield to CLI README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 <br/>
 
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=fern-api%2Ffern)
 [![npm version](https://img.shields.io/npm/v/fern-api)](https://www.npmjs.com/package/fern-api)
 [![2023 Y Combinator Startup](https://img.shields.io/badge/Y%20Combinator-2023-orange)](https://www.ycombinator.com/companies/fern)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue)


### PR DESCRIPTION
## Description

Adds the "Built with Fern" shield badge to the top of the CLI README, matching the badge used in generated SDK readmes.

## Changes Made
- Added `[![fern shield](https://img.shields.io/badge/...)](https://buildwithfern.com...)` badge to the shield row in `README.md`

## Testing
- [x] Manual testing completed — verified badge renders correctly in markdown preview


Link to Devin session: https://app.devin.ai/sessions/3d9680ebba5445eba4d8c1301f8d9634
Requested by: @jon-fern