### PR TITLE
chore(seed): remove stale go-sdk oauth-client-credentials allowedFailure

### DIFF
--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -374,7 +374,5 @@ allowedFailures:
   # Dynamic snippet generation produces code that does not compile.
   - server-sent-event-examples:with-wire-tests # TODO: update wiretests geranation then remove it
 
-  # Wire tests fail at runtime.
-  - oauth-client-credentials:.
   # exhaustive:omit-empty-request-wrappers wire tests fail due to missing Authorization header
   - exhaustive:omit-empty-request-wrappers


### PR DESCRIPTION
## Description
Part of the one-by-one effort to clear go-sdk `allowedFailures`.

`oauth-client-credentials:.` is a **stale** allowed failure — it passes. The fixture runs OAuth client-credentials wire tests (`enableWireTests: true`), and the v2 OAuth wire-test generation (`core/token_provider.go`, `auth/oauth_wire_test/oauth_wire_test.go`) now produces passing tests.

## Changes Made
- Removed `oauth-client-credentials:.` from `allowedFailures` in `seed/go-sdk/seed.yml`.
- No generator code change required (hence no changelog entry).

## Testing
- [x] Ran the fixture in isolation 3x with wire tests enabled — passes every time (~36s). Seed CLI reports: "1/1 test cases succeeded unexpectedly. Consider removing the following fixtures from allowedFailures: oauth-client-credentials:.."
- [x] Confirmed regeneration produces byte-identical generated code (only local-env metadata/`go.mod` toolchain lines differ, which are not committed).
- [x] PR marked ready for review so the go-sdk seed matrix actually runs (the matrix is gated on `pull_request.draft == false`).


Link to Devin session: https://app.devin.ai/sessions/6ba63e4405694aa8ab8875f0dbfd9afc
Requested by: @iamnamananand996