### PR TITLE
fix(cli): send correct Content-Type for ledger file uploads

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-ledger-upload-content-type.yml
+++ b/packages/cli/cli/changes/unreleased/fix-ledger-upload-content-type.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix ledger file uploads sending incorrect Content-Type header. The upload
+    function now infers MIME type from the file extension (e.g. image/png for
+    .png files) instead of hardcoding application/octet-stream for all blobs.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -11,6 +11,7 @@ import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { TaskContext } from "@fern-api/task-context";
 import { createHash } from "crypto";
 import { readFile } from "fs/promises";
+import * as mime from "mime-types";
 
 import { buildTranslatedDocsDefinition } from "./buildTranslatedDocsDefinition.js";
 import { mapDocsConfigToLedgerConfig } from "./mapDocsConfigToLedgerConfig.js";
@@ -329,19 +330,27 @@ export async function uploadMissingBlobs(
         const results = await asyncPool(UPLOAD_CONCURRENCY, [...missingContent], async ({ hash, uploadUrl }) => {
             // Prefer in-memory blobs (pages, config, apiManifest).
             let blob = blobs.get(hash);
+            let contentType = "application/octet-stream";
             if (blob == null && filePaths != null) {
                 // Lazy read: only load file content for blobs the server
                 // actually needs, and discard after upload.
                 const filePath = filePaths.get(hash);
                 if (filePath != null) {
                     blob = await readFile(filePath);
+                    // Infer MIME type from the file extension so S3 stores the
+                    // correct Content-Type (e.g. image/png for .png files).
+                    // The presigned URL enforces this value in its signature.
+                    const inferred = mime.lookup(filePath);
+                    if (inferred !== false) {
+                        contentType = inferred;
+                    }
                 }
             }
             if (blob == null) {
                 context.logger.warn(`[ledger] Server requested blob ${hash} but we don't have it — skipping`);
                 return "skipped" as const;
             }
-            return uploadBlobWithRetry(blob, uploadUrl, hash, context);
+            return uploadBlobWithRetry(blob, uploadUrl, hash, contentType, context);
         });
 
         const uploaded = results.filter((r) => r === "uploaded").length;
@@ -371,6 +380,7 @@ async function uploadBlobWithRetry(
     blob: Buffer,
     uploadUrl: string,
     hash: string,
+    contentType: string,
     context: TaskContext
 ): Promise<UploadResult> {
     const body = blob.buffer.slice(blob.byteOffset, blob.byteOffset + blob.byteLength) as ArrayBuffer;
@@ -378,7 +388,7 @@ async function uploadBlobWithRetry(
     for (let attempt = 0; attempt <= UPLOAD_MAX_RETRIES; attempt++) {
         const response = await fetch(uploadUrl, {
             method: "PUT",
-            headers: { "Content-Type": "application/octet-stream" },
+            headers: { "Content-Type": contentType },
             body
         });
 


### PR DESCRIPTION
## Description

Fixes og:image URLs (and all other file assets) being served with `application/octet-stream` instead of their correct MIME type (e.g. `image/png`) when published via the docs ledger flow.

## Changes Made

- `uploadBlobWithRetry` now accepts a `contentType` parameter instead of hardcoding `application/octet-stream`
- `uploadMissingBlobs` infers MIME type from the file extension via `mime.lookup()` when loading file blobs from disk
- In-memory blobs (pages, config, apiManifest) continue to use `application/octet-stream` as before — they're consumed programmatically by the docs renderer, not served directly to browsers

**Root cause**: The presigned S3 URL from FDR's register endpoint bakes in `ContentType: "image/png"` (from the fileManifest), but `uploadBlobWithRetry` was sending `Content-Type: application/octet-stream` for every upload. On S3 mocks (local dev) this results in the object being stored with the wrong content-type. On real S3, it would cause a `SignatureDoesNotMatch` rejection.

## Testing

- [x] Verified `mime-types` is already a dependency of this package
- [x] Confirmed compilation produces no new errors (4 pre-existing `integrations` type errors unrelated to this change)
- [x] Lint passes cleanly

Link to Devin session: https://app.devin.ai/sessions/fbaf3abac9be4944827cccb80dbd549e
Requested by: @broady
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->