### PR TITLE
fix(cli-generator): update sync-sdk.sh for cli-sdk autobins layout

### DIFF
--- a/generators/cli/build.mjs
+++ b/generators/cli/build.mjs
@@ -19,7 +19,8 @@ const SDK_IGNORE = [
     "docs/**",
 
     // Template-dev integration tests coupled to the SDK template's own
-    // dev fixture under `cli/openapi-fixture/` (also pruned below).
+    // dev fixture under `cli/openapi-fixture/` (synced from cli-sdk's
+    // `src/bin/openapi-fixture/`; also pruned below).
     // `overlay_fixture.rs` `include_str!`s that spec to exercise the
     // overlay → discovery pipeline via library calls; `tests/fixtures/`
     // holds fixture data. `copySpecs` writes a fresh main.rs against the

--- a/generators/cli/scripts/strip-fixture-tests.py
+++ b/generators/cli/scripts/strip-fixture-tests.py
@@ -313,7 +313,7 @@ def _extract_items(lines: list[str], body_start: int, body_end: int) -> list[dic
 def process_file(path: Path) -> bool:
     """Process a single .rs file. Returns True if the file was modified."""
     content = path.read_text()
-    if '../../cli/' not in content:
+    if '../../cli/' not in content and '../bin/' not in content:
         return False
 
     lines = content.split('\n')

--- a/generators/cli/scripts/strip-fixture-tests.py
+++ b/generators/cli/scripts/strip-fixture-tests.py
@@ -6,9 +6,9 @@ Usage:
 
 Removes #[test] functions, #[cfg(test)] helper items, and entire
 #[cfg(test)] modules that reference fixture files via
-include_str!("../../cli/...") paths. Those fixtures exist in the source
-cli-sdk repo but are NOT synced into the vendored copy, so they break
-`cargo test` compilation.
+include_str!("../../cli/...") or include_str!("../bin/...") paths.
+Those fixtures exist in the source cli-sdk repo but are NOT synced into
+the vendored copy, so they break `cargo test` compilation.
 
 Non-fixture tests are preserved. If stripping leaves a #[cfg(test)]
 module with no remaining #[test] functions, the entire module is removed.
@@ -23,7 +23,7 @@ import re
 import sys
 from pathlib import Path
 
-FIXTURE_RE = re.compile(r'include_str!\s*\(\s*"[^"]*\.\./\.\./cli/')
+FIXTURE_RE = re.compile(r'include_str!\s*\(\s*"[^"]*\.\./(\.\./)?(cli|bin)/')
 
 
 # ---------------------------------------------------------------------------

--- a/generators/cli/scripts/strip-fixture-tests.py
+++ b/generators/cli/scripts/strip-fixture-tests.py
@@ -313,7 +313,7 @@ def _extract_items(lines: list[str], body_start: int, body_end: int) -> list[dic
 def process_file(path: Path) -> bool:
     """Process a single .rs file. Returns True if the file was modified."""
     content = path.read_text()
-    if '../../cli/' not in content and '../bin/' not in content:
+    if '../cli/' not in content and '../bin/' not in content:
         return False
 
     lines = content.split('\n')

--- a/generators/cli/scripts/sync-sdk.sh
+++ b/generators/cli/scripts/sync-sdk.sh
@@ -36,10 +36,16 @@ echo "==> Syncing cli-sdk@${CLI_SDK_SHORT} (${CLI_SDK_SHA}) into generators/cli/
 # ---------------------------------------------------------------------------
 # 1. Rsync source files + openapi-fixture dev binary
 # ---------------------------------------------------------------------------
-echo "--- Syncing src/, cli/openapi-fixture/ ..."
+echo "--- Syncing src/, src/bin/openapi-fixture/ ..."
 
+# cli-sdk uses autobins — src/bin/ contains ~30 demo binary directories.
+# We exclude them all (--filter) so the vendored SDK only ships the
+# library code + strip_schema.rs. openapi-fixture is synced separately
+# into cli/openapi-fixture/ to preserve the path that patchCargoToml.ts
+# anchors on.
 rsync -a --delete \
   --exclude='.DS_Store' \
+  --filter='- bin/*/' \
   "$CLI_SDK_DIR/src/" "$SDK_DIR/src/"
 
 # Tests are NOT synced. cli-sdk's own CI validates test compilation;
@@ -48,10 +54,13 @@ rsync -a --delete \
 # (smoke tests, parser.rs #[cfg(test)] include_str! calls) and would
 # fail to compile in the projected single-package layout.
 
-# Sync cli/openapi-fixture/ (the dev fixture used by seed)
+# Sync openapi-fixture (the dev fixture used by seed).
+# cli-sdk moved binaries from cli/<name>/ to src/bin/<name>/ (autobins)
+# but the vendored SDK keeps cli/openapi-fixture/ because
+# patchCargoToml.ts anchors on that path.
 mkdir -p "$SDK_DIR/cli/openapi-fixture"
 rsync -a --delete \
-  "$CLI_SDK_DIR/cli/openapi-fixture/" "$SDK_DIR/cli/openapi-fixture/"
+  "$CLI_SDK_DIR/src/bin/openapi-fixture/" "$SDK_DIR/cli/openapi-fixture/"
 
 # Remove stale tests/ directory if present from a prior sync revision
 if [[ -d "$SDK_DIR/tests" ]]; then
@@ -63,8 +72,9 @@ fi
 # 1b. Strip fixture-dependent inline tests from src/
 # ---------------------------------------------------------------------------
 # cli-sdk's #[cfg(test)] modules reference fixture specs via
-# include_str!("../../cli/<dir>/...") that are NOT synced. Removing them
-# keeps `cargo test` clean in both the vendored SDK and generated CLIs.
+# include_str!("../bin/<dir>/...") (or the legacy "../../cli/<dir>/...")
+# that are NOT synced. Removing them keeps `cargo test` clean in both
+# the vendored SDK and generated CLIs.
 echo "--- Stripping fixture-dependent inline tests from src/ ..."
 python3 "$SCRIPT_DIR/strip-fixture-tests.py" "$SDK_DIR/src/"
 


### PR DESCRIPTION
## Description

Fixes the daily `sync-cli-sdk.yml` workflow which has been failing since cli-sdk's autobins refactor (`fern-api/cli-sdk#132`) moved binaries from `cli/<name>/` to `src/bin/<name>/`.

The error was:
```
rsync: [sender] change_dir ".../cli/openapi-fixture" failed: No such file or directory (2)
```

## Changes Made

- **`sync-sdk.sh`**: 
  - Excludes `src/bin/*/` directories from the `src/` rsync (prevents ~30 demo binary dirs from leaking into the vendored SDK)
  - Sources `openapi-fixture` from `src/bin/openapi-fixture/` instead of `cli/openapi-fixture/`
  - Destination remains `cli/openapi-fixture/` to preserve the `patchCargoToml.ts` anchors
- **`strip-fixture-tests.py`**: Regex now matches both the old `../../cli/` and new `../bin/` `include_str!` paths
- **`build.mjs`**: Updated comment for clarity

## Testing

- [x] Ran `sync-sdk.sh` locally against a fresh cli-sdk `main` checkout — sync completed successfully
- [x] Verified `cargo build --locked --no-default-features --features rustls` passes on the synced SDK
- [x] Verified only `strip_schema.rs` remains in `src/bin/` (no leaked demo binaries)
- [x] Verified `cli/openapi-fixture/` contains `main.rs`, `openapi.yaml`, and `AUTH.md`

Link to Devin session: https://app.devin.ai/sessions/eb005ea06dfc4b9b8574730a741e6f4c
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->