### PR TITLE
fix(php): use ->value and ::from() for enum variants in union serialization

### DIFF
--- a/generators/php/model/src/union/UnionGenerator.ts
+++ b/generators/php/model/src/union/UnionGenerator.ts
@@ -307,6 +307,27 @@ export class UnionGenerator extends FileGenerator<PhpFile, ModelCustomConfigSche
         }
     }
 
+    private isVariantEnumType(variant: FernIr.SingleUnionType): boolean {
+        if (variant.shape.propertiesType !== "singleProperty") {
+            return false;
+        }
+        return this.isEnumTypeRef(variant.shape.type);
+    }
+
+    private isEnumTypeRef(typeRef: FernIr.TypeReference): boolean {
+        if (typeRef.type !== "named") {
+            return false;
+        }
+        const decl = this.context.getTypeDeclarationOrThrow(typeRef.typeId);
+        if (decl.shape.type === "enum") {
+            return true;
+        }
+        if (decl.shape.type === "alias") {
+            return this.isEnumTypeRef(decl.shape.aliasOf);
+        }
+        return false;
+    }
+
     private getTypeCheckConditional(
         variant: FernIr.SingleUnionType,
         variableGetter: php.CodeBlock
@@ -781,6 +802,13 @@ export class UnionGenerator extends FileGenerator<PhpFile, ModelCustomConfigSche
                 if (declaredVariableName != null) {
                     argument = php.codeblock(declaredVariableName);
                 }
+                if (this.isVariantEnumType(variant)) {
+                    return php.codeblock((writer) => {
+                        writer.write("$value = ");
+                        writer.writeNode(argument);
+                        writer.writeTextStatement("->value");
+                    });
+                }
                 return php.codeblock((writer) => {
                     writer.write("$value = ");
                     writer.writeNodeStatement(
@@ -1149,6 +1177,43 @@ export class UnionGenerator extends FileGenerator<PhpFile, ModelCustomConfigSche
         const discriminantGetter = php.codeblock(`$data['${getWireValue(variant.discriminantValue)}']`);
         switch (type.internalType.type) {
             case "reference":
+                if (this.isVariantEnumType(variant)) {
+                    return php.codeblock((writer) => {
+                        const typeCheck = this.getTypeCheck(discriminantGetter, php.Type.string());
+
+                        const isNotType = php.codeblock((_writer) => {
+                            _writer.write("!");
+                            _writer.write("(");
+                            _writer.writeNode(typeCheck);
+                            _writer.write(")");
+                        });
+
+                        writer.writeNode(
+                            php.codeblock((_writer) => {
+                                _writer.controlFlow("if", isNotType);
+                                _writer.writeNodeStatement(
+                                    this.getErrorThrow(
+                                        this.getDeserializationTypeCheckErrorMessage(
+                                            variant.discriminantValue,
+                                            php.Type.string()
+                                        )
+                                    )
+                                );
+                                _writer.endControlFlow();
+                            })
+                        );
+
+                        writer.write(`$args['${this.getValueFieldName()}'] = `);
+                        writer.writeNodeStatement(
+                            php.invokeMethod({
+                                method: "from",
+                                arguments_: [discriminantGetter],
+                                static_: true,
+                                on: type.getClassReference()
+                            })
+                        );
+                    });
+                }
                 return php.codeblock((writer) => {
                     const typeCheck = this.getTypeCheck(discriminantGetter, php.Type.array(php.Type.mixed()));
 

--- a/generators/php/sdk/changes/unreleased/fix-union-enum-serialization.yml
+++ b/generators/php/sdk/changes/unreleased/fix-union-enum-serialization.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Fix union serialization for enum variants: use `->value` for serialization
+    and `::from()` for deserialization instead of `->jsonSerialize()` / `::jsonDeserialize()`.
+  type: fix

--- a/seed/php-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/php-sdk/circular-references-advanced/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/circular-references-advanced/src/Ast/Types/FieldValue.php
+++ b/seed/php-sdk/circular-references-advanced/src/Ast/Types/FieldValue.php
@@ -173,7 +173,7 @@ class FieldValue extends JsonSerializableType
 
         switch ($this->type) {
             case 'primitive_value':
-                $value = $this->asPrimitiveValue()->jsonSerialize();
+                $value = $this->asPrimitiveValue()->value;
                 $result['primitive_value'] = $value;
                 break;
             case 'object_value':
@@ -227,12 +227,12 @@ class FieldValue extends JsonSerializableType
                     );
                 }
 
-                if (!(is_array($data['primitive_value']))) {
+                if (!(is_string($data['primitive_value']))) {
                     throw new Exception(
-                        "Expected property 'primitiveValue' in JSON data to be array, instead received " . get_debug_type($data['primitive_value']),
+                        "Expected property 'primitiveValue' in JSON data to be string, instead received " . get_debug_type($data['primitive_value']),
                     );
                 }
-                $args['value'] = PrimitiveValue::jsonDeserialize($data['primitive_value']);
+                $args['value'] = PrimitiveValue::from($data['primitive_value']);
                 break;
             case 'object_value':
                 $args['value'] = ObjectValue::jsonDeserialize($data);

--- a/seed/php-sdk/circular-references/.fern/metadata.json
+++ b/seed/php-sdk/circular-references/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/circular-references/src/Ast/Types/FieldValue.php
+++ b/seed/php-sdk/circular-references/src/Ast/Types/FieldValue.php
@@ -173,7 +173,7 @@ class FieldValue extends JsonSerializableType
 
         switch ($this->type) {
             case 'primitive_value':
-                $value = $this->asPrimitiveValue()->jsonSerialize();
+                $value = $this->asPrimitiveValue()->value;
                 $result['primitive_value'] = $value;
                 break;
             case 'object_value':
@@ -227,12 +227,12 @@ class FieldValue extends JsonSerializableType
                     );
                 }
 
-                if (!(is_array($data['primitive_value']))) {
+                if (!(is_string($data['primitive_value']))) {
                     throw new Exception(
-                        "Expected property 'primitiveValue' in JSON data to be array, instead received " . get_debug_type($data['primitive_value']),
+                        "Expected property 'primitiveValue' in JSON data to be string, instead received " . get_debug_type($data['primitive_value']),
                     );
                 }
-                $args['value'] = PrimitiveValue::jsonDeserialize($data['primitive_value']);
+                $args['value'] = PrimitiveValue::from($data['primitive_value']);
                 break;
             case 'object_value':
                 $args['value'] = ObjectValue::jsonDeserialize($data);

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -192,6 +192,8 @@ allowedFailures:
   # Dynamic snippet syntax errors for examples with Exception-named types.
   - examples:no-custom-config
   - examples:readme-config
+  # PHPDoc unresolvable enum-as-map-key type + dynamic snippet errors (unrelated to union serialization).
+  - trace
 
   # OAuth/InferredAuth custom properties need non-literal property passthrough.
   - oauth-client-credentials-custom

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -192,10 +192,6 @@ allowedFailures:
   # Dynamic snippet syntax errors for examples with Exception-named types.
   - examples:no-custom-config
   - examples:readme-config
-  # Union serialization: jsonSerialize/jsonDeserialize called on enum types.
-  - trace
-  - circular-references
-  - circular-references-advanced
 
   # OAuth/InferredAuth custom properties need non-literal property passthrough.
   - oauth-client-credentials-custom

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -192,8 +192,6 @@ allowedFailures:
   # Dynamic snippet syntax errors for examples with Exception-named types.
   - examples:no-custom-config
   - examples:readme-config
-  # PHPDoc unresolvable enum-as-map-key type + dynamic snippet errors (unrelated to union serialization).
-  - trace
 
   # OAuth/InferredAuth custom properties need non-literal property passthrough.
   - oauth-client-credentials-custom

--- a/seed/php-sdk/trace/src/Submission/Types/TestSubmissionStatus.php
+++ b/seed/php-sdk/trace/src/Submission/Types/TestSubmissionStatus.php
@@ -203,7 +203,7 @@ class TestSubmissionStatus extends JsonSerializableType
                 $result['errored'] = $value;
                 break;
             case 'running':
-                $value = $this->asRunning()->jsonSerialize();
+                $value = $this->asRunning()->value;
                 $result['running'] = $value;
                 break;
             case 'testCaseIdToState':
@@ -270,12 +270,12 @@ class TestSubmissionStatus extends JsonSerializableType
                     );
                 }
 
-                if (!(is_array($data['running']))) {
+                if (!(is_string($data['running']))) {
                     throw new Exception(
-                        "Expected property 'running' in JSON data to be array, instead received " . get_debug_type($data['running']),
+                        "Expected property 'running' in JSON data to be string, instead received " . get_debug_type($data['running']),
                     );
                 }
-                $args['value'] = RunningSubmissionState::jsonDeserialize($data['running']);
+                $args['value'] = RunningSubmissionState::from($data['running']);
                 break;
             case 'testCaseIdToState':
                 if (!array_key_exists('testCaseIdToState', $data)) {

--- a/seed/php-sdk/trace/src/Submission/Types/TestSubmissionUpdateInfo.php
+++ b/seed/php-sdk/trace/src/Submission/Types/TestSubmissionUpdateInfo.php
@@ -255,7 +255,7 @@ class TestSubmissionUpdateInfo extends JsonSerializableType
 
         switch ($this->type) {
             case 'running':
-                $value = $this->asRunning()->jsonSerialize();
+                $value = $this->asRunning()->value;
                 $result['running'] = $value;
                 break;
             case 'stopped':
@@ -319,12 +319,12 @@ class TestSubmissionUpdateInfo extends JsonSerializableType
                     );
                 }
 
-                if (!(is_array($data['running']))) {
+                if (!(is_string($data['running']))) {
                     throw new Exception(
-                        "Expected property 'running' in JSON data to be array, instead received " . get_debug_type($data['running']),
+                        "Expected property 'running' in JSON data to be string, instead received " . get_debug_type($data['running']),
                     );
                 }
-                $args['value'] = RunningSubmissionState::jsonDeserialize($data['running']);
+                $args['value'] = RunningSubmissionState::from($data['running']);
                 break;
             case 'stopped':
                 $args['value'] = null;

--- a/seed/php-sdk/trace/src/Submission/Types/WorkspaceSubmissionStatus.php
+++ b/seed/php-sdk/trace/src/Submission/Types/WorkspaceSubmissionStatus.php
@@ -239,7 +239,7 @@ class WorkspaceSubmissionStatus extends JsonSerializableType
                 $result['errored'] = $value;
                 break;
             case 'running':
-                $value = $this->asRunning()->jsonSerialize();
+                $value = $this->asRunning()->value;
                 $result['running'] = $value;
                 break;
             case 'ran':
@@ -310,12 +310,12 @@ class WorkspaceSubmissionStatus extends JsonSerializableType
                     );
                 }
 
-                if (!(is_array($data['running']))) {
+                if (!(is_string($data['running']))) {
                     throw new Exception(
-                        "Expected property 'running' in JSON data to be array, instead received " . get_debug_type($data['running']),
+                        "Expected property 'running' in JSON data to be string, instead received " . get_debug_type($data['running']),
                     );
                 }
-                $args['value'] = RunningSubmissionState::jsonDeserialize($data['running']);
+                $args['value'] = RunningSubmissionState::from($data['running']);
                 break;
             case 'ran':
                 $args['value'] = WorkspaceRunDetails::jsonDeserialize($data);

--- a/seed/php-sdk/trace/src/Submission/Types/WorkspaceSubmissionUpdateInfo.php
+++ b/seed/php-sdk/trace/src/Submission/Types/WorkspaceSubmissionUpdateInfo.php
@@ -276,7 +276,7 @@ class WorkspaceSubmissionUpdateInfo extends JsonSerializableType
 
         switch ($this->type) {
             case 'running':
-                $value = $this->asRunning()->jsonSerialize();
+                $value = $this->asRunning()->value;
                 $result['running'] = $value;
                 break;
             case 'ran':
@@ -343,12 +343,12 @@ class WorkspaceSubmissionUpdateInfo extends JsonSerializableType
                     );
                 }
 
-                if (!(is_array($data['running']))) {
+                if (!(is_string($data['running']))) {
                     throw new Exception(
-                        "Expected property 'running' in JSON data to be array, instead received " . get_debug_type($data['running']),
+                        "Expected property 'running' in JSON data to be string, instead received " . get_debug_type($data['running']),
                     );
                 }
-                $args['value'] = RunningSubmissionState::jsonDeserialize($data['running']);
+                $args['value'] = RunningSubmissionState::from($data['running']);
                 break;
             case 'ran':
                 $args['value'] = WorkspaceRunDetails::jsonDeserialize($data);


### PR DESCRIPTION
## Description

Fix union types calling `jsonSerialize()`/`jsonDeserialize()` on enum variants. PHP enums don't have these methods — they use `->value` for serialization and `::from()` for deserialization.

## Changes Made

- Added `isVariantEnumType()` / `isEnumTypeRef()` helpers to `UnionGenerator.ts` that resolve whether a single-property variant references an enum type (handles aliases)
- In `jsonSerializeValueCall`: enum reference variants now emit `$this->asXxx()->value` instead of `$this->asXxx()->jsonSerialize()`
- In `jsonDeserializeTypeCall`: enum reference variants now emit `EnumClass::from($data['key'])` with a string type check, instead of `EnumClass::jsonDeserialize($data['key'])` with an array type check
- Removed `circular-references` and `circular-references-advanced` from `allowedFailures`
- `trace` remains in allowedFailures due to additional unrelated issues (PHPDoc unresolvable enum-as-map-key type + dynamic snippet errors)

## Testing

- [x] `seed test --generator php-sdk --fixture circular-references` passes
- [x] `seed test --generator php-sdk --fixture circular-references-advanced` passes
- [x] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/cfede00e80874418a66a835d1356cb4b
Requested by: @iamnamananand996