### PR TITLE
fix(go): reserve ExtraProperties name to avoid getter collision

### DIFF
--- a/generators/go/internal/generator/model.go
+++ b/generators/go/internal/generator/model.go
@@ -2456,9 +2456,13 @@ func capitalizeFirstLetter(s string) string {
 // goReservedIdentifiers contains Go keywords and predeclared types that should be
 // avoided as struct field names. We check case-insensitively since PascalCase versions
 // like "String" should also be prefixed.
+// "extraproperties" is reserved because every generated object already exposes a
+// built-in GetExtraProperties() accessor for unmodeled JSON fields; a user property
+// of the same name would otherwise produce a duplicate field/getter that fails to compile.
 // We will just add to this list as needed
 var goReservedIdentifiers = map[string]bool{
-	"string": true,
+	"string":          true,
+	"extraproperties": true,
 }
 
 // goExportedFieldName converts a name to a valid Go exported identifier.

--- a/generators/go/sdk/changes/unreleased/fix-extra-properties-name-collision.yml
+++ b/generators/go/sdk/changes/unreleased/fix-extra-properties-name-collision.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Reserve the `ExtraProperties` field name so a user-defined property named
+    `EXTRA_PROPERTIES` (or any casing of it) no longer collides with the built-in
+    `GetExtraProperties()` accessor. The user property is now generated as
+    `FieldExtraProperties` (its JSON wire name is unchanged), so the generated Go
+    compiles.
+  type: fix

--- a/seed/go-sdk/mixed-case/default-values/service.go
+++ b/seed/go-sdk/mixed-case/default-values/service.go
@@ -387,15 +387,15 @@ func (r ResourceStatus) Ptr() *ResourceStatus {
 }
 
 var (
-	userFieldUserName        = big.NewInt(1 << 0)
-	userFieldMetadataTags    = big.NewInt(1 << 1)
-	userFieldExtraProperties = big.NewInt(1 << 2)
+	userFieldUserName             = big.NewInt(1 << 0)
+	userFieldMetadataTags         = big.NewInt(1 << 1)
+	userFieldFieldExtraProperties = big.NewInt(1 << 2)
 )
 
 type User struct {
-	UserName        string            `json:"userName" url:"userName"`
-	MetadataTags    []string          `json:"metadata_tags" url:"metadata_tags"`
-	ExtraProperties map[string]string `json:"EXTRA_PROPERTIES" url:"EXTRA_PROPERTIES"`
+	UserName             string            `json:"userName" url:"userName"`
+	MetadataTags         []string          `json:"metadata_tags" url:"metadata_tags"`
+	FieldExtraProperties map[string]string `json:"EXTRA_PROPERTIES" url:"EXTRA_PROPERTIES"`
 
 	// Private bitmask of fields set to an explicit value and therefore not to be omitted
 	explicitFields *big.Int `json:"-" url:"-"`
@@ -418,11 +418,11 @@ func (u *User) GetMetadataTags() []string {
 	return u.MetadataTags
 }
 
-func (u *User) GetExtraProperties() map[string]string {
+func (u *User) GetFieldExtraProperties() map[string]string {
 	if u == nil {
 		return nil
 	}
-	return u.ExtraProperties
+	return u.FieldExtraProperties
 }
 
 func (u *User) GetExtraProperties() map[string]interface{} {
@@ -453,11 +453,11 @@ func (u *User) SetMetadataTags(metadataTags []string) {
 	u.require(userFieldMetadataTags)
 }
 
-// SetExtraProperties sets the ExtraProperties field and marks it as non-optional;
+// SetFieldExtraProperties sets the FieldExtraProperties field and marks it as non-optional;
 // this prevents an empty or null value for this field from being omitted during serialization.
-func (u *User) SetExtraProperties(extraProperties map[string]string) {
-	u.ExtraProperties = extraProperties
-	u.require(userFieldExtraProperties)
+func (u *User) SetFieldExtraProperties(extraProperties map[string]string) {
+	u.FieldExtraProperties = extraProperties
+	u.require(userFieldFieldExtraProperties)
 }
 
 func (u *User) UnmarshalJSON(data []byte) error {

--- a/seed/go-sdk/mixed-case/default-values/service_test.go
+++ b/seed/go-sdk/mixed-case/default-values/service_test.go
@@ -440,11 +440,11 @@ func TestSettersUser(t *testing.T) {
 		assert.NotNil(t, obj.explicitFields)
 	})
 
-	t.Run("SetExtraProperties", func(t *testing.T) {
+	t.Run("SetFieldExtraProperties", func(t *testing.T) {
 		obj := &User{}
-		var fernTestValueExtraProperties map[string]string
-		obj.SetExtraProperties(fernTestValueExtraProperties)
-		assert.Equal(t, fernTestValueExtraProperties, obj.ExtraProperties)
+		var fernTestValueFieldExtraProperties map[string]string
+		obj.SetFieldExtraProperties(fernTestValueFieldExtraProperties)
+		assert.Equal(t, fernTestValueFieldExtraProperties, obj.FieldExtraProperties)
 		assert.NotNil(t, obj.explicitFields)
 	})
 
@@ -507,28 +507,28 @@ func TestGettersUser(t *testing.T) {
 		_ = obj.GetMetadataTags() // Should return zero value
 	})
 
-	t.Run("GetExtraProperties", func(t *testing.T) {
+	t.Run("GetFieldExtraProperties", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		obj := &User{}
 		var expected map[string]string
-		obj.ExtraProperties = expected
+		obj.FieldExtraProperties = expected
 
 		// Act & Assert
-		assert.Equal(t, expected, obj.GetExtraProperties(), "getter should return the property value")
+		assert.Equal(t, expected, obj.GetFieldExtraProperties(), "getter should return the property value")
 	})
 
-	t.Run("GetExtraProperties_NilValue", func(t *testing.T) {
+	t.Run("GetFieldExtraProperties_NilValue", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		obj := &User{}
-		obj.ExtraProperties = nil
+		obj.FieldExtraProperties = nil
 
 		// Act & Assert
-		assert.Nil(t, obj.GetExtraProperties(), "getter should return nil when property is nil")
+		assert.Nil(t, obj.GetFieldExtraProperties(), "getter should return nil when property is nil")
 	})
 
-	t.Run("GetExtraProperties_NilReceiver", func(t *testing.T) {
+	t.Run("GetFieldExtraProperties_NilReceiver", func(t *testing.T) {
 		t.Parallel()
 		var obj *User
 		// Should not panic - getters should handle nil receiver gracefully
@@ -537,7 +537,7 @@ func TestGettersUser(t *testing.T) {
 				t.Errorf("Getter panicked on nil receiver: %v", r)
 			}
 		}()
-		_ = obj.GetExtraProperties() // Should return zero value
+		_ = obj.GetFieldExtraProperties() // Should return zero value
 	})
 
 }
@@ -605,14 +605,14 @@ func TestSettersMarkExplicitUser(t *testing.T) {
 		// It verifies that setting a field via setter allows successful JSON round-trip
 	})
 
-	t.Run("SetExtraProperties_MarksExplicit", func(t *testing.T) {
+	t.Run("SetFieldExtraProperties_MarksExplicit", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		obj := &User{}
-		var fernTestValueExtraProperties map[string]string
+		var fernTestValueFieldExtraProperties map[string]string
 
 		// Act
-		obj.SetExtraProperties(fernTestValueExtraProperties)
+		obj.SetFieldExtraProperties(fernTestValueFieldExtraProperties)
 
 		// Assert - object with explicitly set field can be marshaled/unmarshaled
 		bytes, err := json.Marshal(obj)

--- a/seed/go-sdk/mixed-case/no-custom-config/service.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/service.go
@@ -387,15 +387,15 @@ func (r ResourceStatus) Ptr() *ResourceStatus {
 }
 
 var (
-	userFieldUserName        = big.NewInt(1 << 0)
-	userFieldMetadataTags    = big.NewInt(1 << 1)
-	userFieldExtraProperties = big.NewInt(1 << 2)
+	userFieldUserName             = big.NewInt(1 << 0)
+	userFieldMetadataTags         = big.NewInt(1 << 1)
+	userFieldFieldExtraProperties = big.NewInt(1 << 2)
 )
 
 type User struct {
-	UserName        string            `json:"userName" url:"userName"`
-	MetadataTags    []string          `json:"metadata_tags" url:"metadata_tags"`
-	ExtraProperties map[string]string `json:"EXTRA_PROPERTIES" url:"EXTRA_PROPERTIES"`
+	UserName             string            `json:"userName" url:"userName"`
+	MetadataTags         []string          `json:"metadata_tags" url:"metadata_tags"`
+	FieldExtraProperties map[string]string `json:"EXTRA_PROPERTIES" url:"EXTRA_PROPERTIES"`
 
 	// Private bitmask of fields set to an explicit value and therefore not to be omitted
 	explicitFields *big.Int `json:"-" url:"-"`
@@ -418,11 +418,11 @@ func (u *User) GetMetadataTags() []string {
 	return u.MetadataTags
 }
 
-func (u *User) GetExtraProperties() map[string]string {
+func (u *User) GetFieldExtraProperties() map[string]string {
 	if u == nil {
 		return nil
 	}
-	return u.ExtraProperties
+	return u.FieldExtraProperties
 }
 
 func (u *User) GetExtraProperties() map[string]interface{} {
@@ -453,11 +453,11 @@ func (u *User) SetMetadataTags(metadataTags []string) {
 	u.require(userFieldMetadataTags)
 }
 
-// SetExtraProperties sets the ExtraProperties field and marks it as non-optional;
+// SetFieldExtraProperties sets the FieldExtraProperties field and marks it as non-optional;
 // this prevents an empty or null value for this field from being omitted during serialization.
-func (u *User) SetExtraProperties(extraProperties map[string]string) {
-	u.ExtraProperties = extraProperties
-	u.require(userFieldExtraProperties)
+func (u *User) SetFieldExtraProperties(extraProperties map[string]string) {
+	u.FieldExtraProperties = extraProperties
+	u.require(userFieldFieldExtraProperties)
 }
 
 func (u *User) UnmarshalJSON(data []byte) error {

--- a/seed/go-sdk/mixed-case/no-custom-config/service_test.go
+++ b/seed/go-sdk/mixed-case/no-custom-config/service_test.go
@@ -440,11 +440,11 @@ func TestSettersUser(t *testing.T) {
 		assert.NotNil(t, obj.explicitFields)
 	})
 
-	t.Run("SetExtraProperties", func(t *testing.T) {
+	t.Run("SetFieldExtraProperties", func(t *testing.T) {
 		obj := &User{}
-		var fernTestValueExtraProperties map[string]string
-		obj.SetExtraProperties(fernTestValueExtraProperties)
-		assert.Equal(t, fernTestValueExtraProperties, obj.ExtraProperties)
+		var fernTestValueFieldExtraProperties map[string]string
+		obj.SetFieldExtraProperties(fernTestValueFieldExtraProperties)
+		assert.Equal(t, fernTestValueFieldExtraProperties, obj.FieldExtraProperties)
 		assert.NotNil(t, obj.explicitFields)
 	})
 
@@ -507,28 +507,28 @@ func TestGettersUser(t *testing.T) {
 		_ = obj.GetMetadataTags() // Should return zero value
 	})
 
-	t.Run("GetExtraProperties", func(t *testing.T) {
+	t.Run("GetFieldExtraProperties", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		obj := &User{}
 		var expected map[string]string
-		obj.ExtraProperties = expected
+		obj.FieldExtraProperties = expected
 
 		// Act & Assert
-		assert.Equal(t, expected, obj.GetExtraProperties(), "getter should return the property value")
+		assert.Equal(t, expected, obj.GetFieldExtraProperties(), "getter should return the property value")
 	})
 
-	t.Run("GetExtraProperties_NilValue", func(t *testing.T) {
+	t.Run("GetFieldExtraProperties_NilValue", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		obj := &User{}
-		obj.ExtraProperties = nil
+		obj.FieldExtraProperties = nil
 
 		// Act & Assert
-		assert.Nil(t, obj.GetExtraProperties(), "getter should return nil when property is nil")
+		assert.Nil(t, obj.GetFieldExtraProperties(), "getter should return nil when property is nil")
 	})
 
-	t.Run("GetExtraProperties_NilReceiver", func(t *testing.T) {
+	t.Run("GetFieldExtraProperties_NilReceiver", func(t *testing.T) {
 		t.Parallel()
 		var obj *User
 		// Should not panic - getters should handle nil receiver gracefully
@@ -537,7 +537,7 @@ func TestGettersUser(t *testing.T) {
 				t.Errorf("Getter panicked on nil receiver: %v", r)
 			}
 		}()
-		_ = obj.GetExtraProperties() // Should return zero value
+		_ = obj.GetFieldExtraProperties() // Should return zero value
 	})
 
 }
@@ -605,14 +605,14 @@ func TestSettersMarkExplicitUser(t *testing.T) {
 		// It verifies that setting a field via setter allows successful JSON round-trip
 	})
 
-	t.Run("SetExtraProperties_MarksExplicit", func(t *testing.T) {
+	t.Run("SetFieldExtraProperties_MarksExplicit", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		obj := &User{}
-		var fernTestValueExtraProperties map[string]string
+		var fernTestValueFieldExtraProperties map[string]string
 
 		// Act
-		obj.SetExtraProperties(fernTestValueExtraProperties)
+		obj.SetFieldExtraProperties(fernTestValueFieldExtraProperties)
 
 		// Assert - object with explicitly set field can be marshaled/unmarshaled
 		bytes, err := json.Marshal(obj)

--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -367,8 +367,6 @@ allowedFailures:
   # Generated Go code does not compile. Each needs a generator fix.
   - enum # enum-union header value is not converted to a string
   - literal
-  - mixed-case:no-custom-config # user property `extraProperties` collides with the generated accessor
-  - mixed-case:default-values
   - property-access # union member name `Normal` is declared twice
   - trace # generated v2/ subpackage references undefined test types
   - request-parameters # int64 default 9223372036854775807 loses precision in the IR pipeline


### PR DESCRIPTION
## Description
Third in the one-by-one series to clear `seed/go-sdk/seed.yml` `allowedFailures`. Fixes both `mixed-case:no-custom-config` and `mixed-case:default-values` (same root cause).

Every generated Go object exposes a built-in `GetExtraProperties() map[string]interface{}` accessor for unmodeled JSON fields. The `mixed-case` fixture defines a user property `EXTRA_PROPERTIES: map<string, string>` on `User`, which mapped to a Go field `ExtraProperties` and getter `GetExtraProperties() map[string]string` — colliding with the built-in:

```
./service.go:428:16: method User.GetExtraProperties already declared at ./service.go:421:16
```

so the generated SDK did not compile. (For reference, the Java SDK avoids this by naming its built-in bag `additionalProperties`/`getAdditionalProperties()`; renaming Go's long-standing `GetExtraProperties()` globally would be a breaking change, so instead we reserve the name on the user side.)

## Changes Made
- `generators/go/internal/generator/model.go`: added `"extraproperties"` to `goReservedIdentifiers` (the same case-insensitive mechanism that already maps a user property `string` → `FieldString`). A user property whose name normalizes to `extraproperties` is now generated as `FieldExtraProperties` with getter `GetFieldExtraProperties()`; its JSON wire name is unchanged (`json:"EXTRA_PROPERTIES"`). The built-in `GetExtraProperties()` is preserved for every object.
- `seed/go-sdk/seed.yml`: removed `mixed-case:no-custom-config` and `mixed-case:default-values` from `allowedFailures`.
- Regenerated `seed/go-sdk/mixed-case/{no-custom-config,default-values}/` (`service.go`, `service_test.go`).
- Added changelog `generators/go/sdk/changes/unreleased/fix-extra-properties-name-collision.yml` (`type: fix`).
- [ ] Updated README.md generator (if applicable) — n/a

## Testing
- [x] `pnpm seed test --generator go-sdk --fixture mixed-case --local` — both variants now pass (was a `build` failure: `GetExtraProperties already declared`).
- [x] Full local `go-sdk` seed suite: only `mixed-case` output changed (verified via `git status`); no other fixture's generated code changed. No other test definition declares a property normalizing to `extraproperties`.
- [x] v1 generator `go build ./...`, `go vet`, `go test ./internal/generator/...`, and `gofmt` all clean.


Link to Devin session: https://app.devin.ai/sessions/6ba63e4405694aa8ab8875f0dbfd9afc
Requested by: @iamnamananand996