### PR TITLE
feat(java): add exported-client-class-name config for docs snippet client name

### DIFF
--- a/generators/java-v2/ast/src/custom-config/BaseJavaCustomConfigSchema.ts
+++ b/generators/java-v2/ast/src/custom-config/BaseJavaCustomConfigSchema.ts
@@ -6,6 +6,7 @@ export const BaseJavaCustomConfigSchema = z.object({
     "base-api-exception-class-name": z.string().optional(),
     "base-exception-class-name": z.string().optional(),
     "client-class-name": z.string().optional(),
+    "exported-client-class-name": z.string().optional(),
     "inline-file-properties": z.boolean().optional(),
     "inline-path-parameters": z.boolean().optional(),
     "package-layout": z.enum(["flat", "nested"]).optional(),

--- a/generators/java-v2/dynamic-snippets/src/__test__/DynamicSnippetsGenerator.test.ts
+++ b/generators/java-v2/dynamic-snippets/src/__test__/DynamicSnippetsGenerator.test.ts
@@ -1,4 +1,6 @@
 import { DynamicSnippetsTestRunner } from "@fern-api/browser-compatible-base-generator";
+import { FernIr } from "@fern-api/dynamic-ir-sdk";
+import { AbsoluteFilePath, join } from "@fern-api/path-utils";
 
 import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
 import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
@@ -8,5 +10,76 @@ describe("snippets (default)", () => {
     runner.runTests({
         buildGenerator: ({ irFilepath }) =>
             buildDynamicSnippetsGenerator({ irFilepath, config: buildGeneratorConfig() })
+    });
+});
+
+const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
+    `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
+);
+
+/**
+ * `exported-client-class-name` is the name customers want surfaced in docs snippets (e.g. a
+ * hand-written wrapper around the generated client). It must override `client-class-name` for
+ * snippet output only, while falling back to `client-class-name` (and then the default) when unset.
+ */
+describe("snippets (exported-client-class-name)", () => {
+    const createMovieRequest: FernIr.dynamic.EndpointSnippetRequest = {
+        endpoint: {
+            method: "POST",
+            path: "/movies/create-movie"
+        },
+        baseURL: undefined,
+        environment: undefined,
+        auth: {
+            type: "bearer",
+            token: "<YOUR_API_KEY>"
+        },
+        pathParameters: undefined,
+        queryParameters: undefined,
+        headers: undefined,
+        requestBody: {
+            title: "The Matrix",
+            rating: 8.2
+        }
+    };
+
+    test("exported-client-class-name overrides client-class-name in the generated snippet", async () => {
+        const generator = buildDynamicSnippetsGenerator({
+            irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "imdb.json")),
+            config: buildGeneratorConfig({
+                customConfig: {
+                    "client-class-name": "BaseAcme",
+                    "exported-client-class-name": "AcmeClient"
+                }
+            })
+        });
+
+        const response = await generator.generate(createMovieRequest);
+
+        expect(response.errors).toBeUndefined();
+        expect(response.snippet).toBeTruthy();
+        const snippet = response.snippet ?? "";
+        // Docs surfaces must instantiate/build the exported name...
+        expect(snippet).toContain("AcmeClient client = AcmeClient");
+        // ...and must never leak the internal client-class-name.
+        expect(snippet).not.toContain("BaseAcme");
+    });
+
+    test("falls back to client-class-name when exported-client-class-name is unset", async () => {
+        const generator = buildDynamicSnippetsGenerator({
+            irFilepath: AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "imdb.json")),
+            config: buildGeneratorConfig({
+                customConfig: {
+                    "client-class-name": "BaseAcme"
+                }
+            })
+        });
+
+        const response = await generator.generate(createMovieRequest);
+
+        expect(response.errors).toBeUndefined();
+        expect(response.snippet).toBeTruthy();
+        const snippet = response.snippet ?? "";
+        expect(snippet).toContain("BaseAcme client = BaseAcme");
     });
 });

--- a/generators/java-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/java-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -89,13 +89,23 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
 
     public getRootClientClassReference(): java.ClassReference {
         return java.classReference({
-            name: this.getRootClientClassName(),
+            name: this.getRootClientClassNameForSnippets(),
             packageName: this.getRootPackageName()
         });
     }
 
     public getRootClientClassName(): string {
         return this.customConfig?.["client-class-name"] ?? `${this.getBaseNamePrefix()}Client`;
+    }
+
+    /**
+     * The client class name surfaced in documentation snippets (dynamic snippets, README, reference.md).
+     * Customers may export the generated root client under a different, hand-written class name; this
+     * accessor reflects that exported name. Falls back to the internal client class name when unset, so
+     * output is unchanged for users who have not configured `exported-client-class-name`.
+     */
+    public getRootClientClassNameForSnippets(): string {
+        return this.customConfig?.["exported-client-class-name"] ?? this.getRootClientClassName();
     }
 
     public getEnvironmentClassName(): string {

--- a/generators/java-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/java-v2/sdk/src/SdkGeneratorContext.ts
@@ -271,7 +271,7 @@ export class SdkGeneratorContext extends AbstractJavaGeneratorContext<SdkCustomC
 
     public getRootClientClassReference(): java.ClassReference {
         return java.classReference({
-            name: this.getRootClientClassName(),
+            name: this.getRootClientClassNameForSnippets(),
             packageName: this.getRootPackageName()
         });
     }
@@ -283,6 +283,20 @@ export class SdkGeneratorContext extends AbstractJavaGeneratorContext<SdkCustomC
 
     public getRootClientClassName(): string {
         return this.customConfig?.["client-class-name"] ?? `${this.getBaseNamePrefix()}Client`;
+    }
+
+    /**
+     * The client class name surfaced in documentation snippets (README, reference.md).
+     * Customers may export the generated root client under a different, hand-written class name; this
+     * accessor reflects that exported name. Falls back to the internal client class name when unset, so
+     * output is unchanged for users who have not configured `exported-client-class-name`.
+     *
+     * Note: wire tests compile against the generated code and must continue to use the internal
+     * `getRootClientClassName()`; the exported class is hand-written by customers and does not exist
+     * in generator output.
+     */
+    public getRootClientClassNameForSnippets(): string {
+        return this.customConfig?.["exported-client-class-name"] ?? this.getRootClientClassName();
     }
 
     public isSelfHosted(): boolean {

--- a/generators/java-v2/sdk/src/__test__/buildWireTestSnippetsConfig.test.ts
+++ b/generators/java-v2/sdk/src/__test__/buildWireTestSnippetsConfig.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { buildWireTestSnippetsConfig } from "../sdk-wire-tests/buildWireTestSnippetsConfig.js";
+
+describe("buildWireTestSnippetsConfig", () => {
+    it("strips exported-client-class-name so wire-test snippets use the internal client", () => {
+        const config = {
+            organization: "acme",
+            customConfig: {
+                "client-class-name": "BaseAcme",
+                "exported-client-class-name": "AcmeClient"
+            }
+        };
+
+        const result = buildWireTestSnippetsConfig(config);
+
+        expect(result.customConfig).toEqual({ "client-class-name": "BaseAcme" });
+        // the original config must not be mutated
+        expect(config.customConfig).toEqual({
+            "client-class-name": "BaseAcme",
+            "exported-client-class-name": "AcmeClient"
+        });
+    });
+
+    it("returns the config unchanged when exported-client-class-name is not set", () => {
+        const config = {
+            organization: "acme",
+            customConfig: { "client-class-name": "BaseAcme" }
+        };
+
+        const result = buildWireTestSnippetsConfig(config);
+
+        expect(result.customConfig).toEqual({ "client-class-name": "BaseAcme" });
+    });
+
+    it("returns the config unchanged when customConfig is undefined", () => {
+        const config = { organization: "acme", customConfig: undefined };
+
+        const result = buildWireTestSnippetsConfig(config);
+
+        expect(result).toBe(config);
+    });
+
+    it("returns the config unchanged when customConfig is not an object", () => {
+        const config = { organization: "acme", customConfig: "not-an-object" };
+
+        const result = buildWireTestSnippetsConfig(config);
+
+        expect(result).toBe(config);
+    });
+});

--- a/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -181,7 +181,7 @@ UpdateRequest request = UpdateRequest.builder()
     }
 
     private getOAuthTokenOverrideDocumentation(): string {
-        const clientClassName = this.context.getRootClientClassName();
+        const clientClassName = this.context.getRootClientClassNameForSnippets();
         return `This SDK supports two authentication methods:
 
 ### Option 1: Direct Bearer Token

--- a/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/SdkWireTestGenerator.ts
@@ -9,6 +9,7 @@ import { convertDynamicEndpointSnippetRequest } from "../utils/convertEndpointSn
 import { convertIr } from "../utils/convertIr.js";
 import { TestClassBuilder } from "./builders/TestClassBuilder.js";
 import { TestMethodBuilder } from "./builders/TestMethodBuilder.js";
+import { buildWireTestSnippetsConfig } from "./buildWireTestSnippetsConfig.js";
 import { SnippetExtractor } from "./extractors/SnippetExtractor.js";
 import { WireTestDataExtractor, WireTestExample } from "./extractors/TestDataExtractor.js";
 import { TestResourceWriter } from "./resources/TestResourceWriter.js";
@@ -56,7 +57,9 @@ export class SdkWireTestGenerator {
         const convertedIr: any = convertIr(dynamicIr);
         const dynamicSnippetsGenerator = new DynamicSnippetsGenerator({
             ir: convertedIr,
-            config: this.context.config
+            // Wire tests compile against the generated SDK, so their snippets must use the
+            // internal client class name — docs-only overrides are stripped here.
+            config: buildWireTestSnippetsConfig(this.context.config)
         });
 
         await this.generateTestFiles(dynamicIr, dynamicSnippetsGenerator);

--- a/generators/java-v2/sdk/src/sdk-wire-tests/buildWireTestSnippetsConfig.ts
+++ b/generators/java-v2/sdk/src/sdk-wire-tests/buildWireTestSnippetsConfig.ts
@@ -1,0 +1,21 @@
+/**
+ * Wire tests compile against the generated SDK, so the snippets embedded in them must reference
+ * the internal client class. Docs-only naming overrides must not reach the wire-test snippet
+ * generator: the generated snippet's import and instantiation would otherwise name a class (the
+ * customer's hand-written exported wrapper) that does not exist in generator output, and the
+ * extracted imports written into the test file would fail to compile.
+ */
+export function buildWireTestSnippetsConfig<Config extends { customConfig?: unknown }>(config: Config): Config {
+    const { customConfig } = config;
+    if (customConfig == null || typeof customConfig !== "object" || Array.isArray(customConfig)) {
+        return config;
+    }
+    const entries: [string, unknown][] = Object.entries(customConfig);
+    if (!entries.some(([key]) => key === "exported-client-class-name")) {
+        return config;
+    }
+    return {
+        ...config,
+        customConfig: Object.fromEntries(entries.filter(([key]) => key !== "exported-client-class-name"))
+    };
+}

--- a/generators/java/sdk/changes/unreleased/feat-exported-client-class-name.yml
+++ b/generators/java/sdk/changes/unreleased/feat-exported-client-class-name.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Add `exported-client-class-name` config to the Java SDK generator. When set, docs surfaces
+    (dynamic snippets, README, reference.md) display this name for the root client instead of
+    `client-class-name` — for teams that wrap the generated client with a hand-written public class
+    and want documentation to show the wrapper. Generated source code and wire tests are unaffected.
+  type: feat


### PR DESCRIPTION
## Description

Adds a new `exported-client-class-name` config key to the Java SDK generator (java-v2). When set, documentation surfaces (dynamic snippets, README, and reference.md) display this name for the root client instead of `client-class-name`.

### Motivation

Some teams wrap the generated root client with a hand-written public class and ship that wrapper as their SDK's entrypoint. Today docs snippets always show the generated `client-class-name`, which does not match the class their users actually instantiate. This config lets documentation reflect the exported wrapper while leaving generated source untouched.

This brings Java to parity with the other generators:
- C#: `exported-client-class-name`
- Python: `client.exported_class_name`
- Go: `exportedClientName`

### Design notes

- **Docs surfaces only.** A new accessor `getRootClientClassNameForSnippets()` resolves the name used by dynamic snippets, README, and reference.md. The internal `getRootClientClassName()` is unchanged and continues to return the generated class name.
- **Wire tests intentionally keep the internal name.** Wire tests compile against the generated code, and the exported class is hand-written by customers — it does not exist in generator output. `SdkWireTestGenerator` therefore continues to call `getRootClientClassName()`.
- **Fallback chain:** `exported-client-class-name` -> `client-class-name` -> default. When `exported-client-class-name` is unset, all output is byte-identical to today — the full dynamic-snippets snapshot suite is unchanged.
- Schema is declared only in java-v2 (`BaseJavaCustomConfigSchema`); Java v1 is untouched (its Jackson mapper tolerates unknown keys).

### Usage

```yaml
config:
  client-class-name: ExtendClient
  exported-client-class-name: ExtendClientWrapper
```

## Changes Made

- Added `exported-client-class-name` to `BaseJavaCustomConfigSchema` (java-v2 ast).
- Added `getRootClientClassNameForSnippets()` accessor to both `DynamicSnippetsGeneratorContext` and `SdkGeneratorContext`, with the documented fallback chain.
- Switched docs-surface call sites to the new accessor: `getRootClientClassReference()` (consumed only by snippet/README builders) in both contexts, and `ReadmeSnippetBuilder` OAuth token-override doc.
- Wire tests left on the internal `getRootClientClassName()`.
- [ ] Updated README.md generator (if applicable)

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

New red->green tests in `DynamicSnippetsGenerator.test.ts`:
- `exported-client-class-name` overrides `client-class-name` in the generated snippet (and never leaks the internal name).
- Falls back to `client-class-name` when `exported-client-class-name` is unset.

Full dynamic-snippets suite passes (35 tests) with all existing snapshots identical, confirming no output change when the flag is unset. `@fern-api/java-sdk` and `@fern-api/java-dynamic-snippets` compile clean.
