### PR TITLE
chore(seed): remove stale swift-sdk allowedFailures

### DIFF
--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -127,16 +127,8 @@ fixtures:
       outputFolder: with-custom-config
 
 allowedFailures:
-  - schemaless-request-body-examples
-  - api-wide-base-path
-  - bytes-upload
   - audiences
-  - header-auth-environment-variable
-  - client-side-params:with-custom-config
-  - client-side-params:no-custom-config
-  - cross-package-type-names
   - enum
-  - errors
   - examples:no-custom-config
   - examples:readme-config
   - exhaustive
@@ -147,10 +139,7 @@ allowedFailures:
   - inferred-auth-implicit
   - inferred-auth-implicit-no-expiry
   - inferred-auth-implicit-api-key
-  - inferred-auth-implicit-reference
   - literal
-  - mixed-case
-  - mixed-file-directory
   - multi-url-environment
   - multi-url-environment-no-default
   - multi-url-environment-reference
@@ -158,13 +147,10 @@ allowedFailures:
   - nullable:nullable-as-optional
   - nullable-optional:no-custom-config
   - nullable-optional:nullable-as-optional
-  - nullable-request-body
-  - oauth-client-credentials-custom
   - oauth-client-credentials-with-variables
   - pagination:no-custom-config
   - pagination:custom-pager
   - pagination:custom-pager-with-exception-handler
-  - path-parameters
   - plain-text
   - query-parameters
   - request-parameters
@@ -183,11 +169,6 @@ allowedFailures:
   - server-url-templating
   - variables
   - websocket-inferred-auth
-  # Intermediate failures
-  - any-auth
-  - imdb
-  # Boolean literal enum changes require seed snapshot regeneration
-  - null-type
   # Multipart with $ref body — Swift snippet generator emits args in wrong
   # positional order; tracked separately under FER-10087 follow-up.
   - openapi-request-body-ref


### PR DESCRIPTION
## Description
Removes 17 stale entries from the Swift SDK generator's `seed/swift-sdk/seed.yml` `allowedFailures` list. These fixtures already pass the full seed run (generation + Swift build + tests) on `main`, so they no longer belong in `allowedFailures`. The seed framework itself was flagging them via "⚠ succeeded unexpectedly. Consider removing the following fixtures from allowedFailures".

No generator code changed — this is purely a seed-config cleanup.

## Changes Made
Removed the following 17 fixtures (and now-orphaned comments) from `allowedFailures`:
`any-auth`, `api-wide-base-path`, `bytes-upload`, `client-side-params:with-custom-config`, `client-side-params:no-custom-config`, `cross-package-type-names`, `errors`, `header-auth-environment-variable`, `imdb`, `inferred-auth-implicit-reference`, `mixed-case`, `mixed-file-directory`, `null-type`, `nullable-request-body`, `oauth-client-credentials-custom`, `path-parameters`, `schemaless-request-body-examples`.

The remaining 41 `allowedFailures` are genuine Swift-codegen build/test failures (e.g. snippet argument ordering, integer-literal formatting, enum synthesis, nested literal enums, multi-URL environments) and require real generator fixes — those are deferred to separate follow-up PRs.

## Testing
- [x] Manual testing completed — ran the 17 removed fixtures through the full seed suite (generation + build + test) against a clean-`main` Swift generator image: **17/17 passed ✅**.

```
node packages/seed/dist/cli.cjs test --generator swift-sdk -p 3 \
  --fixture any-auth --fixture api-wide-base-path --fixture bytes-upload \
  --fixture client-side-params --fixture cross-package-type-names --fixture errors \
  --fixture header-auth-environment-variable --fixture imdb \
  --fixture inferred-auth-implicit-reference --fixture mixed-case \
  --fixture mixed-file-directory --fixture null-type --fixture nullable-request-body \
  --fixture oauth-client-credentials-custom --fixture path-parameters \
  --fixture schemaless-request-body-examples
=> 17/17 test cases passed ✅
```


Link to Devin session: https://app.devin.ai/sessions/b033c7d30c964b16848de1bbbe08e604
Requested by: @iamnamananand996