### PR TITLE
fix(openapi): check x-fern-server-name extension in getEndpointBaseUrls()

### DIFF
--- a/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts
+++ b/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/OperationConverter.ts
@@ -1036,6 +1036,16 @@ export class OperationConverter extends AbstractOperationConverter {
     }
 
     private getEndpointBaseUrls(): string[] | undefined {
+        const serverFromOperationNameExtension = new Extensions.ServerFromOperationNameExtension({
+            breadcrumbs: this.breadcrumbs,
+            operation: this.operation,
+            context: this.context
+        });
+        const serverFromOperationName = serverFromOperationNameExtension.convert();
+        if (serverFromOperationName != null) {
+            return undefined;
+        }
+
         const operationServers = this.operation.servers ?? this.pathLevelServers;
         if (operationServers == null) {
             return undefined;

--- a/packages/cli/cli/changes/unreleased/fix-v3-importer-server-name-v2baseurls.yml
+++ b/packages/cli/cli/changes/unreleased/fix-v3-importer-server-name-v2baseurls.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix v3 OpenAPI importer to check `x-fern-server-name` extension in `getEndpointBaseUrls()`,
+    preventing path-level server descriptions from being misinterpreted as base URL IDs when the
+    extension is present.
+  type: fix


### PR DESCRIPTION
## Description

Fixes a bug in the v3 OpenAPI importer where `getEndpointBaseUrls()` does not check the `x-fern-server-name` extension before processing path-level servers. This causes path-level server descriptions (e.g. "Production", "UAT") to be misinterpreted as base URL IDs, leading to a 500 error during `fern docs dev` when those IDs don't exist in the environment config.

The sibling method `getEndpointBaseUrl()` (singular) already checks this extension — this PR mirrors that logic in the plural variant.

## Changes Made

- Added `x-fern-server-name` extension check at the top of `getEndpointBaseUrls()` in `OperationConverter.ts`
- When the extension is present, returns `undefined` so the singular `baseUrl` (which correctly resolves to the named URL like `"identity"`) is used instead of path-level server descriptions

## Testing

- [x] Manual testing: `fern export` against customer config (Production/UAT × api/identity) produces correct 4-server output
- [x] Manual testing: `fern docs dev` against proposed-new-spec renders without 500 error (previously crashed with "Encountered undefined server name 'Production'")
- [x] Manual testing: endpoint pages show Production/UAT environment dropdown working correctly
- [x] `pnpm check` passes (Biome checked 4823 files, no issues)

Link to Devin session: https://app.devin.ai/sessions/3bf7706646b64004b70de6606a7badc6
Requested by: @iamnamananand996