### PR TITLE
fix(cli-generator): gracefully skip embedded SDK/types when CLI unavailable

### DIFF
--- a/generators/cli/changes/unreleased/fix-embedded-sdk-resolution.yml
+++ b/generators/cli/changes/unreleased/fix-embedded-sdk-resolution.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Gracefully skip embedded SDK/types generation when the bundled CLI is
+    unavailable instead of crashing the entire generation pipeline.
+  type: fix

--- a/generators/cli/src/generateEmbeddedSdk.ts
+++ b/generators/cli/src/generateEmbeddedSdk.ts
@@ -29,6 +29,16 @@ import { promisify } from "util";
 const execFileAsync = promisify(execFile);
 
 /**
+ * Returns true if the rust-sdk CLI can be resolved — i.e. the bundled
+ * dist exists (Docker) or the monorepo workspace package is compiled.
+ * Used by the pipeline to decide whether to enable SDK-related codegen
+ * steps *before* generating the SDK crate itself.
+ */
+export function isRustSdkCliAvailable(): boolean {
+    return resolveRustSdkCli() != null;
+}
+
+/**
  * Generate the embedded `<api>-sdk` Rust library crate.
  *
  * @param irFilepath      Path to the IR JSON file on disk.
@@ -36,15 +46,22 @@ const execFileAsync = promisify(execFile);
  *                        The SDK crate will be written to `<outputDir>/<sdkCrateName>/`.
  * @param binaryName      Kebab-case CLI binary name (used to derive crate name).
  * @param typesCrateName  Name of the co-generated types crate (e.g. `"my-api-types"`).
- * @returns The generated crate name (e.g. `"my-api-sdk"`).
+ * @returns The generated crate name, or undefined if the CLI is unavailable.
  */
+
 export async function generateEmbeddedSdk(args: {
     irFilepath: string;
     outputDir: string;
     binaryName: string;
     typesCrateName: string;
-}): Promise<string> {
+}): Promise<string | undefined> {
     const { irFilepath, outputDir, binaryName, typesCrateName } = args;
+
+    const cliEntryPoint = resolveRustSdkCli();
+    if (cliEntryPoint == null) {
+        return undefined;
+    }
+
     const sdkCrateName = `${binaryName}-sdk`;
     const sdkOutputDir = path.join(outputDir, sdkCrateName);
     await mkdir(sdkOutputDir, { recursive: true });
@@ -74,8 +91,6 @@ export async function generateEmbeddedSdk(args: {
 
     const configPath = path.join(sdkOutputDir, ".generator-config.json");
     await writeFile(configPath, JSON.stringify(generatorConfig, null, 2));
-
-    const cliEntryPoint = resolveRustSdkCli();
 
     try {
         await execFileAsync("node", ["--enable-source-maps", cliEntryPoint, configPath], {
@@ -199,7 +214,7 @@ async function patchSdkCrate(args: {
  *   2. Monorepo workspace — `@fern-api/rust-sdk` package's compiled
  *      `lib/cli.js` (development, after `pnpm compile`).
  */
-function resolveRustSdkCli(): string {
+function resolveRustSdkCli(): string | undefined {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const scriptDir: string = import.meta.dirname ?? (typeof __dirname !== "undefined" ? __dirname : ".");
 
@@ -226,9 +241,5 @@ function resolveRustSdkCli(): string {
         // fall through
     }
 
-    throw new Error(
-        "Could not resolve the @fern-api/rust-sdk CLI. " +
-            "Ensure `pnpm turbo run dist:cli --filter @fern-api/rust-sdk` has been run, " +
-            "or that @fern-api/rust-sdk is installed in the workspace."
-    );
+    return undefined;
 }

--- a/generators/cli/src/generateEmbeddedTypes.ts
+++ b/generators/cli/src/generateEmbeddedTypes.ts
@@ -27,20 +27,34 @@ import { promisify } from "util";
 const execFileAsync = promisify(execFile);
 
 /**
+ * Returns true if the rust-model CLI can be resolved — i.e. the bundled
+ * dist exists (Docker) or the monorepo workspace package is compiled.
+ */
+export function isRustModelCliAvailable(): boolean {
+    return resolveRustModelCli() != null;
+}
+
+/**
  * Generate the embedded `<api>-types` Rust library crate (types only).
  *
  * @param irFilepath Path to the IR JSON file on disk.
  * @param outputDir  Absolute path to the CLI generator's output root.
  *                   The types crate will be written to `<outputDir>/<typesCrateName>/`.
  * @param binaryName Kebab-case CLI binary name (used to derive crate name).
- * @returns The generated crate name (e.g. `"my-api-types"`).
+ * @returns The generated crate name, or undefined if the CLI is unavailable.
  */
 export async function generateEmbeddedTypes(args: {
     irFilepath: string;
     outputDir: string;
     binaryName: string;
-}): Promise<string> {
+}): Promise<string | undefined> {
     const { irFilepath, outputDir, binaryName } = args;
+
+    const cliEntryPoint = resolveRustModelCli();
+    if (cliEntryPoint == null) {
+        return undefined;
+    }
+
     const typesCrateName = `${binaryName}-types`;
     const typesOutputDir = path.join(outputDir, typesCrateName);
     await mkdir(typesOutputDir, { recursive: true });
@@ -68,8 +82,6 @@ export async function generateEmbeddedTypes(args: {
 
     const configPath = path.join(typesOutputDir, ".generator-config.json");
     await writeFile(configPath, JSON.stringify(generatorConfig, null, 2));
-
-    const cliEntryPoint = resolveRustModelCli();
 
     try {
         await execFileAsync("node", ["--enable-source-maps", cliEntryPoint, configPath], {
@@ -305,7 +317,7 @@ function resolveAsIsDir(): string {
  *   2. Monorepo workspace — `@fern-api/rust-model` package's compiled
  *      `lib/cli.js` (development, after `pnpm compile`).
  */
-function resolveRustModelCli(): string {
+function resolveRustModelCli(): string | undefined {
     // Resolve the directory containing this script. In the CJS bundle
     // `import.meta` is empty so we fall back to Node's native `__dirname`.
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -335,9 +347,5 @@ function resolveRustModelCli(): string {
         // fall through
     }
 
-    throw new Error(
-        "Could not resolve the @fern-api/rust-model CLI. " +
-            "Ensure `pnpm turbo run dist:cli --filter @fern-api/rust-model` has been run, " +
-            "or that @fern-api/rust-model is installed in the workspace."
-    );
+    return undefined;
 }

--- a/generators/cli/src/runPipeline.ts
+++ b/generators/cli/src/runPipeline.ts
@@ -7,8 +7,8 @@ import { detectAuthBindings } from "./detectAuth.js";
 import { emitCiWorkflow, emitPublishWorkflow } from "./emitPublishWorkflow.js";
 import { emitReadme } from "./emitReadme.js";
 import { emitReference } from "./emitReference.js";
-import { generateEmbeddedSdk } from "./generateEmbeddedSdk.js";
-import { generateEmbeddedTypes } from "./generateEmbeddedTypes.js";
+import { generateEmbeddedSdk, isRustSdkCliAvailable } from "./generateEmbeddedSdk.js";
+import { generateEmbeddedTypes, isRustModelCliAvailable } from "./generateEmbeddedTypes.js";
 import { generateSdkGlue } from "./generateSdkGlue.js";
 import { deriveBinaryName } from "./identity.js";
 import type { IrSummary } from "./ir.js";
@@ -80,8 +80,8 @@ export async function runPipeline(args: {
     await copySdk(outputDir, sdkTemplateDir ?? SDK_TEMPLATE_DIRECTORY);
     await patchCargoToml({ outputDir, binaryName, version: outputConfig.version });
     await patchDistWorkspaceToml({ outputDir });
-    const embedTypes = customConfig.embedTypes !== false && irFilepath != null;
-    const embedSdk = customConfig.embedSdk !== false && embedTypes;
+    const embedTypes = customConfig.embedTypes !== false && irFilepath != null && isRustModelCliAvailable();
+    const embedSdk = customConfig.embedSdk !== false && embedTypes && isRustSdkCliAvailable();
     await copySpecs({ outputDir, binaryName, authBindings, specsDir, embedTypes, embedSdk });
     await writeGitignore(outputDir);
     await emitReadme({
@@ -107,7 +107,9 @@ export async function runPipeline(args: {
             outputDir,
             binaryName
         });
-        await writeFernignore(outputDir, binaryName);
+        if (typesCrateName != null) {
+            await writeFernignore(outputDir, binaryName);
+        }
     }
 
     // Generate the embedded SDK crate (on by default; requires embedTypes).


### PR DESCRIPTION
## Description

Fixes the error `fernapi/fern-cli-generator Could not resolve the @fern-api/rust-sdk CLI` that crashes CLI generation when the Docker image doesn't have the bundled `rust-sdk-dist/` or `rust-model-dist/` directories.

## Changes Made

- `resolveRustSdkCli()` and `resolveRustModelCli()` now return `undefined` instead of throwing when the CLI can't be found
- Added `isRustSdkCliAvailable()` and `isRustModelCliAvailable()` exports for early availability checks
- `runPipeline` checks CLI availability *before* `copySpecs` so `main.rs` won't reference modules that don't exist (e.g. `mod sdk_glue;`)
- `generateEmbeddedSdk` and `generateEmbeddedTypes` return `undefined` when the CLI is unavailable — downstream code already handles this gracefully
- [x] Updated changelog entry

## Testing

- [x] Unit tests pass (129 tests, 14 test files)
- [x] Compilation passes
- The fix is backward-compatible: older Docker images that lack the bundled dist will produce working CLI output without embedded crates instead of crashing

Link to Devin session: https://app.devin.ai/sessions/7a8a6e1b66c7441caf6124259895c0d0
Requested by: @cade-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->