### PR TITLE
fix(cli): backfill missing required fields in AI-enhanced examples

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-ai-example-backfill-missing-fields.yml
+++ b/packages/cli/cli/changes/unreleased/fix-ai-example-backfill-missing-fields.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix AI example enhancement to backfill missing required fields from the auto-generated
+    example. When the AI Lambda produces a partial example (e.g., missing fields from nested
+    allOf chains), the missing fields are now merged from the correct auto-generated example,
+    ensuring all required fields are present in published documentation.
+  type: fix

--- a/packages/cli/register/src/ai-example-enhancer/__test__/backfillMissingFields.test.ts
+++ b/packages/cli/register/src/ai-example-enhancer/__test__/backfillMissingFields.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { backfillMissingFields } from "../enhanceExamplesWithAI.js";
+
+describe("backfillMissingFields", () => {
+    it("backfills missing fields from original into enhanced", () => {
+        const enhanced = { channelIds: [101, 202] };
+        const original = {
+            firstName: "string",
+            lastName: "string",
+            email: "string",
+            role: "string",
+            companyId: 1,
+            channelIds: [1]
+        };
+
+        const result = backfillMissingFields(enhanced, original);
+        expect(result).toEqual({
+            firstName: "string",
+            lastName: "string",
+            email: "string",
+            role: "string",
+            companyId: 1,
+            channelIds: [101, 202]
+        });
+    });
+
+    it("preserves AI values when both have the same field", () => {
+        const enhanced = { name: "Jane Doe", email: "jane@example.com" };
+        const original = { name: "string", email: "string", age: 1 };
+
+        const result = backfillMissingFields(enhanced, original);
+        expect(result).toEqual({
+            name: "Jane Doe",
+            email: "jane@example.com",
+            age: 1
+        });
+    });
+
+    it("returns enhanced unchanged when no fields are missing", () => {
+        const enhanced = { a: 1, b: 2 };
+        const original = { a: 0, b: 0 };
+
+        const result = backfillMissingFields(enhanced, original);
+        expect(result).toBe(enhanced);
+    });
+
+    it("returns enhanced when enhanced is not an object", () => {
+        expect(backfillMissingFields("hello", { a: 1 })).toBe("hello");
+        expect(backfillMissingFields(42, { a: 1 })).toBe(42);
+        expect(backfillMissingFields(null, { a: 1 })).toBe(null);
+    });
+
+    it("returns enhanced when original is not an object", () => {
+        const enhanced = { a: 1 };
+        expect(backfillMissingFields(enhanced, "hello")).toBe(enhanced);
+        expect(backfillMissingFields(enhanced, null)).toBe(enhanced);
+        expect(backfillMissingFields(enhanced, 42)).toBe(enhanced);
+    });
+
+    it("returns enhanced when both are arrays", () => {
+        const enhanced = [1, 2, 3];
+        const original = [4, 5, 6, 7];
+        expect(backfillMissingFields(enhanced, original)).toBe(enhanced);
+    });
+
+    it("handles empty enhanced object by filling all fields from original", () => {
+        const enhanced = {};
+        const original = { firstName: "string", lastName: "string" };
+
+        const result = backfillMissingFields(enhanced, original);
+        expect(result).toEqual({ firstName: "string", lastName: "string" });
+    });
+
+    it("handles empty original object with no backfill needed", () => {
+        const enhanced = { a: 1 };
+        const result = backfillMissingFields(enhanced, {});
+        expect(result).toBe(enhanced);
+    });
+});

--- a/packages/cli/register/src/ai-example-enhancer/__test__/backfillMissingFields.test.ts
+++ b/packages/cli/register/src/ai-example-enhancer/__test__/backfillMissingFields.test.ts
@@ -87,11 +87,11 @@ describe("unwrapLambdaBodyEnvelope", () => {
         expect(result.inner).toEqual({ channelIds: [101, 202] });
     });
 
-    it("does not unwrap when body is not the only key", () => {
-        const notWrapped = { body: { a: 1 }, extra: "field" };
-        const result = unwrapLambdaBodyEnvelope(notWrapped);
-        expect(result.wasWrapped).toBe(false);
-        expect(result.inner).toBe(notWrapped);
+    it("unwraps even when body is not the only key", () => {
+        const multiKey = { body: { a: 1 }, statusCode: 200 };
+        const result = unwrapLambdaBodyEnvelope(multiKey);
+        expect(result.wasWrapped).toBe(true);
+        expect(result.inner).toEqual({ a: 1 });
     });
 
     it("does not unwrap non-objects", () => {

--- a/packages/cli/register/src/ai-example-enhancer/__test__/backfillMissingFields.test.ts
+++ b/packages/cli/register/src/ai-example-enhancer/__test__/backfillMissingFields.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { backfillMissingFields } from "../enhanceExamplesWithAI.js";
+import { backfillMissingFields, unwrapLambdaBodyEnvelope } from "../enhanceExamplesWithAI.js";
 
 describe("backfillMissingFields", () => {
     it("backfills missing fields from original into enhanced", () => {
@@ -76,5 +76,53 @@ describe("backfillMissingFields", () => {
         const enhanced = { a: 1 };
         const result = backfillMissingFields(enhanced, {});
         expect(result).toBe(enhanced);
+    });
+});
+
+describe("unwrapLambdaBodyEnvelope", () => {
+    it("unwraps {body: {...}} envelope", () => {
+        const wrapped = { body: { channelIds: [101, 202] } };
+        const result = unwrapLambdaBodyEnvelope(wrapped);
+        expect(result.wasWrapped).toBe(true);
+        expect(result.inner).toEqual({ channelIds: [101, 202] });
+    });
+
+    it("does not unwrap when body is not the only key", () => {
+        const notWrapped = { body: { a: 1 }, extra: "field" };
+        const result = unwrapLambdaBodyEnvelope(notWrapped);
+        expect(result.wasWrapped).toBe(false);
+        expect(result.inner).toBe(notWrapped);
+    });
+
+    it("does not unwrap non-objects", () => {
+        expect(unwrapLambdaBodyEnvelope("hello")).toEqual({ wasWrapped: false, inner: "hello" });
+        expect(unwrapLambdaBodyEnvelope(null)).toEqual({ wasWrapped: false, inner: null });
+        expect(unwrapLambdaBodyEnvelope(42)).toEqual({ wasWrapped: false, inner: 42 });
+    });
+
+    it("does not unwrap arrays", () => {
+        const arr = [1, 2, 3];
+        expect(unwrapLambdaBodyEnvelope(arr)).toEqual({ wasWrapped: false, inner: arr });
+    });
+
+    it("backfills correctly through body envelope", () => {
+        const wrapped = { body: { channelIds: [101, 202] } };
+        const original = {
+            firstName: "string",
+            lastName: "string",
+            email: "string",
+            channelIds: [1]
+        };
+
+        const unwrapped = unwrapLambdaBodyEnvelope(wrapped);
+        expect(unwrapped.wasWrapped).toBe(true);
+
+        const backfilled = backfillMissingFields(unwrapped.inner, original);
+        expect(backfilled).toEqual({
+            firstName: "string",
+            lastName: "string",
+            email: "string",
+            channelIds: [101, 202]
+        });
     });
 });

--- a/packages/cli/register/src/ai-example-enhancer/__test__/backfillMissingFields.test.ts
+++ b/packages/cli/register/src/ai-example-enhancer/__test__/backfillMissingFields.test.ts
@@ -125,4 +125,31 @@ describe("unwrapLambdaBodyEnvelope", () => {
             channelIds: [101, 202]
         });
     });
+
+    it("treats body as envelope only when original does NOT have body key", () => {
+        // Lambda envelope case: original has no "body" key → unwrap
+        const envelopeEnhanced = { body: { channelIds: [101] } };
+        const originalNoBody = { channelIds: [1], firstName: "string" };
+
+        const unwrapped = unwrapLambdaBodyEnvelope(envelopeEnhanced);
+        expect(unwrapped.wasWrapped).toBe(true);
+        // Caller should check originalHasBody=false → treat as envelope
+
+        // Schema field case: original HAS a "body" key → not an envelope
+        const schemaEnhanced = { body: "Hello world", subject: "Greetings" };
+        const originalWithBody = { body: "string", subject: "string", to: "string" };
+
+        const unwrappedSchema = unwrapLambdaBodyEnvelope(schemaEnhanced);
+        // unwrapLambdaBodyEnvelope still returns wasWrapped=true (it's a detection helper),
+        // but the caller checks originalHasBody and skips the envelope path.
+        expect(unwrappedSchema.wasWrapped).toBe(true);
+
+        // When original has body, caller uses direct backfill (no unwrap/rewrap)
+        const directBackfill = backfillMissingFields(schemaEnhanced, originalWithBody);
+        expect(directBackfill).toEqual({
+            body: "Hello world",
+            subject: "Greetings",
+            to: "string"
+        });
+    });
 });

--- a/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
+++ b/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
@@ -1661,12 +1661,7 @@ function extractExampleValue(bodyV3: BodyV3 | undefined): unknown {
  * The Lambda sometimes wraps the request example in a "body" key.
  */
 export function unwrapLambdaBodyEnvelope(value: unknown): { wasWrapped: boolean; inner: unknown } {
-    if (
-        typeof value === "object" &&
-        value !== null &&
-        !Array.isArray(value) &&
-        "body" in value
-    ) {
+    if (typeof value === "object" && value !== null && !Array.isArray(value) && "body" in value) {
         return { wasWrapped: true, inner: (value as Record<string, unknown>).body };
     }
     return { wasWrapped: false, inner: value };

--- a/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
+++ b/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
@@ -1120,10 +1120,12 @@ async function processEndpoint(
 
         // Backfill any required fields the AI may have missed from the original auto-generated example.
         // The AI Lambda may not fully resolve nested allOf chains, producing partial examples.
-        // Handle the Lambda's {body: {...}} envelope if present.
+        // Handle the Lambda's {body: {...}} envelope if present, but only when the original
+        // does NOT have a "body" key (distinguishes envelope from schemas with a literal body field).
         if (result.enhancedRequestExample != null && request.originalRequestExample != null) {
             const unwrapped = unwrapLambdaBodyEnvelope(result.enhancedRequestExample);
-            if (unwrapped.wasWrapped) {
+            const originalHasBody = isObjectWithKey(request.originalRequestExample, "body");
+            if (unwrapped.wasWrapped && !originalHasBody) {
                 const backfilled = backfillMissingFields(unwrapped.inner, request.originalRequestExample);
                 result.enhancedRequestExample = { body: backfilled };
             } else {
@@ -1654,6 +1656,13 @@ function extractExampleValue(bodyV3: BodyV3 | undefined): unknown {
         default:
             return bodyV3.value;
     }
+}
+
+/**
+ * Checks whether a value is a non-array object containing a specific key.
+ */
+function isObjectWithKey(value: unknown, key: string): boolean {
+    return typeof value === "object" && value !== null && !Array.isArray(value) && key in value;
 }
 
 /**

--- a/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
+++ b/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
@@ -1126,8 +1126,10 @@ async function processEndpoint(
             const unwrapped = unwrapLambdaBodyEnvelope(result.enhancedRequestExample);
             const originalHasBody = isObjectWithKey(request.originalRequestExample, "body");
             if (unwrapped.wasWrapped && !originalHasBody) {
-                const backfilled = backfillMissingFields(unwrapped.inner, request.originalRequestExample);
-                result.enhancedRequestExample = { body: backfilled };
+                // Lambda envelope detected — backfill the inner value directly.
+                // Do NOT re-wrap: the IR path only handles FDR {type,value} wrappers,
+                // and writeAiExamplesOverride has its own unwrap logic.
+                result.enhancedRequestExample = backfillMissingFields(unwrapped.inner, request.originalRequestExample);
             } else {
                 result.enhancedRequestExample = backfillMissingFields(
                     result.enhancedRequestExample,

--- a/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
+++ b/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
@@ -1118,6 +1118,15 @@ async function processEndpoint(
         // Record success in circuit breaker
         circuitBreaker?.recordSuccess();
 
+        // Backfill any required fields the AI may have missed from the original auto-generated example.
+        // The AI Lambda may not fully resolve nested allOf chains, producing partial examples.
+        if (result.enhancedRequestExample != null && request.originalRequestExample != null) {
+            result.enhancedRequestExample = backfillMissingFields(
+                result.enhancedRequestExample,
+                request.originalRequestExample
+            );
+        }
+
         // Check if anything was actually enhanced
         const requestChanged = result.enhancedRequestExample !== request.originalRequestExample;
         const responseChanged = result.enhancedResponseExample !== request.originalResponseExample;
@@ -1638,4 +1647,45 @@ function extractExampleValue(bodyV3: BodyV3 | undefined): unknown {
         default:
             return bodyV3.value;
     }
+}
+
+/**
+ * Backfills missing top-level fields from the original auto-generated example into the
+ * AI-enhanced example. Preserves the AI's realistic values for fields it provided while
+ * ensuring all required fields from the schema are present in the final output.
+ */
+export function backfillMissingFields(enhanced: unknown, original: unknown): unknown {
+    if (
+        typeof enhanced !== "object" ||
+        enhanced === null ||
+        typeof original !== "object" ||
+        original === null ||
+        Array.isArray(enhanced) ||
+        Array.isArray(original)
+    ) {
+        return enhanced;
+    }
+
+    const enhancedObj = enhanced as Record<string, unknown>;
+    const originalObj = original as Record<string, unknown>;
+
+    let hasMissing = false;
+    for (const key of Object.keys(originalObj)) {
+        if (!(key in enhancedObj)) {
+            hasMissing = true;
+            break;
+        }
+    }
+
+    if (!hasMissing) {
+        return enhanced;
+    }
+
+    const merged: Record<string, unknown> = { ...enhancedObj };
+    for (const [key, value] of Object.entries(originalObj)) {
+        if (!(key in merged)) {
+            merged[key] = value;
+        }
+    }
+    return merged;
 }

--- a/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
+++ b/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
@@ -1665,8 +1665,7 @@ export function unwrapLambdaBodyEnvelope(value: unknown): { wasWrapped: boolean;
         typeof value === "object" &&
         value !== null &&
         !Array.isArray(value) &&
-        "body" in value &&
-        Object.keys(value).length === 1
+        "body" in value
     ) {
         return { wasWrapped: true, inner: (value as Record<string, unknown>).body };
     }

--- a/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
+++ b/packages/cli/register/src/ai-example-enhancer/enhanceExamplesWithAI.ts
@@ -1120,11 +1120,18 @@ async function processEndpoint(
 
         // Backfill any required fields the AI may have missed from the original auto-generated example.
         // The AI Lambda may not fully resolve nested allOf chains, producing partial examples.
+        // Handle the Lambda's {body: {...}} envelope if present.
         if (result.enhancedRequestExample != null && request.originalRequestExample != null) {
-            result.enhancedRequestExample = backfillMissingFields(
-                result.enhancedRequestExample,
-                request.originalRequestExample
-            );
+            const unwrapped = unwrapLambdaBodyEnvelope(result.enhancedRequestExample);
+            if (unwrapped.wasWrapped) {
+                const backfilled = backfillMissingFields(unwrapped.inner, request.originalRequestExample);
+                result.enhancedRequestExample = { body: backfilled };
+            } else {
+                result.enhancedRequestExample = backfillMissingFields(
+                    result.enhancedRequestExample,
+                    request.originalRequestExample
+                );
+            }
         }
 
         // Check if anything was actually enhanced
@@ -1647,6 +1654,23 @@ function extractExampleValue(bodyV3: BodyV3 | undefined): unknown {
         default:
             return bodyV3.value;
     }
+}
+
+/**
+ * Detects and unwraps the Lambda's `{body: {...}}` envelope format.
+ * The Lambda sometimes wraps the request example in a "body" key.
+ */
+export function unwrapLambdaBodyEnvelope(value: unknown): { wasWrapped: boolean; inner: unknown } {
+    if (
+        typeof value === "object" &&
+        value !== null &&
+        !Array.isArray(value) &&
+        "body" in value &&
+        Object.keys(value).length === 1
+    ) {
+        return { wasWrapped: true, inner: (value as Record<string, unknown>).body };
+    }
+    return { wasWrapped: false, inner: value };
 }
 
 /**


### PR DESCRIPTION
## Description
Linear ticket: Refs [FER-10987](https://linear.app/buildwithfern/issue/FER-10987/)

When `fern docs` publishes with AI example enhancement enabled (the default), the Lambda may produce partial request body examples for endpoints with nested allOf schemas. The AI doesn't fully resolve allOf chains, so it generates examples missing required fields (e.g., only `{channelIds: [101, 202]}` instead of all 6 required fields for BigCommerce's `UserPost` schema).

This is why `fern docs dev` shows correct examples locally (no AI enhancement in preview) but the published site shows incomplete ones.

## Changes Made
- Added `backfillMissingFields()` in the AI enhancement pipeline (`processEndpoint`) that merges missing top-level fields from the correct auto-generated example into the AI Lambda output
- AI's realistic values are preserved for fields it provided; only genuinely missing fields are backfilled from auto-gen
- No-op when enhanced example already has all fields from the original
- Added 8 unit tests covering: missing fields backfill, AI value preservation, no-op when complete, non-object edge cases, arrays, empty objects
- [x] Updated changelog entry

## Testing
- [x] Unit tests added (8 tests in `backfillMissingFields.test.ts`)
- [x] All 223 existing register package tests pass
- [x] Biome lint passes

Link to Devin session: https://app.devin.ai/sessions/e439335bc1b043a9b568c0044d8246cd
Requested by: @cade-fern