### PR TITLE
fix(python): forward OAuth token-endpoint request properties to token provider

### DIFF
--- a/generators/python/sdk/changes/unreleased/fix-oauth-token-endpoint-request-properties.yml
+++ b/generators/python/sdk/changes/unreleased/fix-oauth-token-endpoint-request-properties.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Forward all OAuth token-endpoint request properties from the generated client to the
+    `OAuthTokenProvider`. Previously only `client_id`/`client_secret` were passed, so token
+    endpoints that required configured scopes or custom properties (e.g. `entity_id`, `scope`)
+    generated code that omitted those arguments and failed type checking. These properties are
+    now exposed as client constructor parameters (required ones required, optional ones default
+    to `None`) and threaded through to the token request.
+  type: fix

--- a/generators/python/src/fern_python/generators/sdk/client_generator/oauth_token_provider_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/oauth_token_provider_generator.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
 
 from ..context.sdk_generator_context import SdkGeneratorContext
@@ -9,6 +10,76 @@ from fern_python.utils.name_resolver import get_name_from_wire_value, resolve_na
 import fern.ir.resources as ir_types
 
 DEFAULT_EXPIRES_IN_SECONDS = 3600  # 1 hour
+
+
+@dataclass
+class OAuthAdditionalTokenProperty:
+    """
+    A request property the token endpoint requires beyond client_id/client_secret
+    (e.g. configured scopes or arbitrary custom properties). The SDK user must supply
+    these and they are forwarded to the token endpoint when fetching a token.
+    """
+
+    field_name: str
+    is_optional: bool
+
+
+def _request_property_value_type(request_property: ir_types.RequestProperty) -> ir_types.TypeReference:
+    return request_property.property.visit(
+        query=lambda query_parameter: query_parameter.value_type,
+        body=lambda object_property: object_property.value_type,
+    )
+
+
+def _request_property_name(request_property: ir_types.RequestProperty) -> str:
+    return request_property.property.visit(
+        query=lambda query_parameter: resolve_name(get_name_from_wire_value(query_parameter.name)).snake_case.safe_name,
+        body=lambda object_property: resolve_name(get_name_from_wire_value(object_property.name)).snake_case.safe_name,
+    )
+
+
+def _type_reference_is_literal(type_reference: ir_types.TypeReference) -> bool:
+    type_union = type_reference.get_as_union()
+    if type_union.type == "container":
+        return type_union.container.get_as_union().type == "literal"
+    return False
+
+
+def _type_reference_is_optional(type_reference: ir_types.TypeReference) -> bool:
+    type_union = type_reference.get_as_union()
+    if type_union.type == "container":
+        return type_union.container.get_as_union().type == "optional"
+    return False
+
+
+def get_oauth_additional_token_request_properties(
+    client_credentials: ir_types.OAuthClientCredentials,
+) -> List[OAuthAdditionalTokenProperty]:
+    """
+    Collect the token endpoint's request properties that must be supplied by the SDK user
+    in addition to client_id/client_secret. Literal properties are auto-populated by the
+    generated client method, so they are excluded.
+    """
+    token_request_properties = client_credentials.token_endpoint.request_properties
+
+    candidates: List[ir_types.RequestProperty] = []
+    if token_request_properties.scopes is not None:
+        candidates.append(token_request_properties.scopes)
+    if token_request_properties.custom_properties is not None:
+        candidates.extend(token_request_properties.custom_properties)
+
+    properties: List[OAuthAdditionalTokenProperty] = []
+    for request_property in candidates:
+        value_type = _request_property_value_type(request_property)
+        if _type_reference_is_literal(value_type):
+            continue
+        properties.append(
+            OAuthAdditionalTokenProperty(
+                field_name=_request_property_name(request_property),
+                is_optional=_type_reference_is_optional(value_type),
+            )
+        )
+    return properties
 
 
 class OAuthTokenProviderGenerator:
@@ -50,7 +121,9 @@ class OAuthTokenProviderGenerator:
     def _create_client_credentials_class_declaration(
         self, client_credentials: ir_types.OAuthClientCredentials, *, is_async: bool
     ) -> AST.ClassDeclaration:
-        constructor_parameters = self._get_constructor_parameters(is_async=is_async)
+        constructor_parameters = self._get_constructor_parameters(
+            client_credentials=client_credentials, is_async=is_async
+        )
 
         named_parameters = [
             AST.NamedFunctionParameter(
@@ -98,7 +171,9 @@ class OAuthTokenProviderGenerator:
 
         return class_declaration
 
-    def _get_constructor_parameters(self, *, is_async: bool) -> List[ConstructorParameter]:
+    def _get_constructor_parameters(
+        self, *, client_credentials: ir_types.OAuthClientCredentials, is_async: bool
+    ) -> List[ConstructorParameter]:
         parameters: List[ConstructorParameter] = []
 
         parameters.append(
@@ -116,6 +191,22 @@ class OAuthTokenProviderGenerator:
                 type_hint=AST.TypeHint.str_(),
             )
         )
+
+        # The token endpoint may require additional request properties (configured scopes
+        # or custom properties) beyond client_id/client_secret. Accept them so they can be
+        # forwarded when fetching a token.
+        for additional_property in get_oauth_additional_token_request_properties(client_credentials):
+            type_hint = AST.TypeHint.str_()
+            if additional_property.is_optional:
+                type_hint = AST.TypeHint.optional(type_hint)
+            parameters.append(
+                ConstructorParameter(
+                    constructor_parameter_name=additional_property.field_name,
+                    private_member_name=f"_{additional_property.field_name}",
+                    type_hint=type_hint,
+                    initializer=AST.Expression("None") if additional_property.is_optional else None,
+                )
+            )
 
         parameters.append(
             ConstructorParameter(
@@ -548,6 +639,15 @@ class OAuthTokenProviderGenerator:
             ),
         ]
         if client_credentials.refresh_endpoint is None:
+            # Forward any additional token-endpoint request properties (configured scopes or
+            # custom properties) that the user supplied to the token provider.
+            for additional_property in get_oauth_additional_token_request_properties(client_credentials):
+                kwargs.append(
+                    (
+                        additional_property.field_name,
+                        AST.Expression(f"self._{additional_property.field_name}"),
+                    )
+                )
             token_endpoint: ir_types.HttpEndpoint = self._get_endpoint_for_id(
                 client_credentials.token_endpoint.endpoint_reference.endpoint_id
             )

--- a/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -15,6 +15,9 @@ from .inferred_auth_token_provider_generator import (
     CredentialProperty,
     InferredAuthTokenProviderGenerator,
 )
+from .oauth_token_provider_generator import (
+    get_oauth_additional_token_request_properties,
+)
 from fern_python.codegen import AST, SourceFile
 from fern_python.codegen.ast.nodes.code_writer.code_writer import CodeWriterFunction
 from fern_python.external_dependencies import HttpX
@@ -701,6 +704,22 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
                         ),
                     ),
                 )
+                # The token endpoint may require additional request properties (configured scopes
+                # or custom properties) beyond client_id/client_secret. Expose them as constructor
+                # parameters so they can be forwarded to the OAuth token provider.
+                for additional_property in get_oauth_additional_token_request_properties(oauth):
+                    additional_type_hint = AST.TypeHint.str_()
+                    if additional_property.is_optional:
+                        additional_type_hint = AST.TypeHint.optional(additional_type_hint)
+                    parameters.append(
+                        RootClientConstructorParameter(
+                            constructor_parameter_name=additional_property.field_name,
+                            type_hint=additional_type_hint,
+                            initializer=AST.Expression("None") if additional_property.is_optional else None,
+                            docs="A property required by the OAuth token endpoint.",
+                            exclude_from_wrapper_construction=True,
+                        ),
+                    )
             parameters.append(
                 RootClientConstructorParameter(
                     constructor_parameter_name=self.TOKEN_GETTER_PARAM_NAME,
@@ -1056,6 +1075,7 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
                                 "client_secret",
                                 AST.Expression("client_secret"),
                             ),
+                            *self._get_oauth_additional_property_kwargs(),
                             (
                                 "client_wrapper",
                                 AST.Expression(
@@ -1228,6 +1248,21 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
             inferred_auth_scheme=inferred_auth_scheme,
         ).get_credential_properties()
 
+    def _get_oauth_additional_property_kwargs(self) -> List[typing.Tuple[str, AST.Expression]]:
+        """
+        Constructor kwargs forwarding additional token-endpoint request properties (configured
+        scopes or custom properties) from the root client to the OAuth token provider.
+        """
+        if self._oauth_scheme is None:
+            return []
+        oauth = self._oauth_scheme.configuration.get_as_union()
+        if oauth.type != "clientCredentials":
+            return []
+        return [
+            (additional_property.field_name, AST.Expression(additional_property.field_name))
+            for additional_property in get_oauth_additional_token_request_properties(oauth)
+        ]
+
     def _write_oauth_token_override_constructor_body(
         self,
         *,
@@ -1314,6 +1349,7 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
                             "client_secret",
                             AST.Expression("client_secret"),
                         ),
+                        *self._get_oauth_additional_property_kwargs(),
                         (
                             "client_wrapper",
                             AST.Expression(

--- a/seed/python-sdk/oauth-client-credentials-custom/snippet.json
+++ b/seed/python-sdk/oauth-client-credentials-custom/snippet.json
@@ -9,8 +9,8 @@
                 "identifier_override": "endpoint_auth.getTokenWithClientCredentials"
             },
             "snippet": {
-                "sync_client": "from seed import SeedOauthClientCredentials\n\nclient = SeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\nclient.auth.get_token_with_client_credentials(\n    cid=\"cid\",\n    csr=\"csr\",\n    scp=\"scp\",\n    entity_id=\"entity_id\",\n    scope=\"scope\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedOauthClientCredentials\n\nclient = AsyncSeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\n\n\nasync def main() -> None:\n    await client.auth.get_token_with_client_credentials(\n        cid=\"cid\",\n        csr=\"csr\",\n        scp=\"scp\",\n        entity_id=\"entity_id\",\n        scope=\"scope\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import SeedOauthClientCredentials\n\nclient = SeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    scp=\"YOUR_SCP\",\n    entity_id=\"YOUR_ENTITY_ID\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\nclient.auth.get_token_with_client_credentials(\n    cid=\"cid\",\n    csr=\"csr\",\n    scp=\"scp\",\n    entity_id=\"entity_id\",\n    scope=\"scope\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncSeedOauthClientCredentials\n\nclient = AsyncSeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    scp=\"YOUR_SCP\",\n    entity_id=\"YOUR_ENTITY_ID\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\n\n\nasync def main() -> None:\n    await client.auth.get_token_with_client_credentials(\n        cid=\"cid\",\n        csr=\"csr\",\n        scp=\"scp\",\n        entity_id=\"entity_id\",\n        scope=\"scope\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -22,8 +22,8 @@
                 "identifier_override": "endpoint_auth.refreshToken"
             },
             "snippet": {
-                "sync_client": "from seed import SeedOauthClientCredentials\n\nclient = SeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\nclient.auth.refresh_token(\n    client_id=\"client_id\",\n    client_secret=\"client_secret\",\n    refresh_token=\"refresh_token\",\n    scope=\"scope\",\n)\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedOauthClientCredentials\n\nclient = AsyncSeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\n\n\nasync def main() -> None:\n    await client.auth.refresh_token(\n        client_id=\"client_id\",\n        client_secret=\"client_secret\",\n        refresh_token=\"refresh_token\",\n        scope=\"scope\",\n    )\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import SeedOauthClientCredentials\n\nclient = SeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    scp=\"YOUR_SCP\",\n    entity_id=\"YOUR_ENTITY_ID\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\nclient.auth.refresh_token(\n    client_id=\"client_id\",\n    client_secret=\"client_secret\",\n    refresh_token=\"refresh_token\",\n    scope=\"scope\",\n)\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncSeedOauthClientCredentials\n\nclient = AsyncSeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    scp=\"YOUR_SCP\",\n    entity_id=\"YOUR_ENTITY_ID\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\n\n\nasync def main() -> None:\n    await client.auth.refresh_token(\n        client_id=\"client_id\",\n        client_secret=\"client_secret\",\n        refresh_token=\"refresh_token\",\n        scope=\"scope\",\n    )\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -35,8 +35,8 @@
                 "identifier_override": "endpoint_nested-no-auth/api.getSomething"
             },
             "snippet": {
-                "sync_client": "from seed import SeedOauthClientCredentials\n\nclient = SeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\nclient.nested_no_auth.api.get_something()\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedOauthClientCredentials\n\nclient = AsyncSeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\n\n\nasync def main() -> None:\n    await client.nested_no_auth.api.get_something()\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import SeedOauthClientCredentials\n\nclient = SeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    scp=\"YOUR_SCP\",\n    entity_id=\"YOUR_ENTITY_ID\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\nclient.nested_no_auth.api.get_something()\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncSeedOauthClientCredentials\n\nclient = AsyncSeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    scp=\"YOUR_SCP\",\n    entity_id=\"YOUR_ENTITY_ID\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\n\n\nasync def main() -> None:\n    await client.nested_no_auth.api.get_something()\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -48,8 +48,8 @@
                 "identifier_override": "endpoint_nested/api.getSomething"
             },
             "snippet": {
-                "sync_client": "from seed import SeedOauthClientCredentials\n\nclient = SeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\nclient.nested.api.get_something()\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedOauthClientCredentials\n\nclient = AsyncSeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\n\n\nasync def main() -> None:\n    await client.nested.api.get_something()\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import SeedOauthClientCredentials\n\nclient = SeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    scp=\"YOUR_SCP\",\n    entity_id=\"YOUR_ENTITY_ID\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\nclient.nested.api.get_something()\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncSeedOauthClientCredentials\n\nclient = AsyncSeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    scp=\"YOUR_SCP\",\n    entity_id=\"YOUR_ENTITY_ID\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\n\n\nasync def main() -> None:\n    await client.nested.api.get_something()\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         },
@@ -61,8 +61,8 @@
                 "identifier_override": "endpoint_simple.getSomething"
             },
             "snippet": {
-                "sync_client": "from seed import SeedOauthClientCredentials\n\nclient = SeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\nclient.simple.get_something()\n",
-                "async_client": "import asyncio\n\nfrom seed import AsyncSeedOauthClientCredentials\n\nclient = AsyncSeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\n\n\nasync def main() -> None:\n    await client.simple.get_something()\n\n\nasyncio.run(main())\n",
+                "sync_client": "from seed import SeedOauthClientCredentials\n\nclient = SeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    scp=\"YOUR_SCP\",\n    entity_id=\"YOUR_ENTITY_ID\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\nclient.simple.get_something()\n",
+                "async_client": "import asyncio\n\nfrom seed import AsyncSeedOauthClientCredentials\n\nclient = AsyncSeedOauthClientCredentials(\n    base_url=\"YOUR_BASE_URL\",\n    scp=\"YOUR_SCP\",\n    entity_id=\"YOUR_ENTITY_ID\",\n    client_id=\"YOUR_CLIENT_ID\",\n    client_secret=\"YOUR_CLIENT_SECRET\",\n)\n\n\nasync def main() -> None:\n    await client.simple.get_something()\n\n\nasyncio.run(main())\n",
                 "type": "python"
             }
         }

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/auth/client.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/auth/client.py
@@ -62,6 +62,8 @@ class AuthClient:
 
         client = SeedOauthClientCredentials(
             base_url="YOUR_BASE_URL",
+            scp="YOUR_SCP",
+            entity_id="YOUR_ENTITY_ID",
             client_id="YOUR_CLIENT_ID",
             client_secret="YOUR_CLIENT_SECRET",
         )
@@ -111,6 +113,8 @@ class AuthClient:
 
         client = SeedOauthClientCredentials(
             base_url="YOUR_BASE_URL",
+            scp="YOUR_SCP",
+            entity_id="YOUR_ENTITY_ID",
             client_id="YOUR_CLIENT_ID",
             client_secret="YOUR_CLIENT_SECRET",
         )
@@ -184,6 +188,8 @@ class AsyncAuthClient:
 
         client = AsyncSeedOauthClientCredentials(
             base_url="YOUR_BASE_URL",
+            scp="YOUR_SCP",
+            entity_id="YOUR_ENTITY_ID",
             client_id="YOUR_CLIENT_ID",
             client_secret="YOUR_CLIENT_SECRET",
         )
@@ -241,6 +247,8 @@ class AsyncAuthClient:
 
         client = AsyncSeedOauthClientCredentials(
             base_url="YOUR_BASE_URL",
+            scp="YOUR_SCP",
+            entity_id="YOUR_ENTITY_ID",
             client_id="YOUR_CLIENT_ID",
             client_secret="YOUR_CLIENT_SECRET",
         )

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/client.py
@@ -71,6 +71,8 @@ class SeedOauthClientCredentials:
 
     client = SeedOauthClientCredentials(
         base_url="YOUR_BASE_URL",
+        scp="YOUR_SCP",
+        entity_id="YOUR_ENTITY_ID",
         client_id="YOUR_CLIENT_ID",
         client_secret="YOUR_CLIENT_SECRET",
     )
@@ -91,6 +93,9 @@ class SeedOauthClientCredentials:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scp: str,
+        entity_id: str,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -105,6 +110,9 @@ class SeedOauthClientCredentials:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scp: str,
+        entity_id: str,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -120,6 +128,9 @@ class SeedOauthClientCredentials:
         client_id: typing.Optional[str] = None,
         client_secret: typing.Optional[str] = None,
         token: typing.Optional[typing.Callable[[], str]] = None,
+        scp: str,
+        entity_id: str,
+        scope: typing.Optional[str] = None,
         _token_getter_override: typing.Optional[typing.Callable[[], str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -149,6 +160,9 @@ class SeedOauthClientCredentials:
             oauth_token_provider = OAuthTokenProvider(
                 client_id=client_id,
                 client_secret=client_secret,
+                scp=scp,
+                entity_id=entity_id,
+                scope=scope,
                 client_wrapper=SyncClientWrapper(
                     base_url=base_url,
                     headers=headers,
@@ -289,6 +303,8 @@ class AsyncSeedOauthClientCredentials:
 
     client = AsyncSeedOauthClientCredentials(
         base_url="YOUR_BASE_URL",
+        scp="YOUR_SCP",
+        entity_id="YOUR_ENTITY_ID",
         client_id="YOUR_CLIENT_ID",
         client_secret="YOUR_CLIENT_SECRET",
     )
@@ -309,6 +325,9 @@ class AsyncSeedOauthClientCredentials:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scp: str,
+        entity_id: str,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -323,6 +342,9 @@ class AsyncSeedOauthClientCredentials:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scp: str,
+        entity_id: str,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -338,6 +360,9 @@ class AsyncSeedOauthClientCredentials:
         client_id: typing.Optional[str] = None,
         client_secret: typing.Optional[str] = None,
         token: typing.Optional[typing.Callable[[], str]] = None,
+        scp: str,
+        entity_id: str,
+        scope: typing.Optional[str] = None,
         _token_getter_override: typing.Optional[typing.Callable[[], str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -365,6 +390,9 @@ class AsyncSeedOauthClientCredentials:
             oauth_token_provider = AsyncOAuthTokenProvider(
                 client_id=client_id,
                 client_secret=client_secret,
+                scp=scp,
+                entity_id=entity_id,
+                scope=scope,
                 client_wrapper=AsyncClientWrapper(
                     base_url=base_url,
                     headers=headers,

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/oauth_token_provider.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/oauth_token_provider.py
@@ -14,9 +14,21 @@ from .client_wrapper import AsyncClientWrapper, SyncClientWrapper
 class OAuthTokenProvider:
     BUFFER_IN_MINUTES = 2
 
-    def __init__(self, *, client_id: str, client_secret: str, client_wrapper: SyncClientWrapper):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        scp: str,
+        entity_id: str,
+        scope: typing.Optional[str] = None,
+        client_wrapper: SyncClientWrapper,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
+        self._scp = scp
+        self._entity_id = entity_id
+        self._scope = scope
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
         self._auth_client = AuthClient(client_wrapper=client_wrapper)
@@ -32,7 +44,7 @@ class OAuthTokenProvider:
 
     def _refresh(self) -> str:
         token_response = self._auth_client.get_token_with_client_credentials(
-            cid=self._client_id, csr=self._client_secret
+            cid=self._client_id, csr=self._client_secret, scp=self._scp, entity_id=self._entity_id, scope=self._scope
         )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(
@@ -47,9 +59,21 @@ class OAuthTokenProvider:
 class AsyncOAuthTokenProvider:
     BUFFER_IN_MINUTES = 2
 
-    def __init__(self, *, client_id: str, client_secret: str, client_wrapper: AsyncClientWrapper):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        scp: str,
+        entity_id: str,
+        scope: typing.Optional[str] = None,
+        client_wrapper: AsyncClientWrapper,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
+        self._scp = scp
+        self._entity_id = entity_id
+        self._scope = scope
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
         self._auth_client = AsyncAuthClient(client_wrapper=client_wrapper)
@@ -65,7 +89,7 @@ class AsyncOAuthTokenProvider:
 
     async def _refresh(self) -> str:
         token_response = await self._auth_client.get_token_with_client_credentials(
-            cid=self._client_id, csr=self._client_secret
+            cid=self._client_id, csr=self._client_secret, scp=self._scp, entity_id=self._entity_id, scope=self._scope
         )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/nested/api/client.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/nested/api/client.py
@@ -39,6 +39,8 @@ class ApiClient:
 
         client = SeedOauthClientCredentials(
             base_url="YOUR_BASE_URL",
+            scp="YOUR_SCP",
+            entity_id="YOUR_ENTITY_ID",
             client_id="YOUR_CLIENT_ID",
             client_secret="YOUR_CLIENT_SECRET",
         )
@@ -82,6 +84,8 @@ class AsyncApiClient:
 
         client = AsyncSeedOauthClientCredentials(
             base_url="YOUR_BASE_URL",
+            scp="YOUR_SCP",
+            entity_id="YOUR_ENTITY_ID",
             client_id="YOUR_CLIENT_ID",
             client_secret="YOUR_CLIENT_SECRET",
         )

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/nested_no_auth/api/client.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/nested_no_auth/api/client.py
@@ -39,6 +39,8 @@ class ApiClient:
 
         client = SeedOauthClientCredentials(
             base_url="YOUR_BASE_URL",
+            scp="YOUR_SCP",
+            entity_id="YOUR_ENTITY_ID",
             client_id="YOUR_CLIENT_ID",
             client_secret="YOUR_CLIENT_SECRET",
         )
@@ -82,6 +84,8 @@ class AsyncApiClient:
 
         client = AsyncSeedOauthClientCredentials(
             base_url="YOUR_BASE_URL",
+            scp="YOUR_SCP",
+            entity_id="YOUR_ENTITY_ID",
             client_id="YOUR_CLIENT_ID",
             client_secret="YOUR_CLIENT_SECRET",
         )

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/simple/client.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/simple/client.py
@@ -39,6 +39,8 @@ class SimpleClient:
 
         client = SeedOauthClientCredentials(
             base_url="YOUR_BASE_URL",
+            scp="YOUR_SCP",
+            entity_id="YOUR_ENTITY_ID",
             client_id="YOUR_CLIENT_ID",
             client_secret="YOUR_CLIENT_SECRET",
         )
@@ -82,6 +84,8 @@ class AsyncSimpleClient:
 
         client = AsyncSeedOauthClientCredentials(
             base_url="YOUR_BASE_URL",
+            scp="YOUR_SCP",
+            entity_id="YOUR_ENTITY_ID",
             client_id="YOUR_CLIENT_ID",
             client_secret="YOUR_CLIENT_SECRET",
         )

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/client.py
@@ -92,6 +92,7 @@ class SeedOauthClientCredentialsEnvironmentVariables:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -106,6 +107,7 @@ class SeedOauthClientCredentialsEnvironmentVariables:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -121,6 +123,7 @@ class SeedOauthClientCredentialsEnvironmentVariables:
         client_id: typing.Optional[str] = os.getenv("CLIENT_ID"),
         client_secret: typing.Optional[str] = os.getenv("CLIENT_SECRET"),
         token: typing.Optional[typing.Callable[[], str]] = None,
+        scope: typing.Optional[str] = None,
         _token_getter_override: typing.Optional[typing.Callable[[], str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -150,6 +153,7 @@ class SeedOauthClientCredentialsEnvironmentVariables:
             oauth_token_provider = OAuthTokenProvider(
                 client_id=client_id,
                 client_secret=client_secret,
+                scope=scope,
                 client_wrapper=SyncClientWrapper(
                     base_url=base_url,
                     headers=headers,
@@ -310,6 +314,7 @@ class AsyncSeedOauthClientCredentialsEnvironmentVariables:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -324,6 +329,7 @@ class AsyncSeedOauthClientCredentialsEnvironmentVariables:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -339,6 +345,7 @@ class AsyncSeedOauthClientCredentialsEnvironmentVariables:
         client_id: typing.Optional[str] = os.getenv("CLIENT_ID"),
         client_secret: typing.Optional[str] = os.getenv("CLIENT_SECRET"),
         token: typing.Optional[typing.Callable[[], str]] = None,
+        scope: typing.Optional[str] = None,
         _token_getter_override: typing.Optional[typing.Callable[[], str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -366,6 +373,7 @@ class AsyncSeedOauthClientCredentialsEnvironmentVariables:
             oauth_token_provider = AsyncOAuthTokenProvider(
                 client_id=client_id,
                 client_secret=client_secret,
+                scope=scope,
                 client_wrapper=AsyncClientWrapper(
                     base_url=base_url,
                     headers=headers,

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/oauth_token_provider.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/oauth_token_provider.py
@@ -14,9 +14,17 @@ from .client_wrapper import AsyncClientWrapper, SyncClientWrapper
 class OAuthTokenProvider:
     BUFFER_IN_MINUTES = 2
 
-    def __init__(self, *, client_id: str, client_secret: str, client_wrapper: SyncClientWrapper):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        scope: typing.Optional[str] = None,
+        client_wrapper: SyncClientWrapper,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
+        self._scope = scope
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
         self._auth_client = AuthClient(client_wrapper=client_wrapper)
@@ -32,7 +40,7 @@ class OAuthTokenProvider:
 
     def _refresh(self) -> str:
         token_response = self._auth_client.get_token_with_client_credentials(
-            client_id=self._client_id, client_secret=self._client_secret
+            client_id=self._client_id, client_secret=self._client_secret, scope=self._scope
         )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(
@@ -47,9 +55,17 @@ class OAuthTokenProvider:
 class AsyncOAuthTokenProvider:
     BUFFER_IN_MINUTES = 2
 
-    def __init__(self, *, client_id: str, client_secret: str, client_wrapper: AsyncClientWrapper):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        scope: typing.Optional[str] = None,
+        client_wrapper: AsyncClientWrapper,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
+        self._scope = scope
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
         self._auth_client = AsyncAuthClient(client_wrapper=client_wrapper)
@@ -65,7 +81,7 @@ class AsyncOAuthTokenProvider:
 
     async def _refresh(self) -> str:
         token_response = await self._auth_client.get_token_with_client_credentials(
-            client_id=self._client_id, client_secret=self._client_secret
+            client_id=self._client_id, client_secret=self._client_secret, scope=self._scope
         )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/client.py
@@ -90,6 +90,7 @@ class SeedOauthClientCredentialsMandatoryAuth:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -104,6 +105,7 @@ class SeedOauthClientCredentialsMandatoryAuth:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -119,6 +121,7 @@ class SeedOauthClientCredentialsMandatoryAuth:
         client_id: typing.Optional[str] = None,
         client_secret: typing.Optional[str] = None,
         token: typing.Optional[typing.Callable[[], str]] = None,
+        scope: typing.Optional[str] = None,
         _token_getter_override: typing.Optional[typing.Callable[[], str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -148,6 +151,7 @@ class SeedOauthClientCredentialsMandatoryAuth:
             oauth_token_provider = OAuthTokenProvider(
                 client_id=client_id,
                 client_secret=client_secret,
+                scope=scope,
                 client_wrapper=SyncClientWrapper(
                     base_url=base_url,
                     headers=headers,
@@ -299,6 +303,7 @@ class AsyncSeedOauthClientCredentialsMandatoryAuth:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -313,6 +318,7 @@ class AsyncSeedOauthClientCredentialsMandatoryAuth:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -328,6 +334,7 @@ class AsyncSeedOauthClientCredentialsMandatoryAuth:
         client_id: typing.Optional[str] = None,
         client_secret: typing.Optional[str] = None,
         token: typing.Optional[typing.Callable[[], str]] = None,
+        scope: typing.Optional[str] = None,
         _token_getter_override: typing.Optional[typing.Callable[[], str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -355,6 +362,7 @@ class AsyncSeedOauthClientCredentialsMandatoryAuth:
             oauth_token_provider = AsyncOAuthTokenProvider(
                 client_id=client_id,
                 client_secret=client_secret,
+                scope=scope,
                 client_wrapper=AsyncClientWrapper(
                     base_url=base_url,
                     headers=headers,

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/oauth_token_provider.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/oauth_token_provider.py
@@ -14,9 +14,17 @@ from .client_wrapper import AsyncClientWrapper, SyncClientWrapper
 class OAuthTokenProvider:
     BUFFER_IN_MINUTES = 2
 
-    def __init__(self, *, client_id: str, client_secret: str, client_wrapper: SyncClientWrapper):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        scope: typing.Optional[str] = None,
+        client_wrapper: SyncClientWrapper,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
+        self._scope = scope
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
         self._auth_client = AuthClient(client_wrapper=client_wrapper)
@@ -32,7 +40,7 @@ class OAuthTokenProvider:
 
     def _refresh(self) -> str:
         token_response = self._auth_client.get_token_with_client_credentials(
-            client_id=self._client_id, client_secret=self._client_secret
+            client_id=self._client_id, client_secret=self._client_secret, scope=self._scope
         )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(
@@ -47,9 +55,17 @@ class OAuthTokenProvider:
 class AsyncOAuthTokenProvider:
     BUFFER_IN_MINUTES = 2
 
-    def __init__(self, *, client_id: str, client_secret: str, client_wrapper: AsyncClientWrapper):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        scope: typing.Optional[str] = None,
+        client_wrapper: AsyncClientWrapper,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
+        self._scope = scope
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
         self._auth_client = AsyncAuthClient(client_wrapper=client_wrapper)
@@ -65,7 +81,7 @@ class AsyncOAuthTokenProvider:
 
     async def _refresh(self) -> str:
         token_response = await self._auth_client.get_token_with_client_credentials(
-            client_id=self._client_id, client_secret=self._client_secret
+            client_id=self._client_id, client_secret=self._client_secret, scope=self._scope
         )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/client.py
@@ -91,6 +91,7 @@ class SeedOauthClientCredentials:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -105,6 +106,7 @@ class SeedOauthClientCredentials:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -120,6 +122,7 @@ class SeedOauthClientCredentials:
         client_id: typing.Optional[str] = None,
         client_secret: typing.Optional[str] = None,
         token: typing.Optional[typing.Callable[[], str]] = None,
+        scope: typing.Optional[str] = None,
         _token_getter_override: typing.Optional[typing.Callable[[], str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -149,6 +152,7 @@ class SeedOauthClientCredentials:
             oauth_token_provider = OAuthTokenProvider(
                 client_id=client_id,
                 client_secret=client_secret,
+                scope=scope,
                 client_wrapper=SyncClientWrapper(
                     base_url=base_url,
                     headers=headers,
@@ -309,6 +313,7 @@ class AsyncSeedOauthClientCredentials:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -323,6 +328,7 @@ class AsyncSeedOauthClientCredentials:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -338,6 +344,7 @@ class AsyncSeedOauthClientCredentials:
         client_id: typing.Optional[str] = None,
         client_secret: typing.Optional[str] = None,
         token: typing.Optional[typing.Callable[[], str]] = None,
+        scope: typing.Optional[str] = None,
         _token_getter_override: typing.Optional[typing.Callable[[], str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -365,6 +372,7 @@ class AsyncSeedOauthClientCredentials:
             oauth_token_provider = AsyncOAuthTokenProvider(
                 client_id=client_id,
                 client_secret=client_secret,
+                scope=scope,
                 client_wrapper=AsyncClientWrapper(
                     base_url=base_url,
                     headers=headers,

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/oauth_token_provider.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/oauth_token_provider.py
@@ -14,9 +14,17 @@ from .client_wrapper import AsyncClientWrapper, SyncClientWrapper
 class OAuthTokenProvider:
     BUFFER_IN_MINUTES = 2
 
-    def __init__(self, *, client_id: str, client_secret: str, client_wrapper: SyncClientWrapper):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        scope: typing.Optional[str] = None,
+        client_wrapper: SyncClientWrapper,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
+        self._scope = scope
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
         self._auth_client = AuthClient(client_wrapper=client_wrapper)
@@ -31,7 +39,9 @@ class OAuthTokenProvider:
             return self._refresh()
 
     def _refresh(self) -> str:
-        token_response = self._auth_client.get_token(client_id=self._client_id, client_secret=self._client_secret)
+        token_response = self._auth_client.get_token(
+            client_id=self._client_id, client_secret=self._client_secret, scope=self._scope
+        )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(
             expires_in_seconds=token_response.expires_in, buffer_in_minutes=self.BUFFER_IN_MINUTES
@@ -45,9 +55,17 @@ class OAuthTokenProvider:
 class AsyncOAuthTokenProvider:
     BUFFER_IN_MINUTES = 2
 
-    def __init__(self, *, client_id: str, client_secret: str, client_wrapper: AsyncClientWrapper):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        scope: typing.Optional[str] = None,
+        client_wrapper: AsyncClientWrapper,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
+        self._scope = scope
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
         self._auth_client = AsyncAuthClient(client_wrapper=client_wrapper)
@@ -62,7 +80,9 @@ class AsyncOAuthTokenProvider:
             return await self._refresh()
 
     async def _refresh(self) -> str:
-        token_response = await self._auth_client.get_token(client_id=self._client_id, client_secret=self._client_secret)
+        token_response = await self._auth_client.get_token(
+            client_id=self._client_id, client_secret=self._client_secret, scope=self._scope
+        )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(
             expires_in_seconds=token_response.expires_in, buffer_in_minutes=self.BUFFER_IN_MINUTES

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/client.py
@@ -94,6 +94,7 @@ class SeedOauthClientCredentialsWithVariables:
         base_url: str,
         root_variable: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -109,6 +110,7 @@ class SeedOauthClientCredentialsWithVariables:
         base_url: str,
         root_variable: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -125,6 +127,7 @@ class SeedOauthClientCredentialsWithVariables:
         client_id: typing.Optional[str] = None,
         client_secret: typing.Optional[str] = None,
         token: typing.Optional[typing.Callable[[], str]] = None,
+        scope: typing.Optional[str] = None,
         _token_getter_override: typing.Optional[typing.Callable[[], str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -155,6 +158,7 @@ class SeedOauthClientCredentialsWithVariables:
             oauth_token_provider = OAuthTokenProvider(
                 client_id=client_id,
                 client_secret=client_secret,
+                scope=scope,
                 client_wrapper=SyncClientWrapper(
                     base_url=base_url,
                     root_variable=root_variable,
@@ -328,6 +332,7 @@ class AsyncSeedOauthClientCredentialsWithVariables:
         base_url: str,
         root_variable: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -343,6 +348,7 @@ class AsyncSeedOauthClientCredentialsWithVariables:
         base_url: str,
         root_variable: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -359,6 +365,7 @@ class AsyncSeedOauthClientCredentialsWithVariables:
         client_id: typing.Optional[str] = None,
         client_secret: typing.Optional[str] = None,
         token: typing.Optional[typing.Callable[[], str]] = None,
+        scope: typing.Optional[str] = None,
         _token_getter_override: typing.Optional[typing.Callable[[], str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -387,6 +394,7 @@ class AsyncSeedOauthClientCredentialsWithVariables:
             oauth_token_provider = AsyncOAuthTokenProvider(
                 client_id=client_id,
                 client_secret=client_secret,
+                scope=scope,
                 client_wrapper=AsyncClientWrapper(
                     base_url=base_url,
                     root_variable=root_variable,

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/oauth_token_provider.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/oauth_token_provider.py
@@ -14,9 +14,17 @@ from .client_wrapper import AsyncClientWrapper, SyncClientWrapper
 class OAuthTokenProvider:
     BUFFER_IN_MINUTES = 2
 
-    def __init__(self, *, client_id: str, client_secret: str, client_wrapper: SyncClientWrapper):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        scope: typing.Optional[str] = None,
+        client_wrapper: SyncClientWrapper,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
+        self._scope = scope
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
         self._auth_client = AuthClient(client_wrapper=client_wrapper)
@@ -32,7 +40,7 @@ class OAuthTokenProvider:
 
     def _refresh(self) -> str:
         token_response = self._auth_client.get_token_with_client_credentials(
-            client_id=self._client_id, client_secret=self._client_secret
+            client_id=self._client_id, client_secret=self._client_secret, scope=self._scope
         )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(
@@ -47,9 +55,17 @@ class OAuthTokenProvider:
 class AsyncOAuthTokenProvider:
     BUFFER_IN_MINUTES = 2
 
-    def __init__(self, *, client_id: str, client_secret: str, client_wrapper: AsyncClientWrapper):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        scope: typing.Optional[str] = None,
+        client_wrapper: AsyncClientWrapper,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
+        self._scope = scope
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
         self._auth_client = AsyncAuthClient(client_wrapper=client_wrapper)
@@ -65,7 +81,7 @@ class AsyncOAuthTokenProvider:
 
     async def _refresh(self) -> str:
         token_response = await self._auth_client.get_token_with_client_credentials(
-            client_id=self._client_id, client_secret=self._client_secret
+            client_id=self._client_id, client_secret=self._client_secret, scope=self._scope
         )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(

--- a/seed/python-sdk/oauth-client-credentials/src/seed/client.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/client.py
@@ -91,6 +91,7 @@ class SeedOauthClientCredentials:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -105,6 +106,7 @@ class SeedOauthClientCredentials:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -120,6 +122,7 @@ class SeedOauthClientCredentials:
         client_id: typing.Optional[str] = None,
         client_secret: typing.Optional[str] = None,
         token: typing.Optional[typing.Callable[[], str]] = None,
+        scope: typing.Optional[str] = None,
         _token_getter_override: typing.Optional[typing.Callable[[], str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -149,6 +152,7 @@ class SeedOauthClientCredentials:
             oauth_token_provider = OAuthTokenProvider(
                 client_id=client_id,
                 client_secret=client_secret,
+                scope=scope,
                 client_wrapper=SyncClientWrapper(
                     base_url=base_url,
                     headers=headers,
@@ -309,6 +313,7 @@ class AsyncSeedOauthClientCredentials:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -323,6 +328,7 @@ class AsyncSeedOauthClientCredentials:
         *,
         base_url: str,
         headers: typing.Optional[typing.Dict[str, str]] = None,
+        scope: typing.Optional[str] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -338,6 +344,7 @@ class AsyncSeedOauthClientCredentials:
         client_id: typing.Optional[str] = None,
         client_secret: typing.Optional[str] = None,
         token: typing.Optional[typing.Callable[[], str]] = None,
+        scope: typing.Optional[str] = None,
         _token_getter_override: typing.Optional[typing.Callable[[], str]] = None,
         timeout: typing.Optional[float] = None,
         max_retries: typing.Optional[int] = None,
@@ -365,6 +372,7 @@ class AsyncSeedOauthClientCredentials:
             oauth_token_provider = AsyncOAuthTokenProvider(
                 client_id=client_id,
                 client_secret=client_secret,
+                scope=scope,
                 client_wrapper=AsyncClientWrapper(
                     base_url=base_url,
                     headers=headers,

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/oauth_token_provider.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/oauth_token_provider.py
@@ -14,9 +14,17 @@ from .client_wrapper import AsyncClientWrapper, SyncClientWrapper
 class OAuthTokenProvider:
     BUFFER_IN_MINUTES = 2
 
-    def __init__(self, *, client_id: str, client_secret: str, client_wrapper: SyncClientWrapper):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        scope: typing.Optional[str] = None,
+        client_wrapper: SyncClientWrapper,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
+        self._scope = scope
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
         self._auth_client = AuthClient(client_wrapper=client_wrapper)
@@ -32,7 +40,7 @@ class OAuthTokenProvider:
 
     def _refresh(self) -> str:
         token_response = self._auth_client.get_token_with_client_credentials(
-            client_id=self._client_id, client_secret=self._client_secret
+            client_id=self._client_id, client_secret=self._client_secret, scope=self._scope
         )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(
@@ -47,9 +55,17 @@ class OAuthTokenProvider:
 class AsyncOAuthTokenProvider:
     BUFFER_IN_MINUTES = 2
 
-    def __init__(self, *, client_id: str, client_secret: str, client_wrapper: AsyncClientWrapper):
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        scope: typing.Optional[str] = None,
+        client_wrapper: AsyncClientWrapper,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
+        self._scope = scope
         self._access_token: typing.Optional[str] = None
         self._expires_at: dt.datetime = dt.datetime.now()
         self._auth_client = AsyncAuthClient(client_wrapper=client_wrapper)
@@ -65,7 +81,7 @@ class AsyncOAuthTokenProvider:
 
     async def _refresh(self) -> str:
         token_response = await self._auth_client.get_token_with_client_credentials(
-            client_id=self._client_id, client_secret=self._client_secret
+            client_id=self._client_id, client_secret=self._client_secret, scope=self._scope
         )
         self._access_token = token_response.access_token
         self._expires_at = self._get_expires_at(

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -500,7 +500,6 @@ scripts:
 allowedFailures:
   - examples:legacy-wire-tests
   - exhaustive:deps_with_min_python_version
-  - oauth-client-credentials-custom
   - streaming-parameter
   - trace
   - unions:union-naming-v1-wire-tests


### PR DESCRIPTION
## Description
Fixes the `oauth-client-credentials-custom` seed fixture build failure in the Python generator.

The fixture's token endpoint (`getTokenWithClientCredentials`) maps extra request properties beyond `client_id`/`client_secret` — configured scopes (`scp`) and custom properties (`entity_id`, optional `scope`). The generator only ever forwarded `client_id`/`client_secret` to the token endpoint, so the generated `OAuthTokenProvider._refresh()` call was missing required arguments and failed `mypy`. The fixture was parked in `allowedFailures`.

## Changes Made
- `oauth_token_provider_generator.py`: add `get_oauth_additional_token_request_properties()` which collects the token endpoint's non-literal `scopes` + `customProperties` (literals are auto-filled, so excluded). These are added to the `OAuthTokenProvider` constructor (required → `str`, optional → `Optional[str] = None`), stored as members, and forwarded in `_refresh()`'s token call:
  ```
  self._auth_client.get_token_with_client_credentials(
      cid=self._client_id, csr=self._client_secret,
      scp=self._scp, entity_id=self._entity_id, scope=self._scope,
  )
  ```
- `root_client_generator.py`: expose the same properties as root-client constructor params and thread them into both `OAuthTokenProvider` instantiation sites via `_get_oauth_additional_property_kwargs()`. They flow into the constructor overloads/snippets automatically since they are non-OAuth-specific params.
- Removed `oauth-client-credentials-custom` from `seed/python-sdk/seed.yml` `allowedFailures`.
- Regenerated all affected `oauth-client-credentials*` fixtures. The standard fixtures gain a backwards-compatible optional `scope` param (an optional custom property that was previously silently dropped).
- Added generator changelog entry (`type: fix`).

## Testing
- [x] `oauth-client-credentials-custom` regenerated; `poetry run mypy .` → no issues (61 files), `pytest` → 66 passed / 4 skipped.
- [x] Regression: `oauth-client-credentials`, `-environment-variables`, `-mandatory-auth`, `-nested-root`, `-with-variables` all regenerated and pass mypy + pytest. `-default`, `-openapi`, `-reference` produce no output change.
- [x] `poetry run mypy src` on the generator (238 files) and `poetry run pre-commit run -a` both pass.
- [x] Manual testing completed


Link to Devin session: https://app.devin.ai/sessions/9192ac51bbfb4aeab0d83109065b605b
Requested by: @iamnamananand996