### PR TITLE
chore(seed): add cli generator to automated seed update workflow

### DIFF
--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -22,6 +22,7 @@ on:
           - swift
           - rust
           - openapi
+          - cli
       commit-on-failure:
         description: 'Commit successful seed changes even if some seed runs fail'
         required: false
@@ -141,7 +142,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        generator-name: [seed, ruby-v2, openapi, python, java, typescript, go, csharp, php, swift, rust]
+        generator-name: [seed, ruby-v2, openapi, python, java, typescript, go, csharp, php, swift, rust, cli]
         include:
           - files: |
               packages/seed/
@@ -201,6 +202,10 @@ jobs:
               seed/rust-model/
               seed/rust-sdk/
             generator-name: rust
+          - files: |
+              generators/cli/
+              seed/cli/
+            generator-name: cli
     outputs:
       seed: ${{ steps.set-output.outputs.seed-changes }}
       ruby-v2: ${{ steps.set-output.outputs.ruby-v2-changes }}
@@ -213,6 +218,7 @@ jobs:
       php: ${{ steps.set-output.outputs.php-changes }}
       swift: ${{ steps.set-output.outputs.swift-changes }}
       rust: ${{ steps.set-output.outputs.rust-changes }}
+      cli: ${{ steps.set-output.outputs.cli-changes }}
 
     steps:
       - name: Checkout Files
@@ -291,6 +297,7 @@ jobs:
       swift-sdk: ${{ steps.create-dynamic-matrix.outputs.swift-sdk-test-matrix }}
       rust-model: ${{ steps.create-dynamic-matrix.outputs.rust-model-test-matrix }}
       rust-sdk: ${{ steps.create-dynamic-matrix.outputs.rust-sdk-test-matrix }}
+      cli: ${{ steps.create-dynamic-matrix.outputs.cli-test-matrix }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -315,7 +322,7 @@ jobs:
           # so the seed CLI does not error with "Generators X not found" when building
           # the test matrix. Their per-generator seed-update jobs below are already
           # gated with `if: false # generator not actively supported`.
-          GENERATORS="ruby-sdk-v2 python-sdk openapi java-sdk ts-sdk go-sdk csharp-sdk php-sdk swift-sdk rust-sdk"
+          GENERATORS="ruby-sdk-v2 python-sdk openapi java-sdk ts-sdk go-sdk csharp-sdk php-sdk swift-sdk rust-sdk cli"
           
           # Process each generator and set its output
           for GEN in $GENERATORS; do
@@ -919,6 +926,42 @@ jobs:
           dockerhub-username: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY }}
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
+  cli-seed-update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: [changes, setup, get-all-test-matrices]
+    if: >-
+      ${{ 
+        always() && !cancelled() &&
+        (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'cli') &&
+        (github.event_name == 'workflow_dispatch' || needs.changes.outputs.cli == 'true' || needs.changes.outputs.seed == 'true') &&
+        needs.get-all-test-matrices.outputs.cli != ''
+      }}
+    strategy:
+      fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
+      max-parallel: 15 # Limit the number of runners for this job
+      matrix:
+        include: ${{ fromJSON(needs.get-all-test-matrices.outputs.cli) }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github/actions/
+
+      - name: Update seed
+        uses: ./.github/actions/auto-update-seed
+        with:
+          generator-name: cli
+          generator-path: generators/cli
+          allow-unexpected-failures: true
+          fixtures-to-run: ${{ toJson(matrix.fixtures) }}
+          index: ${{ strategy.job-index }}
+          skip-scripts: ${{ needs.setup.outputs.skip-scripts }}
+          dockerhub-username: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY }}
+          dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
+
   # Use always() to ensure this runs even if stages from needs are skipped.
   # By default, block on failures. If commit-on-failure is true, continue even if some seed runs fail.
   commit-seed-changes-by-push:
@@ -946,7 +989,8 @@ jobs:
         php-sdk-seed-update,
         swift-sdk-seed-update,
         rust-model-seed-update,
-        rust-sdk-seed-update
+        rust-sdk-seed-update,
+        cli-seed-update
       ]
     runs-on: ubuntu-latest
 
@@ -1029,7 +1073,8 @@ jobs:
         php-sdk-seed-update,
         swift-sdk-seed-update,
         rust-model-seed-update,
-        rust-sdk-seed-update
+        rust-sdk-seed-update,
+        cli-seed-update
       ]
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Description

The cli generator (`seed/cli/`, image `fernapi/fern-cli-generator`) had seed fixtures and a `seed.yml` config but was not wired into the automated `update-seed.yml` workflow that all other generators use. This PR adds it.

## Changes Made

All changes are in `.github/workflows/update-seed.yml`:

- Added `cli` to the `language` dropdown in `workflow_dispatch` inputs
- Added `cli` to the `changes` detection matrix (watches `generators/cli/` and `seed/cli/`)
- Added `cli` output to the `changes` job outputs
- Added `cli` to `get-all-test-matrices` outputs and the `GENERATORS` list in the dynamic matrix step
- Added `cli-seed-update` job (same pattern as `rust-sdk-seed-update` et al.)
- Added `cli-seed-update` to the `needs` list in both `commit-seed-changes-by-push` and `commit-seed-changes-by-pr`

## Testing

- [x] Verified the new job structure mirrors existing generator seed-update jobs exactly
- [x] No code changes; workflow-only change validated by reviewing the diff

Link to Devin session: https://app.devin.ai/sessions/8bd5243945a643d09db027f93e015c4f
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->