### PR TITLE
fix(cli): add request timeouts to `fern docs md generate` to prevent hanging

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-library-docs-generate-hang.yml
+++ b/packages/cli/cli/changes/unreleased/fix-library-docs-generate-hang.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Add per-request timeouts to `fern docs md generate` HTTP calls so the CLI
+    exits with a clear error instead of hanging indefinitely when the server is
+    slow or unreachable (30s per API request, 60s for IR download).
+  type: fix

--- a/packages/cli/library-docs-generator/src/orchestrate.ts
+++ b/packages/cli/library-docs-generator/src/orchestrate.ts
@@ -68,9 +68,8 @@ export function createLibraryDocsClient({ token }: { token: string }): LibraryDo
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
-        let response: Response;
         try {
-            response = await fetch(`${docsBase}${path}`, {
+            const response = await fetch(`${docsBase}${path}`, {
                 method,
                 headers: {
                     Authorization: `Bearer ${token}`,
@@ -79,6 +78,13 @@ export function createLibraryDocsClient({ token }: { token: string }): LibraryDo
                 body: body != null ? JSON.stringify(body) : undefined,
                 signal: controller.signal
             });
+
+            if (!response.ok) {
+                const text = await response.text().catch(() => "");
+                throw new CliError({ message: `HTTP ${response.status}: ${text}`, code: CliError.Code.NetworkError });
+            }
+
+            return (await response.json()) as T;
         } catch (error: unknown) {
             if (isAbortError(error)) {
                 throw new CliError({
@@ -90,13 +96,6 @@ export function createLibraryDocsClient({ token }: { token: string }): LibraryDo
         } finally {
             clearTimeout(timer);
         }
-
-        if (!response.ok) {
-            const text = await response.text().catch(() => "");
-            throw new CliError({ message: `HTTP ${response.status}: ${text}`, code: CliError.Code.NetworkError });
-        }
-
-        return (await response.json()) as T;
     }
 
     return {
@@ -438,15 +437,28 @@ async function downloadIr(
     const downloadController = new AbortController();
     const downloadTimer = setTimeout(() => downloadController.abort(), DOWNLOAD_TIMEOUT_MS);
 
-    let irFetchResponse: Response;
+    let ir: unknown;
     try {
-        irFetchResponse = await fetch(resultUrl, { signal: downloadController.signal });
+        const irFetchResponse = await fetch(resultUrl, { signal: downloadController.signal });
+
+        if (!irFetchResponse.ok) {
+            throw new CliError({
+                message: `Failed to download IR for library '${libraryName}': HTTP ${irFetchResponse.status}`,
+                code: CliError.Code.NetworkError
+            });
+        }
+
+        const irWrapper = (await irFetchResponse.json()) as { ir?: unknown };
+        ir = irWrapper.ir;
     } catch (error: unknown) {
         if (isAbortError(error)) {
             throw new CliError({
                 message: `IR download timed out for library '${libraryName}' after ${DOWNLOAD_TIMEOUT_MS / 1000}s`,
                 code: CliError.Code.NetworkError
             });
+        }
+        if (error instanceof CliError) {
+            throw error;
         }
         throw new CliError({
             message: `Failed to download IR for library '${libraryName}': ${extractErrorMessage(error)}`,
@@ -455,16 +467,6 @@ async function downloadIr(
     } finally {
         clearTimeout(downloadTimer);
     }
-
-    if (!irFetchResponse.ok) {
-        throw new CliError({
-            message: `Failed to download IR for library '${libraryName}': HTTP ${irFetchResponse.status}`,
-            code: CliError.Code.NetworkError
-        });
-    }
-
-    const irWrapper = (await irFetchResponse.json()) as { ir?: unknown };
-    const ir = irWrapper.ir;
 
     if (ir == null) {
         throw new CliError({

--- a/packages/cli/library-docs-generator/src/orchestrate.ts
+++ b/packages/cli/library-docs-generator/src/orchestrate.ts
@@ -12,6 +12,8 @@ import type { CppLibraryDocsIr } from "./types/CppLibraryDocsIr.js";
 
 const POLL_INTERVAL_MS = 3000;
 const POLL_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
+const REQUEST_TIMEOUT_MS = 30_000; // 30 seconds per HTTP request
+const DOWNLOAD_TIMEOUT_MS = 60_000; // 60 seconds for downloading IR
 
 type LibraryLanguage = "PYTHON" | "CPP";
 
@@ -63,14 +65,31 @@ export function createLibraryDocsClient({ token }: { token: string }): LibraryDo
     const docsBase = `${baseUrl}/v2/registry/docs`;
 
     async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
-        const response = await fetch(`${docsBase}${path}`, {
-            method,
-            headers: {
-                Authorization: `Bearer ${token}`,
-                "Content-Type": "application/json"
-            },
-            body: body != null ? JSON.stringify(body) : undefined
-        });
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+        let response: Response;
+        try {
+            response = await fetch(`${docsBase}${path}`, {
+                method,
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json"
+                },
+                body: body != null ? JSON.stringify(body) : undefined,
+                signal: controller.signal
+            });
+        } catch (error: unknown) {
+            if (isAbortError(error)) {
+                throw new CliError({
+                    message: `Request to ${method} ${path} timed out after ${REQUEST_TIMEOUT_MS / 1000}s`,
+                    code: CliError.Code.NetworkError
+                });
+            }
+            throw error;
+        } finally {
+            clearTimeout(timer);
+        }
 
         if (!response.ok) {
             const text = await response.text().catch(() => "");
@@ -91,6 +110,10 @@ export function createLibraryDocsClient({ token }: { token: string }): LibraryDo
             return request("GET", `/library-docs/result/${input.jobId}`);
         }
     };
+}
+
+function isAbortError(error: unknown): boolean {
+    return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError");
 }
 
 function isGitLibraryInput(
@@ -412,7 +435,27 @@ async function downloadIr(
         });
     }
 
-    const irFetchResponse = await fetch(resultUrl);
+    const downloadController = new AbortController();
+    const downloadTimer = setTimeout(() => downloadController.abort(), DOWNLOAD_TIMEOUT_MS);
+
+    let irFetchResponse: Response;
+    try {
+        irFetchResponse = await fetch(resultUrl, { signal: downloadController.signal });
+    } catch (error: unknown) {
+        if (isAbortError(error)) {
+            throw new CliError({
+                message: `IR download timed out for library '${libraryName}' after ${DOWNLOAD_TIMEOUT_MS / 1000}s`,
+                code: CliError.Code.NetworkError
+            });
+        }
+        throw new CliError({
+            message: `Failed to download IR for library '${libraryName}': ${extractErrorMessage(error)}`,
+            code: CliError.Code.NetworkError
+        });
+    } finally {
+        clearTimeout(downloadTimer);
+    }
+
     if (!irFetchResponse.ok) {
         throw new CliError({
             message: `Failed to download IR for library '${libraryName}': HTTP ${irFetchResponse.status}`,


### PR DESCRIPTION
## Description

Refs: Nvidia #21191 — `fern docs md generate` hangs in CI when the FDR server is slow or unreachable.

The library docs HTTP client (`createLibraryDocsClient`) used plain `fetch()` with no `AbortController`, so the CLI hung indefinitely when the server didn't respond. The 3-minute polling deadline was also bypassed because a single hanging fetch prevented the `while` loop from re-checking `Date.now() < deadline`.

## Changes Made

- Add `AbortController` with 30s timeout to every API request in `createLibraryDocsClient`
- Add `AbortController` with 60s timeout to the IR download `fetch` in `downloadIr`
- Add `isAbortError` helper for robust abort detection across Node.js versions
- Clear timeouts in `finally` blocks to avoid timer leaks

Constants: `REQUEST_TIMEOUT_MS = 30_000`, `DOWNLOAD_TIMEOUT_MS = 60_000`

## Testing

- [x] All 355 existing unit tests pass (`pnpm turbo run test --filter @fern-api/library-docs-generator`)
- [x] Lint passes (`pnpm run check`)
- [x] Manual code review — abort signals are passed to fetch, timeouts are cleaned up in `finally` blocks

Link to Devin session: https://app.devin.ai/sessions/f0cb107e5a9e4aceb76d7805e38a5b46
Requested by: @cdonel707
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->