### PR TITLE
feat(cli): co-vendor SDK crate in CLI generation pipeline

### DIFF
--- a/generators/cli/build.mjs
+++ b/generators/cli/build.mjs
@@ -58,3 +58,18 @@ try {
     // Non-fatal: the rust-model dist may not exist during a plain
     // `pnpm compile`. It's only required for `dist:cli` / Docker.
 }
+
+// Copy the pre-built rust-sdk generator CLI into dist/ so the Docker
+// image can invoke it as a child process for embedded SDK generation.
+// Same pattern as the rust-model copy above.
+try {
+    const { readlink: readlinkSdk } = await import("fs/promises");
+    const sdkSymlink = path.resolve(dirname, "node_modules", "@fern-api", "rust-sdk");
+    const sdkTarget = await readlinkSdk(sdkSymlink);
+    const rustSdkPkg = path.resolve(path.dirname(sdkSymlink), sdkTarget);
+    const rustSdkDistDir = path.join(rustSdkPkg, "dist");
+    await cp(rustSdkDistDir, path.join(dirname, "dist", "rust-sdk-dist"), { recursive: true });
+} catch (_e) {
+    // Non-fatal: the rust-sdk dist may not exist during a plain
+    // `pnpm compile`. It's only required for `dist:cli` / Docker.
+}

--- a/generators/cli/changes/unreleased/co-vendor-sdk.yml
+++ b/generators/cli/changes/unreleased/co-vendor-sdk.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Co-vendor the Rust SDK crate alongside the types crate in CLI generation.
+    When `embedSdk` is enabled (default), the pipeline invokes `@fern-api/rust-sdk`
+    in `cliEmbedded` mode to produce a `<api>-sdk` workspace member with a path
+    dependency on the types crate and a `prelude` module that re-exports all types
+    for single type identity.
+  type: feat

--- a/generators/cli/package.json
+++ b/generators/cli/package.json
@@ -39,6 +39,7 @@
     "@fern-api/generator-cli": "workspace:*",
     "@fern-api/rust-base": "workspace:*",
     "@fern-api/rust-model": "workspace:*",
+    "@fern-api/rust-sdk": "workspace:*",
     "@fern-fern/ir-sdk": "67.0.0",
     "@types/node": "catalog:",
     "commander": "^14.0.3",

--- a/generators/cli/src/__test__/customConfig.test.ts
+++ b/generators/cli/src/__test__/customConfig.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { validateCustomConfig } from "../customConfig.js";
 
 describe("validateCustomConfig", () => {
-    it("returns defaults (embedTypes: true) for null/undefined", () => {
-        expect(validateCustomConfig(null)).toEqual({ embedTypes: true });
-        expect(validateCustomConfig(undefined)).toEqual({ embedTypes: true });
+    it("returns defaults (embedTypes: true, embedSdk: true) for null/undefined", () => {
+        expect(validateCustomConfig(null)).toEqual({ embedTypes: true, embedSdk: true });
+        expect(validateCustomConfig(undefined)).toEqual({ embedTypes: true, embedSdk: true });
     });
 
     it("returns the empty result for an empty object (embedTypes resolved at pipeline level)", () => {
@@ -37,5 +37,13 @@ describe("validateCustomConfig", () => {
 
     it("throws on non-object input (array)", () => {
         expect(() => validateCustomConfig(["acme"])).toThrow(/expected an object, got array/);
+    });
+
+    it("accepts a boolean embedSdk", () => {
+        expect(validateCustomConfig({ embedSdk: false })).toEqual({ embedSdk: false });
+    });
+
+    it("throws on non-boolean embedSdk", () => {
+        expect(() => validateCustomConfig({ embedSdk: "yes" })).toThrow(/expected a boolean, got string/);
     });
 });

--- a/generators/cli/src/copySpecs.ts
+++ b/generators/cli/src/copySpecs.ts
@@ -119,6 +119,7 @@ async function scaffoldCustomRs(binDir: string, binaryName: string): Promise<voi
         // does not exist — scaffold it below
     }
     const typesCrate = `${binaryName.replace(/-/g, "_")}_types`;
+    const sdkCrate = `${binaryName.replace(/-/g, "_")}_sdk`;
     const content = [
         "//! Custom command handlers.",
         "//!",
@@ -136,6 +137,8 @@ async function scaffoldCustomRs(binDir: string, binaryName: string): Promise<voi
         "//! `execute()` methods use the CLI's native HTTP executor.",
         `//! Combine these with the typed structs from \`${typesCrate}\``,
         "//! for strongly-typed request/response serialization.",
+        `//! The SDK crate (\`${sdkCrate}\`) provides typed client helpers`,
+        "//! via `ctx.sdk_client()` (available once the runtime handle lands).",
         "",
         "use fern_cli_sdk::app::CliApp;",
         "",
@@ -169,6 +172,10 @@ async function scaffoldCustomRs(binDir: string, binaryName: string): Promise<voi
         "    //         Ok(())",
         "    //     },",
         "    // );",
+        "    //",
+        "    // SDK client usage (available after the runtime handle lands):",
+        `    // use ${sdkCrate}::prelude::*;`,
+        "    // let client = ctx.sdk_client();",
         "    app",
         "}",
         ""

--- a/generators/cli/src/customConfig.ts
+++ b/generators/cli/src/customConfig.ts
@@ -24,9 +24,21 @@ export interface FernCliCustomConfig {
      * Set to `false` to disable types generation.
      */
     embedTypes?: boolean;
+
+    /**
+     * When true (the default), the generator invokes `@fern-api/rust-sdk`
+     * in `cliEmbedded` mode to produce a `<binaryName>-sdk` library crate
+     * alongside the CLI. The SDK crate provides an HTTP client with the
+     * `RequestExecutor` trait, enabling `ctx.sdk_client()` in custom
+     * command handlers. Requires `embedTypes` to also be enabled (the SDK
+     * re-exports the types crate for single type identity).
+     *
+     * Set to `false` to disable SDK generation.
+     */
+    embedSdk?: boolean;
 }
 
-const DEFAULT_FERN_CLI_CUSTOM_CONFIG: FernCliCustomConfig = { embedTypes: true };
+const DEFAULT_FERN_CLI_CUSTOM_CONFIG: FernCliCustomConfig = { embedTypes: true, embedSdk: true };
 
 export function getCustomConfig(generatorConfig: GeneratorConfig): FernCliCustomConfig {
     if (generatorConfig.customConfig == null) {
@@ -63,6 +75,12 @@ export function validateCustomConfig(raw: unknown): FernCliCustomConfig {
             throw new Error(`Invalid customConfig.embedTypes: expected a boolean, got ${typeof obj.embedTypes}.`);
         }
         result.embedTypes = obj.embedTypes;
+    }
+    if ("embedSdk" in obj && obj.embedSdk !== undefined) {
+        if (typeof obj.embedSdk !== "boolean") {
+            throw new Error(`Invalid customConfig.embedSdk: expected a boolean, got ${typeof obj.embedSdk}.`);
+        }
+        result.embedSdk = obj.embedSdk;
     }
     return result;
 }

--- a/generators/cli/src/generateEmbeddedSdk.ts
+++ b/generators/cli/src/generateEmbeddedSdk.ts
@@ -1,0 +1,220 @@
+/**
+ * Invoke the Rust SDK generator against the same IR to produce a
+ * `<api>-sdk` library crate that the CLI crate uses as a path
+ * dependency.
+ *
+ * The generated crate contains an HTTP client with the
+ * `RequestExecutor` trait — the transport seam that lets the CLI's
+ * native executor handle all HTTP while the SDK provides typed
+ * request/response helpers. Custom command handlers use
+ * `ctx.sdk_client()` to get a fully-wired SDK instance.
+ *
+ * Single type identity: the SDK crate declares a path dependency on
+ * the co-generated `<api>-types` crate and re-exports all types via
+ * `pub use <types_crate>::*;`. This means `<api>_sdk::Pet` and
+ * `<api>_types::Pet` are the same type — no `From`/`Into` shims.
+ *
+ * Implementation note: We invoke the rust-sdk generator as a child
+ * process (same pattern as `generateEmbeddedTypes`) because the CLI
+ * generator and the rust-sdk generator pin different IR SDK versions.
+ */
+
+import { execFile } from "child_process";
+import { accessSync, constants } from "fs";
+import { mkdir, readFile, rm, unlink, writeFile } from "fs/promises";
+import { createRequire } from "module";
+import path from "path";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Generate the embedded `<api>-sdk` Rust library crate.
+ *
+ * @param irFilepath      Path to the IR JSON file on disk.
+ * @param outputDir       Absolute path to the CLI generator's output root.
+ *                        The SDK crate will be written to `<outputDir>/<sdkCrateName>/`.
+ * @param binaryName      Kebab-case CLI binary name (used to derive crate name).
+ * @param typesCrateName  Name of the co-generated types crate (e.g. `"my-api-types"`).
+ * @returns The generated crate name (e.g. `"my-api-sdk"`).
+ */
+export async function generateEmbeddedSdk(args: {
+    irFilepath: string;
+    outputDir: string;
+    binaryName: string;
+    typesCrateName: string;
+}): Promise<string> {
+    const { irFilepath, outputDir, binaryName, typesCrateName } = args;
+    const sdkCrateName = `${binaryName}-sdk`;
+    const sdkOutputDir = path.join(outputDir, sdkCrateName);
+    await mkdir(sdkOutputDir, { recursive: true });
+
+    // Write a minimal generator config that the rust-sdk CLI reads.
+    // `cliEmbedded: true` tells the SDK generator to skip model/type
+    // generation (types come from the co-generated types crate).
+    const generatorConfig = {
+        irFilepath,
+        output: {
+            path: sdkOutputDir,
+            mode: { type: "downloadFiles" as const }
+        },
+        customConfig: {
+            crateName: sdkCrateName.replace(/-/g, "_"),
+            cliEmbedded: true
+        },
+        workspaceName: binaryName,
+        organization: "",
+        environment: { _type: "local" as const, type: "local" as const },
+        dryRun: false,
+        whitelabel: false,
+        writeUnitTests: false,
+        generateOauthClients: false,
+        generatePaginatedClients: false
+    };
+
+    const configPath = path.join(sdkOutputDir, ".generator-config.json");
+    await writeFile(configPath, JSON.stringify(generatorConfig, null, 2));
+
+    const cliEntryPoint = resolveRustSdkCli();
+
+    try {
+        await execFileAsync("node", ["--enable-source-maps", cliEntryPoint, configPath], {
+            cwd: sdkOutputDir,
+            timeout: 120_000,
+            env: { ...process.env }
+        });
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`Embedded SDK generation failed: ${message}`);
+    } finally {
+        await unlink(configPath).catch((_e: unknown) => undefined);
+    }
+
+    // The rust-sdk generator produces a full crate including Cargo.toml.
+    // Patch it to add the types crate as a path dependency and write
+    // the prelude re-export for single type identity.
+    await patchSdkCrate({ sdkOutputDir, sdkCrateName, typesCrateName });
+
+    return sdkCrateName;
+}
+
+/**
+ * Patch the SDK crate after the generator runs:
+ *   1. Add path dependency on the types crate to Cargo.toml.
+ *   2. Write `src/prelude.rs` that re-exports all types.
+ *   3. Inject `pub mod prelude;` into `src/lib.rs`.
+ *   4. Remove the `.fern/` metadata directory.
+ */
+async function patchSdkCrate(args: {
+    sdkOutputDir: string;
+    sdkCrateName: string;
+    typesCrateName: string;
+}): Promise<void> {
+    const { sdkOutputDir, sdkCrateName, typesCrateName } = args;
+    const typesSnakeName = typesCrateName.replace(/-/g, "_");
+    const sdkSnakeName = sdkCrateName.replace(/-/g, "_");
+
+    // 1. Patch Cargo.toml — add types crate as a path dependency.
+    const cargoTomlPath = path.join(sdkOutputDir, "Cargo.toml");
+    let cargoToml: string;
+    try {
+        cargoToml = await readFile(cargoTomlPath, "utf-8");
+    } catch (_e: unknown) {
+        // If the SDK generator didn't produce a Cargo.toml, write a
+        // minimal one (same fallback pattern as generateEmbeddedTypes).
+        cargoToml = [
+            "[package]",
+            `name = "${sdkSnakeName}"`,
+            'version = "0.0.0"',
+            'edition = "2021"',
+            "",
+            "[lib]",
+            "doctest = false",
+            ""
+        ].join("\n");
+    }
+
+    // Insert path dependency on types crate before [profile] or at end.
+    const typesDep = `\n[dependencies.${typesSnakeName}]\npath = "../${typesCrateName}"\n`;
+    const profileIdx = cargoToml.indexOf("\n[profile.");
+    if (profileIdx !== -1) {
+        cargoToml = cargoToml.slice(0, profileIdx) + typesDep + cargoToml.slice(profileIdx);
+    } else {
+        cargoToml = cargoToml.trimEnd() + "\n" + typesDep;
+    }
+    await writeFile(cargoTomlPath, cargoToml);
+
+    // 2. Write src/prelude.rs — re-exports the types crate for single
+    //    type identity (`<sdk>::Pet` == `<types>::Pet`).
+    const srcDir = path.join(sdkOutputDir, "src");
+    await mkdir(srcDir, { recursive: true });
+    const preludeContent = `pub use ${typesSnakeName}::*;\n`;
+    await writeFile(path.join(srcDir, "prelude.rs"), preludeContent);
+
+    // 3. Inject `pub mod prelude;` into lib.rs if not already present.
+    const libPath = path.join(srcDir, "lib.rs");
+    try {
+        const libContent = await readFile(libPath, "utf-8");
+        if (!libContent.includes("pub mod prelude;")) {
+            // Insert after the header comment / first blank line.
+            const insertIdx = libContent.indexOf("\n\n");
+            if (insertIdx !== -1) {
+                const patched =
+                    libContent.slice(0, insertIdx + 2) + "pub mod prelude;\n" + libContent.slice(insertIdx + 2);
+                await writeFile(libPath, patched);
+            } else {
+                await writeFile(libPath, libContent + "\npub mod prelude;\n");
+            }
+        }
+    } catch (_e: unknown) {
+        // lib.rs doesn't exist — write a minimal one.
+        await writeFile(libPath, `//! Generated SDK by Fern\n\npub mod prelude;\n`);
+    }
+
+    // 4. Remove the .fern/ metadata directory written by the base
+    //    generator framework — not needed inside a workspace member.
+    await rm(path.join(sdkOutputDir, ".fern"), { recursive: true, force: true });
+}
+
+/**
+ * Resolve the rust-sdk generator's CLI entry point.
+ *
+ * Resolution order:
+ *   1. Bundled `rust-sdk-cli.cjs` next to the CLI generator's own
+ *      bundled entry (Docker image, after `build.mjs` copies it).
+ *   2. Monorepo workspace — `@fern-api/rust-sdk` package's compiled
+ *      `lib/cli.js` (development, after `pnpm compile`).
+ */
+function resolveRustSdkCli(): string {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const scriptDir: string = import.meta.dirname ?? (typeof __dirname !== "undefined" ? __dirname : ".");
+
+    // 1. Docker / dist:cli build — bundled in dist/rust-sdk-dist/
+    const bundled = path.resolve(scriptDir, "rust-sdk-dist", "cli.cjs");
+    try {
+        accessSync(bundled, constants.R_OK);
+        return bundled;
+    } catch (_e: unknown) {
+        // Not found — fall through to monorepo resolution.
+    }
+
+    // 2. Monorepo dev — resolve via pnpm workspace link.
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        const base = import.meta.url || (typeof __filename !== "undefined" ? `file://${__filename}` : "file:///");
+        const require = createRequire(base);
+        const sdkPkg = require.resolve("@fern-api/rust-sdk/package.json");
+        const sdkRoot = path.dirname(sdkPkg);
+        const devEntry = path.join(sdkRoot, "lib", "cli.js");
+        accessSync(devEntry, constants.R_OK);
+        return devEntry;
+    } catch (_e: unknown) {
+        // fall through
+    }
+
+    throw new Error(
+        "Could not resolve the @fern-api/rust-sdk CLI. " +
+            "Ensure `pnpm turbo run dist:cli --filter @fern-api/rust-sdk` has been run, " +
+            "or that @fern-api/rust-sdk is installed in the workspace."
+    );
+}

--- a/generators/cli/src/patchCargoToml.ts
+++ b/generators/cli/src/patchCargoToml.ts
@@ -39,13 +39,20 @@ export async function patchCargoToml(args: {
     binaryName: string;
     version?: string;
     typesCrateName?: string;
+    sdkCrateName?: string;
 }): Promise<void> {
-    const { outputDir, binaryName, version, typesCrateName } = args;
+    const { outputDir, binaryName, version, typesCrateName, sdkCrateName } = args;
     const cargoTomlPath = path.join(outputDir, "Cargo.toml");
     const contents = await readFile(cargoTomlPath, "utf-8");
 
-    if (typesCrateName != null) {
-        const patched = addTypesDependency(contents, typesCrateName);
+    if (typesCrateName != null || sdkCrateName != null) {
+        let patched = contents;
+        if (typesCrateName != null) {
+            patched = addCrateDependency(patched, typesCrateName);
+        }
+        if (sdkCrateName != null) {
+            patched = addCrateDependency(patched, sdkCrateName);
+        }
         await writeFile(cargoTomlPath, patched);
         return;
     }
@@ -95,18 +102,24 @@ export function applyCargoTomlPatch(cargoToml: string, binaryName: string, versi
 }
 
 /**
- * Append a `[dependencies.<typesCrateName>]` path dependency to the
- * Cargo.toml, linking the CLI crate to the generated types crate.
+ * Append a `[dependencies.<crateName>]` path dependency to the
+ * Cargo.toml, linking the CLI crate to a generated workspace member.
+ * Used for both the types crate and the SDK crate.
  */
-export function addTypesDependency(cargoToml: string, typesCrateName: string): string {
-    const snakeName = typesCrateName.replace(/-/g, "_");
-    const depBlock = `\n[dependencies.${snakeName}]\npath = "${typesCrateName}"\n`;
+export function addCrateDependency(cargoToml: string, crateName: string): string {
+    const snakeName = crateName.replace(/-/g, "_");
+    const depBlock = `\n[dependencies.${snakeName}]\npath = "${crateName}"\n`;
     // Append before [profile] sections if present, else at the end.
     const profileIdx = cargoToml.indexOf("\n[profile.");
     if (profileIdx !== -1) {
         return cargoToml.slice(0, profileIdx) + depBlock + cargoToml.slice(profileIdx);
     }
     return cargoToml + depBlock;
+}
+
+/** @deprecated Use {@link addCrateDependency} instead. */
+export function addTypesDependency(cargoToml: string, typesCrateName: string): string {
+    return addCrateDependency(cargoToml, typesCrateName);
 }
 
 /**
@@ -200,6 +213,71 @@ export function addTypesCrateToLock(cargoLock: string, typesCrateName: string): 
         const depsBody = match[2] ?? "";
         const depLine = ` "${snakeName}",`;
         // Parse existing deps and insert in sorted order.
+        const lines = depsBody.split("\n").filter((l) => l.trim().length > 0);
+        lines.push(depLine);
+        lines.sort((a, b) => a.trim().localeCompare(b.trim()));
+        const newDepsBody = "\n" + lines.join("\n") + "\n";
+        patched = patched.replace(fullMatch, prefix + newDepsBody + match[3]);
+    }
+
+    return patched;
+}
+
+/**
+ * Patch Cargo.lock to include the generated SDK crate as a workspace
+ * member. Same pattern as `patchCargoLockForTypes`, but the SDK crate's
+ * dependency list is different: it depends on the types crate plus
+ * reqwest, serde, serde_json, tokio, and futures (all already resolved
+ * in the lock file from the CLI SDK's own dep tree).
+ */
+export async function patchCargoLockForSdk(args: {
+    outputDir: string;
+    sdkCrateName: string;
+    typesCrateName: string;
+}): Promise<void> {
+    const { outputDir, sdkCrateName, typesCrateName } = args;
+    const lockPath = path.join(outputDir, "Cargo.lock");
+    const contents = await readFile(lockPath, "utf-8");
+    const patched = addSdkCrateToLock(contents, sdkCrateName, typesCrateName);
+    await writeFile(lockPath, patched);
+}
+
+/**
+ * Pure transformation for unit-test access.
+ */
+export function addSdkCrateToLock(cargoLock: string, sdkCrateName: string, typesCrateName: string): string {
+    const sdkSnakeName = sdkCrateName.replace(/-/g, "_");
+    const typesSnakeName = typesCrateName.replace(/-/g, "_");
+
+    // 1. Append [[package]] entry for the SDK crate. Its dependencies
+    //    include the types crate plus the HTTP client stack that the
+    //    rust-sdk generator pulls in (all already in the lockfile).
+    const packageEntry = [
+        "",
+        "[[package]]",
+        `name = "${sdkSnakeName}"`,
+        'version = "0.0.0"',
+        "dependencies = [",
+        ` "${typesSnakeName}",`,
+        ' "futures",',
+        ' "reqwest",',
+        ' "serde",',
+        ' "serde_json",',
+        ' "tokio",',
+        "]",
+        ""
+    ].join("\n");
+
+    let patched = cargoLock.trimEnd() + "\n" + packageEntry;
+
+    // 2. Add the SDK crate to fern-cli-sdk's dependency list.
+    const sdkDepsPattern = /(name = "fern-cli-sdk"\nversion = "[^"]*"\ndependencies = \[)([\s\S]*?)(\])/;
+    const match = patched.match(sdkDepsPattern);
+    if (match != null) {
+        const fullMatch = match[0];
+        const prefix = match[1] ?? "";
+        const depsBody = match[2] ?? "";
+        const depLine = ` "${sdkSnakeName}",`;
         const lines = depsBody.split("\n").filter((l) => l.trim().length > 0);
         lines.push(depLine);
         lines.sort((a, b) => a.trim().localeCompare(b.trim()));

--- a/generators/cli/src/patchDistWorkspace.ts
+++ b/generators/cli/src/patchDistWorkspace.ts
@@ -18,8 +18,12 @@ import path from "path";
  * No-op when the file doesn't exist (e.g. if a future change removes
  * the dist-workspace.toml from the SDK template entirely).
  */
-export async function patchDistWorkspaceToml(args: { outputDir: string; typesCrateName?: string }): Promise<void> {
-    const { outputDir, typesCrateName } = args;
+export async function patchDistWorkspaceToml(args: {
+    outputDir: string;
+    typesCrateName?: string;
+    sdkCrateName?: string;
+}): Promise<void> {
+    const { outputDir, typesCrateName, sdkCrateName } = args;
     const distTomlPath = path.join(outputDir, "dist-workspace.toml");
     let contents: string;
     try {
@@ -28,8 +32,14 @@ export async function patchDistWorkspaceToml(args: { outputDir: string; typesCra
         return;
     }
 
-    if (typesCrateName != null) {
-        const patched = addWorkspaceMember(contents, typesCrateName);
+    if (typesCrateName != null || sdkCrateName != null) {
+        let patched = contents;
+        if (typesCrateName != null) {
+            patched = addWorkspaceMember(patched, typesCrateName);
+        }
+        if (sdkCrateName != null) {
+            patched = addWorkspaceMember(patched, sdkCrateName);
+        }
         await writeFile(distTomlPath, patched);
         return;
     }

--- a/generators/cli/src/runPipeline.ts
+++ b/generators/cli/src/runPipeline.ts
@@ -7,10 +7,11 @@ import { detectAuthBindings } from "./detectAuth.js";
 import { emitCiWorkflow, emitPublishWorkflow } from "./emitPublishWorkflow.js";
 import { emitReadme } from "./emitReadme.js";
 import { emitReference } from "./emitReference.js";
+import { generateEmbeddedSdk } from "./generateEmbeddedSdk.js";
 import { generateEmbeddedTypes } from "./generateEmbeddedTypes.js";
 import { deriveBinaryName } from "./identity.js";
 import type { IrSummary } from "./ir.js";
-import { patchCargoLockForTypes, patchCargoToml } from "./patchCargoToml.js";
+import { patchCargoLockForSdk, patchCargoLockForTypes, patchCargoToml } from "./patchCargoToml.js";
 import { patchDistWorkspaceToml } from "./patchDistWorkspace.js";
 import type { ResolvedOutputConfig } from "./resolveOutputConfig.js";
 import { writeGitignore } from "./writeGitignore.js";
@@ -68,7 +69,10 @@ export async function runPipeline(args: {
     //      `cli/<binaryName>/`, wiring the IR-derived auth bindings.
     //   4. generateEmbeddedTypes generates the typed Rust model crate
     //      as a workspace member (path dependency from the CLI crate).
-    //   5. emitCiWorkflow / emitPublishWorkflow writes
+    //   5. generateEmbeddedSdk generates the Rust SDK crate in
+    //      cliEmbedded mode as a workspace member, with a path dep
+    //      on the types crate for single type identity.
+    //   6. emitCiWorkflow / emitPublishWorkflow writes
     //      `.github/workflows/ci.yml` when output mode is `github`.
     //      Build+test jobs are always emitted; publish jobs only when
     //      npm publish info is present.
@@ -94,16 +98,37 @@ export async function runPipeline(args: {
     });
 
     // Generate the embedded types crate (on by default; opt-out via embedTypes: false).
+    let typesCrateName: string | undefined;
     if (embedTypes && irFilepath != null) {
-        const typesCrateName = await generateEmbeddedTypes({
+        typesCrateName = await generateEmbeddedTypes({
             irFilepath,
             outputDir,
             binaryName
         });
-        await patchCargoToml({ outputDir, binaryName, typesCrateName });
-        await patchCargoLockForTypes({ outputDir, typesCrateName });
-        await patchDistWorkspaceToml({ outputDir, typesCrateName });
         await writeFernignore(outputDir, binaryName);
+    }
+
+    // Generate the embedded SDK crate (on by default; requires embedTypes).
+    let sdkCrateName: string | undefined;
+    if (customConfig.embedSdk !== false && embedTypes && irFilepath != null && typesCrateName != null) {
+        sdkCrateName = await generateEmbeddedSdk({
+            irFilepath,
+            outputDir,
+            binaryName,
+            typesCrateName
+        });
+    }
+
+    // Wire up path dependencies and workspace members for generated crates.
+    if (typesCrateName != null || sdkCrateName != null) {
+        await patchCargoToml({ outputDir, binaryName, typesCrateName, sdkCrateName });
+        if (typesCrateName != null) {
+            await patchCargoLockForTypes({ outputDir, typesCrateName });
+        }
+        if (sdkCrateName != null && typesCrateName != null) {
+            await patchCargoLockForSdk({ outputDir, sdkCrateName, typesCrateName });
+        }
+        await patchDistWorkspaceToml({ outputDir, typesCrateName, sdkCrateName });
     }
 
     if (outputConfig.isGithubOutput) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -807,6 +807,9 @@ importers:
       '@fern-api/rust-model':
         specifier: workspace:*
         version: link:../rust/model
+      '@fern-api/rust-sdk':
+        specifier: workspace:*
+        version: link:../rust/sdk
       '@fern-fern/ir-sdk':
         specifier: 67.0.0
         version: 67.0.0


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-11026
<!-- Co-vendor SDK crate in CLI generation pipeline -->

Adds `generateEmbeddedSdk` pipeline step that invokes `@fern-api/rust-sdk` in `cliEmbedded` mode to produce a `<api>-sdk` workspace member alongside the existing `<api>-types` crate. The SDK crate declares a path dependency on types and re-exports everything via `pub use <types_crate>::*;` for single type identity.

This unblocks FER-11027 (runtime handle in cli-sdk).

## Changes Made
- New `generateEmbeddedSdk.ts` — mirrors `generateEmbeddedTypes.ts` pattern; invokes rust-sdk generator as child process with `cliEmbedded: true`, patches output with `Cargo.toml` types dep + `src/prelude.rs` re-export + `pub mod prelude;` in `lib.rs`
- `customConfig.ts` — new `embedSdk?: boolean` flag (default `true`, requires `embedTypes`)
- `runPipeline.ts` — new step after `generateEmbeddedTypes`; consolidated crate wiring into single block for `patchCargoToml`/`patchCargoLock`/`patchDistWorkspace`
- `patchCargoToml.ts` — generalized `addTypesDependency` → `addCrateDependency`; new `patchCargoLockForSdk` + `addSdkCrateToLock`; `patchCargoToml` accepts `sdkCrateName`
- `patchDistWorkspace.ts` — `patchDistWorkspaceToml` accepts `sdkCrateName`
- `copySpecs.ts` — `scaffoldCustomRs` now includes SDK usage hints (`use <api>_sdk::prelude::*;`, `ctx.sdk_client()`)
- `build.mjs` — copies `@fern-api/rust-sdk` dist into `dist/rust-sdk-dist/` for Docker
- `package.json` — added `@fern-api/rust-sdk: workspace:*` dependency
- Changelog entry in `generators/cli/changes/unreleased/co-vendor-sdk.yml`

## Testing
- [x] Unit tests added/updated — `customConfig.test.ts` updated for `embedSdk` defaults + validation
- [x] All 129 existing tests pass (14 test files)
- [x] TypeScript compilation passes

Link to Devin session: https://app.devin.ai/sessions/aeb8b621dcc44c9790ca371e4a381611
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->