### PR TITLE
fix(openapi): emit top-level servers for multipleBaseUrls environments with descriptions

### DIFF
--- a/generators/openapi/src/convertToOpenApi.ts
+++ b/generators/openapi/src/convertToOpenApi.ts
@@ -87,16 +87,40 @@ export function convertToOpenApi({
         }
     };
 
-    if (ir.environments != null && ir.environments.environments.type === "singleBaseUrl") {
-        openAPISpec.servers = ir.environments.environments.environments.map((environment) => {
-            return {
-                url: environment.url,
-                description:
-                    environment.docs != null
-                        ? `${getOriginalName(environment.name)} (${environment.docs})`
-                        : getOriginalName(environment.name)
-            };
-        });
+    if (ir.environments != null) {
+        const envs = ir.environments.environments;
+        if (envs.type === "singleBaseUrl") {
+            openAPISpec.servers = envs.environments.map((environment) => {
+                return {
+                    url: environment.url,
+                    description:
+                        environment.docs != null
+                            ? `${getOriginalName(environment.name)} (${environment.docs})`
+                            : getOriginalName(environment.name)
+                };
+            });
+        } else if (envs.type === "multipleBaseUrls") {
+            const servers: OpenAPIV3.ServerObject[] = [];
+            for (const environment of envs.environments) {
+                const envName = getOriginalName(environment.name);
+                for (const baseUrlDef of envs.baseUrls) {
+                    const url = environment.urls[baseUrlDef.id];
+                    if (url != null) {
+                        const urlName = getOriginalName(baseUrlDef.name);
+                        servers.push({
+                            url,
+                            description:
+                                environment.docs != null
+                                    ? `${envName} - ${urlName} (${environment.docs})`
+                                    : `${envName} (${urlName})`
+                        });
+                    }
+                }
+            }
+            if (servers.length > 0) {
+                openAPISpec.servers = servers;
+            }
+        }
     }
 
     return openAPISpec as unknown as OpenAPIV3_1.Document;

--- a/generators/openapi/src/converters/servicesConverter.ts
+++ b/generators/openapi/src/converters/servicesConverter.ts
@@ -174,10 +174,11 @@ function convertHttpEndpoint({
             if (url == null) {
                 throw new Error("No URL defined for " + baseUrlId);
             }
-            const server: OpenAPIV3.ServerObject = { url };
-            if (environment.docs != null) {
-                server.description = environment.docs;
-            }
+            const envName = getOriginalName(environment.name);
+            const server: OpenAPIV3.ServerObject = {
+                url,
+                description: environment.docs != null ? `${envName} (${environment.docs})` : envName
+            };
             return server;
         });
     }

--- a/packages/cli/cli/changes/unreleased/fix-export-multipleBaseUrls-servers.yml
+++ b/packages/cli/cli/changes/unreleased/fix-export-multipleBaseUrls-servers.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix `fern export` to emit top-level `servers` array for multi-URL environments
+    (`multipleBaseUrls`). Previously only single-URL environments produced servers.
+    Each environment × base-URL combination is now listed with a description like
+    `"Production (api)"`. Endpoint-level servers also now include the environment
+    name in their description.
+  type: fix

--- a/packages/cli/cli/src/commands/export/convertIrToOpenApi.ts
+++ b/packages/cli/cli/src/commands/export/convertIrToOpenApi.ts
@@ -72,16 +72,40 @@ export function convertIrToOpenApi({
         }
     };
 
-    if (ir.environments != null && ir.environments.environments.type === "singleBaseUrl") {
-        openAPISpec.servers = ir.environments.environments.environments.map((environment) => {
-            return {
-                url: environment.url,
-                description:
-                    environment.docs != null
-                        ? `${getOriginalName(environment.name)} (${environment.docs})`
-                        : getOriginalName(environment.name)
-            };
-        });
+    if (ir.environments != null) {
+        const envs = ir.environments.environments;
+        if (envs.type === "singleBaseUrl") {
+            openAPISpec.servers = envs.environments.map((environment) => {
+                return {
+                    url: environment.url,
+                    description:
+                        environment.docs != null
+                            ? `${getOriginalName(environment.name)} (${environment.docs})`
+                            : getOriginalName(environment.name)
+                };
+            });
+        } else if (envs.type === "multipleBaseUrls") {
+            const servers: OpenAPIV3.ServerObject[] = [];
+            for (const environment of envs.environments) {
+                const envName = getOriginalName(environment.name);
+                for (const baseUrlDef of envs.baseUrls) {
+                    const url = environment.urls[baseUrlDef.id];
+                    if (url != null) {
+                        const urlName = getOriginalName(baseUrlDef.name);
+                        servers.push({
+                            url,
+                            description:
+                                environment.docs != null
+                                    ? `${envName} - ${urlName} (${environment.docs})`
+                                    : `${envName} (${urlName})`
+                        });
+                    }
+                }
+            }
+            if (servers.length > 0) {
+                openAPISpec.servers = servers;
+            }
+        }
     }
 
     return openAPISpec;

--- a/packages/cli/cli/src/commands/export/converters/servicesConverter.ts
+++ b/packages/cli/cli/src/commands/export/converters/servicesConverter.ts
@@ -190,10 +190,11 @@ function convertHttpEndpoint({
             if (url == null) {
                 throw new CliError({ message: "No URL defined for " + baseUrlId, code: CliError.Code.InternalError });
             }
-            const server: OpenAPIV3.ServerObject = { url };
-            if (environment.docs != null) {
-                server.description = environment.docs;
-            }
+            const envName = getOriginalName(environment.name);
+            const server: OpenAPIV3.ServerObject = {
+                url,
+                description: environment.docs != null ? `${envName} (${environment.docs})` : envName
+            };
             return server;
         });
     }


### PR DESCRIPTION
## Description

When an API defines `multipleBaseUrls` environments (e.g. `api` + `identity` URLs per environment), the OpenAPI export was missing the top-level `servers` array entirely. Additionally, endpoint-level servers for multi-URL endpoints had no `description`, making it impossible for consumers to distinguish environments.

## Changes Made

### Top-level servers for `multipleBaseUrls` (`convertToOpenApi.ts` + CLI twin)

Previously only `singleBaseUrl` environments populated `servers`:
```typescript
if (envs.type === "singleBaseUrl") { ... }
// multipleBaseUrls → no servers emitted
```

Now both types are handled. For `multipleBaseUrls`, each environment × base-URL combination becomes a server entry:
```yaml
servers:
  - url: https://api.payroc.com/v1
    description: "Production (api)"
  - url: https://identity.payroc.com
    description: "Production (identity)"
  - url: https://api.uat.payroc.com/v1
    description: "UAT (api)"
  - url: https://identity.uat.payroc.com
    description: "UAT (identity)"
```

### Endpoint-level server descriptions (`servicesConverter.ts` + CLI twin)

Endpoint-level servers for `multipleBaseUrls` now include the environment name:
```yaml
# Before
servers:
  - url: https://identity.payroc.com
  - url: https://identity.uat.payroc.com

# After
servers:
  - url: https://identity.payroc.com
    description: Production
  - url: https://identity.uat.payroc.com
    description: UAT
```

### Files changed
- `generators/openapi/src/convertToOpenApi.ts` — handle `multipleBaseUrls` for top-level servers
- `generators/openapi/src/converters/servicesConverter.ts` — add env name to endpoint-level server descriptions
- `packages/cli/cli/src/commands/export/convertIrToOpenApi.ts` — same fix for CLI export path
- `packages/cli/cli/src/commands/export/converters/servicesConverter.ts` — same fix for CLI export path

## Testing
- [x] `pnpm run check` passes
- [x] Existing `multi-url-environment` seed fixture validates the endpoint-level server logic
- [x] Manual review of all four changed files for consistency

Link to Devin session: https://app.devin.ai/sessions/3bf7706646b64004b70de6606a7badc6
Requested by: @iamnamananand996