### PR TITLE
feat(cli-generator): restructure README with progressive disclosure

### DIFF
--- a/generators/cli/changes/unreleased/progressive-disclosure-readme.yml
+++ b/generators/cli/changes/unreleased/progressive-disclosure-readme.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Restructure generated README to follow progressive disclosure: TOC,
+    Install → Auth → Quick start → Usage → Documentation link → Advanced
+    (Common flags, Environment variables, Output formats, Shell completion
+    collapsed as subsections). Removes the --help dump from Usage.
+  type: feat

--- a/generators/cli/src/__test__/emitReadme.test.ts
+++ b/generators/cli/src/__test__/emitReadme.test.ts
@@ -57,6 +57,7 @@ describe("emitReadme", () => {
 
         expect(readme).toContain("# Petstore CLI");
         expect(readme).toContain("Command-line interface for the Petstore API.");
+        expect(readme).toContain("## Table of contents");
         expect(readme).toContain("npm install -g @petstore/cli");
         expect(readme).toContain("npx @petstore/cli --help");
         expect(readme).toContain("### Build from source");
@@ -70,6 +71,7 @@ describe("emitReadme", () => {
         expect(readme).toContain("PETSTORE_API_CA_BUNDLE");
         expect(readme).toContain("PETSTORE_API_TIMEOUT_SECS");
         expect(readme).toContain("petstore-api completion <bash|zsh|fish|powershell>");
+        expect(readme).toContain("reference.md");
     });
 
     // ── Build from source when npmPublishInfo absent ────────────────
@@ -207,9 +209,9 @@ describe("emitReadme", () => {
         expect(usageIdx).toBeGreaterThan(customIdx);
     });
 
-    // ── Section order ───────────────────────────────────────────────
+    // ── Section order (progressive disclosure) ──────────────────────
 
-    it("emits sections in the specified order", async () => {
+    it("emits sections in progressive disclosure order", async () => {
         const readme = await emitAndRead({
             outputDir,
             binaryName: "acme",
@@ -219,13 +221,13 @@ describe("emitReadme", () => {
         });
 
         const expectedOrder = [
+            "## Table of contents",
             "## Installation",
             "## Authentication",
+            "## Quick start",
             "## Usage",
-            "## Common flags",
-            "## Environment variables",
-            "## Output formats",
-            "## Shell completion"
+            "## Documentation",
+            "## Advanced"
         ];
 
         let lastIndex = -1;
@@ -236,9 +238,27 @@ describe("emitReadme", () => {
         }
     });
 
-    // ── Help output in Usage section ────────────────────────────────
+    // ── Advanced subsections ────────────────────────────────────────
 
-    it("renders a representative --help output in the Usage section", async () => {
+    it("nests Common flags, Environment variables, Output formats, Shell completion under Advanced", async () => {
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "acme",
+            apiDisplayName: "Acme",
+            authBindings: [bearerBinding],
+            npmPublishInfo
+        });
+
+        const advancedSection = readme.split("## Advanced")[1] ?? "";
+        expect(advancedSection).toContain("### Common flags");
+        expect(advancedSection).toContain("### Environment variables");
+        expect(advancedSection).toContain("### Output formats");
+        expect(advancedSection).toContain("### Shell completion");
+    });
+
+    // ── Quick start section ─────────────────────────────────────────
+
+    it("renders a Quick start section with basic examples", async () => {
         const readme = await emitAndRead({
             outputDir,
             binaryName: "petstore-api",
@@ -247,14 +267,82 @@ describe("emitReadme", () => {
             npmPublishInfo
         });
 
-        const usageSection = readme.split("## Usage")[1]?.split("## Common flags")[0] ?? "";
-        expect(usageSection).toContain("Petstore");
-        expect(usageSection).toContain("Usage: petstore-api [OPTIONS] <COMMAND>");
-        expect(usageSection).toContain("generate-skills");
-        expect(usageSection).toContain("completion");
-        expect(usageSection).toContain("--dry-run");
-        expect(usageSection).toContain("PETSTORE_API_BASE_URL");
-        expect(usageSection).toContain("PETSTORE_API_TOKEN");
+        const quickStartSection = readme.split("## Quick start")[1]?.split("## Usage")[0] ?? "";
+        expect(quickStartSection).toContain("petstore-api --help");
+        expect(quickStartSection).toContain("petstore-api <resource> <method>");
+        expect(quickStartSection).toContain("petstore-api <resource> --help");
+    });
+
+    // ── Usage is trimmed (no --help dump) ───────────────────────────
+
+    it("renders trimmed Usage without --help dump", async () => {
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "petstore-api",
+            apiDisplayName: "Petstore",
+            authBindings: [bearerBinding],
+            npmPublishInfo
+        });
+
+        const usageSection = readme.split("## Usage")[1]?.split("## Documentation")[0] ?? "";
+        expect(usageSection).toContain("petstore-api <resource> <method>");
+        expect(usageSection).toContain("--json");
+        // No --help dump
+        expect(usageSection).not.toContain("Commands:");
+        expect(usageSection).not.toContain("generate-skills");
+        expect(usageSection).not.toContain("Options:");
+    });
+
+    // ── Table of contents ───────────────────────────────────────────
+
+    it("generates a table of contents with Advanced subsections", async () => {
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "acme",
+            apiDisplayName: "Acme",
+            authBindings: [bearerBinding],
+            npmPublishInfo
+        });
+
+        const tocSection = readme.split("## Table of contents")[1]?.split("## Installation")[0] ?? "";
+        expect(tocSection).toContain("[Installation](#installation)");
+        expect(tocSection).toContain("[Authentication](#authentication)");
+        expect(tocSection).toContain("[Quick start](#quick-start)");
+        expect(tocSection).toContain("[Usage](#usage)");
+        expect(tocSection).toContain("[Documentation](#documentation)");
+        expect(tocSection).toContain("[Advanced](#advanced)");
+        expect(tocSection).toContain("[Common flags](#common-flags)");
+        expect(tocSection).toContain("[Shell completion](#shell-completion)");
+    });
+
+    // ── TOC includes customer-added sections ────────────────────────
+
+    it("includes customer-added sections in the table of contents", async () => {
+        const existingReadme = [
+            "# Old Header",
+            "",
+            "## Installation",
+            "",
+            "Old content",
+            "",
+            "## My Custom Section",
+            "",
+            "Custom content",
+            ""
+        ].join("\n");
+
+        await writeFile(path.join(outputDir, "README.md"), existingReadme);
+
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "acme",
+            apiDisplayName: "Acme",
+            authBindings: [],
+            npmPublishInfo: undefined
+        });
+
+        const tocSection = readme.split("## Table of contents")[1]?.split("## Installation")[0] ?? "";
+        expect(tocSection).toContain("[My Custom Section](#my-custom-section)");
     });
 
     // ── .env support mentioned in Authentication ────────────────────

--- a/generators/cli/src/emitReadme.ts
+++ b/generators/cli/src/emitReadme.ts
@@ -15,12 +15,10 @@ import type { ResolvedNpmPublishInfo } from "./resolveOutputConfig.js";
  * whose id is NOT in the generated set are kept in their original
  * position.
  *
- * Unlike the SDK `ReadmeGenerator` (which renders language-specific
- * install commands, code-snippet features, and badge shields), the CLI
- * README documents binary invocation, auth env vars, output formats,
- * and shell completions — content that has no overlap with the SDK
- * feature model. We therefore build our own `Block[]` list directly
- * rather than constructing a `ReadmeConfig` for the SDK generator.
+ * The README follows progressive disclosure: install → auth → quick
+ * start → reference link, then an Advanced section for deeper config.
+ * `ReadmeParser` strips `## Table of contents` from an existing README
+ * so the TOC is regenerated cleanly after the block merge.
  */
 export async function emitReadme(args: {
     outputDir: string;
@@ -39,7 +37,8 @@ export async function emitReadme(args: {
     const existing = await readExistingReadme(readmePath);
     const finalBlocks = mergeWithExisting({ existing, generatedBlocks: blocks });
 
-    const content = header + finalBlocks.map((b) => b.content).join("");
+    const toc = generateTableOfContents(finalBlocks);
+    const content = header + toc + finalBlocks.map((b) => b.content).join("");
     await writeFile(readmePath, content);
 }
 
@@ -53,6 +52,52 @@ function generateHeader(displayName: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Table of contents — generated after the block merge so it reflects
+// customer-added sections too.  ReadmeParser strips any existing
+// `## Table of contents` block, so we never get duplicates.
+// ---------------------------------------------------------------------------
+
+function generateTableOfContents(blocks: Block[]): string {
+    if (blocks.length === 0) {
+        return "";
+    }
+    const tocLines: string[] = [];
+    for (const block of blocks) {
+        const title = extractBlockTitle(block);
+        if (title == null) {
+            continue;
+        }
+        const anchor = toAnchor(title);
+        tocLines.push(`- [${title}](#${anchor})`);
+        if (block.id === "ADVANCED") {
+            for (const sub of extractSubsectionTitles(block)) {
+                tocLines.push(`  - [${sub}](#${toAnchor(sub)})`);
+            }
+        }
+    }
+    return lines("## Table of contents", "", ...tocLines, "");
+}
+
+function extractBlockTitle(block: Block): string | undefined {
+    const match = block.content.match(/^## (.+)/);
+    return match?.[1];
+}
+
+function extractSubsectionTitles(block: Block): string[] {
+    const titles: string[] = [];
+    for (const match of block.content.matchAll(/^### (.+)/gm)) {
+        if (match[1] != null) {
+            titles.push(match[1]);
+        }
+    }
+    return titles;
+}
+
+function toAnchor(title: string): string {
+    return title.toLowerCase().replace(/\s+/g, "-");
+}
+
+// ---------------------------------------------------------------------------
 // Block builders — one per generated H2 section.
 //
 // Each follows the same convention as ReadmeGenerator's private helpers:
@@ -60,6 +105,11 @@ function generateHeader(displayName: string): string {
 // trailing blank line (`\n`), and wrap it in a `Block` keyed by a
 // SCREAMING_SNAKE_CASE id that ReadmeParser.sectionNameToID would
 // produce from the heading text.
+//
+// Progressive disclosure ordering:
+//   Layer 1 (80% path): Installation → Authentication → Quick start
+//   Layer 2 (bridge):   Usage → Documentation
+//   Layer 3 (deep):     Advanced (Common flags / Env vars / Output / Completion)
 // ---------------------------------------------------------------------------
 
 function generateBlocks(args: {
@@ -68,26 +118,21 @@ function generateBlocks(args: {
     authBindings: DetectedAuthBinding[];
     npmPublishInfo: ResolvedNpmPublishInfo | undefined;
 }): Block[] {
-    const { binaryName, displayName, authBindings, npmPublishInfo } = args;
+    const { binaryName, authBindings, npmPublishInfo } = args;
     const envPrefix = toEnvVarPrefix(binaryName);
     return [
         generateInstallation({ binaryName, npmPublishInfo }),
         generateAuthentication({ binaryName, authBindings }),
-        generateUsage({ binaryName, displayName, envPrefix, authBindings }),
-        generateCommonFlags(binaryName),
-        generateEnvironmentVariables(envPrefix),
-        generateOutputFormats(binaryName),
-        generateShellCompletion(binaryName),
-        generateDocumentation()
+        generateQuickStart(binaryName),
+        generateUsage(binaryName),
+        generateDocumentation(),
+        generateAdvanced({ binaryName, envPrefix })
     ];
 }
 
-function generateDocumentation(): Block {
-    return new Block({
-        id: "DOCUMENTATION",
-        content: lines("## Documentation", "", "See [reference.md](./reference.md) for the full command reference.", "")
-    });
-}
+// ---------------------------------------------------------------------------
+// Installation (unchanged)
+// ---------------------------------------------------------------------------
 
 function generateInstallation(args: { binaryName: string; npmPublishInfo: ResolvedNpmPublishInfo | undefined }): Block {
     const { binaryName, npmPublishInfo } = args;
@@ -140,6 +185,10 @@ function generateInstallation(args: { binaryName: string; npmPublishInfo: Resolv
     return new Block({ id: "INSTALLATION", content });
 }
 
+// ---------------------------------------------------------------------------
+// Authentication (unchanged)
+// ---------------------------------------------------------------------------
+
 function generateAuthentication(args: { binaryName: string; authBindings: DetectedAuthBinding[] }): Block {
     const { binaryName, authBindings } = args;
     if (authBindings.length === 0) {
@@ -176,75 +225,97 @@ function generateAuthentication(args: { binaryName: string; authBindings: Detect
     });
 }
 
-function generateUsage(args: {
-    binaryName: string;
-    displayName: string;
-    envPrefix: string;
-    authBindings: DetectedAuthBinding[];
-}): Block {
-    const { binaryName, displayName, envPrefix, authBindings } = args;
+// ---------------------------------------------------------------------------
+// Quick start (new — layer 1 "try it now")
+// ---------------------------------------------------------------------------
 
-    const helpBlock = buildHelpOutput({ binaryName, displayName, envPrefix, authBindings });
+function generateQuickStart(binaryName: string): Block {
+    return new Block({
+        id: "QUICK_START",
+        content: lines(
+            "## Quick start",
+            "",
+            "List available commands:",
+            "",
+            "```bash",
+            `${binaryName} --help`,
+            "```",
+            "",
+            "Call an API endpoint:",
+            "",
+            "```bash",
+            `${binaryName} <resource> <method>`,
+            "```",
+            "",
+            `Run \`${binaryName} <resource> --help\` to see available methods for a resource.`,
+            ""
+        )
+    });
+}
 
+// ---------------------------------------------------------------------------
+// Usage (trimmed — no --help dump, subcommand pattern + --json)
+// ---------------------------------------------------------------------------
+
+function generateUsage(binaryName: string): Block {
     return new Block({
         id: "USAGE",
         content: lines(
             "## Usage",
             "",
-            "```",
-            ...helpBlock,
-            "```",
+            `Every API resource appears as a subcommand (e.g. \`${binaryName} <resource> <method>\`). ` +
+                `Run \`${binaryName} <resource> --help\` to see available methods.`,
             "",
-            "Every API resource appears as a subcommand (e.g. `" +
-                binaryName +
-                " <resource> <method>`). " +
-                "Run `" +
-                binaryName +
-                " <resource> --help` to see available methods.",
+            "Provide request parameters as flags or as JSON:",
+            "",
+            "```bash",
+            `${binaryName} <resource> <method> --json '{"key": "value"}'`,
+            "```",
             ""
         )
     });
 }
 
-function generateCommonFlags(binaryName: string): Block {
+// ---------------------------------------------------------------------------
+// Documentation (reference.md link)
+// ---------------------------------------------------------------------------
+
+function generateDocumentation(): Block {
     return new Block({
-        id: "COMMON_FLAGS",
+        id: "DOCUMENTATION",
+        content: lines("## Documentation", "", "See [reference.md](./reference.md) for the full command reference.", "")
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Advanced — collapses Common flags / Environment variables / Output
+// formats / Shell completion into ### subsections under one H2.
+// ---------------------------------------------------------------------------
+
+function generateAdvanced(args: { binaryName: string; envPrefix: string }): Block {
+    const { binaryName, envPrefix } = args;
+    return new Block({
+        id: "ADVANCED",
         content: lines(
-            "## Common flags",
+            "## Advanced",
+            "",
+            "### Common flags",
             "",
             "These flags are available on every operation:",
             "",
             "| Flag | Description |",
             "|------|-------------|",
-            "| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |",
-            "| `--json <JSON\\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |",
+            "| `--dry-run` | Validate the request locally and print the HTTP request without sending it |",
+            "| `--json <JSON\\|->` | Supply a request body as JSON (or `-` to read stdin) |",
             "| `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |",
             "| `--format <json\\|table\\|yaml\\|csv>` | Output format (default `json`) |",
             "| `--output <PATH>` | Write binary responses to a file |",
-            "| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |",
+            "| `--base-url <URL>` | Override the API base URL |",
             "| `--page-all` | Auto-paginate and stream results as NDJSON |",
             "| `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |",
             "| `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |",
             "",
-            "### Dry run",
-            "",
-            "The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. " +
-                "This is particularly valuable for AI agent integration — agents can validate their intent " +
-                "before committing to a write operation:",
-            "",
-            "```bash",
-            `${binaryName} <resource> <method> --dry-run`,
-            "```",
-            ""
-        )
-    });
-}
-
-function generateEnvironmentVariables(envPrefix: string): Block {
-    return new Block({
-        id: "ENVIRONMENT_VARIABLES",
-        content: lines(
-            "## Environment variables",
+            "### Environment variables",
             "",
             `| Variable | Description |`,
             `|----------|-------------|`,
@@ -255,16 +326,8 @@ function generateEnvironmentVariables(envPrefix: string): Block {
             `| \`${envPrefix}_TIMEOUT_SECS\` | Total request timeout in seconds |`,
             "",
             "Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.",
-            ""
-        )
-    });
-}
-
-function generateOutputFormats(binaryName: string): Block {
-    return new Block({
-        id: "OUTPUT_FORMATS",
-        content: lines(
-            "## Output formats",
+            "",
+            "### Output formats",
             "",
             "Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.",
             "",
@@ -275,16 +338,8 @@ function generateOutputFormats(binaryName: string): Block {
             "# Machine-readable catalog of every operation",
             `${binaryName} --help --format json | jq 'length'`,
             "```",
-            ""
-        )
-    });
-}
-
-function generateShellCompletion(binaryName: string): Block {
-    return new Block({
-        id: "SHELL_COMPLETION",
-        content: lines(
-            "## Shell completion",
+            "",
+            "### Shell completion",
             "",
             "Generate shell completion scripts:",
             "",
@@ -297,79 +352,8 @@ function generateShellCompletion(binaryName: string): Block {
 }
 
 // ---------------------------------------------------------------------------
-// Help-output builder — renders a representative top-level --help block
-// with the correct binary name, display name, env-var prefix, and auth
-// env vars substituted in.
-// ---------------------------------------------------------------------------
-
-function buildHelpOutput(args: {
-    binaryName: string;
-    displayName: string;
-    envPrefix: string;
-    authBindings: DetectedAuthBinding[];
-}): string[] {
-    const { binaryName, displayName, envPrefix, authBindings } = args;
-
-    const out: string[] = [];
-    out.push(displayName);
-    out.push("");
-    out.push(`Usage: ${binaryName} [OPTIONS] <COMMAND>`);
-    out.push("");
-    out.push("Commands:");
-    out.push("  ...                API resource commands (run --help to list)");
-    out.push("  generate-skills    Generate SKILL.md files for AI agent integration");
-    out.push("  completion         Generate shell completion scripts");
-    out.push("  man                Generate a man page (roff format)");
-    out.push("  help               Print this message or the help of the given subcommand(s)");
-    out.push("");
-    out.push("Options:");
-    out.push("      --dry-run          Validate the request locally without sending it to the API");
-    out.push("      --format <FORMAT>  Output format: json (default), table, yaml, csv");
-    out.push("      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)");
-    out.push("  -q, --quiet            Suppress stdout output on success (errors still go to stderr)");
-    out.push("  -h, --help             Print help");
-    out.push("  -V, --version          Print version");
-    out.push("");
-    out.push("Environment variables:");
-
-    // Auth env vars first
-    for (const binding of authBindings) {
-        for (const envVar of binding.envVars) {
-            out.push(`  ${padEnvVar(envVar)}${describeAuthEnvVar(binding.kind)}`);
-        }
-    }
-
-    out.push(`  ${padEnvVar(`${envPrefix}_BASE_URL`)}Override the API base URL`);
-    out.push(`  ${padEnvVar(`${envPrefix}_CA_BUNDLE`)}Path to PEM file with extra trust roots (or SSL_CERT_FILE)`);
-    out.push(`  ${padEnvVar(`${envPrefix}_INSECURE=1`)}Skip TLS verification (debugging only)`);
-    out.push(`  ${padEnvVar(`${envPrefix}_PROXY`)}HTTP(S) proxy URL`);
-    out.push(`  ${padEnvVar(`${envPrefix}_TIMEOUT_SECS`)}Total request timeout`);
-    out.push("");
-    out.push("Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.");
-
-    return out;
-}
-
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-const ENV_VAR_COL_WIDTH = 36;
-
-function padEnvVar(envVar: string): string {
-    return envVar.padEnd(ENV_VAR_COL_WIDTH);
-}
-
-function describeAuthEnvVar(kind: DetectedAuthBinding["kind"]): string {
-    switch (kind) {
-        case "bearer":
-            return "Bearer token for authentication";
-        case "header":
-            return "API key for authentication";
-        case "basic":
-            return "Credential for authentication";
-    }
-}
 
 function placeholderForKind(kind: DetectedAuthBinding["kind"]): string {
     switch (kind) {

--- a/seed/cli/allof-inline/README.md
+++ b/seed/cli/allof-inline/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the allOf Composition API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `allof-composition --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+allof-composition --help
+```
+
+Call an API endpoint:
+
+```bash
+allof-composition <resource> <method>
+```
+
+Run `allof-composition <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-allOf Composition
-
-Usage: allof-composition [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  ALLOF_COMPOSITION_BASE_URL          Override the API base URL
-  ALLOF_COMPOSITION_CA_BUNDLE         Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  ALLOF_COMPOSITION_INSECURE=1        Skip TLS verification (debugging only)
-  ALLOF_COMPOSITION_PROXY             HTTP(S) proxy URL
-  ALLOF_COMPOSITION_TIMEOUT_SECS      Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `allof-composition <resource> <method>`). Run `allof-composition <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+allof-composition <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-allof-composition <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ allof-composition <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ allof-composition <resource> <method> --format json | jq
 allof-composition --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/allof/README.md
+++ b/seed/cli/allof/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the allOf Composition API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `allof-composition --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+allof-composition --help
+```
+
+Call an API endpoint:
+
+```bash
+allof-composition <resource> <method>
+```
+
+Run `allof-composition <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-allOf Composition
-
-Usage: allof-composition [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  ALLOF_COMPOSITION_BASE_URL          Override the API base URL
-  ALLOF_COMPOSITION_CA_BUNDLE         Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  ALLOF_COMPOSITION_INSECURE=1        Skip TLS verification (debugging only)
-  ALLOF_COMPOSITION_PROXY             HTTP(S) proxy URL
-  ALLOF_COMPOSITION_TIMEOUT_SECS      Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `allof-composition <resource> <method>`). Run `allof-composition <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+allof-composition <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-allof-composition <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ allof-composition <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ allof-composition <resource> <method> --format json | jq
 allof-composition --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/api-wide-base-path-with-default/README.md
+++ b/seed/cli/api-wide-base-path-with-default/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the api-wide-base-path-with-default API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `api-wide-base-path-with-default --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+api-wide-base-path-with-default --help
+```
+
+Call an API endpoint:
+
+```bash
+api-wide-base-path-with-default <resource> <method>
+```
+
+Run `api-wide-base-path-with-default <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-api-wide-base-path-with-default
-
-Usage: api-wide-base-path-with-default [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  API_WIDE_BASE_PATH_WITH_DEFAULT_BASE_URLOverride the API base URL
-  API_WIDE_BASE_PATH_WITH_DEFAULT_CA_BUNDLEPath to PEM file with extra trust roots (or SSL_CERT_FILE)
-  API_WIDE_BASE_PATH_WITH_DEFAULT_INSECURE=1Skip TLS verification (debugging only)
-  API_WIDE_BASE_PATH_WITH_DEFAULT_PROXYHTTP(S) proxy URL
-  API_WIDE_BASE_PATH_WITH_DEFAULT_TIMEOUT_SECSTotal request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `api-wide-base-path-with-default <resource> <method>`). Run `api-wide-base-path-with-default <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+api-wide-base-path-with-default <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-api-wide-base-path-with-default <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ api-wide-base-path-with-default <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ api-wide-base-path-with-default <resource> <method> --format json | jq
 api-wide-base-path-with-default --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/cli-multi-spec-namespaced/no-custom-config/README.md
+++ b/seed/cli/cli-multi-spec-namespaced/no-custom-config/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the Users API (v1) API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -27,66 +40,55 @@ export ACME_VERSIONED_TOKEN="<your token>"
 
 A `.env` file in the working directory is also supported — the CLI auto-loads it on startup.
 
+## Quick start
+
+List available commands:
+
+```bash
+acme-versioned --help
+```
+
+Call an API endpoint:
+
+```bash
+acme-versioned <resource> <method>
+```
+
+Run `acme-versioned <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-Users API (v1)
-
-Usage: acme-versioned [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  ACME_VERSIONED_TOKEN                Bearer token for authentication
-  ACME_VERSIONED_BASE_URL             Override the API base URL
-  ACME_VERSIONED_CA_BUNDLE            Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  ACME_VERSIONED_INSECURE=1           Skip TLS verification (debugging only)
-  ACME_VERSIONED_PROXY                HTTP(S) proxy URL
-  ACME_VERSIONED_TIMEOUT_SECS         Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `acme-versioned <resource> <method>`). Run `acme-versioned <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+acme-versioned <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-acme-versioned <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -98,7 +100,7 @@ acme-versioned <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -110,7 +112,7 @@ acme-versioned <resource> <method> --format json | jq
 acme-versioned --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/cli-multi-spec/no-custom-config/README.md
+++ b/seed/cli/cli-multi-spec/no-custom-config/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the Users API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `acme-cli --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+acme-cli --help
+```
+
+Call an API endpoint:
+
+```bash
+acme-cli <resource> <method>
+```
+
+Run `acme-cli <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-Users API
-
-Usage: acme-cli [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  ACME_CLI_BASE_URL                   Override the API base URL
-  ACME_CLI_CA_BUNDLE                  Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  ACME_CLI_INSECURE=1                 Skip TLS verification (debugging only)
-  ACME_CLI_PROXY                      HTTP(S) proxy URL
-  ACME_CLI_TIMEOUT_SECS               Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `acme-cli <resource> <method>`). Run `acme-cli <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+acme-cli <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-acme-cli <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ acme-cli <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ acme-cli <resource> <method> --format json | jq
 acme-cli --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/file-upload-openapi/README.md
+++ b/seed/cli/file-upload-openapi/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the api.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `api --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+api --help
+```
+
+Call an API endpoint:
+
+```bash
+api <resource> <method>
+```
+
+Run `api <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-api
-
-Usage: api [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  API_BASE_URL                        Override the API base URL
-  API_CA_BUNDLE                       Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  API_INSECURE=1                      Skip TLS verification (debugging only)
-  API_PROXY                           HTTP(S) proxy URL
-  API_TIMEOUT_SECS                    Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `api <resource> <method>`). Run `api <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+api <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-api <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ api <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ api <resource> <method> --format json | jq
 api --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/imdb/README.md
+++ b/seed/cli/imdb/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the api.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -27,66 +40,55 @@ export API_TOKEN="<your token>"
 
 A `.env` file in the working directory is also supported — the CLI auto-loads it on startup.
 
+## Quick start
+
+List available commands:
+
+```bash
+api --help
+```
+
+Call an API endpoint:
+
+```bash
+api <resource> <method>
+```
+
+Run `api <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-api
-
-Usage: api [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  API_TOKEN                           Bearer token for authentication
-  API_BASE_URL                        Override the API base URL
-  API_CA_BUNDLE                       Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  API_INSECURE=1                      Skip TLS verification (debugging only)
-  API_PROXY                           HTTP(S) proxy URL
-  API_TIMEOUT_SECS                    Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `api <resource> <method>`). Run `api <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+api <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-api <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -98,7 +100,7 @@ api <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -110,15 +112,11 @@ api <resource> <method> --format json | jq
 api --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 
 ```bash
 api completion <bash|zsh|fish|powershell>
 ```
-
-## Documentation
-
-See [reference.md](./reference.md) for the full command reference.
 

--- a/seed/cli/multi-url-environment-reference/README.md
+++ b/seed/cli/multi-url-environment-reference/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the multi-url-environment-reference API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -27,66 +40,55 @@ export MULTI_URL_ENVIRONMENT_REFERENCE_TOKEN="<your token>"
 
 A `.env` file in the working directory is also supported — the CLI auto-loads it on startup.
 
+## Quick start
+
+List available commands:
+
+```bash
+multi-url-environment-reference --help
+```
+
+Call an API endpoint:
+
+```bash
+multi-url-environment-reference <resource> <method>
+```
+
+Run `multi-url-environment-reference <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-multi-url-environment-reference
-
-Usage: multi-url-environment-reference [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  MULTI_URL_ENVIRONMENT_REFERENCE_TOKENBearer token for authentication
-  MULTI_URL_ENVIRONMENT_REFERENCE_BASE_URLOverride the API base URL
-  MULTI_URL_ENVIRONMENT_REFERENCE_CA_BUNDLEPath to PEM file with extra trust roots (or SSL_CERT_FILE)
-  MULTI_URL_ENVIRONMENT_REFERENCE_INSECURE=1Skip TLS verification (debugging only)
-  MULTI_URL_ENVIRONMENT_REFERENCE_PROXYHTTP(S) proxy URL
-  MULTI_URL_ENVIRONMENT_REFERENCE_TIMEOUT_SECSTotal request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `multi-url-environment-reference <resource> <method>`). Run `multi-url-environment-reference <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+multi-url-environment-reference <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-multi-url-environment-reference <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -98,7 +100,7 @@ multi-url-environment-reference <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -110,7 +112,7 @@ multi-url-environment-reference <resource> <method> --format json | jq
 multi-url-environment-reference --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/no-content-response/README.md
+++ b/seed/cli/no-content-response/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the no-content-response API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `no-content-response --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+no-content-response --help
+```
+
+Call an API endpoint:
+
+```bash
+no-content-response <resource> <method>
+```
+
+Run `no-content-response <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-no-content-response
-
-Usage: no-content-response [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  NO_CONTENT_RESPONSE_BASE_URL        Override the API base URL
-  NO_CONTENT_RESPONSE_CA_BUNDLE       Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  NO_CONTENT_RESPONSE_INSECURE=1      Skip TLS verification (debugging only)
-  NO_CONTENT_RESPONSE_PROXY           HTTP(S) proxy URL
-  NO_CONTENT_RESPONSE_TIMEOUT_SECS    Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `no-content-response <resource> <method>`). Run `no-content-response <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+no-content-response <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-no-content-response <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ no-content-response <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ no-content-response <resource> <method> --format json | jq
 no-content-response --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/null-type/README.md
+++ b/seed/cli/null-type/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the null-type API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `null-type --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+null-type --help
+```
+
+Call an API endpoint:
+
+```bash
+null-type <resource> <method>
+```
+
+Run `null-type <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-null-type
-
-Usage: null-type [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  NULL_TYPE_BASE_URL                  Override the API base URL
-  NULL_TYPE_CA_BUNDLE                 Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  NULL_TYPE_INSECURE=1                Skip TLS verification (debugging only)
-  NULL_TYPE_PROXY                     HTTP(S) proxy URL
-  NULL_TYPE_TIMEOUT_SECS              Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `null-type <resource> <method>`). Run `null-type <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+null-type <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-null-type <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ null-type <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ null-type <resource> <method> --format json | jq
 null-type --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/nullable-allof-extends/README.md
+++ b/seed/cli/nullable-allof-extends/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the Nullable AllOf Extends Test API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `nullable-allof-extends-test --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+nullable-allof-extends-test --help
+```
+
+Call an API endpoint:
+
+```bash
+nullable-allof-extends-test <resource> <method>
+```
+
+Run `nullable-allof-extends-test <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-Nullable AllOf Extends Test
-
-Usage: nullable-allof-extends-test [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  NULLABLE_ALLOF_EXTENDS_TEST_BASE_URLOverride the API base URL
-  NULLABLE_ALLOF_EXTENDS_TEST_CA_BUNDLEPath to PEM file with extra trust roots (or SSL_CERT_FILE)
-  NULLABLE_ALLOF_EXTENDS_TEST_INSECURE=1Skip TLS verification (debugging only)
-  NULLABLE_ALLOF_EXTENDS_TEST_PROXY   HTTP(S) proxy URL
-  NULLABLE_ALLOF_EXTENDS_TEST_TIMEOUT_SECSTotal request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `nullable-allof-extends-test <resource> <method>`). Run `nullable-allof-extends-test <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+nullable-allof-extends-test <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-nullable-allof-extends-test <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ nullable-allof-extends-test <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ nullable-allof-extends-test <resource> <method> --format json | jq
 nullable-allof-extends-test --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/nullable-request-body/README.md
+++ b/seed/cli/nullable-request-body/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the nullable-request-body API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `nullable-request-body --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+nullable-request-body --help
+```
+
+Call an API endpoint:
+
+```bash
+nullable-request-body <resource> <method>
+```
+
+Run `nullable-request-body <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-nullable-request-body
-
-Usage: nullable-request-body [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  NULLABLE_REQUEST_BODY_BASE_URL      Override the API base URL
-  NULLABLE_REQUEST_BODY_CA_BUNDLE     Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  NULLABLE_REQUEST_BODY_INSECURE=1    Skip TLS verification (debugging only)
-  NULLABLE_REQUEST_BODY_PROXY         HTTP(S) proxy URL
-  NULLABLE_REQUEST_BODY_TIMEOUT_SECS  Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `nullable-request-body <resource> <method>`). Run `nullable-request-body <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+nullable-request-body <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-nullable-request-body <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ nullable-request-body <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ nullable-request-body <resource> <method> --format json | jq
 nullable-request-body --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/oauth-client-credentials-openapi/README.md
+++ b/seed/cli/oauth-client-credentials-openapi/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the OAuth Client Credentials OpenAPI.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `oauth-client-credentials-openapi --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+oauth-client-credentials-openapi --help
+```
+
+Call an API endpoint:
+
+```bash
+oauth-client-credentials-openapi <resource> <method>
+```
+
+Run `oauth-client-credentials-openapi <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-OAuth Client Credentials OpenAPI
-
-Usage: oauth-client-credentials-openapi [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  OAUTH_CLIENT_CREDENTIALS_OPENAPI_BASE_URLOverride the API base URL
-  OAUTH_CLIENT_CREDENTIALS_OPENAPI_CA_BUNDLEPath to PEM file with extra trust roots (or SSL_CERT_FILE)
-  OAUTH_CLIENT_CREDENTIALS_OPENAPI_INSECURE=1Skip TLS verification (debugging only)
-  OAUTH_CLIENT_CREDENTIALS_OPENAPI_PROXYHTTP(S) proxy URL
-  OAUTH_CLIENT_CREDENTIALS_OPENAPI_TIMEOUT_SECSTotal request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `oauth-client-credentials-openapi <resource> <method>`). Run `oauth-client-credentials-openapi <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+oauth-client-credentials-openapi <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-oauth-client-credentials-openapi <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ oauth-client-credentials-openapi <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ oauth-client-credentials-openapi <resource> <method> --format json | jq
 oauth-client-credentials-openapi --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/openapi-request-body-ref/README.md
+++ b/seed/cli/openapi-request-body-ref/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the openapi-request-body-ref API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `openapi-request-body-ref --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+openapi-request-body-ref --help
+```
+
+Call an API endpoint:
+
+```bash
+openapi-request-body-ref <resource> <method>
+```
+
+Run `openapi-request-body-ref <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-openapi-request-body-ref
-
-Usage: openapi-request-body-ref [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  OPENAPI_REQUEST_BODY_REF_BASE_URL   Override the API base URL
-  OPENAPI_REQUEST_BODY_REF_CA_BUNDLE  Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  OPENAPI_REQUEST_BODY_REF_INSECURE=1 Skip TLS verification (debugging only)
-  OPENAPI_REQUEST_BODY_REF_PROXY      HTTP(S) proxy URL
-  OPENAPI_REQUEST_BODY_REF_TIMEOUT_SECSTotal request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `openapi-request-body-ref <resource> <method>`). Run `openapi-request-body-ref <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+openapi-request-body-ref <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-openapi-request-body-ref <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ openapi-request-body-ref <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ openapi-request-body-ref <resource> <method> --format json | jq
 openapi-request-body-ref --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/query-param-name-conflict/README.md
+++ b/seed/cli/query-param-name-conflict/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the Query Param Name Conflict API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `query-param-name-conflict-api --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+query-param-name-conflict-api --help
+```
+
+Call an API endpoint:
+
+```bash
+query-param-name-conflict-api <resource> <method>
+```
+
+Run `query-param-name-conflict-api <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-Query Param Name Conflict API
-
-Usage: query-param-name-conflict-api [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  QUERY_PARAM_NAME_CONFLICT_API_BASE_URLOverride the API base URL
-  QUERY_PARAM_NAME_CONFLICT_API_CA_BUNDLEPath to PEM file with extra trust roots (or SSL_CERT_FILE)
-  QUERY_PARAM_NAME_CONFLICT_API_INSECURE=1Skip TLS verification (debugging only)
-  QUERY_PARAM_NAME_CONFLICT_API_PROXY HTTP(S) proxy URL
-  QUERY_PARAM_NAME_CONFLICT_API_TIMEOUT_SECSTotal request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `query-param-name-conflict-api <resource> <method>`). Run `query-param-name-conflict-api <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+query-param-name-conflict-api <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-query-param-name-conflict-api <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ query-param-name-conflict-api <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ query-param-name-conflict-api <resource> <method> --format json | jq
 query-param-name-conflict-api --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/query-parameters-openapi-as-objects/README.md
+++ b/seed/cli/query-parameters-openapi-as-objects/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the Query Parameters API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `query-parameters-api --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+query-parameters-api --help
+```
+
+Call an API endpoint:
+
+```bash
+query-parameters-api <resource> <method>
+```
+
+Run `query-parameters-api <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-Query Parameters API
-
-Usage: query-parameters-api [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  QUERY_PARAMETERS_API_BASE_URL       Override the API base URL
-  QUERY_PARAMETERS_API_CA_BUNDLE      Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  QUERY_PARAMETERS_API_INSECURE=1     Skip TLS verification (debugging only)
-  QUERY_PARAMETERS_API_PROXY          HTTP(S) proxy URL
-  QUERY_PARAMETERS_API_TIMEOUT_SECS   Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `query-parameters-api <resource> <method>`). Run `query-parameters-api <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+query-parameters-api <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-query-parameters-api <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ query-parameters-api <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ query-parameters-api <resource> <method> --format json | jq
 query-parameters-api --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/query-parameters-openapi/github-npm/README.md
+++ b/seed/cli/query-parameters-openapi/github-npm/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the Query Parameters API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the CLI globally via npm:
@@ -29,65 +42,55 @@ cargo build --release
 
 This API requires authentication. Run `query-parameters-api --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+query-parameters-api --help
+```
+
+Call an API endpoint:
+
+```bash
+query-parameters-api <resource> <method>
+```
+
+Run `query-parameters-api <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-Query Parameters API
-
-Usage: query-parameters-api [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  QUERY_PARAMETERS_API_BASE_URL       Override the API base URL
-  QUERY_PARAMETERS_API_CA_BUNDLE      Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  QUERY_PARAMETERS_API_INSECURE=1     Skip TLS verification (debugging only)
-  QUERY_PARAMETERS_API_PROXY          HTTP(S) proxy URL
-  QUERY_PARAMETERS_API_TIMEOUT_SECS   Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `query-parameters-api <resource> <method>`). Run `query-parameters-api <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+query-parameters-api <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-query-parameters-api <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -99,7 +102,7 @@ query-parameters-api <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -111,15 +114,11 @@ query-parameters-api <resource> <method> --format json | jq
 query-parameters-api --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 
 ```bash
 query-parameters-api completion <bash|zsh|fish|powershell>
 ```
-
-## Documentation
-
-See [reference.md](./reference.md) for the full command reference.
 

--- a/seed/cli/query-parameters-openapi/no-custom-config/README.md
+++ b/seed/cli/query-parameters-openapi/no-custom-config/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the Query Parameters API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `query-parameters-api --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+query-parameters-api --help
+```
+
+Call an API endpoint:
+
+```bash
+query-parameters-api <resource> <method>
+```
+
+Run `query-parameters-api <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-Query Parameters API
-
-Usage: query-parameters-api [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  QUERY_PARAMETERS_API_BASE_URL       Override the API base URL
-  QUERY_PARAMETERS_API_CA_BUNDLE      Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  QUERY_PARAMETERS_API_INSECURE=1     Skip TLS verification (debugging only)
-  QUERY_PARAMETERS_API_PROXY          HTTP(S) proxy URL
-  QUERY_PARAMETERS_API_TIMEOUT_SECS   Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `query-parameters-api <resource> <method>`). Run `query-parameters-api <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+query-parameters-api <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-query-parameters-api <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ query-parameters-api <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,15 +106,11 @@ query-parameters-api <resource> <method> --format json | jq
 query-parameters-api --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 
 ```bash
 query-parameters-api completion <bash|zsh|fish|powershell>
 ```
-
-## Documentation
-
-See [reference.md](./reference.md) for the full command reference.
 

--- a/seed/cli/schemaless-request-body-examples/README.md
+++ b/seed/cli/schemaless-request-body-examples/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the Schemaless Request Body Examples API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `schemaless-request-body-examples-api --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+schemaless-request-body-examples-api --help
+```
+
+Call an API endpoint:
+
+```bash
+schemaless-request-body-examples-api <resource> <method>
+```
+
+Run `schemaless-request-body-examples-api <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-Schemaless Request Body Examples API
-
-Usage: schemaless-request-body-examples-api [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  SCHEMALESS_REQUEST_BODY_EXAMPLES_API_BASE_URLOverride the API base URL
-  SCHEMALESS_REQUEST_BODY_EXAMPLES_API_CA_BUNDLEPath to PEM file with extra trust roots (or SSL_CERT_FILE)
-  SCHEMALESS_REQUEST_BODY_EXAMPLES_API_INSECURE=1Skip TLS verification (debugging only)
-  SCHEMALESS_REQUEST_BODY_EXAMPLES_API_PROXYHTTP(S) proxy URL
-  SCHEMALESS_REQUEST_BODY_EXAMPLES_API_TIMEOUT_SECSTotal request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `schemaless-request-body-examples-api <resource> <method>`). Run `schemaless-request-body-examples-api <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+schemaless-request-body-examples-api <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-schemaless-request-body-examples-api <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ schemaless-request-body-examples-api <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ schemaless-request-body-examples-api <resource> <method> --format json | jq
 schemaless-request-body-examples-api --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/server-sent-events-openapi/README.md
+++ b/seed/cli/server-sent-events-openapi/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the server-sent-events-openapi.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `server-sent-events-openapi --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+server-sent-events-openapi --help
+```
+
+Call an API endpoint:
+
+```bash
+server-sent-events-openapi <resource> <method>
+```
+
+Run `server-sent-events-openapi <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-server-sent-events-openapi
-
-Usage: server-sent-events-openapi [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  SERVER_SENT_EVENTS_OPENAPI_BASE_URL Override the API base URL
-  SERVER_SENT_EVENTS_OPENAPI_CA_BUNDLEPath to PEM file with extra trust roots (or SSL_CERT_FILE)
-  SERVER_SENT_EVENTS_OPENAPI_INSECURE=1Skip TLS verification (debugging only)
-  SERVER_SENT_EVENTS_OPENAPI_PROXY    HTTP(S) proxy URL
-  SERVER_SENT_EVENTS_OPENAPI_TIMEOUT_SECSTotal request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `server-sent-events-openapi <resource> <method>`). Run `server-sent-events-openapi <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+server-sent-events-openapi <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-server-sent-events-openapi <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ server-sent-events-openapi <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ server-sent-events-openapi <resource> <method> --format json | jq
 server-sent-events-openapi --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/server-url-templating/README.md
+++ b/seed/cli/server-url-templating/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the Server URL Templating API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `server-url-templating-api --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+server-url-templating-api --help
+```
+
+Call an API endpoint:
+
+```bash
+server-url-templating-api <resource> <method>
+```
+
+Run `server-url-templating-api <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-Server URL Templating API
-
-Usage: server-url-templating-api [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  SERVER_URL_TEMPLATING_API_BASE_URL  Override the API base URL
-  SERVER_URL_TEMPLATING_API_CA_BUNDLE Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  SERVER_URL_TEMPLATING_API_INSECURE=1Skip TLS verification (debugging only)
-  SERVER_URL_TEMPLATING_API_PROXY     HTTP(S) proxy URL
-  SERVER_URL_TEMPLATING_API_TIMEOUT_SECSTotal request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `server-url-templating-api <resource> <method>`). Run `server-url-templating-api <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+server-url-templating-api <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-server-url-templating-api <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ server-url-templating-api <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ server-url-templating-api <resource> <method> --format json | jq
 server-url-templating-api --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/url-form-encoded/README.md
+++ b/seed/cli/url-form-encoded/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the URL Form Encoded API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `url-form-encoded-api --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+url-form-encoded-api --help
+```
+
+Call an API endpoint:
+
+```bash
+url-form-encoded-api <resource> <method>
+```
+
+Run `url-form-encoded-api <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-URL Form Encoded API
-
-Usage: url-form-encoded-api [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  URL_FORM_ENCODED_API_BASE_URL       Override the API base URL
-  URL_FORM_ENCODED_API_CA_BUNDLE      Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  URL_FORM_ENCODED_API_INSECURE=1     Skip TLS verification (debugging only)
-  URL_FORM_ENCODED_API_PROXY          HTTP(S) proxy URL
-  URL_FORM_ENCODED_API_TIMEOUT_SECS   Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `url-form-encoded-api <resource> <method>`). Run `url-form-encoded-api <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+url-form-encoded-api <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-url-form-encoded-api <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ url-form-encoded-api <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ url-form-encoded-api <resource> <method> --format json | jq
 url-form-encoded-api --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/webhook-audience/README.md
+++ b/seed/cli/webhook-audience/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the Webhook Audience Test API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `webhook-audience-test --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+webhook-audience-test --help
+```
+
+Call an API endpoint:
+
+```bash
+webhook-audience-test <resource> <method>
+```
+
+Run `webhook-audience-test <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-Webhook Audience Test
-
-Usage: webhook-audience-test [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  WEBHOOK_AUDIENCE_TEST_BASE_URL      Override the API base URL
-  WEBHOOK_AUDIENCE_TEST_CA_BUNDLE     Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  WEBHOOK_AUDIENCE_TEST_INSECURE=1    Skip TLS verification (debugging only)
-  WEBHOOK_AUDIENCE_TEST_PROXY         HTTP(S) proxy URL
-  WEBHOOK_AUDIENCE_TEST_TIMEOUT_SECS  Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `webhook-audience-test <resource> <method>`). Run `webhook-audience-test <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+webhook-audience-test <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-webhook-audience-test <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ webhook-audience-test <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ webhook-audience-test <resource> <method> --format json | jq
 webhook-audience-test --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 

--- a/seed/cli/x-fern-default/README.md
+++ b/seed/cli/x-fern-default/README.md
@@ -2,6 +2,19 @@
 
 Command-line interface for the x-fern-default test API.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Authentication](#authentication)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Documentation](#documentation)
+- [Advanced](#advanced)
+  - [Common flags](#common-flags)
+  - [Environment variables](#environment-variables)
+  - [Output formats](#output-formats)
+  - [Shell completion](#shell-completion)
+
 ## Installation
 
 Install the [Rust toolchain](https://rustup.rs/) if you don't have it:
@@ -21,65 +34,55 @@ cargo build --release
 
 This API requires authentication. Run `x-fern-default-test --help` for details.
 
+## Quick start
+
+List available commands:
+
+```bash
+x-fern-default-test --help
+```
+
+Call an API endpoint:
+
+```bash
+x-fern-default-test <resource> <method>
+```
+
+Run `x-fern-default-test <resource> --help` to see available methods for a resource.
+
 ## Usage
-
-```
-x-fern-default test
-
-Usage: x-fern-default-test [OPTIONS] <COMMAND>
-
-Commands:
-  ...                API resource commands (run --help to list)
-  generate-skills    Generate SKILL.md files for AI agent integration
-  completion         Generate shell completion scripts
-  man                Generate a man page (roff format)
-  help               Print this message or the help of the given subcommand(s)
-
-Options:
-      --dry-run          Validate the request locally without sending it to the API
-      --format <FORMAT>  Output format: json (default), table, yaml, csv
-      --base-url <URL>   Override the API base URL (e.g. for testing against a mock server)
-  -q, --quiet            Suppress stdout output on success (errors still go to stderr)
-  -h, --help             Print help
-  -V, --version          Print version
-
-Environment variables:
-  X_FERN_DEFAULT_TEST_BASE_URL        Override the API base URL
-  X_FERN_DEFAULT_TEST_CA_BUNDLE       Path to PEM file with extra trust roots (or SSL_CERT_FILE)
-  X_FERN_DEFAULT_TEST_INSECURE=1      Skip TLS verification (debugging only)
-  X_FERN_DEFAULT_TEST_PROXY           HTTP(S) proxy URL
-  X_FERN_DEFAULT_TEST_TIMEOUT_SECS    Total request timeout
-
-Standard env vars (HTTPS_PROXY / HTTP_PROXY / NO_PROXY / SSL_CERT_FILE) are also honored.
-```
 
 Every API resource appears as a subcommand (e.g. `x-fern-default-test <resource> <method>`). Run `x-fern-default-test <resource> --help` to see available methods.
 
-## Common flags
+Provide request parameters as flags or as JSON:
+
+```bash
+x-fern-default-test <resource> <method> --json '{"key": "value"}'
+```
+
+## Documentation
+
+See [reference.md](./reference.md) for the full command reference.
+
+## Advanced
+
+### Common flags
 
 These flags are available on every operation:
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Validate the request locally and print the HTTP request without sending it — useful for scripting and agent workflows |
-| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin); individual body fields also have their own flags |
+| `--dry-run` | Validate the request locally and print the HTTP request without sending it |
+| `--json <JSON\|->` | Supply a request body as JSON (or `-` to read stdin) |
 | `--params <JSON>` | Merge extra parameters as JSON (overrides individual flags) |
 | `--format <json\|table\|yaml\|csv>` | Output format (default `json`) |
 | `--output <PATH>` | Write binary responses to a file |
-| `--base-url <URL>` | Override the API base URL (e.g. for testing against a mock server) |
+| `--base-url <URL>` | Override the API base URL |
 | `--page-all` | Auto-paginate and stream results as NDJSON |
 | `--page-limit <N>` | Max pages to fetch when auto-paginating (default `10`) |
 | `-q, --quiet` | Suppress stdout output on success (errors still go to stderr) |
 
-### Dry run
-
-The `--dry-run` flag renders the exact HTTP request the CLI would send, without executing it. This is particularly valuable for AI agent integration — agents can validate their intent before committing to a write operation:
-
-```bash
-x-fern-default-test <resource> <method> --dry-run
-```
-
-## Environment variables
+### Environment variables
 
 | Variable | Description |
 |----------|-------------|
@@ -91,7 +94,7 @@ x-fern-default-test <resource> <method> --dry-run
 
 Standard environment variables (`HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `SSL_CERT_FILE`) are also honored.
 
-## Output formats
+### Output formats
 
 Use the global `--format` flag to control output. Supported values: `json` (default), `table`, `yaml`, `csv`.
 
@@ -103,7 +106,7 @@ x-fern-default-test <resource> <method> --format json | jq
 x-fern-default-test --help --format json | jq 'length'
 ```
 
-## Shell completion
+### Shell completion
 
 Generate shell completion scripts:
 


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-11018

Restructures the CLI generator's emitted `README.md` to follow progressive disclosure — essential info (install, auth, quick start) surfaces first, deeper config (flags, env vars, output formats, completions) is grouped under a single "Advanced" section.

## Changes Made

**`generators/cli/src/emitReadme.ts`**
- New section order: TOC → Installation → Authentication → Quick start → Usage → Documentation → Advanced
- `generateTableOfContents()` — built from merged blocks (post-merge, so customer sections appear too); `ReadmeParser` strips old TOC automatically
- `generateQuickStart()` — minimal "try it" examples (`--help`, `<resource> <method>`)
- `generateUsage()` — trimmed to subcommand pattern + `--json`; removed `buildHelpOutput`/`padEnvVar`/`describeAuthEnvVar` (only served the old `--help` dump)
- `generateAdvanced()` — single H2 collapsing Common flags / Environment variables / Output formats / Shell completion as `###` subsections
- Removed ~100 lines of help-dump generation code

**`generators/cli/src/__test__/emitReadme.test.ts`**
- 13 tests covering: progressive disclosure order, TOC generation (including customer sections), Quick start content, trimmed Usage (no `--help` dump), Advanced subsections, merge preservation, auth variants

**Seed snapshots** — 24 `README.md` files regenerated via `pnpm seed test --generator cli`

## Testing
- [x] Unit tests added/updated (13 passing)
- [x] Seed snapshot tests pass (127/127)
- [x] `pnpm run check` (biome) passes


Link to Devin session: https://app.devin.ai/sessions/27049145bbf24f5786f435f3278d6521
Requested by: @jsklan