### PR TITLE
fix(cli): avoid root redirect warnings for empty slug rows

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-missing-redirects-empty-slug-false-positives.yml
+++ b/packages/cli/cli/changes/unreleased/fix-missing-redirects-empty-slug-false-positives.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix false positive warnings in the `missing-redirects` check for changelog
+    entries and embedded content pages. FDR stores an empty slug for pages that
+    don't resolve to a standalone navigation node; these are no longer reported as
+    removed pages whose previously published URL was "/", even when the site's home
+    page lives under a non-root slug or basepath.
+  type: fix

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/__test__/missing-redirects.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/__test__/missing-redirects.test.ts
@@ -137,6 +137,27 @@ describe("findRemovedSlugs", () => {
         expect(findRemovedSlugs(published, local)).toEqual([]);
     });
 
+    it("skips published entries with empty slug even when no local page serves root", () => {
+        // Reproduces the false positives reported against changelog entries and
+        // embedded API-reference content pages: FDR's writer stores `?? ""` for any
+        // page that doesn't resolve to a standalone nav node, and the site's home
+        // page lives under a non-root slug, so nothing locally serves "". These
+        // empty-slug rows must never be reported as removed "/" pages.
+        const published: MarkdownEntry[] = [
+            { pageId: "changelog/2020-05-15.mdx", slug: "", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            {
+                pageId: "docs/pages/api-reference/content-api/pages.mdx",
+                slug: "",
+                lastUpdated: "2024-01-01T00:00:00.000Z"
+            }
+        ];
+        const local = slugMap([
+            ["docs/pages/home.mdx", "welcome"],
+            ["changelog/2026-05-19.mdx", "changelog"]
+        ]);
+        expect(findRemovedSlugs(published, local)).toEqual([]);
+    });
+
     it("still flags removed page when no local page serves the old slug", () => {
         const published: MarkdownEntry[] = [
             { pageId: "docs/old.mdx", slug: "unique-old-slug", lastUpdated: "2024-01-01T00:00:00.000Z" }

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects-logic.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects-logic.ts
@@ -93,6 +93,11 @@ export function findRemovedSlugs(
     }
     const removed: RemovedSlug[] = [];
     for (const publishedEntry of publishedEntries) {
+        // Empty slugs are FDR's fallback for pages without standalone nav nodes
+        // (for example changelog entries), not distinct redirectable URLs.
+        if (publishedEntry.slug.trim() === "") {
+            continue;
+        }
         const localSlugs = localPageIdToSlugs.get(publishedEntry.pageId);
         if (localSlugs == null) {
             if (activeSlugs.has(publishedEntry.slug)) {


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-11013

Fixes false positive `missing-redirects` warnings where changelog entries and embedded content pages were reported as removed pages with previously published URL `/`.

FDR stores an empty slug for docs pages that do not resolve to a standalone navigation node. The CLI now treats those empty-slug rows as non-redirectable fallback entries instead of removed root pages.

## Changes Made
- Skip empty published slug-table entries in the `missing-redirects` rule.
- Add coverage for empty-slug rows when no local page serves the root slug.
- Add a CLI changelog entry for the fix.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

Ran:

`pnpm turbo run test --filter @fern-api/docs-validator -- missing-redirects`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->