### PR TITLE
fix(php): use strict null comparison for literal boolean headers

### DIFF
--- a/generators/php/sdk/changes/unreleased/fix-literal-header-ternary.yml
+++ b/generators/php/sdk/changes/unreleased/fix-literal-header-ternary.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Fix PHPStan error for literal boolean headers by using strict null comparison
+    (`!== null`) instead of loose comparison (`!= null`).
+  type: fix

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -364,7 +364,7 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                 }
                 for (const param of constructorParameters.literal) {
                     if (param.header != null) {
-                        writer.controlFlow("if", php.codeblock(`$${param.name} != null`));
+                        writer.controlFlow("if", php.codeblock(`$${param.name} !== null`));
                         writer.write(`$defaultHeaders['${param.header.name}'] = `);
                         if (param.value.type === "boolean") {
                             writer.writeTextStatement(`$${param.name} ? 'true' : 'false'`);

--- a/seed/php-sdk/literal/.fern/metadata.json
+++ b/seed/php-sdk/literal/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/literal/src/SeedClient.php
+++ b/seed/php-sdk/literal/src/SeedClient.php
@@ -77,10 +77,10 @@ class SeedClient
             'X-Fern-SDK-Version' => '0.0.1',
             'User-Agent' => 'seed/seed/0.0.1',
         ];
-        if ($version != null) {
+        if ($version !== null) {
             $defaultHeaders['X-API-Version'] = $version;
         }
-        if ($auditLogging != null) {
+        if ($auditLogging !== null) {
             $defaultHeaders['X-API-Enable-Audit-Logging'] = $auditLogging ? 'true' : 'false';
         }
 

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -196,8 +196,7 @@ allowedFailures:
   - trace
   - circular-references
   - circular-references-advanced
-  # Literal header: ternary condition always true.
-  - literal
+
   # OAuth/InferredAuth custom properties need non-literal property passthrough.
   - oauth-client-credentials-custom
   - oauth-client-credentials-reference


### PR DESCRIPTION
## Description

Fix PHPStan "Ternary operator condition is always true" error for literal boolean headers in the PHP SDK generator.

## Changes Made

- Changed `!= null` to `!== null` in the literal header override block in `RootClientGenerator.ts`
  - In PHP, `false == null` is `true` (loose comparison), so inside `if ($param != null)` PHPStan infers the bool can only be `true`, making `$param ? 'true' : 'false'` always-true
  - Strict comparison (`!== null`) preserves both `true`/`false` as possible values
- Removed `literal` from `allowedFailures` in `seed/php-sdk/seed.yml`

## Testing

- [x] `seed test --generator php-sdk --fixture literal` passes (PHPStan + build + tests)
- [x] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/cfede00e80874418a66a835d1356cb4b
Requested by: @iamnamananand996