### PR TITLE
fix(generator-cli): create GitHub release tag in pull-request mode

### DIFF
--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -303,10 +303,9 @@ export class GithubStep extends BaseStep {
             }
         }
 
-        // Create a GitHub release if a new version is available.
-        // The release tag points to the signed commit on the PR branch so it exists
-        // immediately — the same pattern commitAndRelease mode uses.
-        if (resolved.newVersion != null) {
+        // Create a GitHub release if a new version is available, the PR was
+        // actually created/updated, and we are not in preview mode.
+        if (!this.config.previewMode && resolved.newVersion != null && result.prNumber != null) {
             try {
                 const tagName = resolved.newVersion;
                 const headSha = await repository.getHeadSha();

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -303,6 +303,30 @@ export class GithubStep extends BaseStep {
             }
         }
 
+        // Create a GitHub release if a new version is available.
+        // The release tag points to the signed commit on the PR branch so it exists
+        // immediately — the same pattern commitAndRelease mode uses.
+        if (resolved.newVersion != null) {
+            try {
+                const tagName = resolved.newVersion;
+                const headSha = await repository.getHeadSha();
+                await octokit.repos.createRelease({
+                    owner,
+                    repo,
+                    tag_name: tagName,
+                    target_commitish: headSha,
+                    name: tagName,
+                    body: resolved.changelogEntry ?? resolved.commitMessage,
+                    draft: false,
+                    prerelease: false
+                });
+                this.logger.info(`Created GitHub release ${tagName}`);
+                result.releaseUrl = `https://${remote}/${owner}/${repo}/releases/tag/${tagName}`;
+            } catch (error) {
+                this.logger.warn(`Could not create GitHub release: ${extractErrorMessage(error)}`);
+            }
+        }
+
         return result;
     }
 


### PR DESCRIPTION
## Description

Closes the gap where `pull-request` output mode never created a GitHub release/tag. Customers like IcePanel using PR mode for autorelease had PRs created by fern-bot but no git tags — `executePullRequestMode` simply returned after creating the PR.

## Changes Made

- Added release creation to `GithubStep.executePullRequestMode()` — after the PR is created/updated, if `resolved.newVersion` is available, creates a GitHub Release pointing at the signed commit on the PR branch (same `octokit.repos.createRelease` pattern as `executeCommitAndReleaseMode`).
- Guarded by `!this.config.previewMode` (consistent with commit-and-release mode) and `result.prNumber != null` (skip when PR creation failed).
- Sets `result.releaseUrl` so downstream consumers can surface the release link.

**Known trade-off**: The tag points at the signed commit on the PR branch. After squash merge the SHA becomes orphaned (though the tag keeps the commit alive in the object store). A proper post-merge webhook in fern-autopilot would be the long-term fix — this gives customers the release they're currently missing entirely.

## Testing

- [x] `pnpm turbo run test --filter @fern-api/generator-cli` — 412 tests pass
- [x] Compilation passes
- [ ] Updated README.md generator (if applicable) — N/A

Link to Devin session: https://app.devin.ai/sessions/b73be219981c4d53bbc4a706b0d9be3c
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->