### PR TITLE
fix(php): reorder union factory method args in dynamic snippets to match PHP Method AST

### DIFF
--- a/generators/php/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/php/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -196,7 +196,7 @@ export class DynamicTypeLiteralMapper {
                             name: this.context.getClassName(discriminatedUnion.declaration.name),
                             namespace: this.context.getTypesNamespace(discriminatedUnion.declaration.fernFilepath)
                         }),
-                        method: this.context.getMethodName(unionVariant.discriminantValue.name),
+                        method: this.context.getPropertyName(unionVariant.discriminantValue.name),
                         arguments_: this.convertDiscriminatedUnionVariantArgs({
                             discriminatedUnionTypeInstance,
                             unionVariant,
@@ -250,12 +250,14 @@ export class DynamicTypeLiteralMapper {
                             }
                         ];
                     }
+                    const wireValue = unionVariant.discriminantValue.wireValue;
+                    const singlePropertyValue = record[wireValue] ?? record["value"];
                     return [
                         {
                             name: this.context.getPropertyName(unionVariant.discriminantValue.name),
                             value: this.convert({
                                 typeReference: unionVariant.typeReference,
-                                value: record[unionVariant.discriminantValue.wireValue]
+                                value: singlePropertyValue
                             })
                         }
                     ];
@@ -284,14 +286,11 @@ export class DynamicTypeLiteralMapper {
             singleDiscriminatedUnionType: unionVariant
         });
         if (unionVariant.type === "singleProperty") {
-            const record = this.context.getRecord(discriminatedUnionTypeInstance.value);
-            if (record == null && unionProperties.length === 1) {
+            const singleProperty = unionProperties[0];
+            if (singleProperty != null) {
                 return [
                     ...requiredBaseFields,
-                    this.convert({
-                        typeReference: unionVariant.typeReference,
-                        value: discriminatedUnionTypeInstance.value
-                    }),
+                    singleProperty.value,
                     ...optionalBaseFields
                 ];
             }

--- a/generators/php/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/php/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -279,20 +279,20 @@ export class DynamicTypeLiteralMapper {
         unionVariant: FernIr.dynamic.SingleDiscriminatedUnionType;
         unionProperties: php.ConstructorField[];
     }): php.AstNode[] {
-        const baseFields = this.getBaseFields({
+        const { required: requiredBaseFields, optional: optionalBaseFields } = this.getBaseFields({
             discriminatedUnionTypeInstance,
             singleDiscriminatedUnionType: unionVariant
         });
         if (unionVariant.type === "singleProperty") {
             const record = this.context.getRecord(discriminatedUnionTypeInstance.value);
             if (record == null && unionProperties.length === 1) {
-                // The union is a single value without any base properties, e.g.
                 return [
-                    ...baseFields,
+                    ...requiredBaseFields,
                     this.convert({
                         typeReference: unionVariant.typeReference,
                         value: discriminatedUnionTypeInstance.value
-                    })
+                    }),
+                    ...optionalBaseFields
                 ];
             }
         }
@@ -304,17 +304,18 @@ export class DynamicTypeLiteralMapper {
                 return [];
             }
             return [
-                ...baseFields,
+                ...requiredBaseFields,
                 php.TypeLiteral.class_({
                     reference: php.classReference({
                         name: this.context.getClassName(named.declaration.name),
                         namespace: this.context.getTypesNamespace(named.declaration.fernFilepath)
                     }),
                     fields: unionProperties
-                })
+                }),
+                ...optionalBaseFields
             ];
         }
-        return baseFields;
+        return [...requiredBaseFields, ...optionalBaseFields];
     }
 
     private getBaseFields({
@@ -323,7 +324,7 @@ export class DynamicTypeLiteralMapper {
     }: {
         discriminatedUnionTypeInstance: DiscriminatedUnionTypeInstance;
         singleDiscriminatedUnionType: FernIr.dynamic.SingleDiscriminatedUnionType;
-    }): php.AstNode[] {
+    }): { required: php.AstNode[]; optional: php.AstNode[] } {
         const properties = this.context.associateByWireValue({
             parameters: singleDiscriminatedUnionType.properties ?? [],
             values: this.context.getRecord(discriminatedUnionTypeInstance.value) ?? {},
@@ -332,14 +333,22 @@ export class DynamicTypeLiteralMapper {
             // are handled by the union variant.
             ignoreMissingParameters: true
         });
-        return properties.map((property) => {
+        const required: php.AstNode[] = [];
+        const optional: php.AstNode[] = [];
+        for (const property of properties) {
             this.context.errors.scope(property.name.wireValue);
             try {
-                return this.convert(property);
+                const converted = this.convert(property);
+                if (this.isOptionalOrNullable(property.typeReference)) {
+                    optional.push(converted);
+                } else {
+                    required.push(converted);
+                }
             } finally {
                 this.context.errors.unscope();
             }
-        });
+        }
+        return { required, optional };
     }
 
     private convertObject({ object_, value }: { object_: FernIr.dynamic.ObjectType; value: unknown }): php.TypeLiteral {

--- a/generators/php/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/php/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -288,11 +288,7 @@ export class DynamicTypeLiteralMapper {
         if (unionVariant.type === "singleProperty") {
             const singleProperty = unionProperties[0];
             if (singleProperty != null) {
-                return [
-                    ...requiredBaseFields,
-                    singleProperty.value,
-                    ...optionalBaseFields
-                ];
+                return [...requiredBaseFields, singleProperty.value, ...optionalBaseFields];
             }
         }
         if (unionVariant.type === "samePropertiesAsObject") {

--- a/generators/php/sdk/changes/unreleased/fix-union-snippet-param-order.yml
+++ b/generators/php/sdk/changes/unreleased/fix-union-snippet-param-order.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix dynamic snippet argument ordering for discriminated union factory methods
+    with optional base properties. Required base fields now come before the variant
+    value, and optional base fields come after, matching the PHP Method AST's
+    automatic parameter reordering.
+  type: fix

--- a/seed/php-sdk/examples/no-custom-config/reference.md
+++ b/seed/php-sdk/examples/no-custom-config/reference.md
@@ -499,7 +499,7 @@ $client->service->createBigEntity(
             'extra' => 'extra',
         ], [
             'tags',
-        ]),
+        ], 'metadata'),
         'commonMetadata' => new \Seed\Commons\Types\Types\Metadata([
             'id' => 'id',
             'data' => [
@@ -514,7 +514,7 @@ $client->service->createBigEntity(
             ],
             'jsonString' => 'jsonString',
         ])),
-        'data' => Data::string(),
+        'data' => Data::string('data'),
         'migration' => new Migration([
             'name' => 'name',
             'status' => MigrationStatus::Running->value,
@@ -524,7 +524,7 @@ $client->service->createBigEntity(
             'exceptionMessage' => 'exceptionMessage',
             'exceptionStacktrace' => 'exceptionStacktrace',
         ])),
-        'test' => Test::and_(),
+        'test' => Test::and(true),
         'node' => new Node([
             'name' => 'name',
             'nodes' => [

--- a/seed/php-sdk/examples/no-custom-config/src/dynamic-snippets/example19/snippet.php
+++ b/seed/php-sdk/examples/no-custom-config/src/dynamic-snippets/example19/snippet.php
@@ -63,7 +63,7 @@ $client->service->createBigEntity(
             'extra' => 'extra',
         ], [
             'tags',
-        ]),
+        ], 'metadata'),
         'commonMetadata' => new \Seed\Commons\Types\Types\Metadata([
             'id' => 'id',
             'data' => [
@@ -78,7 +78,7 @@ $client->service->createBigEntity(
             ],
             'jsonString' => 'jsonString',
         ])),
-        'data' => Data::string(),
+        'data' => Data::string('data'),
         'migration' => new Migration([
             'name' => 'name',
             'status' => MigrationStatus::Running->value,
@@ -88,7 +88,7 @@ $client->service->createBigEntity(
             'exceptionMessage' => 'exceptionMessage',
             'exceptionStacktrace' => 'exceptionStacktrace',
         ])),
-        'test' => Test::and_(),
+        'test' => Test::and(true),
         'node' => new Node([
             'name' => 'name',
             'nodes' => [

--- a/seed/php-sdk/examples/readme-config/reference.md
+++ b/seed/php-sdk/examples/readme-config/reference.md
@@ -499,7 +499,7 @@ $client->service->createBigEntity(
             'extra' => 'extra',
         ], [
             'tags',
-        ]),
+        ], 'metadata'),
         'commonMetadata' => new \Seed\Commons\Types\Types\Metadata([
             'id' => 'id',
             'data' => [
@@ -514,7 +514,7 @@ $client->service->createBigEntity(
             ],
             'jsonString' => 'jsonString',
         ])),
-        'data' => Data::string(),
+        'data' => Data::string('data'),
         'migration' => new Migration([
             'name' => 'name',
             'status' => MigrationStatus::Running->value,
@@ -524,7 +524,7 @@ $client->service->createBigEntity(
             'exceptionMessage' => 'exceptionMessage',
             'exceptionStacktrace' => 'exceptionStacktrace',
         ])),
-        'test' => Test::and_(),
+        'test' => Test::and(true),
         'node' => new Node([
             'name' => 'name',
             'nodes' => [

--- a/seed/php-sdk/examples/readme-config/src/dynamic-snippets/example19/snippet.php
+++ b/seed/php-sdk/examples/readme-config/src/dynamic-snippets/example19/snippet.php
@@ -63,7 +63,7 @@ $client->service->createBigEntity(
             'extra' => 'extra',
         ], [
             'tags',
-        ]),
+        ], 'metadata'),
         'commonMetadata' => new \Seed\Commons\Types\Types\Metadata([
             'id' => 'id',
             'data' => [
@@ -78,7 +78,7 @@ $client->service->createBigEntity(
             ],
             'jsonString' => 'jsonString',
         ])),
-        'data' => Data::string(),
+        'data' => Data::string('data'),
         'migration' => new Migration([
             'name' => 'name',
             'status' => MigrationStatus::Running->value,
@@ -88,7 +88,7 @@ $client->service->createBigEntity(
             'exceptionMessage' => 'exceptionMessage',
             'exceptionStacktrace' => 'exceptionStacktrace',
         ])),
-        'test' => Test::and_(),
+        'test' => Test::and(true),
         'node' => new Node([
             'name' => 'name',
             'nodes' => [

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -190,10 +190,6 @@ allowedFailures:
   - variables
   - oauth-client-credentials-with-variables
 
-  # Dynamic snippet: union factory method param count mismatch (Exception-named types, singleProperty value drops).
-  - examples:no-custom-config
-  - examples:readme-config
-  - unions-with-local-date
   # PHPDoc unresolvable enum-as-map-key type + dynamic snippet errors (unrelated to union serialization).
   - trace
   # OAuth/InferredAuth custom properties need non-literal property passthrough.

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -189,19 +189,12 @@ allowedFailures:
   # Dynamic snippet: variable-typed path params not provided in snippet request.
   - variables
   - oauth-client-credentials-with-variables
-  # Dynamic snippet: union factory method param mismatch.
-  - examples:no-custom-config
-  - examples:readme-config
+
   # PHPDoc unresolvable enum-as-map-key type + dynamic snippet errors (unrelated to union serialization).
   - trace
-
   # OAuth/InferredAuth custom properties need non-literal property passthrough.
   - oauth-client-credentials-custom
   - oauth-client-credentials-reference
   - inferred-auth-implicit-reference
-  # Union dynamic snippets (i.e. BigUnion).
-  - unions:no-custom-config
-  - unions:property-accessors
-  - unions-with-local-date
 
 

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -190,6 +190,10 @@ allowedFailures:
   - variables
   - oauth-client-credentials-with-variables
 
+  # Dynamic snippet: union factory method param count mismatch (Exception-named types, singleProperty value drops).
+  - examples:no-custom-config
+  - examples:readme-config
+  - unions-with-local-date
   # PHPDoc unresolvable enum-as-map-key type + dynamic snippet errors (unrelated to union serialization).
   - trace
   # OAuth/InferredAuth custom properties need non-literal property passthrough.

--- a/seed/php-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/php-sdk/unions-with-local-date/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions-with-local-date/reference.md
+++ b/seed/php-sdk/unions-with-local-date/reference.md
@@ -192,7 +192,7 @@ $client->types->get(
 
 ```php
 $client->types->update(
-    UnionWithTime::date(),
+    UnionWithTime::date(new DateTime('1994-01-01')),
 );
 ```
 </dd>

--- a/seed/php-sdk/unions-with-local-date/reference.md
+++ b/seed/php-sdk/unions-with-local-date/reference.md
@@ -56,9 +56,9 @@ $client->bigunion->get(
 
 ```php
 $client->bigunion->update(
-    BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+    BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
         'value' => 'value',
-    ])),
+    ]), new DateTime('2024-01-15T09:30:00Z')),
 );
 ```
 </dd>
@@ -101,12 +101,12 @@ $client->bigunion->update(
 ```php
 $client->bigunion->updateMany(
     [
-        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
             'value' => 'value',
-        ])),
-        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+        ]), new DateTime('2024-01-15T09:30:00Z')),
+        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
             'value' => 'value',
-        ])),
+        ]), new DateTime('2024-01-15T09:30:00Z')),
     ],
 );
 ```

--- a/seed/php-sdk/unions-with-local-date/src/dynamic-snippets/example1/snippet.php
+++ b/seed/php-sdk/unions-with-local-date/src/dynamic-snippets/example1/snippet.php
@@ -13,7 +13,7 @@ $client = new SeedClient(
     ],
 );
 $client->bigunion->update(
-    BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+    BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
         'value' => 'value',
-    ])),
+    ]), new DateTime('2024-01-15T09:30:00Z')),
 );

--- a/seed/php-sdk/unions-with-local-date/src/dynamic-snippets/example2/snippet.php
+++ b/seed/php-sdk/unions-with-local-date/src/dynamic-snippets/example2/snippet.php
@@ -14,11 +14,11 @@ $client = new SeedClient(
 );
 $client->bigunion->updateMany(
     [
-        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
             'value' => 'value',
-        ])),
-        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+        ]), new DateTime('2024-01-15T09:30:00Z')),
+        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
             'value' => 'value',
-        ])),
+        ]), new DateTime('2024-01-15T09:30:00Z')),
     ],
 );

--- a/seed/php-sdk/unions-with-local-date/src/dynamic-snippets/example6/snippet.php
+++ b/seed/php-sdk/unions-with-local-date/src/dynamic-snippets/example6/snippet.php
@@ -4,6 +4,7 @@ namespace Example;
 
 use Seed\SeedClient;
 use Seed\Types\Types\UnionWithTime;
+use DateTime;
 
 $client = new SeedClient(
     options: [
@@ -11,5 +12,5 @@ $client = new SeedClient(
     ],
 );
 $client->types->update(
-    UnionWithTime::date(),
+    UnionWithTime::date(new DateTime('1994-01-01')),
 );

--- a/seed/php-sdk/unions-with-local-date/src/dynamic-snippets/example7/snippet.php
+++ b/seed/php-sdk/unions-with-local-date/src/dynamic-snippets/example7/snippet.php
@@ -4,6 +4,7 @@ namespace Example;
 
 use Seed\SeedClient;
 use Seed\Types\Types\UnionWithTime;
+use DateTime;
 
 $client = new SeedClient(
     options: [
@@ -11,5 +12,5 @@ $client = new SeedClient(
     ],
 );
 $client->types->update(
-    UnionWithTime::datetime(),
+    UnionWithTime::datetime(new DateTime('1994-01-01T01:01:01Z')),
 );

--- a/seed/php-sdk/unions-with-local-date/src/dynamic-snippets/example8/snippet.php
+++ b/seed/php-sdk/unions-with-local-date/src/dynamic-snippets/example8/snippet.php
@@ -11,5 +11,5 @@ $client = new SeedClient(
     ],
 );
 $client->types->update(
-    UnionWithTime::value(),
+    UnionWithTime::value(1),
 );

--- a/seed/php-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/unions/no-custom-config/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions/no-custom-config/reference.md
+++ b/seed/php-sdk/unions/no-custom-config/reference.md
@@ -56,9 +56,9 @@ $client->bigunion->get(
 
 ```php
 $client->bigunion->update(
-    BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+    BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
         'value' => 'value',
-    ])),
+    ]), new DateTime('2024-01-15T09:30:00Z')),
 );
 ```
 </dd>
@@ -101,12 +101,12 @@ $client->bigunion->update(
 ```php
 $client->bigunion->updateMany(
     [
-        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
             'value' => 'value',
-        ])),
-        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+        ]), new DateTime('2024-01-15T09:30:00Z')),
+        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
             'value' => 'value',
-        ])),
+        ]), new DateTime('2024-01-15T09:30:00Z')),
     ],
 );
 ```

--- a/seed/php-sdk/unions/no-custom-config/src/dynamic-snippets/example1/snippet.php
+++ b/seed/php-sdk/unions/no-custom-config/src/dynamic-snippets/example1/snippet.php
@@ -13,7 +13,7 @@ $client = new SeedClient(
     ],
 );
 $client->bigunion->update(
-    BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+    BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
         'value' => 'value',
-    ])),
+    ]), new DateTime('2024-01-15T09:30:00Z')),
 );

--- a/seed/php-sdk/unions/no-custom-config/src/dynamic-snippets/example2/snippet.php
+++ b/seed/php-sdk/unions/no-custom-config/src/dynamic-snippets/example2/snippet.php
@@ -14,11 +14,11 @@ $client = new SeedClient(
 );
 $client->bigunion->updateMany(
     [
-        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
             'value' => 'value',
-        ])),
-        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+        ]), new DateTime('2024-01-15T09:30:00Z')),
+        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
             'value' => 'value',
-        ])),
+        ]), new DateTime('2024-01-15T09:30:00Z')),
     ],
 );

--- a/seed/php-sdk/unions/property-accessors/.fern/metadata.json
+++ b/seed/php-sdk/unions/property-accessors/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions/property-accessors/reference.md
+++ b/seed/php-sdk/unions/property-accessors/reference.md
@@ -56,9 +56,9 @@ $client->bigunion->get(
 
 ```php
 $client->bigunion->update(
-    BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+    BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
         'value' => 'value',
-    ])),
+    ]), new DateTime('2024-01-15T09:30:00Z')),
 );
 ```
 </dd>
@@ -101,12 +101,12 @@ $client->bigunion->update(
 ```php
 $client->bigunion->updateMany(
     [
-        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
             'value' => 'value',
-        ])),
-        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+        ]), new DateTime('2024-01-15T09:30:00Z')),
+        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
             'value' => 'value',
-        ])),
+        ]), new DateTime('2024-01-15T09:30:00Z')),
     ],
 );
 ```

--- a/seed/php-sdk/unions/property-accessors/src/dynamic-snippets/example1/snippet.php
+++ b/seed/php-sdk/unions/property-accessors/src/dynamic-snippets/example1/snippet.php
@@ -13,7 +13,7 @@ $client = new SeedClient(
     ],
 );
 $client->bigunion->update(
-    BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+    BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
         'value' => 'value',
-    ])),
+    ]), new DateTime('2024-01-15T09:30:00Z')),
 );

--- a/seed/php-sdk/unions/property-accessors/src/dynamic-snippets/example2/snippet.php
+++ b/seed/php-sdk/unions/property-accessors/src/dynamic-snippets/example2/snippet.php
@@ -14,11 +14,11 @@ $client = new SeedClient(
 );
 $client->bigunion->updateMany(
     [
-        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
             'value' => 'value',
-        ])),
-        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
+        ]), new DateTime('2024-01-15T09:30:00Z')),
+        BigUnion::normalSweet('id', new DateTime('2024-01-15T09:30:00Z'), new NormalSweet([
             'value' => 'value',
-        ])),
+        ]), new DateTime('2024-01-15T09:30:00Z')),
     ],
 );


### PR DESCRIPTION
## Description
Fix dynamic snippet generation for discriminated union factory methods in PHP SDK. Three distinct bugs fixed:

## Changes Made

### 1. Union factory method argument ordering for optional base properties
The PHP Method AST reorders parameters (required before optional), but the snippet generator was assembling arguments in the IR order. Now splits base fields into `required`/`optional` and interleaves: `[...requiredBase, variantValue, ...optionalBase]`.

### 2. Single-property variant value lookup
`convertDiscriminatedUnionProperties` looked up `record[discriminantValue.wireValue]` (e.g., `record["html"]`), but the dynamic snippet IR stores single-property variant values under `record["value"]`. Added fallback: `record[wireValue] ?? record["value"]`.

### 3. Factory method naming for reserved words
Snippet generator used `getMethodName()` → `safeName` → `"and_"`, but the PHP model generator uses `getPropertyName()` → `unsafeName` → `"and"`. Switched to `getPropertyName` to match.

**Before** (PHPStan errors):
```php
Metadata::html(['extra'=>'extra'], ['tags'])          // 2 args, needs 3
Data::string()                                         // 0 args, needs 1
Test::and_()                                           // wrong method name + 0 args
BigUnion::normalSweet('id', DateTime, DateTime, NormalSweet)  // wrong order
```

**After**:
```php
Metadata::html(['extra'=>'extra'], ['tags'], 'metadata')  // 3 args ✓
Data::string('data')                                       // 1 arg ✓
Test::and(true)                                            // correct name + arg ✓
BigUnion::normalSweet('id', DateTime, NormalSweet, ?DateTime)  // matches signature ✓
```

Removes 5 fixtures from `allowedFailures`: `unions:no-custom-config`, `unions:property-accessors`, `unions-with-local-date`, `examples:no-custom-config`, `examples:readme-config`.

## Testing
- [x] 38/38 dynamic-snippets unit tests pass
- [x] All 5 seed fixtures pass: `unions:no-custom-config`, `unions:property-accessors`, `unions-with-local-date`, `examples:no-custom-config`, `examples:readme-config`

Link to Devin session: https://app.devin.ai/sessions/cfede00e80874418a66a835d1356cb4b
Requested by: @iamnamananand996