### PR TITLE
feat(cli-generator): generate reference.md for the generated CLI

### DIFF
--- a/generators/cli/sdk/changes/unreleased/generate-reference-md.yml
+++ b/generators/cli/sdk/changes/unreleased/generate-reference-md.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Generate `reference.md` documenting all CLI commands, subcommands, flags,
+    and HTTP mappings. Produced automatically during generation by parsing the
+    mounted OpenAPI spec(s). A link to the reference is added to the generated
+    README's Documentation section.
+  type: feat

--- a/generators/cli/src/__test__/emitReference.test.ts
+++ b/generators/cli/src/__test__/emitReference.test.ts
@@ -1,0 +1,341 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { DetectedAuthBinding } from "../detectAuth.js";
+import { emitReference } from "../emitReference.js";
+import { SPECS_MANIFEST_FILENAME } from "../copySpecs.js";
+
+describe("emitReference", () => {
+    let tmpDir: string;
+    let outputDir: string;
+    let specsDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), "emitReference-"));
+        outputDir = path.join(tmpDir, "out");
+        specsDir = path.join(tmpDir, "specs");
+        await mkdir(outputDir, { recursive: true });
+        await mkdir(specsDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    async function writeSpec(filename: string, spec: object): Promise<string> {
+        const specPath = path.join(specsDir, filename);
+        await writeFile(specPath, JSON.stringify(spec));
+        return specPath;
+    }
+
+    async function writeManifest(specs: Array<{ type: string; specPath: string; namespace?: string }>): Promise<void> {
+        await writeFile(path.join(specsDir, SPECS_MANIFEST_FILENAME), JSON.stringify({ specs }));
+    }
+
+    async function emitAndRead(args: Parameters<typeof emitReference>[0]): Promise<string> {
+        await emitReference(args);
+        return readFile(path.join(args.outputDir, "reference.md"), "utf-8");
+    }
+
+    // ── Fixtures ────────────────────────────────────────────────────
+
+    const bearerBinding: DetectedAuthBinding = {
+        schemeName: "BearerAuth",
+        rustCall: '.auth(BearerAuth::new("BearerAuth").env("PETSTORE_API_TOKEN"))',
+        placement: "root",
+        authTypeImport: "BearerAuth",
+        envVars: ["PETSTORE_API_TOKEN"],
+        kind: "bearer"
+    };
+
+    const minimalSpec = {
+        openapi: "3.0.0",
+        info: { title: "Petstore", version: "1.0.0" },
+        paths: {
+            "/pets": {
+                get: {
+                    operationId: "pets_list",
+                    tags: ["Pets"],
+                    summary: "List all pets",
+                    parameters: [
+                        {
+                            name: "limit",
+                            in: "query",
+                            required: false,
+                            description: "Maximum number of pets to return",
+                            schema: { type: "integer" }
+                        }
+                    ],
+                    responses: { "200": { description: "A list of pets" } }
+                },
+                post: {
+                    operationId: "pets_create",
+                    tags: ["Pets"],
+                    summary: "Create a pet",
+                    requestBody: {
+                        required: true,
+                        content: { "application/json": { schema: { type: "object" } } }
+                    },
+                    responses: { "201": { description: "Pet created" } }
+                }
+            },
+            "/pets/{petId}": {
+                get: {
+                    operationId: "pets_get",
+                    tags: ["Pets"],
+                    description: "Get a specific pet by ID",
+                    parameters: [
+                        {
+                            name: "petId",
+                            in: "path",
+                            required: true,
+                            description: "The pet ID",
+                            schema: { type: "string" }
+                        }
+                    ],
+                    responses: { "200": { description: "A pet" } }
+                }
+            }
+        }
+    };
+
+    // ── Basic generation ─────────────────────────────────────────────
+
+    it("generates a reference.md with resources and methods", async () => {
+        const specPath = await writeSpec("openapi0.json", minimalSpec);
+        await writeManifest([{ type: "openapi", specPath }]);
+
+        const reference = await emitAndRead({
+            outputDir,
+            binaryName: "petstore",
+            apiDisplayName: "Petstore",
+            authBindings: [bearerBinding],
+            specsDir
+        });
+
+        expect(reference).toContain("# Petstore CLI Reference");
+        expect(reference).toContain("Full command reference for `petstore`.");
+        expect(reference).toContain("`petstore pets`");
+        expect(reference).toContain("`petstore pets list`");
+        expect(reference).toContain("`petstore pets create`");
+        expect(reference).toContain("`petstore pets get`");
+        expect(reference).toContain("List all pets");
+        expect(reference).toContain("Create a pet");
+        expect(reference).toContain("Get a specific pet by ID");
+        expect(reference).toContain("`GET /pets`");
+        expect(reference).toContain("`POST /pets`");
+        expect(reference).toContain("`GET /pets/{petId}`");
+        expect(reference).toContain("`--limit`");
+        expect(reference).toContain("`--pet-id`");
+        expect(reference).toContain("## Global flags");
+    });
+
+    // ── Tag prefix stripping ─────────────────────────────────────────
+
+    it("strips tag prefix from operationId", async () => {
+        const spec = {
+            openapi: "3.0.0",
+            info: { title: "API", version: "1.0.0" },
+            paths: {
+                "/customers": {
+                    get: {
+                        operationId: "customersList",
+                        tags: ["Customers"],
+                        responses: { "200": { description: "ok" } }
+                    }
+                }
+            }
+        };
+        const specPath = await writeSpec("openapi0.json", spec);
+        await writeManifest([{ type: "openapi", specPath }]);
+
+        const reference = await emitAndRead({
+            outputDir,
+            binaryName: "my-api",
+            apiDisplayName: "My API",
+            authBindings: [],
+            specsDir
+        });
+
+        expect(reference).toContain("`my-api customers list`");
+    });
+
+    // ── x-fern-sdk-group-name and x-fern-sdk-method-name ─────────────
+
+    it("respects x-fern-sdk-group-name and x-fern-sdk-method-name", async () => {
+        const spec = {
+            openapi: "3.0.0",
+            info: { title: "API", version: "1.0.0" },
+            paths: {
+                "/movies/create-movie": {
+                    post: {
+                        operationId: "imdb_createMovie",
+                        tags: ["Imdb"],
+                        description: "Add a movie to the database",
+                        "x-fern-sdk-group-name": ["imdb"],
+                        "x-fern-sdk-method-name": "createMovie",
+                        requestBody: { required: true, content: { "application/json": {} } },
+                        responses: { "201": { description: "Created" } }
+                    }
+                }
+            }
+        };
+        const specPath = await writeSpec("openapi0.json", spec);
+        await writeManifest([{ type: "openapi", specPath }]);
+
+        const reference = await emitAndRead({
+            outputDir,
+            binaryName: "api",
+            apiDisplayName: "api",
+            authBindings: [],
+            specsDir
+        });
+
+        expect(reference).toContain("`api imdb`");
+        expect(reference).toContain("`api imdb create-movie`");
+        expect(reference).toContain("Add a movie to the database");
+    });
+
+    // ── No-op when no specs ──────────────────────────────────────────
+
+    it("is a no-op when no specs are mounted", async () => {
+        await emitReference({
+            outputDir,
+            binaryName: "my-api",
+            apiDisplayName: "My API",
+            authBindings: [],
+            specsDir
+        });
+
+        // No reference.md should be written
+        await expect(readFile(path.join(outputDir, "reference.md"), "utf-8")).rejects.toThrow();
+    });
+
+    // ── Availability badges ──────────────────────────────────────────
+
+    it("renders availability badges", async () => {
+        const spec = {
+            openapi: "3.0.0",
+            info: { title: "API", version: "1.0.0" },
+            paths: {
+                "/beta-endpoint": {
+                    get: {
+                        operationId: "getBeta",
+                        tags: ["Beta"],
+                        "x-fern-availability": "beta",
+                        responses: { "200": { description: "ok" } }
+                    }
+                },
+                "/deprecated-endpoint": {
+                    get: {
+                        operationId: "getOld",
+                        tags: ["Legacy"],
+                        deprecated: true,
+                        responses: { "200": { description: "ok" } }
+                    }
+                }
+            }
+        };
+        const specPath = await writeSpec("openapi0.json", spec);
+        await writeManifest([{ type: "openapi", specPath }]);
+
+        const reference = await emitAndRead({
+            outputDir,
+            binaryName: "my-api",
+            apiDisplayName: "My API",
+            authBindings: [],
+            specsDir
+        });
+
+        expect(reference).toContain("`[BETA]`");
+        expect(reference).toContain("`[DEPRECATED]`");
+    });
+
+    // ── x-fern-ignore operations are skipped ─────────────────────────
+
+    it("skips operations with x-fern-ignore", async () => {
+        const spec = {
+            openapi: "3.0.0",
+            info: { title: "API", version: "1.0.0" },
+            paths: {
+                "/visible": {
+                    get: {
+                        operationId: "getVisible",
+                        tags: ["Things"],
+                        responses: { "200": { description: "ok" } }
+                    }
+                },
+                "/hidden": {
+                    get: {
+                        operationId: "getHidden",
+                        tags: ["Things"],
+                        "x-fern-ignore": true,
+                        responses: { "200": { description: "ok" } }
+                    }
+                }
+            }
+        };
+        const specPath = await writeSpec("openapi0.json", spec);
+        await writeManifest([{ type: "openapi", specPath }]);
+
+        const reference = await emitAndRead({
+            outputDir,
+            binaryName: "my-api",
+            apiDisplayName: "My API",
+            authBindings: [],
+            specsDir
+        });
+
+        expect(reference).toContain("get-visible");
+        expect(reference).not.toContain("get-hidden");
+    });
+
+    // ── Namespace support ────────────────────────────────────────────
+
+    it("prepends namespace to resource names when present", async () => {
+        const spec = {
+            openapi: "3.0.0",
+            info: { title: "API", version: "1.0.0" },
+            paths: {
+                "/items": {
+                    get: {
+                        operationId: "items_list",
+                        tags: ["Items"],
+                        responses: { "200": { description: "ok" } }
+                    }
+                }
+            }
+        };
+        const specPath = await writeSpec("openapi0.json", spec);
+        await writeManifest([{ type: "openapi", specPath, namespace: "store" }]);
+
+        const reference = await emitAndRead({
+            outputDir,
+            binaryName: "my-api",
+            apiDisplayName: "My API",
+            authBindings: [],
+            specsDir
+        });
+
+        expect(reference).toContain("`my-api store items`");
+    });
+
+    // ── Fallback to binaryName when no apiDisplayName ────────────────
+
+    it("falls back to binaryName in header when apiDisplayName is undefined", async () => {
+        const specPath = await writeSpec("openapi0.json", minimalSpec);
+        await writeManifest([{ type: "openapi", specPath }]);
+
+        const reference = await emitAndRead({
+            outputDir,
+            binaryName: "my-tool",
+            apiDisplayName: undefined,
+            authBindings: [],
+            specsDir
+        });
+
+        expect(reference).toContain("# my-tool CLI Reference");
+    });
+});

--- a/generators/cli/src/__test__/emitReference.test.ts
+++ b/generators/cli/src/__test__/emitReference.test.ts
@@ -3,9 +3,9 @@ import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { SPECS_MANIFEST_FILENAME } from "../copySpecs.js";
 import type { DetectedAuthBinding } from "../detectAuth.js";
 import { emitReference } from "../emitReference.js";
-import { SPECS_MANIFEST_FILENAME } from "../copySpecs.js";
 
 describe("emitReference", () => {
     let tmpDir: string;

--- a/generators/cli/src/emitReadme.ts
+++ b/generators/cli/src/emitReadme.ts
@@ -77,8 +77,16 @@ function generateBlocks(args: {
         generateCommonFlags(binaryName),
         generateEnvironmentVariables(envPrefix),
         generateOutputFormats(binaryName),
-        generateShellCompletion(binaryName)
+        generateShellCompletion(binaryName),
+        generateDocumentation()
     ];
+}
+
+function generateDocumentation(): Block {
+    return new Block({
+        id: "DOCUMENTATION",
+        content: lines("## Documentation", "", "See [reference.md](./reference.md) for the full command reference.", "")
+    });
 }
 
 function generateInstallation(args: { binaryName: string; npmPublishInfo: ResolvedNpmPublishInfo | undefined }): Block {

--- a/generators/cli/src/emitReference.ts
+++ b/generators/cli/src/emitReference.ts
@@ -434,7 +434,7 @@ function renderMethod(args: {
         for (const param of allParams) {
             const flagName = param.name.startsWith("--") ? param.name : `--${toFlagName(param.name)}`;
             const required = param.required ? "Yes" : "No";
-            const desc = param.description ?? "";
+            const desc = (param.description ?? "").replace(/\|/g, "\\|");
             lines.push(`| \`${flagName}\` | \`${param.type}\` | ${required} | ${desc} |`);
         }
         lines.push("");

--- a/generators/cli/src/emitReference.ts
+++ b/generators/cli/src/emitReference.ts
@@ -1,8 +1,8 @@
 import { readFile, writeFile } from "fs/promises";
 import path from "path";
 
-import type { DetectedAuthBinding } from "./detectAuth.js";
 import { readSpecsManifest } from "./copySpecs.js";
+import type { DetectedAuthBinding } from "./detectAuth.js";
 
 /**
  * Emit `reference.md` — a full command reference for the generated CLI.
@@ -173,7 +173,8 @@ function collectResources(
             if (!resources.has(groupName)) {
                 resources.set(groupName, { methods: new Map() });
             }
-            const resource = resources.get(groupName)!;
+            // Safe: we just ensured the key exists above.
+            const resource = resources.get(groupName) ?? { methods: new Map() };
             resource.methods.set(methodName, {
                 description: operation.description ?? operation.summary,
                 httpMethod: method.toUpperCase(),

--- a/generators/cli/src/emitReference.ts
+++ b/generators/cli/src/emitReference.ts
@@ -349,7 +349,7 @@ function renderReference(args: {
 
         // TOC
         for (const [resourceName] of sortedResources) {
-            const anchor = resourceName.replace(/\s+/g, "-").toLowerCase();
+            const anchor = `${binaryName} ${resourceName}`.replace(/\s+/g, "-").toLowerCase();
             lines.push(`- [\`${binaryName} ${resourceName}\`](#${anchor})`);
         }
         lines.push("");

--- a/generators/cli/src/emitReference.ts
+++ b/generators/cli/src/emitReference.ts
@@ -1,0 +1,459 @@
+import { readFile, writeFile } from "fs/promises";
+import path from "path";
+
+import type { DetectedAuthBinding } from "./detectAuth.js";
+import { readSpecsManifest } from "./copySpecs.js";
+
+/**
+ * Emit `reference.md` — a full command reference for the generated CLI.
+ *
+ * Parses the mounted OpenAPI spec(s) to derive the same resource → method
+ * command tree the Rust runtime builds, then renders a markdown file that
+ * documents every subcommand, its HTTP mapping, and available flags.
+ *
+ * The command-tree derivation mirrors the Rust parser's logic:
+ *   - Group = `x-fern-sdk-group-name` || first tag || first path segment
+ *   - Method = `x-fern-sdk-method-name` || operationId (tag-prefix-stripped, kebab-cased)
+ *   - Parameters from path-level + operation-level `parameters` arrays
+ */
+export async function emitReference(args: {
+    outputDir: string;
+    binaryName: string;
+    apiDisplayName: string | undefined;
+    authBindings: DetectedAuthBinding[];
+    specsDir?: string;
+}): Promise<void> {
+    const { outputDir, binaryName, apiDisplayName, specsDir } = args;
+
+    const manifest = await readSpecsManifest(specsDir);
+    if (manifest == null) {
+        return;
+    }
+
+    const openapiSpecs = manifest.specs.filter((entry) => entry.type === "openapi");
+    if (openapiSpecs.length === 0) {
+        return;
+    }
+
+    // Parse all OpenAPI specs and merge into a unified resource tree.
+    const resources: Map<string, ResourceEntry> = new Map();
+
+    for (const spec of openapiSpecs) {
+        const raw = await readFile(spec.specPath, "utf-8");
+        const doc = JSON.parse(raw) as OpenApiDocument;
+        collectResources(doc, resources, spec.namespace);
+    }
+
+    const displayName = apiDisplayName ?? binaryName;
+    const content = renderReference({ binaryName, displayName, resources });
+    await writeFile(path.join(outputDir, "reference.md"), content);
+}
+
+// ---------------------------------------------------------------------------
+// OpenAPI types (minimal, only what we need for reference generation)
+// ---------------------------------------------------------------------------
+
+interface OpenApiDocument {
+    info?: { title?: string; version?: string };
+    paths?: Record<string, Record<string, OpenApiOperation>>;
+    components?: { schemas?: Record<string, unknown> };
+}
+
+interface OpenApiOperation {
+    operationId?: string;
+    summary?: string;
+    description?: string;
+    tags?: string[];
+    parameters?: OpenApiParameter[];
+    requestBody?: OpenApiRequestBody;
+    "x-fern-sdk-group-name"?: string | string[];
+    "x-fern-sdk-method-name"?: string;
+    "x-fern-availability"?: string;
+    "x-fern-ignore"?: boolean;
+    deprecated?: boolean;
+}
+
+interface OpenApiParameter {
+    name: string;
+    in: "query" | "path" | "header" | "cookie";
+    required?: boolean;
+    description?: string;
+    schema?: OpenApiSchema;
+    "x-fern-ignore"?: boolean;
+}
+
+interface OpenApiRequestBody {
+    required?: boolean;
+    content?: Record<string, { schema?: OpenApiSchema }>;
+}
+
+interface OpenApiSchema {
+    type?: string;
+    format?: string;
+    items?: OpenApiSchema;
+    $ref?: string;
+    enum?: string[];
+    properties?: Record<string, OpenApiSchema>;
+    required?: string[];
+    description?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal resource/method tree
+// ---------------------------------------------------------------------------
+
+interface ResourceEntry {
+    methods: Map<string, MethodEntry>;
+}
+
+interface MethodEntry {
+    description: string | undefined;
+    httpMethod: string;
+    path: string;
+    parameters: ParameterEntry[];
+    hasRequestBody: boolean;
+    requestBodyRequired: boolean;
+    availability: string | undefined;
+}
+
+interface ParameterEntry {
+    name: string;
+    location: "query" | "path" | "header";
+    type: string;
+    required: boolean;
+    description: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// OpenAPI → resource tree extraction
+// ---------------------------------------------------------------------------
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head", "options"] as const;
+
+function collectResources(
+    doc: OpenApiDocument,
+    resources: Map<string, ResourceEntry>,
+    namespace: string | undefined
+): void {
+    const paths = doc.paths ?? {};
+
+    for (const [pathStr, pathItem] of Object.entries(paths)) {
+        // Collect path-level parameters (inherited by all operations)
+        const pathParams: OpenApiParameter[] =
+            ((pathItem as Record<string, unknown>).parameters as OpenApiParameter[] | undefined) ?? [];
+
+        for (const method of HTTP_METHODS) {
+            const operation = pathItem[method] as OpenApiOperation | undefined;
+            if (operation == null) {
+                continue;
+            }
+            if (operation["x-fern-ignore"] === true) {
+                continue;
+            }
+
+            const groupName = resolveGroupName(operation, pathStr, namespace);
+            const methodName = resolveMethodName(operation, method, pathStr);
+            const availability = resolveAvailability(operation);
+
+            // Merge path-level + operation-level params (operation wins on conflict).
+            const params = mergeParameters(pathParams, operation.parameters ?? []);
+            const paramEntries = params
+                .filter((p) => p["x-fern-ignore"] !== true && p.in !== "cookie")
+                .map((p) => ({
+                    name: p.name,
+                    location: p.in as "query" | "path" | "header",
+                    type: schemaToTypeString(p.schema),
+                    required: p.required === true,
+                    description: p.description
+                }));
+
+            const hasBody = operation.requestBody != null;
+            const bodyRequired = operation.requestBody?.required === true;
+
+            if (!resources.has(groupName)) {
+                resources.set(groupName, { methods: new Map() });
+            }
+            const resource = resources.get(groupName)!;
+            resource.methods.set(methodName, {
+                description: operation.description ?? operation.summary,
+                httpMethod: method.toUpperCase(),
+                path: pathStr,
+                parameters: paramEntries,
+                hasRequestBody: hasBody,
+                requestBodyRequired: bodyRequired,
+                availability
+            });
+        }
+    }
+}
+
+/**
+ * Convert camelCase/PascalCase/mixed strings to kebab-case, splitting
+ * on word boundaries. Mirrors the Rust parser's `camel_to_kebab`.
+ *
+ *   "createMovie"   → "create-movie"
+ *   "ACMEPublic"    → "acme-public"
+ *   "getHTTPSUrl"   → "get-https-url"
+ *   "Customers"     → "customers"
+ *   "foo bar"       → "foo-bar"
+ */
+function camelToKebab(input: string): string {
+    return input
+        .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+        .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .replace(/-{2,}/g, "-");
+}
+
+function resolveGroupName(op: OpenApiOperation, pathStr: string, namespace: string | undefined): string {
+    const fernGroup = op["x-fern-sdk-group-name"];
+    let groupParts: string[];
+
+    if (fernGroup != null) {
+        groupParts = Array.isArray(fernGroup) ? fernGroup : [fernGroup];
+    } else if (op.tags != null && op.tags.length > 0 && op.tags[0] != null) {
+        groupParts = [op.tags[0]];
+    } else {
+        const segment = pathStr.replace(/^\//, "").split("/")[0] ?? "default";
+        groupParts = [segment];
+    }
+
+    const kebab = groupParts.map((p) => camelToKebab(p)).join(" ");
+    if (namespace != null) {
+        return `${camelToKebab(namespace)} ${kebab}`;
+    }
+    return kebab;
+}
+
+function resolveMethodName(op: OpenApiOperation, httpMethod: string, pathStr: string): string {
+    if (op["x-fern-sdk-method-name"] != null) {
+        return camelToKebab(op["x-fern-sdk-method-name"]);
+    }
+    if (op.operationId != null) {
+        const fernGroup = op["x-fern-sdk-group-name"];
+        // When group comes from tag (no x-fern-sdk-group-name), strip tag prefix
+        if (fernGroup == null && op.tags != null && op.tags.length > 0 && op.tags[0] != null) {
+            const stripped = stripTagPrefix(op.operationId, op.tags[0]);
+            return camelToKebab(stripped);
+        }
+        return camelToKebab(op.operationId);
+    }
+    // Fallback: http-method-path
+    return `${httpMethod}-${pathStr.replace(/^\//, "").replace(/\//g, "-")}`;
+}
+
+/**
+ * Mirror Fern's behavior: strip tag tokens that prefix the operationId.
+ * `tag="Customers", operationId="customersList"` → `list`.
+ */
+function stripTagPrefix(operationId: string, tag: string): string {
+    const tagTokens = tokenize(tag);
+    const opTokens = tokenize(operationId);
+
+    if (tagTokens.length === 0 || opTokens.length <= tagTokens.length) {
+        return operationId;
+    }
+
+    for (let i = 0; i < tagTokens.length; i++) {
+        if (opTokens[i] !== tagTokens[i]) {
+            return operationId;
+        }
+    }
+
+    return opTokens.slice(tagTokens.length).join("-");
+}
+
+/**
+ * Split a string into lowercase tokens on word boundaries (matching the
+ * Rust parser's tokenize logic).
+ */
+function tokenize(input: string): string[] {
+    return input
+        .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+        .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter((t) => t.length > 0);
+}
+
+function resolveAvailability(op: OpenApiOperation): string | undefined {
+    const fern = op["x-fern-availability"];
+    if (fern != null) {
+        return fern;
+    }
+    if (op.deprecated === true) {
+        return "deprecated";
+    }
+    return undefined;
+}
+
+function mergeParameters(pathLevel: OpenApiParameter[], opLevel: OpenApiParameter[]): OpenApiParameter[] {
+    const merged = new Map<string, OpenApiParameter>();
+    for (const p of pathLevel) {
+        merged.set(`${p.in}:${p.name}`, p);
+    }
+    // Operation-level wins on conflict
+    for (const p of opLevel) {
+        merged.set(`${p.in}:${p.name}`, p);
+    }
+    return [...merged.values()];
+}
+
+function schemaToTypeString(schema: OpenApiSchema | undefined): string {
+    if (schema == null) {
+        return "string";
+    }
+    if (schema.$ref != null) {
+        const refName = schema.$ref.split("/").pop() ?? "object";
+        return refName;
+    }
+    if (schema.enum != null) {
+        return schema.enum.join(" | ");
+    }
+    if (schema.type === "array") {
+        const itemType = schemaToTypeString(schema.items);
+        return `${itemType}[]`;
+    }
+    if (schema.format != null) {
+        return `${schema.type} (${schema.format})`;
+    }
+    return schema.type ?? "string";
+}
+
+// ---------------------------------------------------------------------------
+// Markdown rendering
+// ---------------------------------------------------------------------------
+
+function renderReference(args: {
+    binaryName: string;
+    displayName: string;
+    resources: Map<string, ResourceEntry>;
+}): string {
+    const { binaryName, displayName, resources } = args;
+    const lines: string[] = [];
+
+    lines.push(`# ${displayName} CLI Reference`);
+    lines.push("");
+    lines.push(`Full command reference for \`${binaryName}\`.`);
+    lines.push("");
+
+    // Table of contents
+    if (resources.size > 0) {
+        lines.push("## Commands");
+        lines.push("");
+
+        const sortedResources = [...resources.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+
+        // TOC
+        for (const [resourceName] of sortedResources) {
+            const anchor = resourceName.replace(/\s+/g, "-").toLowerCase();
+            lines.push(`- [\`${binaryName} ${resourceName}\`](#${anchor})`);
+        }
+        lines.push("");
+
+        // Per-resource sections
+        for (const [resourceName, resource] of sortedResources) {
+            lines.push(`---`);
+            lines.push("");
+            lines.push(`### \`${binaryName} ${resourceName}\``);
+            lines.push("");
+
+            const sortedMethods = [...resource.methods.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+
+            for (const [methodName, method] of sortedMethods) {
+                renderMethod({ lines, binaryName, resourceName, methodName, method });
+            }
+        }
+    }
+
+    // Global flags section
+    lines.push("---");
+    lines.push("");
+    lines.push("## Global flags");
+    lines.push("");
+    lines.push("These flags are available on every command:");
+    lines.push("");
+    lines.push("| Flag | Description |");
+    lines.push("|------|-------------|");
+    lines.push("| `--dry-run` | Print the HTTP request without sending it |");
+    lines.push("| `--json <JSON\\|->` | Supply the request body as JSON (or `-` for stdin) |");
+    lines.push("| `--params <JSON>` | Merge extra parameters as JSON |");
+    lines.push("| `--format <json\\|table\\|yaml\\|csv>` | Output format (default: `json`) |");
+    lines.push("| `--output <PATH>` | Write binary responses to a file |");
+    lines.push("| `--base-url <URL>` | Override the API base URL |");
+    lines.push("| `--page-all` | Auto-paginate and stream all results |");
+    lines.push("| `--page-limit <N>` | Max pages to fetch (default: `10`) |");
+    lines.push("| `-q, --quiet` | Suppress stdout on success |");
+    lines.push("| `-h, --help` | Print help |");
+    lines.push("| `-V, --version` | Print version |");
+    lines.push("");
+
+    return lines.join("\n") + "\n";
+}
+
+function renderMethod(args: {
+    lines: string[];
+    binaryName: string;
+    resourceName: string;
+    methodName: string;
+    method: MethodEntry;
+}): void {
+    const { lines, binaryName, resourceName, methodName, method } = args;
+
+    const badge = availabilityBadge(method.availability);
+    lines.push(`#### \`${binaryName} ${resourceName} ${methodName}\`${badge}`);
+    lines.push("");
+
+    if (method.description != null) {
+        lines.push(method.description);
+        lines.push("");
+    }
+
+    lines.push(`\`${method.httpMethod} ${method.path}\``);
+    lines.push("");
+
+    // Parameters table
+    const allParams = [...method.parameters];
+    if (method.hasRequestBody) {
+        allParams.push({
+            name: "--json",
+            location: "query",
+            type: "JSON",
+            required: method.requestBodyRequired,
+            description: "Request body as JSON (or use individual body-field flags)"
+        });
+    }
+
+    if (allParams.length > 0) {
+        lines.push("| Flag | Type | Required | Description |");
+        lines.push("|------|------|----------|-------------|");
+
+        for (const param of allParams) {
+            const flagName = param.name.startsWith("--") ? param.name : `--${toFlagName(param.name)}`;
+            const required = param.required ? "Yes" : "No";
+            const desc = param.description ?? "";
+            lines.push(`| \`${flagName}\` | \`${param.type}\` | ${required} | ${desc} |`);
+        }
+        lines.push("");
+    }
+}
+
+function toFlagName(name: string): string {
+    // Convert param name to CLI flag style: camelCase → kebab-case
+    return name
+        .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+        .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+}
+
+function availabilityBadge(availability: string | undefined): string {
+    if (availability == null || availability === "generally-available" || availability === "ga") {
+        return "";
+    }
+    const label = availability.replace(/-/g, " ").toUpperCase();
+    return ` \`[${label}]\``;
+}

--- a/generators/cli/src/index.ts
+++ b/generators/cli/src/index.ts
@@ -11,6 +11,7 @@ export {
 export { type FernCliCustomConfig, getCustomConfig } from "./customConfig.js";
 export { type DetectedAuthBinding, detectAuthBindings } from "./detectAuth.js";
 export { emitPublishWorkflow } from "./emitPublishWorkflow.js";
+export { emitReference } from "./emitReference.js";
 export { deriveBinaryName, TEMPLATE_BINARY_NAME, toEnvVarPrefix, toKebabCase } from "./identity.js";
 export { type IrSummary, readIrSummary } from "./ir.js";
 export { applyCargoTomlPatch, patchCargoLockVersion, patchCargoToml } from "./patchCargoToml.js";

--- a/generators/cli/src/runPipeline.ts
+++ b/generators/cli/src/runPipeline.ts
@@ -6,6 +6,7 @@ import type { FernCliCustomConfig } from "./customConfig.js";
 import { detectAuthBindings } from "./detectAuth.js";
 import { emitPublishWorkflow } from "./emitPublishWorkflow.js";
 import { emitReadme } from "./emitReadme.js";
+import { emitReference } from "./emitReference.js";
 import { generateEmbeddedTypes } from "./generateEmbeddedTypes.js";
 import { deriveBinaryName } from "./identity.js";
 import type { IrSummary } from "./ir.js";
@@ -81,6 +82,13 @@ export async function runPipeline(args: {
         apiDisplayName: ir.apiDisplayName,
         authBindings,
         npmPublishInfo: outputConfig.npmPublishInfo
+    });
+    await emitReference({
+        outputDir,
+        binaryName,
+        apiDisplayName: ir.apiDisplayName,
+        authBindings,
+        specsDir
     });
 
     // Generate the embedded types crate (on by default; opt-out via embedTypes: false).

--- a/seed/cli/imdb/README.md
+++ b/seed/cli/imdb/README.md
@@ -118,3 +118,7 @@ Generate shell completion scripts:
 api completion <bash|zsh|fish|powershell>
 ```
 
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+

--- a/seed/cli/imdb/reference.md
+++ b/seed/cli/imdb/reference.md
@@ -1,0 +1,50 @@
+# api CLI Reference
+
+Full command reference for `api`.
+
+## Commands
+
+- [`api imdb`](#imdb)
+
+---
+
+### `api imdb`
+
+#### `api imdb create-movie` `[PRE RELEASE]`
+
+Add a movie to the database using the movies/* /... path.
+
+`POST /movies/create-movie`
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--json` | `JSON` | Yes | Request body as JSON (or use individual body-field flags) |
+
+#### `api imdb get-movie` `[DEPRECATED]`
+
+`GET /movies/{movieId}`
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--movie-id` | `MovieId` | Yes |  |
+
+---
+
+## Global flags
+
+These flags are available on every command:
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply the request body as JSON (or `-` for stdin) |
+| `--params <JSON>` | Merge extra parameters as JSON |
+| `--format <json\|table\|yaml\|csv>` | Output format (default: `json`) |
+| `--output <PATH>` | Write binary responses to a file |
+| `--base-url <URL>` | Override the API base URL |
+| `--page-all` | Auto-paginate and stream all results |
+| `--page-limit <N>` | Max pages to fetch (default: `10`) |
+| `-q, --quiet` | Suppress stdout on success |
+| `-h, --help` | Print help |
+| `-V, --version` | Print version |
+

--- a/seed/cli/imdb/reference.md
+++ b/seed/cli/imdb/reference.md
@@ -4,7 +4,7 @@ Full command reference for `api`.
 
 ## Commands
 
-- [`api imdb`](#imdb)
+- [`api imdb`](#api-imdb)
 
 ---
 

--- a/seed/cli/query-parameters-openapi/github-npm/README.md
+++ b/seed/cli/query-parameters-openapi/github-npm/README.md
@@ -119,3 +119,7 @@ Generate shell completion scripts:
 query-parameters-api completion <bash|zsh|fish|powershell>
 ```
 
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+

--- a/seed/cli/query-parameters-openapi/github-npm/reference.md
+++ b/seed/cli/query-parameters-openapi/github-npm/reference.md
@@ -4,7 +4,7 @@ Full command reference for `query-parameters-api`.
 
 ## Commands
 
-- [`query-parameters-api user`](#user)
+- [`query-parameters-api user`](#query-parameters-api-user)
 
 ---
 

--- a/seed/cli/query-parameters-openapi/github-npm/reference.md
+++ b/seed/cli/query-parameters-openapi/github-npm/reference.md
@@ -1,0 +1,57 @@
+# Query Parameters API CLI Reference
+
+Full command reference for `query-parameters-api`.
+
+## Commands
+
+- [`query-parameters-api user`](#user)
+
+---
+
+### `query-parameters-api user`
+
+#### `query-parameters-api user search`
+
+`GET /user/getUsername`
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--limit` | `integer` | Yes |  |
+| `--id` | `string` | Yes |  |
+| `--date` | `string (date)` | Yes |  |
+| `--deadline` | `string (date-time)` | Yes |  |
+| `--bytes` | `string (base64)` | Yes |  |
+| `--user` | `User` | Yes |  |
+| `--user-list` | `User[]` | Yes |  |
+| `--optional-deadline` | `string (date-time)` | No |  |
+| `--key-value` | `object` | No |  |
+| `--optional-string` | `string` | No |  |
+| `--nested-user` | `NestedUser` | No |  |
+| `--optional-user` | `User` | No |  |
+| `--exclude-user` | `User[]` | No |  |
+| `--filter` | `string[]` | No |  |
+| `--tags` | `string[]` | Yes | List of tags. Serialized as a comma-separated list. |
+| `--optional-tags` | `string[]` | No | Optional list of tags. Serialized as a comma-separated list. |
+| `--neighbor` | `string` | No |  |
+| `--neighbor-required` | `string` | Yes |  |
+
+---
+
+## Global flags
+
+These flags are available on every command:
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply the request body as JSON (or `-` for stdin) |
+| `--params <JSON>` | Merge extra parameters as JSON |
+| `--format <json\|table\|yaml\|csv>` | Output format (default: `json`) |
+| `--output <PATH>` | Write binary responses to a file |
+| `--base-url <URL>` | Override the API base URL |
+| `--page-all` | Auto-paginate and stream all results |
+| `--page-limit <N>` | Max pages to fetch (default: `10`) |
+| `-q, --quiet` | Suppress stdout on success |
+| `-h, --help` | Print help |
+| `-V, --version` | Print version |
+

--- a/seed/cli/query-parameters-openapi/no-custom-config/README.md
+++ b/seed/cli/query-parameters-openapi/no-custom-config/README.md
@@ -111,3 +111,7 @@ Generate shell completion scripts:
 query-parameters-api completion <bash|zsh|fish|powershell>
 ```
 
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+

--- a/seed/cli/query-parameters-openapi/no-custom-config/reference.md
+++ b/seed/cli/query-parameters-openapi/no-custom-config/reference.md
@@ -4,7 +4,7 @@ Full command reference for `query-parameters-api`.
 
 ## Commands
 
-- [`query-parameters-api user`](#user)
+- [`query-parameters-api user`](#query-parameters-api-user)
 
 ---
 

--- a/seed/cli/query-parameters-openapi/no-custom-config/reference.md
+++ b/seed/cli/query-parameters-openapi/no-custom-config/reference.md
@@ -1,0 +1,57 @@
+# Query Parameters API CLI Reference
+
+Full command reference for `query-parameters-api`.
+
+## Commands
+
+- [`query-parameters-api user`](#user)
+
+---
+
+### `query-parameters-api user`
+
+#### `query-parameters-api user search`
+
+`GET /user/getUsername`
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--limit` | `integer` | Yes |  |
+| `--id` | `string` | Yes |  |
+| `--date` | `string (date)` | Yes |  |
+| `--deadline` | `string (date-time)` | Yes |  |
+| `--bytes` | `string (base64)` | Yes |  |
+| `--user` | `User` | Yes |  |
+| `--user-list` | `User[]` | Yes |  |
+| `--optional-deadline` | `string (date-time)` | No |  |
+| `--key-value` | `object` | No |  |
+| `--optional-string` | `string` | No |  |
+| `--nested-user` | `NestedUser` | No |  |
+| `--optional-user` | `User` | No |  |
+| `--exclude-user` | `User[]` | No |  |
+| `--filter` | `string[]` | No |  |
+| `--tags` | `string[]` | Yes | List of tags. Serialized as a comma-separated list. |
+| `--optional-tags` | `string[]` | No | Optional list of tags. Serialized as a comma-separated list. |
+| `--neighbor` | `string` | No |  |
+| `--neighbor-required` | `string` | Yes |  |
+
+---
+
+## Global flags
+
+These flags are available on every command:
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply the request body as JSON (or `-` for stdin) |
+| `--params <JSON>` | Merge extra parameters as JSON |
+| `--format <json\|table\|yaml\|csv>` | Output format (default: `json`) |
+| `--output <PATH>` | Write binary responses to a file |
+| `--base-url <URL>` | Override the API base URL |
+| `--page-all` | Auto-paginate and stream all results |
+| `--page-limit <N>` | Max pages to fetch (default: `10`) |
+| `-q, --quiet` | Suppress stdout on success |
+| `-h, --help` | Print help |
+| `-V, --version` | Print version |
+


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-11016

Adds automatic `reference.md` generation to the CLI generator output, documenting all commands, subcommands, flags, and HTTP mappings — analogous to SDK reference docs.

## Changes Made
- New `emitReference.ts` module that parses the mounted OpenAPI spec(s) at generation time to derive the resource→method command tree (mirrors the Rust parser's `camel_to_kebab`, `strip_tag_prefix`, and group resolution logic)
- Integrated into `runPipeline.ts` as a new pipeline step after `emitReadme`
- Added a "Documentation" section to the generated README linking to `reference.md`
- [x] Updated README.md generator (added Documentation block)

## Testing
- [x] Unit tests added (8 tests covering: basic generation, tag prefix stripping, `x-fern-sdk-group-name`/`x-fern-sdk-method-name`, no-op when no specs, availability badges, `x-fern-ignore` skipping, namespace support, fallback to binaryName)
- [x] All 118 existing tests continue to pass
- [x] Seed tests pass for `imdb` and `query-parameters-openapi` fixtures
- [x] No new type errors (pre-existing ones in `cli.ts` and `emitReadme.ts` unchanged)

Link to Devin session: https://app.devin.ai/sessions/28485d830c174016898dffb4b118b8d3
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->