### PR TITLE
feat(cli): propagate collapsed config from API reference to child package nodes

### DIFF
--- a/packages/cli/cli/changes/unreleased/propagate-collapsed-to-api-packages.yml
+++ b/packages/cli/cli/changes/unreleased/propagate-collapsed-to-api-packages.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Propagate `collapsed` config from `- api` entry to child API package nodes (endpoint groups).
+    Setting `collapsed: open-by-default` or `collapsed: true` on an API reference section
+    now cascades to all auto-generated endpoint group sections in the sidebar.
+  type: feat

--- a/packages/cli/docs-resolver/src/ApiReferenceNodeConverter.ts
+++ b/packages/cli/docs-resolver/src/ApiReferenceNodeConverter.ts
@@ -332,7 +332,7 @@ export class ApiReferenceNodeConverter {
             return {
                 id: subpackageNodeId,
                 type: "apiPackage",
-                collapsed: undefined,
+                collapsed: this.apiSection.collapsed,
                 children: convertedItems,
                 title:
                     pkg.title ??
@@ -369,7 +369,7 @@ export class ApiReferenceNodeConverter {
             return {
                 id: this.#idgen.get(explicitOverviewPageId ?? `${this.apiDefinitionId}:${kebabCase(pkg.package)}`),
                 type: "apiPackage",
-                collapsed: undefined,
+                collapsed: this.apiSection.collapsed,
                 children: convertedItems,
                 title: pkg.title ?? pkg.package,
                 slug: slug.get(),
@@ -503,7 +503,7 @@ export class ApiReferenceNodeConverter {
             return {
                 id: subpackageNodeId,
                 type: "apiPackage",
-                collapsed: undefined,
+                collapsed: this.apiSection.collapsed,
                 children: [],
                 title: isSubpackage(subpackage)
                     ? (subpackage.displayName ?? titleCase(subpackage.name))
@@ -1083,7 +1083,7 @@ export class ApiReferenceNodeConverter {
                 additionalChildren.push({
                     id: FernNavigation.V1.NodeId(`${this.apiDefinitionId}:${subpackageId}`),
                     type: "apiPackage",
-                    collapsed: undefined,
+                    collapsed: this.apiSection.collapsed,
                     children: subpackageChildren,
                     title: isSubpackage(subpackage)
                         ? (subpackage.displayName ?? titleCase(subpackage.name))
@@ -1213,7 +1213,7 @@ export class ApiReferenceNodeConverter {
                 const sectionNode = {
                     id: this.#idgen.get(`${this.apiDefinitionId}:graphql:${namespace}:${operationType}`),
                     type: "apiPackage",
-                    collapsed: undefined,
+                    collapsed: this.apiSection.collapsed,
                     children,
                     title: sectionTitle,
                     slug: sectionSlug.get(),
@@ -1240,7 +1240,7 @@ export class ApiReferenceNodeConverter {
             const namespaceNode = {
                 id: this.#idgen.get(`${this.apiDefinitionId}:graphql:namespace:${namespace}`),
                 type: "apiPackage",
-                collapsed: undefined,
+                collapsed: this.apiSection.collapsed,
                 children: namespaceChildren,
                 title: titleCase(namespace),
                 slug: namespaceSlug.get(),
@@ -1298,7 +1298,7 @@ export class ApiReferenceNodeConverter {
             const sectionNode = {
                 id: this.#idgen.get(`${this.apiDefinitionId}:graphql:${operationType}`),
                 type: "apiPackage",
-                collapsed: undefined,
+                collapsed: this.apiSection.collapsed,
                 children,
                 title: sectionTitle,
                 slug: sectionSlug.get(),


### PR DESCRIPTION
## Description

Setting `collapsed: open-by-default` or `collapsed: true` on an `- api` entry in `docs.yml` now cascades to all auto-generated endpoint group sections (API package nodes) in the sidebar.

Previously, the `collapsed` value was only set on the top-level `ApiReferenceNode` but not propagated to child `ApiPackageNode`s — every child had `collapsed: undefined` hardcoded. The frontend already handles `collapsed` on any node via `getInitiallyCollapsedNodes` / `getInitiallyOpenByDefaultNodes`, so the only gap was the CLI not passing the value through.

## Changes Made

- In `ApiReferenceNodeConverter.ts`, changed 7 locations where `apiPackage` nodes had `collapsed: undefined` to inherit `this.apiSection.collapsed`
- Explicit `section` entries in the layout that set their own `collapsed` are unchanged (line 464)
- Added unreleased changelog entry

## Testing

- [x] `pnpm --filter @fern-api/docs-resolver test` — 44/44 passed
- [x] `pnpm --filter @fern-api/configuration-loader test -- --testPathPattern collapsible` — 13/13 collapsed tests + 252 total passed
- [x] `pnpm check` — biome lint clean

Link to Devin session: https://app.devin.ai/sessions/f50b384f315b4bb8975f66c337f5fdb4
Requested by: @cade-fern