### PR TITLE
chore(cli-generator): add changelog for cli-sdk sync with CliExecutor

### DIFF
--- a/generators/cli/changes/unreleased/sync-cli-sdk-executor.yml
+++ b/generators/cli/changes/unreleased/sync-cli-sdk-executor.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Sync cli-sdk runtime with CliExecutor bridge for SDK
+    execution-sharing in custom commands.
+  type: feat


### PR DESCRIPTION
## Description
Refs FER-11008

Adds an unreleased changelog entry so the release automation publishes a new cli-generator version that includes the synced `CliExecutor` runtime bridge from `fern-api/cli-sdk` (landed in the sync PR #16301).

Without this entry the sync commit sits on `main` but never triggers a Docker image publish — so `fern-cli-generator@0.12.1` is stale and doesn't contain the `sdk_executor` module.

## Changes Made
- Added `generators/cli/changes/unreleased/sync-cli-sdk-executor.yml` with a `feat` changelog entry

## Testing
- No code changes — changelog entry only

Link to Devin session: https://app.devin.ai/sessions/43902260bcd24c30a736668435461686
Requested by: @jsklan