### PR TITLE
fix(deps): bump pip to 26.1.2 to fix CVE-2026-8643 in python-sdk-generator container

### DIFF
--- a/generators/python/pydantic/Dockerfile
+++ b/generators/python/pydantic/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update \
 ENV PYTHONPATH=${PYTHONPATH}:${PWD}
 ENV _TYPER_STANDARD_TRACEBACK=1
 
+# Upgrade pip to fix CVE-2026-8643 (directory traversal via malicious wheel
+# entry-point names).
+RUN pip3 install --upgrade pip==26.1.2
 # Keep in sync with the poetry-core version in pyproject.toml.
 RUN pip3 install poetry==2.4.1
 RUN poetry config virtualenvs.create false

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -86,9 +86,10 @@ RUN ruff --version
 ENV PYTHONPATH=${PYTHONPATH}:${PWD}
 ENV _TYPER_STANDARD_TRACEBACK=1
 
-# Upgrade pip to 26.1+ to address CVE-2025-8869, CVE-2026-3219, CVE-2026-6357,
-# and CVE-2026-1703 (self-update flaw running after wheel install).
-RUN pip3 install --upgrade pip==26.1
+# Upgrade pip to 26.1.2+ to address CVE-2025-8869, CVE-2026-3219, CVE-2026-6357,
+# CVE-2026-1703 (self-update flaw running after wheel install), and
+# CVE-2026-8643 (directory traversal via malicious wheel entry-point names).
+RUN pip3 install --upgrade pip==26.1.2
 # Keep in sync with the poetry-core version in pyproject.toml.
 RUN pip3 install poetry==2.4.1
 RUN poetry config virtualenvs.create false

--- a/generators/python/sdk/changes/unreleased/bump-pip-cve-2026-8643.yml
+++ b/generators/python/sdk/changes/unreleased/bump-pip-cve-2026-8643.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump pip from 26.1 to 26.1.2 in the container to fix CVE-2026-8643
+    (directory traversal via malicious wheel entry-point names).
+  type: chore


### PR DESCRIPTION
## Description

Bumps pip from 26.1 to 26.1.2 in the python-sdk-generator and pydantic-model containers to fix CVE-2026-8643 (directory traversal via malicious wheel entry-point names).

CVE details: pip would treat `console_scripts` and `gui_scripts` as paths instead of file names without sanitizing the resolved absolute path to the installation directory, leading to entry points being installed outside the installation directory.

Fix: https://github.com/pypa/pip/pull/14000

## Changes Made

- `generators/python/sdk/Dockerfile`: bump `pip==26.1` → `pip==26.1.2`, update comment listing addressed CVEs
- `generators/python/pydantic/Dockerfile`: add `pip3 install --upgrade pip==26.1.2` (previously relied on base-image default)

## Testing

- Dockerfile-only change; no generator logic affected
- CI will verify the container builds successfully with the new pip version

Link to Devin session: https://app.devin.ai/sessions/3b71f975ffde4f43b1f2cb40fb2bd422
Requested by: @davidkonigsberg