### PR TITLE
chore(seed): remove stale go-sdk allowedFailures entries

### DIFF
--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -355,45 +355,29 @@ scripts:
           fi
           exit $TEST_EXIT_CODE
 allowedFailures:
-  - schemaless-request-body-examples
-  - alias-extends
-  - bytes-upload
+  # Unsupported features in the v1 Go generator (generation aborts with
+  # "not supported yet" or a nil-pointer panic). These need feature work.
+  - alias-extends # object/request body extends an alias; v1 assumes extends are objects
   - bytes-download
-  - enum
-  - errors
-  - literal
-  - mixed-case:no-custom-config
-  - mixed-case:default-values
-  - request-parameters
-  - reserved-keywords
+  - bytes-upload
   - streaming-parameter
-  - server-sent-event-examples:with-wire-tests # TODO: update wiretests geranation then remove it
-  - server-sent-events:with-wire-tests # TODO: update wiretests geranation then remove it
-  - server-sent-events-openapi:with-wire-tests # TODO: fix go wire test generation for augmented fixture
-  - server-url-templating
-  - trace
-  - property-access
-  - oauth-client-credentials:.
-  - oauth-client-credentials-reference
-
-  # TODO: Fix example generator to produce valid dynamic snippets.
   - pagination
   - pagination-uri-path
 
-  # TODO: Update the dynamic snippet generator to handle these cases.
-  - examples:exported-client-name
-  - path-parameters:no-custom-config
-  - path-parameters:package-name
+  # Generated Go code does not compile. Each needs a generator fix.
+  - enum # enum-union header value is not converted to a string
+  - literal
+  - mixed-case:no-custom-config # user property `extraProperties` collides with the generated accessor
+  - mixed-case:default-values
+  - property-access # union member name `Normal` is declared twice
+  - trace # generated v2/ subpackage references undefined test types
+  - request-parameters # int64 default 9223372036854775807 loses precision in the IR pipeline
 
-  - oauth-client-credentials-with-variables
-  - variables
+  # Dynamic snippet generation produces code that does not compile.
+  - examples:exported-client-name # snippet calls client.NewAcmeClient but the SDK exports NewClient
+  - server-sent-event-examples:with-wire-tests # TODO: update wiretests geranation then remove it
 
-  # Will include these back in once we fix dynamic snippets for inline file properties
-  - file-upload:no-custom-config
-  - file-upload:package-name
-  - file-upload-openapi
-
-  - go-deterministic-ordering:.
-
+  # Wire tests fail at runtime.
+  - oauth-client-credentials:.
   # exhaustive:omit-empty-request-wrappers wire tests fail due to missing Authorization header
   - exhaustive:omit-empty-request-wrappers


### PR DESCRIPTION
## Description
Removes `allowedFailures` entries from the Go SDK seed config (`seed/go-sdk/seed.yml`) that **already pass**, so seed enforces them going forward. The fixtures that still genuinely fail are kept, but reorganized and annotated by root cause for a follow-up PR.

Per the request, this PR only does the "easy" part (removing stale entries). All remaining failures require non-trivial generator work and are intentionally left for a separate PR.

## Changes Made
- Removed **15** stale entries that now pass (re-verified locally with `pnpm seed:local test --generator go-sdk --local`): `schemaless-request-body-examples`, `errors`, `reserved-keywords`, `server-url-templating`, `oauth-client-credentials-reference`, `path-parameters:no-custom-config`, `path-parameters:package-name`, `oauth-client-credentials-with-variables`, `variables`, `file-upload:no-custom-config`, `file-upload:package-name`, `file-upload-openapi`, `go-deterministic-ordering:.`, `server-sent-events:with-wire-tests`, `server-sent-events-openapi:with-wire-tests`.
- Kept the **17** still-failing entries, grouped with concise root-cause notes. No generator code was changed.
- [ ] Updated README.md generator (if applicable) — N/A

### Why the remaining entries are kept (follow-up PR)
- **v1 feature gaps / panics**: `alias-extends` (object extends an alias; v1 assumes extends are objects), `bytes-download`, `bytes-upload`, `streaming-parameter`, `pagination`, `pagination-uri-path`.
- **Generated Go does not compile**: `enum` (enum-union header not cast to string), `literal`, `mixed-case:*` (`extraProperties` collides with the generated accessor), `property-access` (`Normal` declared twice), `trace` (generated `v2/` subpackage references undefined test types), `request-parameters` (int64 default `9223372036854775807` loses precision in the IR pipeline).
- **Dynamic snippets do not compile**: `examples:exported-client-name` (snippet calls `client.NewAcmeClient` but SDK exports `NewClient`), `server-sent-event-examples:with-wire-tests`.
- **Wire tests fail at runtime**: `oauth-client-credentials:.`, `exhaustive:omit-empty-request-wrappers` (flaky — missing Authorization header).

## Testing
- [x] Manual testing completed — ran the 15 removed fixtures locally; all pass reliably (the seed runner itself flagged them as "succeeded unexpectedly, consider removing"). `exhaustive:omit-empty-request-wrappers` was observed to be flaky and is deliberately retained.
- [ ] Unit tests added/updated — N/A (seed config only)


Link to Devin session: https://app.devin.ai/sessions/6ba63e4405694aa8ab8875f0dbfd9afc
Requested by: @iamnamananand996