### PR TITLE
fix(go): honor exportedClientName for generated root client constructor

### DIFF
--- a/generators/go-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/go-v2/sdk/src/SdkGeneratorContext.ts
@@ -102,6 +102,9 @@ export class SdkGeneratorContext extends AbstractGoGeneratorContext<SdkCustomCon
             if (this.customConfig.clientConstructorName != null) {
                 return this.customConfig.clientConstructorName;
             }
+            if (this.customConfig.exportedClientName != null) {
+                return `New${this.customConfig.exportedClientName}`;
+            }
             if (this.customConfig.clientName != null) {
                 return `New${this.customConfig.clientName}`;
             }

--- a/generators/go/internal/generator/generator.go
+++ b/generators/go/internal/generator/generator.go
@@ -617,7 +617,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 			files = append(files, newMultipartFile(g.coordinator))
 			files = append(files, newMultipartTestFile(g.coordinator))
 		}
-		clientTestFile, err := newClientTestFile(g.config.FullImportPath, rootPackageName, g.coordinator, g.config.ClientName, g.config.ClientConstructorName)
+		clientTestFile, err := newClientTestFile(g.config.FullImportPath, rootPackageName, g.coordinator, g.config.ClientName, g.config.ExportedClientName, g.config.ClientConstructorName)
 		if err != nil {
 			return nil, err
 		}
@@ -1284,6 +1284,7 @@ func newClientTestFile(
 	rootPackageName string,
 	coordinator *coordinator.Client,
 	clientNameOverride string,
+	exportedClientNameOverride string,
 	clientConstructorNameOverride string,
 ) (*File, error) {
 	var filename = "client/client_test.go"
@@ -1307,7 +1308,7 @@ func newClientTestFile(
 		nil,
 		coordinator,
 	)
-	content := replaceClientTestConstructorName(clientTestFile, clientNameOverride, clientConstructorNameOverride)
+	content := replaceClientTestConstructorName(clientTestFile, clientNameOverride, exportedClientNameOverride, clientConstructorNameOverride)
 	f.WriteRaw(content)
 	return f.File()
 }
@@ -1458,13 +1459,18 @@ func newExtraPropertiesTestFile(coordinator *coordinator.Client) *File {
 	)
 }
 
-func replaceClientTestConstructorName(content string, clientNameOverride string, clientConstructorNameOverride string) string {
-	if clientNameOverride == "" && clientConstructorNameOverride == "" {
+func replaceClientTestConstructorName(content string, clientNameOverride string, exportedClientNameOverride string, clientConstructorNameOverride string) string {
+	if clientNameOverride == "" && exportedClientNameOverride == "" && clientConstructorNameOverride == "" {
 		return content
 	}
-	override := "New" + clientNameOverride
-	if clientConstructorNameOverride != "" {
+	override := "NewClient"
+	switch {
+	case clientConstructorNameOverride != "":
 		override = clientConstructorNameOverride
+	case exportedClientNameOverride != "":
+		override = "New" + exportedClientNameOverride
+	case clientNameOverride != "":
+		override = "New" + clientNameOverride
 	}
 	return strings.Replace(
 		content,

--- a/generators/go/sdk/changes/unreleased/fix-exported-client-name-constructor.yml
+++ b/generators/go/sdk/changes/unreleased/fix-exported-client-name-constructor.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Honor the `exportedClientName` config when naming the generated root client
+    constructor. Previously the SDK always exported `NewClient` while generated
+    dynamic snippets referenced `New<exportedClientName>`, producing snippets
+    that did not compile.
+  type: fix

--- a/seed/go-sdk/examples/exported-client-name/client/client.go
+++ b/seed/go-sdk/examples/exported-client-name/client/client.go
@@ -25,7 +25,7 @@ type Client struct {
 	caller  *internal.Caller
 }
 
-func NewClient(opts ...option.RequestOption) *Client {
+func NewAcmeClient(opts ...option.RequestOption) *Client {
 	options := core.NewRequestOptions(opts...)
 	return &Client{
 		File:            client.NewClient(options),

--- a/seed/go-sdk/examples/exported-client-name/client/client_test.go
+++ b/seed/go-sdk/examples/exported-client-name/client/client_test.go
@@ -10,14 +10,14 @@ import (
 	time "time"
 )
 
-func TestNewClient(t *testing.T) {
+func TestNewAcmeClient(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
-		c := NewClient()
+		c := NewAcmeClient()
 		assert.Empty(t, c.baseURL)
 	})
 
 	t.Run("base url", func(t *testing.T) {
-		c := NewClient(
+		c := NewAcmeClient(
 			option.WithBaseURL("test.co"),
 		)
 		assert.Equal(t, "test.co", c.baseURL)
@@ -27,7 +27,7 @@ func TestNewClient(t *testing.T) {
 		httpClient := &http.Client{
 			Timeout: 5 * time.Second,
 		}
-		c := NewClient(
+		c := NewAcmeClient(
 			option.WithHTTPClient(httpClient),
 		)
 		assert.Empty(t, c.baseURL)
@@ -36,7 +36,7 @@ func TestNewClient(t *testing.T) {
 	t.Run("http header", func(t *testing.T) {
 		header := make(http.Header)
 		header.Set("X-API-Tenancy", "test")
-		c := NewClient(
+		c := NewAcmeClient(
 			option.WithHTTPHeader(header),
 		)
 		assert.Empty(t, c.baseURL)

--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -374,7 +374,6 @@ allowedFailures:
   - request-parameters # int64 default 9223372036854775807 loses precision in the IR pipeline
 
   # Dynamic snippet generation produces code that does not compile.
-  - examples:exported-client-name # snippet calls client.NewAcmeClient but the SDK exports NewClient
   - server-sent-event-examples:with-wire-tests # TODO: update wiretests geranation then remove it
 
   # Wire tests fail at runtime.


### PR DESCRIPTION
## Description
Removes `examples:exported-client-name` from the go-sdk `allowedFailures` by fixing the underlying bug.

The `exportedClientName` custom config was wired into the **dynamic snippet** generator (snippets call `client.New<exportedClientName>(...)`) and the v1 README, but the actual generated root client only ever exported `NewClient`. As a result the generated dynamic snippets did not compile:

```
dynamic-snippets/example7/snippet.go:12:22: undefined: client.NewAcmeClient (typecheck)
```

This makes the v2 SDK generator (and the v1 `client_test.go`) honor `exportedClientName` so the actual exported root constructor matches what snippets/README already reference. Only the root **constructor** name changes; the client struct type stays `Client`, consistent with the existing dynamic-snippets behavior and the `snippets (exportedClientName)` unit test (`NewFernClient`).

Constructor-name precedence is now consistent across the SDK generator, dynamic snippets, and the README: `clientConstructorName` > `exportedClientName` > `clientName` > `NewClient`. Default behavior (no `exportedClientName` set) is unchanged.

## Changes Made
- `generators/go-v2/sdk/src/SdkGeneratorContext.ts`: `getClientConstructorName` now returns `New<exportedClientName>` for the root client when `exportedClientName` is set.
- `generators/go/internal/generator/generator.go`: `client/client_test.go` generation (`replaceClientTestConstructorName`) threads through `exportedClientName` with the same precedence.
- `seed/go-sdk/seed.yml`: removed `examples:exported-client-name` from `allowedFailures`.
- Regenerated `seed/go-sdk/examples/exported-client-name/client/{client.go,client_test.go}` (`NewClient` → `NewAcmeClient`).
- Added go-sdk changelog entry.
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] `pnpm seed test --generator go-sdk --fixture examples --outputFolder exported-client-name --local` → passes (was a build failure before).
- [x] `@fern-api/go-dynamic-snippets` unit tests (99 passed) — `snippets (exportedClientName)` snapshot unchanged.
- [x] Go v1 generator package tests pass; `gofmt`/`biome` clean.
- [ ] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/6ba63e4405694aa8ab8875f0dbfd9afc
Requested by: @iamnamananand996