### PR TITLE
fix(cli-generator): add --locked to cargo commands in emitted CI workflow

### DIFF
--- a/generators/cli/changes/unreleased/enforce-lockfile-in-ci-workflow.yml
+++ b/generators/cli/changes/unreleased/enforce-lockfile-in-ci-workflow.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Add `--locked` to cargo check/build/test commands in generated CI workflow
+    so dependency resolution matches the committed lockfile (consistent with the
+    publish job which already used `--locked`).
+  type: fix

--- a/generators/cli/src/emitPublishWorkflow.ts
+++ b/generators/cli/src/emitPublishWorkflow.ts
@@ -88,7 +88,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Check
-        run: cargo check
+        run: cargo check --locked
 
   compile:
     runs-on: ubuntu-latest
@@ -100,7 +100,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Compile
-        run: cargo build
+        run: cargo build --locked
 
   test:
     runs-on: ubuntu-latest
@@ -112,7 +112,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Test
-        run: cargo test
+        run: cargo test --locked
 `;
 }
 
@@ -168,7 +168,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Check
-        run: cargo check
+        run: cargo check --locked
 
   compile:
     runs-on: ubuntu-latest
@@ -180,7 +180,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Compile
-        run: cargo build
+        run: cargo build --locked
 
   test:
     runs-on: ubuntu-latest
@@ -192,7 +192,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Test
-        run: cargo test
+        run: cargo test --locked
 
   publish:
     needs: [check, compile, test]

--- a/seed/cli/query-parameters-openapi/github-no-publish/.github/workflows/ci.yml
+++ b/seed/cli/query-parameters-openapi/github-no-publish/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Check
-        run: cargo check
+        run: cargo check --locked
 
   compile:
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Compile
-        run: cargo build
+        run: cargo build --locked
 
   test:
     runs-on: ubuntu-latest
@@ -44,4 +44,4 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Test
-        run: cargo test
+        run: cargo test --locked

--- a/seed/cli/query-parameters-openapi/github-npm/.github/workflows/ci.yml
+++ b/seed/cli/query-parameters-openapi/github-npm/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Check
-        run: cargo check
+        run: cargo check --locked
 
   compile:
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Compile
-        run: cargo build
+        run: cargo build --locked
 
   test:
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Test
-        run: cargo test
+        run: cargo test --locked
 
   publish:
     needs: [check, compile, test]


### PR DESCRIPTION
## Description

The generated `.github/workflows/ci.yml` emitted by the CLI generator used bare `cargo check`/`cargo build`/`cargo test` in the check/compile/test jobs, allowing dependency re-resolution against the lockfile. The publish job already used `--locked`. This aligns all jobs to enforce the committed lockfile, matching what `seed.yml` does.

## Changes Made
- Added `--locked` to `cargo check`, `cargo build`, and `cargo test` in both `constructBuildTestYaml` and `constructWorkflowYaml` in `emitPublishWorkflow.ts`
- Updated seed snapshot outputs for `github-npm` and `github-no-publish` fixtures

## Testing
- [x] Unit tests pass (129/129 in `generators/cli`)
- [x] Seed snapshots updated to reflect the new `--locked` flag

Link to Devin session: https://app.devin.ai/sessions/acfe2c45830e44e0af353ae6bbf276f5
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->