### PR TITLE
fix(java): use IR discriminatorContext instead of name heuristic for SSE discrimination

### DIFF
--- a/generators/java/sdk/changes/unreleased/fix-sse-discriminator-context.yml
+++ b/generators/java/sdk/changes/unreleased/fix-sse-discriminator-context.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    SSE streaming endpoints now decide protocol-level vs data-level union discrimination from the API spec's x-fern-discriminator-context (IR discriminatorContext) instead of inferring from the discriminator's field name. Unions whose discriminator happens to be named event/id/retry/data but lives in the data payload are now correctly parsed from the data JSON; envelope dispatch only happens when x-fern-discriminator-context: protocol is explicit.
+  type: fix

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/AbstractHttpResponseParserGenerator.java
@@ -988,8 +988,8 @@ public abstract class AbstractHttpResponseParserGenerator {
                             SseDiscriminationAnalyzer.analyze(
                                     sse.getPayload(), clientGeneratorContext.getTypeDeclarations());
 
-                    if (discriminationInfo.getType() == SseDiscriminationAnalyzer.DiscriminationType.EVENT_LEVEL) {
-                        // Event-level discrimination: discriminator is at SSE envelope level
+                    if (discriminationInfo.getType() == SseDiscriminationAnalyzer.DiscriminationType.PROTOCOL_LEVEL) {
+                        // Protocol-level discrimination: discriminator is at SSE envelope level
                         String discriminatorProperty =
                                 discriminationInfo.getDiscriminatorProperty().orElse("event");
                         if (terminator != null) {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SseDiscriminationAnalyzer.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/SseDiscriminationAnalyzer.java
@@ -5,25 +5,20 @@ import com.fern.ir.model.types.NamedType;
 import com.fern.ir.model.types.Type;
 import com.fern.ir.model.types.TypeDeclaration;
 import com.fern.ir.model.types.TypeReference;
+import com.fern.ir.model.types.UnionDiscriminatorContext;
 import com.fern.ir.model.types.UnionTypeDeclaration;
 import com.fern.java.utils.NameUtils;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 /**
- * Analyzes SSE payload types to determine if event-level or data-level discrimination is needed.
+ * Analyzes SSE payload types to determine if protocol-level or data-level discrimination is needed.
  *
- * <p>Following Python's approach from PR #11726: - If the union's discriminator property name matches an SSE envelope
- * field (event, id, retry, data), it's event-level discrimination. - Otherwise, it's data-level discrimination where
- * the discriminator is inside the JSON data payload.
+ * <p>Uses the IR's {@code discriminatorContext} on the union declaration: if the context is {@code PROTOCOL}, the
+ * discriminator lives at the SSE envelope level and requires custom handling. Otherwise (including absent/default), the
+ * discriminator is inside the JSON data payload and Jackson handles it automatically.
  */
 public final class SseDiscriminationAnalyzer {
-
-    /** SSE envelope fields that indicate event-level discrimination when used as a discriminator. */
-    private static final Set<String> SSE_ENVELOPE_FIELDS = new HashSet<>(Arrays.asList("event", "id", "retry", "data"));
 
     /** Type of discrimination for SSE events. */
     public enum DiscriminationType {
@@ -32,7 +27,7 @@ public final class SseDiscriminationAnalyzer {
         /** Discriminator is inside the JSON data payload - Jackson handles automatically */
         DATA_LEVEL,
         /** Discriminator is at SSE envelope level - requires custom handling */
-        EVENT_LEVEL
+        PROTOCOL_LEVEL
     }
 
     /** Result of SSE discrimination analysis. */
@@ -61,8 +56,8 @@ public final class SseDiscriminationAnalyzer {
             return new SseDiscriminationInfo(DiscriminationType.DATA_LEVEL, discriminatorProperty);
         }
 
-        public static SseDiscriminationInfo eventLevel(String discriminatorProperty) {
-            return new SseDiscriminationInfo(DiscriminationType.EVENT_LEVEL, discriminatorProperty);
+        public static SseDiscriminationInfo protocolLevel(String discriminatorProperty) {
+            return new SseDiscriminationInfo(DiscriminationType.PROTOCOL_LEVEL, discriminatorProperty);
         }
     }
 
@@ -92,17 +87,13 @@ public final class SseDiscriminationAnalyzer {
         String discriminatorProperty =
                 NameUtils.getWireValue(unionDeclaration.get().getDiscriminant());
 
-        // Check if the discriminator is an SSE envelope field
-        if (isEventLevelDiscriminator(discriminatorProperty)) {
-            return SseDiscriminationInfo.eventLevel(discriminatorProperty);
+        // Use the IR's discriminatorContext to determine discrimination level
+        Optional<UnionDiscriminatorContext> context = unionDeclaration.get().getDiscriminatorContext();
+        if (context.isPresent() && context.get().equals(UnionDiscriminatorContext.PROTOCOL)) {
+            return SseDiscriminationInfo.protocolLevel(discriminatorProperty);
         } else {
             return SseDiscriminationInfo.dataLevel(discriminatorProperty);
         }
-    }
-
-    /** Checks if the discriminator property indicates event-level discrimination. */
-    public static boolean isEventLevelDiscriminator(String discriminatorProperty) {
-        return SSE_ENVELOPE_FIELDS.contains(discriminatorProperty);
     }
 
     /** Resolves a TypeReference to its UnionTypeDeclaration, following aliases if necessary. */

--- a/generators/java/sdk/src/test/java/com/fern/java/client/generators/endpoint/SseDiscriminationAnalyzerTest.java
+++ b/generators/java/sdk/src/test/java/com/fern/java/client/generators/endpoint/SseDiscriminationAnalyzerTest.java
@@ -78,6 +78,7 @@ class SseDiscriminationAnalyzerTest {
                 SseDiscriminationAnalyzer.analyze(namedReference(UNION_TYPE_ID), declarations);
 
         assertThat(info.getType()).isEqualTo(SseDiscriminationAnalyzer.DiscriminationType.DATA_LEVEL);
+        assertThat(info.getDiscriminatorProperty()).contains("event");
     }
 
     @Test
@@ -89,6 +90,7 @@ class SseDiscriminationAnalyzerTest {
                 SseDiscriminationAnalyzer.analyze(namedReference(UNION_TYPE_ID), declarations);
 
         assertThat(info.getType()).isEqualTo(SseDiscriminationAnalyzer.DiscriminationType.DATA_LEVEL);
+        assertThat(info.getDiscriminatorProperty()).contains("type");
     }
 
     @Test

--- a/generators/java/sdk/src/test/java/com/fern/java/client/generators/endpoint/SseDiscriminationAnalyzerTest.java
+++ b/generators/java/sdk/src/test/java/com/fern/java/client/generators/endpoint/SseDiscriminationAnalyzerTest.java
@@ -1,0 +1,198 @@
+package com.fern.java.client.generators.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fern.ir.model.commons.FernFilepath;
+import com.fern.ir.model.commons.Name;
+import com.fern.ir.model.commons.NameAndWireValue;
+import com.fern.ir.model.commons.NameAndWireValueOrString;
+import com.fern.ir.model.commons.NameOrString;
+import com.fern.ir.model.commons.SafeAndUnsafeString;
+import com.fern.ir.model.commons.TypeId;
+import com.fern.ir.model.types.AliasTypeDeclaration;
+import com.fern.ir.model.types.ContainerType;
+import com.fern.ir.model.types.DeclaredTypeName;
+import com.fern.ir.model.types.NamedType;
+import com.fern.ir.model.types.ObjectTypeDeclaration;
+import com.fern.ir.model.types.ResolvedTypeReference;
+import com.fern.ir.model.types.Type;
+import com.fern.ir.model.types.TypeDeclaration;
+import com.fern.ir.model.types.TypeReference;
+import com.fern.ir.model.types.UnionDiscriminatorContext;
+import com.fern.ir.model.types.UnionTypeDeclaration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SseDiscriminationAnalyzer}.
+ *
+ * <p>These tests pin the correct behavior: the analyzer must derive the SSE discrimination level from the IR's
+ * {@code discriminatorContext} on the union declaration, NOT from a hardcoded name heuristic.
+ *
+ * <ul>
+ *   <li>{@code discriminatorContext == PROTOCOL} -> protocol-level (envelope dispatch)
+ *   <li>{@code discriminatorContext == DATA} or absent -> data-level (Jackson handles the payload)
+ *   <li>non-union payload -> none
+ * </ul>
+ */
+class SseDiscriminationAnalyzerTest {
+
+    private static final TypeId UNION_TYPE_ID = TypeId.of("union-type-id");
+    private static final TypeId OBJECT_TYPE_ID = TypeId.of("object-type-id");
+    private static final TypeId ALIAS_TYPE_ID = TypeId.of("alias-type-id");
+
+    @Test
+    void protocolContext_isProtocolLevel() {
+        Map<TypeId, TypeDeclaration> declarations = new HashMap<>();
+        declarations.put(UNION_TYPE_ID, unionDeclaration("event", Optional.of(UnionDiscriminatorContext.PROTOCOL)));
+
+        SseDiscriminationAnalyzer.SseDiscriminationInfo info =
+                SseDiscriminationAnalyzer.analyze(namedReference(UNION_TYPE_ID), declarations);
+
+        assertThat(info.getType()).isEqualTo(SseDiscriminationAnalyzer.DiscriminationType.PROTOCOL_LEVEL);
+        assertThat(info.getDiscriminatorProperty()).contains("event");
+    }
+
+    @Test
+    void dataContext_isDataLevel() {
+        Map<TypeId, TypeDeclaration> declarations = new HashMap<>();
+        declarations.put(UNION_TYPE_ID, unionDeclaration("event", Optional.of(UnionDiscriminatorContext.DATA)));
+
+        SseDiscriminationAnalyzer.SseDiscriminationInfo info =
+                SseDiscriminationAnalyzer.analyze(namedReference(UNION_TYPE_ID), declarations);
+
+        assertThat(info.getType()).isEqualTo(SseDiscriminationAnalyzer.DiscriminationType.DATA_LEVEL);
+        assertThat(info.getDiscriminatorProperty()).contains("event");
+    }
+
+    @Test
+    void noContextWithEnvelopeNamedDiscriminator_isDataLevel() {
+        // Customer-reported case: discriminator wire value is "event" but there is no protocol context.
+        // The hardcoded SSE_ENVELOPE_FIELDS heuristic wrongly classifies this as protocol/event level.
+        Map<TypeId, TypeDeclaration> declarations = new HashMap<>();
+        declarations.put(UNION_TYPE_ID, unionDeclaration("event", Optional.empty()));
+
+        SseDiscriminationAnalyzer.SseDiscriminationInfo info =
+                SseDiscriminationAnalyzer.analyze(namedReference(UNION_TYPE_ID), declarations);
+
+        assertThat(info.getType()).isEqualTo(SseDiscriminationAnalyzer.DiscriminationType.DATA_LEVEL);
+    }
+
+    @Test
+    void noContextWithOrdinaryDiscriminator_isDataLevel() {
+        Map<TypeId, TypeDeclaration> declarations = new HashMap<>();
+        declarations.put(UNION_TYPE_ID, unionDeclaration("type", Optional.empty()));
+
+        SseDiscriminationAnalyzer.SseDiscriminationInfo info =
+                SseDiscriminationAnalyzer.analyze(namedReference(UNION_TYPE_ID), declarations);
+
+        assertThat(info.getType()).isEqualTo(SseDiscriminationAnalyzer.DiscriminationType.DATA_LEVEL);
+    }
+
+    @Test
+    void nonUnionPayload_isNone() {
+        Map<TypeId, TypeDeclaration> declarations = new HashMap<>();
+        declarations.put(OBJECT_TYPE_ID, objectDeclaration());
+
+        SseDiscriminationAnalyzer.SseDiscriminationInfo info =
+                SseDiscriminationAnalyzer.analyze(namedReference(OBJECT_TYPE_ID), declarations);
+
+        assertThat(info.getType()).isEqualTo(SseDiscriminationAnalyzer.DiscriminationType.NONE);
+    }
+
+    @Test
+    void optionalUnion_isUnwrappedAndAnalyzed() {
+        Map<TypeId, TypeDeclaration> declarations = new HashMap<>();
+        declarations.put(UNION_TYPE_ID, unionDeclaration("event", Optional.of(UnionDiscriminatorContext.PROTOCOL)));
+
+        TypeReference optionalUnion = TypeReference.container(ContainerType.optional(namedReference(UNION_TYPE_ID)));
+
+        SseDiscriminationAnalyzer.SseDiscriminationInfo info =
+                SseDiscriminationAnalyzer.analyze(optionalUnion, declarations);
+
+        assertThat(info.getType()).isEqualTo(SseDiscriminationAnalyzer.DiscriminationType.PROTOCOL_LEVEL);
+    }
+
+    @Test
+    void aliasToUnion_isUnwrappedAndAnalyzed() {
+        Map<TypeId, TypeDeclaration> declarations = new HashMap<>();
+        declarations.put(UNION_TYPE_ID, unionDeclaration("event", Optional.of(UnionDiscriminatorContext.PROTOCOL)));
+        declarations.put(
+                ALIAS_TYPE_ID,
+                typeDeclaration(
+                        ALIAS_TYPE_ID,
+                        Type.alias(AliasTypeDeclaration.builder()
+                                .aliasOf(namedReference(UNION_TYPE_ID))
+                                .resolvedType(ResolvedTypeReference.unknown())
+                                .build())));
+
+        SseDiscriminationAnalyzer.SseDiscriminationInfo info =
+                SseDiscriminationAnalyzer.analyze(namedReference(ALIAS_TYPE_ID), declarations);
+
+        assertThat(info.getType()).isEqualTo(SseDiscriminationAnalyzer.DiscriminationType.PROTOCOL_LEVEL);
+    }
+
+    // ---- IR construction helpers ----
+
+    private static TypeReference namedReference(TypeId typeId) {
+        return TypeReference.named(NamedType.builder()
+                .typeId(typeId)
+                .fernFilepath(fernFilepath())
+                .name(NameOrString.of(name(typeId.get())))
+                .build());
+    }
+
+    private static TypeDeclaration unionDeclaration(
+            String discriminatorWireValue, Optional<UnionDiscriminatorContext> context) {
+        UnionTypeDeclaration union = UnionTypeDeclaration.builder()
+                .discriminant(discriminant(discriminatorWireValue))
+                .discriminatorContext(context)
+                .build();
+        return typeDeclaration(UNION_TYPE_ID, Type.union(union));
+    }
+
+    private static TypeDeclaration objectDeclaration() {
+        return typeDeclaration(
+                OBJECT_TYPE_ID,
+                Type.object(
+                        ObjectTypeDeclaration.builder().extraProperties(false).build()));
+    }
+
+    private static TypeDeclaration typeDeclaration(TypeId typeId, Type shape) {
+        return TypeDeclaration.builder()
+                .name(DeclaredTypeName.builder()
+                        .typeId(typeId)
+                        .fernFilepath(fernFilepath())
+                        .name(NameOrString.of(name(typeId.get())))
+                        .build())
+                .shape(shape)
+                .build();
+    }
+
+    private static NameAndWireValueOrString discriminant(String wireValue) {
+        return NameAndWireValueOrString.of(NameAndWireValue.builder()
+                .wireValue(wireValue)
+                .name(NameOrString.of(name(wireValue)))
+                .build());
+    }
+
+    private static FernFilepath fernFilepath() {
+        return FernFilepath.builder().build();
+    }
+
+    private static Name name(String value) {
+        return Name.builder()
+                .originalName(value)
+                .camelCase(safeAndUnsafe(value))
+                .pascalCase(safeAndUnsafe(value))
+                .snakeCase(safeAndUnsafe(value))
+                .screamingSnakeCase(safeAndUnsafe(value))
+                .build();
+    }
+
+    private static SafeAndUnsafeString safeAndUnsafe(String value) {
+        return SafeAndUnsafeString.builder().unsafeName(value).safeName(value).build();
+    }
+}

--- a/seed/java-sdk/server-sent-event-examples/no-custom-config/src/main/java/com/seed/serverSentEvents/resources/completions/AsyncRawCompletionsClient.java
+++ b/seed/java-sdk/server-sent-event-examples/no-custom-config/src/main/java/com/seed/serverSentEvents/resources/completions/AsyncRawCompletionsClient.java
@@ -159,8 +159,7 @@ public class AsyncRawCompletionsClient {
                     ResponseBody responseBody = response.body();
                     if (response.isSuccessful()) {
                         future.complete(new SeedServerSentEventsHttpResponse<>(
-                                Stream.fromSseWithEventDiscrimination(
-                                        StreamEvent.class, new ResponseBodyReader(response), "event", "[DONE]"),
+                                Stream.fromSse(StreamEvent.class, new ResponseBodyReader(response), "[DONE]"),
                                 response));
                         return;
                     }
@@ -236,7 +235,8 @@ public class AsyncRawCompletionsClient {
                     ResponseBody responseBody = response.body();
                     if (response.isSuccessful()) {
                         future.complete(new SeedServerSentEventsHttpResponse<>(
-                                Stream.fromSse(StreamEventDiscriminantInData.class, new ResponseBodyReader(response)),
+                                Stream.fromSseWithEventDiscrimination(
+                                        StreamEventDiscriminantInData.class, new ResponseBodyReader(response), "type"),
                                 response));
                         return;
                     }

--- a/seed/java-sdk/server-sent-event-examples/no-custom-config/src/main/java/com/seed/serverSentEvents/resources/completions/RawCompletionsClient.java
+++ b/seed/java-sdk/server-sent-event-examples/no-custom-config/src/main/java/com/seed/serverSentEvents/resources/completions/RawCompletionsClient.java
@@ -133,9 +133,7 @@ public class RawCompletionsClient {
             ResponseBody responseBody = response.body();
             if (response.isSuccessful()) {
                 return new SeedServerSentEventsHttpResponse<>(
-                        Stream.fromSseWithEventDiscrimination(
-                                StreamEvent.class, new ResponseBodyReader(response), "event", "[DONE]"),
-                        response);
+                        Stream.fromSse(StreamEvent.class, new ResponseBodyReader(response), "[DONE]"), response);
             }
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             try {
@@ -192,7 +190,8 @@ public class RawCompletionsClient {
             ResponseBody responseBody = response.body();
             if (response.isSuccessful()) {
                 return new SeedServerSentEventsHttpResponse<>(
-                        Stream.fromSse(StreamEventDiscriminantInData.class, new ResponseBodyReader(response)),
+                        Stream.fromSseWithEventDiscrimination(
+                                StreamEventDiscriminantInData.class, new ResponseBodyReader(response), "type"),
                         response);
             }
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";

--- a/seed/java-sdk/server-sent-event-examples/with-wire-tests/src/main/java/com/seed/serverSentEvents/resources/completions/AsyncRawCompletionsClient.java
+++ b/seed/java-sdk/server-sent-event-examples/with-wire-tests/src/main/java/com/seed/serverSentEvents/resources/completions/AsyncRawCompletionsClient.java
@@ -159,8 +159,7 @@ public class AsyncRawCompletionsClient {
                     ResponseBody responseBody = response.body();
                     if (response.isSuccessful()) {
                         future.complete(new SeedServerSentEventsHttpResponse<>(
-                                Stream.fromSseWithEventDiscrimination(
-                                        StreamEvent.class, new ResponseBodyReader(response), "event", "[DONE]"),
+                                Stream.fromSse(StreamEvent.class, new ResponseBodyReader(response), "[DONE]"),
                                 response));
                         return;
                     }
@@ -236,7 +235,8 @@ public class AsyncRawCompletionsClient {
                     ResponseBody responseBody = response.body();
                     if (response.isSuccessful()) {
                         future.complete(new SeedServerSentEventsHttpResponse<>(
-                                Stream.fromSse(StreamEventDiscriminantInData.class, new ResponseBodyReader(response)),
+                                Stream.fromSseWithEventDiscrimination(
+                                        StreamEventDiscriminantInData.class, new ResponseBodyReader(response), "type"),
                                 response));
                         return;
                     }

--- a/seed/java-sdk/server-sent-event-examples/with-wire-tests/src/main/java/com/seed/serverSentEvents/resources/completions/RawCompletionsClient.java
+++ b/seed/java-sdk/server-sent-event-examples/with-wire-tests/src/main/java/com/seed/serverSentEvents/resources/completions/RawCompletionsClient.java
@@ -133,9 +133,7 @@ public class RawCompletionsClient {
             ResponseBody responseBody = response.body();
             if (response.isSuccessful()) {
                 return new SeedServerSentEventsHttpResponse<>(
-                        Stream.fromSseWithEventDiscrimination(
-                                StreamEvent.class, new ResponseBodyReader(response), "event", "[DONE]"),
-                        response);
+                        Stream.fromSse(StreamEvent.class, new ResponseBodyReader(response), "[DONE]"), response);
             }
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             try {
@@ -192,7 +190,8 @@ public class RawCompletionsClient {
             ResponseBody responseBody = response.body();
             if (response.isSuccessful()) {
                 return new SeedServerSentEventsHttpResponse<>(
-                        Stream.fromSse(StreamEventDiscriminantInData.class, new ResponseBodyReader(response)),
+                        Stream.fromSseWithEventDiscrimination(
+                                StreamEventDiscriminantInData.class, new ResponseBodyReader(response), "type"),
                         response);
             }
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";

--- a/seed/java-sdk/server-sent-events-openapi/with-wire-tests/src/main/java/com/seed/api/AsyncRawSeedApiClient.java
+++ b/seed/java-sdk/server-sent-events-openapi/with-wire-tests/src/main/java/com/seed/api/AsyncRawSeedApiClient.java
@@ -294,8 +294,7 @@ public class AsyncRawSeedApiClient {
                     ResponseBody responseBody = response.body();
                     if (response.isSuccessful()) {
                         future.complete(new SeedApiHttpResponse<>(
-                                Stream.fromSseWithEventDiscrimination(
-                                        StreamDataContextResponse.class, new ResponseBodyReader(response), "event"),
+                                Stream.fromSse(StreamDataContextResponse.class, new ResponseBodyReader(response)),
                                 response));
                         return;
                     }
@@ -379,8 +378,7 @@ public class AsyncRawSeedApiClient {
                     ResponseBody responseBody = response.body();
                     if (response.isSuccessful()) {
                         future.complete(new SeedApiHttpResponse<>(
-                                Stream.fromSseWithEventDiscrimination(
-                                        StreamNoContextResponse.class, new ResponseBodyReader(response), "event"),
+                                Stream.fromSse(StreamNoContextResponse.class, new ResponseBodyReader(response)),
                                 response));
                         return;
                     }
@@ -555,10 +553,9 @@ public class AsyncRawSeedApiClient {
                     ResponseBody responseBody = response.body();
                     if (response.isSuccessful()) {
                         future.complete(new SeedApiHttpResponse<>(
-                                Stream.fromSseWithEventDiscrimination(
+                                Stream.fromSse(
                                         StreamDataContextWithEnvelopeSchemaResponse.class,
-                                        new ResponseBodyReader(response),
-                                        "event"),
+                                        new ResponseBodyReader(response)),
                                 response));
                         return;
                     }

--- a/seed/java-sdk/server-sent-events-openapi/with-wire-tests/src/main/java/com/seed/api/RawSeedApiClient.java
+++ b/seed/java-sdk/server-sent-events-openapi/with-wire-tests/src/main/java/com/seed/api/RawSeedApiClient.java
@@ -252,9 +252,7 @@ public class RawSeedApiClient {
             ResponseBody responseBody = response.body();
             if (response.isSuccessful()) {
                 return new SeedApiHttpResponse<>(
-                        Stream.fromSseWithEventDiscrimination(
-                                StreamDataContextResponse.class, new ResponseBodyReader(response), "event"),
-                        response);
+                        Stream.fromSse(StreamDataContextResponse.class, new ResponseBodyReader(response)), response);
             }
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
@@ -322,9 +320,7 @@ public class RawSeedApiClient {
             ResponseBody responseBody = response.body();
             if (response.isSuccessful()) {
                 return new SeedApiHttpResponse<>(
-                        Stream.fromSseWithEventDiscrimination(
-                                StreamNoContextResponse.class, new ResponseBodyReader(response), "event"),
-                        response);
+                        Stream.fromSse(StreamNoContextResponse.class, new ResponseBodyReader(response)), response);
             }
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";
             Object errorBody = ObjectMappers.parseErrorBody(responseBodyString);
@@ -467,10 +463,8 @@ public class RawSeedApiClient {
             ResponseBody responseBody = response.body();
             if (response.isSuccessful()) {
                 return new SeedApiHttpResponse<>(
-                        Stream.fromSseWithEventDiscrimination(
-                                StreamDataContextWithEnvelopeSchemaResponse.class,
-                                new ResponseBodyReader(response),
-                                "event"),
+                        Stream.fromSse(
+                                StreamDataContextWithEnvelopeSchemaResponse.class, new ResponseBodyReader(response)),
                         response);
             }
             String responseBodyString = responseBody != null ? responseBody.string() : "{}";


### PR DESCRIPTION
## Description
SSE streaming endpoints in the Java SDK decided whether a discriminated union was discriminated at the SSE envelope (protocol) level or inside the JSON data payload by matching the discriminator's wire name against a hardcoded set of envelope field names: `event`, `id`, `retry`, `data`.

This misclassifies any union whose discriminator legitimately lives in the data payload but happens to be named like an SSE envelope field. Such unions were routed through the envelope dispatch path (`Stream.fromSseWithEventDiscrimination`) and failed to parse, even though the discriminator was in the data JSON all along.

The fix reads the discrimination level from the IR's `discriminatorContext` on the union declaration (sourced from `x-fern-discriminator-context` in the API spec):

- `PROTOCOL` -> protocol-level: discriminator is at the SSE envelope level, envelope dispatch (`Stream.fromSseWithEventDiscrimination`).
- `DATA` or absent -> data-level: discriminator is inside the JSON data payload, Jackson handles it (`Stream.fromSse`).

The default is now data-level; envelope dispatch is opt-in via an explicit `x-fern-discriminator-context: protocol`. The analyzer enum value was renamed `EVENT_LEVEL` -> `PROTOCOL_LEVEL` to match the IR vocabulary, with the corresponding branch updated in `AbstractHttpResponseParserGenerator`.

This mirrors the equivalent Python generator fix in https://github.com/fern-api/fern/pull/14154.

### Behavior change
Only affects discriminated SSE unions whose discriminator is named `event`/`id`/`retry`/`data` AND that have no explicit `x-fern-discriminator-context`. Previously these were misparsed via envelope dispatch; they now correctly parse from the data payload. Unions with an explicit `x-fern-discriminator-context: protocol` are unchanged.

## Changes Made
- Replace the hardcoded SSE envelope-field name heuristic in `SseDiscriminationAnalyzer` with a decision driven by the IR `discriminatorContext`.
- Rename discrimination enum `EVENT_LEVEL` -> `PROTOCOL_LEVEL` and update the dispatch branch in `AbstractHttpResponseParserGenerator`.
- Add `SseDiscriminationAnalyzerTest` pinning the IR-driven behavior (protocol/data/absent/non-union/optional/alias cases).
- Regenerate the 4 affected java-sdk SSE fixtures (`server-sent-event-examples` and `server-sent-events-openapi`).
- Add a changelog entry.
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated — new `SseDiscriminationAnalyzerTest` (red against the old name heuristic, green with the IR-driven fix).
- [x] Regenerated 4 SSE seed fixtures; diffs show envelope dispatch correctly collapsing to `Stream.fromSse` for data-level unions.
- [x] Docker compile of `server-sent-events-openapi` (`true`).
- [x] Manual testing completed