### PR TITLE
fix(cli): ensure process exits after generation completes

### DIFF
--- a/generators/cli/changes/unreleased/fix-process-hang.yml
+++ b/generators/cli/changes/unreleased/fix-process-hang.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix process hanging indefinitely after generation completes by
+    explicitly calling process.exit() instead of relying on the
+    event loop to drain.
+  type: fix

--- a/generators/cli/src/cli.ts
+++ b/generators/cli/src/cli.ts
@@ -83,6 +83,7 @@ async function generate(configPath: string): Promise<void> {
                     })
                 )
             );
+            throw e;
         }
     } finally {
         // Flush queued Sentry events before the process exits.

--- a/generators/cli/src/cli.ts
+++ b/generators/cli/src/cli.ts
@@ -18,15 +18,16 @@ if (pathToConfig == null) {
     throw new Error("No argument for config filepath.");
 }
 
-generate(pathToConfig)
-    .then(() => {
+(async () => {
+    try {
+        await generate(pathToConfig);
         process.exit(0);
-    })
-    .catch((e: unknown) => {
+    } catch (e: unknown) {
         // biome-ignore lint/suspicious/noConsole: fatal error on exit
         console.error("Encountered error", e);
         process.exit(1);
-    });
+    }
+})();
 
 async function generate(configPath: string): Promise<void> {
     let sentryClient: SentryClient | undefined;

--- a/generators/cli/src/cli.ts
+++ b/generators/cli/src/cli.ts
@@ -18,7 +18,15 @@ if (pathToConfig == null) {
     throw new Error("No argument for config filepath.");
 }
 
-void generate(pathToConfig);
+generate(pathToConfig)
+    .then(() => {
+        process.exit(0);
+    })
+    .catch((e: unknown) => {
+        // biome-ignore lint/suspicious/noConsole: fatal error on exit
+        console.error("Encountered error", e);
+        process.exit(1);
+    });
 
 async function generate(configPath: string): Promise<void> {
     let sentryClient: SentryClient | undefined;
@@ -75,13 +83,6 @@ async function generate(configPath: string): Promise<void> {
                 )
             );
         }
-    } catch (e) {
-        // biome-ignore lint/suspicious/noConsole: generator CLI output
-        console.error("Encountered error", e);
-        if (shouldReportToSentry(e)) {
-            await sentryClient?.captureException(e, { errorCode: resolveErrorCode(e) });
-        }
-        throw e;
     } finally {
         // Flush queued Sentry events before the process exits.
         await sentryClient?.flush();


### PR DESCRIPTION
## Description

Fix CLI generator process hanging indefinitely after generation finishes, preventing agents/automation from detecting completion.

## Changes Made

- Wrap top-level `generate()` call in an async IIFE with `process.exit(0)` on success / `process.exit(1)` on failure, replacing the fire-and-forget `void generate(pathToConfig)`
- Add `throw e` in the inner catch block after error reporting so failures propagate to the IIFE's catch handler (matches the `AbstractGeneratorCli.run()` re-throw pattern)
- Add changelog entry

**Root cause:** The `void` pattern discarded the promise and relied on the Node.js event loop draining naturally. Open handles — `@sentry/node` timers, `GeneratorNotificationService` intervals in remote mode, child-process stdio from `generateEmbeddedTypes` — kept the loop alive indefinitely.

## Testing

- `pnpm seed test --generator cli --fixture simple-api --skip-scripts --local` → exits cleanly with code 0
- `pnpm run check` (biome lint) → passes
- [x] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/688b40247ba246b29250d266f61c206f
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->