### PR TITLE
fix(typescript): collapse duplicate slashes in generated request URLs

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/fix-double-slash-url.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-double-slash-url.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix request URLs containing duplicate slashes (e.g. `/{id}//{nestedId}`) when a
+    base-path, service base-path, and endpoint path are joined together. Consecutive
+    slashes in the generated URL are now collapsed into a single slash, matching the
+    URL used in generated wire tests.
+  type: fix

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/buildUrl.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/buildUrl.test.ts.snap
@@ -1,5 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`buildUrl > collapses duplicate slashes introduced between path parameters 1`] = `"\`/\${id}/\${nestedId}\`"`;
+
 exports[`buildUrl > generates template literal for path with multiple parameters 1`] = `"\`/orgs/\${orgId}/users/\${userId}\`"`;
 
 exports[`buildUrl > generates template literal for path with one parameter 1`] = `"\`/users/\${userId}\`"`;

--- a/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/buildUrl.test.ts
@@ -170,6 +170,65 @@ describe("buildUrl", () => {
         expect(text).toMatchSnapshot();
     });
 
+    it("collapses duplicate slashes in static path with no parameters", () => {
+        const result = buildUrl({
+            endpoint: {
+                sdkRequest: undefined,
+                fullPath: { head: "/api//v1///users", parts: [] },
+                allPathParameters: [],
+                path: { head: "/api//v1///users", parts: [] }
+            },
+            generatedClientClass: createMockGeneratedClientClass(),
+            context: createMockContext(),
+            includeSerdeLayer: false,
+            retainOriginalCasing: false,
+            omitUndefined: false,
+            parameterNaming: "default",
+            getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
+        });
+
+        assert(result != null, "expected buildUrl to return an expression for static path");
+        expect(getTextOfTsNode(result)).toBe('"/api/v1/users"');
+    });
+
+    it("collapses duplicate slashes introduced between path parameters", () => {
+        const idParam = createPathParameter("id");
+        const nestedIdParam = createPathParameter("nestedId");
+
+        const result = buildUrl({
+            endpoint: {
+                sdkRequest: undefined,
+                fullPath: {
+                    head: "/",
+                    parts: [
+                        { pathParameter: "id", tail: "//" },
+                        { pathParameter: "nestedId", tail: "" }
+                    ]
+                },
+                allPathParameters: [idParam, nestedIdParam],
+                path: {
+                    head: "/",
+                    parts: [
+                        { pathParameter: "id", tail: "//" },
+                        { pathParameter: "nestedId", tail: "" }
+                    ]
+                }
+            },
+            generatedClientClass: createMockGeneratedClientClass(),
+            context: createMockContext(),
+            includeSerdeLayer: false,
+            retainOriginalCasing: false,
+            omitUndefined: false,
+            parameterNaming: "default",
+            getReferenceToPathParameterVariableFromRequest: defaultGetReferenceToPathParameterVariableFromRequest
+        });
+
+        assert(result != null, "expected buildUrl to return an expression for nested path parameters");
+        const text = getTextOfTsNode(result);
+        expect(text).not.toContain("}//$");
+        expect(text).toMatchSnapshot();
+    });
+
     it("uses root path parameter reference for ROOT location", () => {
         const rootParam = createPathParameter("tenantId", "ROOT");
 

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/buildUrl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/buildUrl.ts
@@ -40,10 +40,10 @@ export function buildUrl({
         if (endpoint.fullPath.head.length === 0) {
             return undefined;
         }
-        return ts.factory.createStringLiteral(endpoint.fullPath.head);
+        return ts.factory.createStringLiteral(collapseSlashes(endpoint.fullPath.head));
     }
     return ts.factory.createTemplateExpression(
-        ts.factory.createTemplateHead(endpoint.fullPath.head),
+        ts.factory.createTemplateHead(collapseSlashes(endpoint.fullPath.head)),
         endpoint.fullPath.parts.map((part, index) => {
             const pathParameter = endpoint.allPathParameters.find(
                 (param) => getOriginalName(param.name) === part.pathParameter
@@ -107,11 +107,23 @@ export function buildUrl({
             return ts.factory.createTemplateSpan(
                 context.coreUtilities.urlUtils.encodePathParam._invoke(referenceToPathParameterValue),
                 index === endpoint.fullPath.parts.length - 1
-                    ? ts.factory.createTemplateTail(part.tail)
-                    : ts.factory.createTemplateMiddle(part.tail)
+                    ? ts.factory.createTemplateTail(collapseSlashes(part.tail))
+                    : ts.factory.createTemplateMiddle(collapseSlashes(part.tail))
             );
         })
     );
+}
+
+/**
+ * Collapses consecutive slashes in a URL path fragment into a single slash.
+ *
+ * Joining a base-path, service base-path, and endpoint path can introduce duplicate
+ * slashes (e.g. `/{id}` + `/` + `/{nestedId}` => `/{id}//{nestedId}`). The example URL
+ * in the IR already normalizes these, so the request URL must match to keep generated
+ * wire tests (and real requests) consistent.
+ */
+function collapseSlashes(pathFragment: string): string {
+    return pathFragment.replace(/\/{2,}/g, "/");
 }
 
 function getReferenceToPathParameter({

--- a/seed/ts-sdk/package-yml/src/api/resources/service/client/Client.ts
+++ b/seed/ts-sdk/package-yml/src/api/resources/service/client/Client.ts
@@ -40,7 +40,7 @@ export class ServiceClient {
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
                     (await core.Supplier.get(this._options.environment)),
-                `/${core.url.encodePathParam(this._options.id)}//${core.url.encodePathParam(nestedId)}`,
+                `/${core.url.encodePathParam(this._options.id)}/${core.url.encodePathParam(nestedId)}`,
             ),
             method: "GET",
             headers: _headers,

--- a/seed/ts-sdk/seed.yml
+++ b/seed/ts-sdk/seed.yml
@@ -569,7 +569,6 @@ allowedFailures:
   - exhaustive:never-throw-errors
   - exhaustive:multiple-exports
   - oauth-client-credentials-custom
-  - package-yml
   - inferred-auth-implicit-reference
   - unions:serde-layer
   - server-sent-events-openapi:no-custom-config # tmp  - wire test generation is failing


### PR DESCRIPTION
## Description
When the TypeScript SDK generator joins a root base-path, service base-path, and endpoint path, it could emit a request URL containing duplicate slashes (e.g. `/{id}//{nestedId}`). The IR's example URL (used in generated wire tests) already collapses `//` → `/`, so the runtime URL and the test expectation diverged, causing the `package-yml` fixture's wire test to make a real network request and fail.

This fixes the `package-yml` entry in `seed/ts-sdk/seed.yml`'s `allowedFailures` and removes it from that list.

## Changes Made
- Add a `collapseSlashes` helper in `generators/typescript/sdk/client-class-generator/src/endpoints/utils/buildUrl.ts` and apply it to the template head and each template tail so consecutive slashes are collapsed to a single slash.

  ```
  `/${encodePathParam(id)}//${encodePathParam(nestedId)}`  =>  `/${encodePathParam(id)}/${encodePathParam(nestedId)}`
  ```
- Remove `package-yml` from `allowedFailures` in `seed/ts-sdk/seed.yml` and regenerate that fixture's output.
- Add unit tests in `buildUrl.test.ts` covering slash collapsing for static paths and between path parameters.
- Add unreleased changelog entry (`type: fix`).
- [ ] Updated README.md generator (if applicable) — not applicable

## Testing
- [x] Unit tests added/updated — `pnpm vitest run buildUrl` (13 passed), full `client-class-generator` suite (545 passed)
- [x] Manual testing completed — `seed test --generator ts-sdk --fixture package-yml --local` now reports `success` (`1/1 test cases passed`); confirmed generated URL no longer contains `//`

### Deferred to separate PRs (harder fixes, kept in `allowedFailures`)
These remaining fixtures need more involved fixes and are intentionally left out of this PR:
- `inferred-auth-implicit-reference` — reference-body inferred-auth path mishandles literal properties (`audience`/`grant_type`) and reads token-request values from wrong (non-camelCase) option names; the request-wrapper path handles this correctly but the named-reference path reimplements it incorrectly.
- `oauth-client-credentials-custom` — custom OAuth token request omits required body properties.
- `unions:serde-layer`, `cross-package-type-names:serde-layer`, `exhaustive:never-throw-errors`, `exhaustive:multiple-exports`, `server-sent-events-openapi:no-custom-config` — type-system / pagination / tree-shaking / SSE issues.

Link to Devin session: https://app.devin.ai/sessions/26ade34faea643128ea0b09d85df2976
Requested by: @iamnamananand996