### PR TITLE
fix(cli-generator): add @fern-api/rust-sdk#dist:cli to turbo dependency graph

### DIFF
--- a/generators/cli/changes/unreleased/fix-rust-sdk-dist-dependency.yml
+++ b/generators/cli/changes/unreleased/fix-rust-sdk-dist-dependency.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Fix Docker image build to include rust-sdk dist by adding
+    @fern-api/rust-sdk#dist:cli to turbo dependency graph.
+  type: fix

--- a/generators/cli/turbo.jsonc
+++ b/generators/cli/turbo.jsonc
@@ -3,9 +3,10 @@
     "tasks": {
         "dist:cli": {
             // cli-generator's build.mjs copies the rust-model dist/ tree
-            // into dist/rust-model-dist/ so the Docker image can invoke it
-            // as a child process for embedded types generation.
-            "dependsOn": ["^compile", "compile", "@fern-api/rust-model#dist:cli"]
+            // into dist/rust-model-dist/ and the rust-sdk dist/ tree into
+            // dist/rust-sdk-dist/ so the Docker image can invoke them as
+            // child processes for embedded types and SDK generation.
+            "dependsOn": ["^compile", "compile", "@fern-api/rust-model#dist:cli", "@fern-api/rust-sdk#dist:cli"]
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes generation-time failure: `Could not resolve the @fern-api/rust-sdk CLI` when running `fernapi/fern-cli-generator` 0.13.0 remotely.

Reproducer: https://github.com/fern-demo/petstore-fern-config/actions/runs/27043089239/job/79823288211

## Changes Made

- Added `@fern-api/rust-sdk#dist:cli` to `generators/cli/turbo.jsonc`'s `dependsOn` array so the rust-sdk dist is built before the cli-generator's `dist:cli` runs.

**Root cause:** `build.mjs` copies `@fern-api/rust-sdk/dist/` → `dist/rust-sdk-dist/` for the Docker image, but turbo never ran the rust-sdk's `dist:cli` first. The copy failed silently (try/catch), so the Docker image shipped without `rust-sdk-dist/cli.cjs`. At runtime, `resolveRustSdkCli()` threw because neither the bundled path nor workspace resolution found the entry point.

## Testing

- [x] Verified the turbo task graph now includes both `@fern-api/rust-model#dist:cli` and `@fern-api/rust-sdk#dist:cli`
- [x] The fix is a build-graph ordering issue — once released, the next Docker image will include `rust-sdk-dist/cli.cjs` and embedded SDK generation will work

Link to Devin session: https://app.devin.ai/sessions/b3bf9a013c3d4896aa9e8ccf7dab2127
Requested by: @jsklan