### PR TITLE
fix(cli): detect changelog overview pages beyond reserved filenames

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-changelog-overview-detection.yml
+++ b/packages/cli/cli/changes/unreleased/fix-changelog-overview-detection.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix changelog overview page detection to recognize non-date files beyond
+    the reserved names (summary, index, overview). When no reserved-name file
+    is present, the first non-date file in the changelog directory is now
+    treated as the overview page, allowing its frontmatter slug override to
+    propagate correctly to the V1 navigation tree.
+  type: fix

--- a/packages/cli/docs-resolver/src/ChangelogNodeConverter.ts
+++ b/packages/cli/docs-resolver/src/ChangelogNodeConverter.ts
@@ -46,6 +46,7 @@ export class ChangelogNodeConverter {
         }[] = [];
 
         let overviewPagePath: AbsoluteFilePath | undefined = undefined;
+        let fallbackOverviewPath: AbsoluteFilePath | undefined = undefined;
         for (const absoluteFilepath of this.changelogFiles ?? []) {
             const filename = last(absoluteFilepath.split("/"));
             if (filename == null) {
@@ -56,6 +57,8 @@ export class ChangelogNodeConverter {
                 const nameWithoutExtension = filename.split(".")[0]?.toLowerCase();
                 if (nameWithoutExtension != null && RESERVED_OVERVIEW_PAGE_NAMES.includes(nameWithoutExtension)) {
                     overviewPagePath = absoluteFilepath;
+                } else if (fallbackOverviewPath == null) {
+                    fallbackOverviewPath = absoluteFilepath;
                 }
 
                 continue;
@@ -66,6 +69,13 @@ export class ChangelogNodeConverter {
                 pageId: FernNavigation.PageId(relativePath),
                 absoluteFilepath
             });
+        }
+
+        // Fall back to any non-date file as the overview when no reserved-name file is found.
+        // This handles changelogs where the overview page has a non-standard filename
+        // (e.g., "release-notes.mdx") and may carry a frontmatter slug override.
+        if (overviewPagePath == null && fallbackOverviewPath != null) {
+            overviewPagePath = fallbackOverviewPath;
         }
 
         const slug = opts.parentSlug.apply({


### PR DESCRIPTION
## Description

Fixes a changelog URL slug divergence between V2 and ledger rendering. Sites with changelog overview pages that use non-standard filenames (anything other than `summary.mdx`, `index.mdx`, or `overview.mdx`) produce incorrect navigation slugs in the V1 tree, which then propagate through the ledger pipeline.

**Example:** A changelog with an overview file named `release-notes.mdx` containing frontmatter `slug: release-notes` renders as `/docs/release-notes` in V2 but `/docs/changelog/connect` in the ledger.

## Root Cause

`ChangelogNodeConverter.toChangelogNode()` scans changelog directory files and classifies each as either:
1. **Date file** (matches `YYYY-MM-DD` pattern) → changelog entry
2. **Reserved-name file** (`summary`, `index`, `overview`) → overview page
3. **Anything else** → silently skipped

When no reserved-name file exists, `overviewPageId` stays `undefined` and the node's slug falls through to the raw config slug (`opts.slug ?? kebabCase(title)`), ignoring any frontmatter `slug:` override on the non-reserved overview file.

The V2 reader compensates via `fullSlugMap` applied at read time from page markdown (`NavigationConfigConverter` → `ChangelogNavigationConverter`). The ledger pipeline has no equivalent — it trusts the V1 tree's slug as-is. So the V1 tree arriving with the wrong slug produces wrong `sectionPath` in the ledger segment, wrong nav routes, and the URL divergence.

## Changes Made

- Modified `ChangelogNodeConverter.toChangelogNode()` to track the first non-date, non-reserved file as a fallback overview candidate
- When no reserved-name overview is found, the fallback is promoted to `overviewPagePath`
- This allows the file's frontmatter `slug:` override to propagate via `markdownToFullSlug` → `opts.parentSlug.apply({ fullSlug: ... })`, and correctly sets `overviewPageId` on the resulting `ChangelogNode`
- Reserved-name files still take priority (no behavior change for existing changelogs)

## V2 ↔ V1 Tree `fullSlugMap` Parity Analysis

Traced every place V2 uses `fullSlugMap` at read time and compared it against how the CLI's V1 tree builder (`DocsDefinitionResolver`) uses `markdownFilesToFullSlugs` at build time. The changelog overview was the **only gap**:

| Node type | V2 (read time) | CLI V1 tree (build time) | Parity? |
|---|---|---|---|
| Regular pages | `NavigationConfigConverter:330` | `DocsDefinitionResolver:2033` | ✅ |
| Sections with overview | `NavigationConfigConverter:330` | `DocsDefinitionResolver:2071-2091` | ✅ |
| Landing pages | N/A | `DocsDefinitionResolver:1078` | ✅ |
| API reference overview | `ApiReferenceNavigationConverter:76` | `ApiReferenceNodeConverter:94` | ✅ |
| API subpackages | `ApiReferenceNavigationConverter:495` | `ApiReferenceNodeConverter:321,363,443` | ✅ |
| **Changelog overview** | `ChangelogConverter:40` | `ChangelogNodeConverter` — only matched reserved filenames | ❌ → **fixed here** |

This means the CLI fix fully closes the V2 ↔ ledger slug parity gap. No FDR/docs-server changes are needed — the existing transform and read path work correctly once the V1 tree carries the right `overviewPageId` and slug.

## Testing

- [x] All 44 existing `@fern-api/docs-resolver` tests pass
- [x] No compile errors in changed file (pre-existing `integrations` type errors in `mapDocsConfigToLedgerConfig.ts` / `buildLedgerInput.test.ts` on base branch are unrelated — the published `@fern-api/fdr-sdk` doesn't yet include `integrations` on `LedgerConfigSchema`)
- [x] Lint and format checks pass

Link to Devin session: https://app.devin.ai/sessions/ec72b39820204a31be764cd3d1e8f654
Requested by: @emjoseph