### PR TITLE
fix(cli-generator): re-export types crate in api/mod.rs for cliEmbedded mode

### DIFF
--- a/generators/cli/changes/unreleased/fix-cli-embedded-types-reexport.yml
+++ b/generators/cli/changes/unreleased/fix-cli-embedded-types-reexport.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix compilation failure in cliEmbedded mode by re-exporting the
+    co-generated types crate in api/mod.rs so service resource files
+    can resolve request/response types via `use crate::api::*`.
+  type: fix

--- a/generators/cli/src/generateEmbeddedSdk.ts
+++ b/generators/cli/src/generateEmbeddedSdk.ts
@@ -151,6 +151,20 @@ async function patchSdkCrate(args: {
     const preludeContent = `pub use ${typesSnakeName}::*;\n`;
     await writeFile(path.join(srcDir, "prelude.rs"), preludeContent);
 
+    // 2b. Patch src/api/mod.rs — re-export the types crate so that
+    //     service resource files (`use crate::api::*;`) can resolve
+    //     request/response types from the co-generated types crate.
+    const apiModPath = path.join(srcDir, "api", "mod.rs");
+    try {
+        const apiModContent = await readFile(apiModPath, "utf-8");
+        const typesReExport = `pub use ${typesSnakeName}::*;`;
+        if (!apiModContent.includes(typesReExport)) {
+            await writeFile(apiModPath, apiModContent.trimEnd() + `\n\n${typesReExport}\n`);
+        }
+    } catch (_e: unknown) {
+        // api/mod.rs doesn't exist — nothing to patch.
+    }
+
     // 3. Inject `pub mod prelude;` into lib.rs if not already present.
     const libPath = path.join(srcDir, "lib.rs");
     try {


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-11008

Fixes a compilation failure in CLI-generated Rust SDKs when `cliEmbedded: true`. Service resource files (`pets.rs`, `auth.rs`) use `use crate::api::*;` to resolve request/response types, but `api/mod.rs` never re-exported the co-generated types crate, causing E0425 errors for types like `Pet`, `CreatePetRequest`, `GetTokenAuthRequest`, etc.

## Changes Made
- Added step 2b in `patchSdkCrate()` (`generateEmbeddedSdk.ts`) that appends `pub use <types_crate>::*;` to `api/mod.rs` after SDK generation, making types available through `crate::api::*`
- [x] Updated README.md generator (if applicable) — N/A

## Testing
- [x] Unit tests added/updated — all 129 existing CLI generator tests pass
- [x] Manual testing completed:
  - Built local Docker image via `seed img cli --version 99.99.99`
  - Ran `fern generate --group cli --preview --local` against `petstore-fern-config`
  - Verified `cargo check`, `cargo build`, and `cargo test` (1238 tests) all pass on the generated SDK
  - Before fix: compilation failed with E0425 on all type references in service resources
  - After fix: `api/mod.rs` includes `pub use petstore_api_types::*;` and all types resolve correctly

Link to Devin session: https://app.devin.ai/sessions/1c0e75f432934927a646a51056131d78
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->