### PR TITLE
fix(cli): remove --locked from generated CI publish workflows

### DIFF
--- a/generators/cli/changes/unreleased/remove-locked-from-ci.yml
+++ b/generators/cli/changes/unreleased/remove-locked-from-ci.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Remove `--locked` from `cargo build` commands in generated CI
+    publish workflows. The lockfile produced at generation time may
+    become stale when users add custom code or dev-dependencies,
+    causing `--locked` builds to reject the lockfile. CI now allows
+    Cargo to re-resolve dependencies at build time.
+  type: fix

--- a/generators/cli/src/emitPublishWorkflow.ts
+++ b/generators/cli/src/emitPublishWorkflow.ts
@@ -232,10 +232,10 @@ ${matrixIncludes}
         shell: bash
         run: |
           if [[ "\${{ matrix.rust-target }}" == *-linux-musl ]]; then
-            cargo build --release --locked --target \${{ matrix.rust-target }} \\
+            cargo build --release --target \${{ matrix.rust-target }} \\
               --no-default-features --features rustls
           else
-            cargo build --release --locked --target \${{ matrix.rust-target }}
+            cargo build --release --target \${{ matrix.rust-target }}
           fi
 
       - name: Package and publish npm platform package${tokenEnvBlock}

--- a/generators/cli/src/writeGitignore.ts
+++ b/generators/cli/src/writeGitignore.ts
@@ -5,8 +5,9 @@ import path from "path";
  * Writes a basic `.gitignore` for the generated Rust CLI project.
  *
  * Unlike the Rust SDK generator we intentionally keep `Cargo.lock`
- * tracked: the CLI ships with `cargo build --locked`, so the lockfile
- * must be committed for reproducible builds.
+ * tracked: the CLI ships a lockfile so CI builds are reproducible
+ * by default (users can opt into `--locked` if they want strict
+ * enforcement).
  */
 export async function writeGitignore(outputDir: string): Promise<void> {
     const contents = ["/target", "**/*.rs.bk", ".DS_Store", "*.swp", ""].join("\n");

--- a/seed/cli/query-parameters-openapi/github-npm/.github/workflows/ci.yml
+++ b/seed/cli/query-parameters-openapi/github-npm/.github/workflows/ci.yml
@@ -98,10 +98,10 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.rust-target }}" == *-linux-musl ]]; then
-            cargo build --release --locked --target ${{ matrix.rust-target }} \
+            cargo build --release --target ${{ matrix.rust-target }} \
               --no-default-features --features rustls
           else
-            cargo build --release --locked --target ${{ matrix.rust-target }}
+            cargo build --release --target ${{ matrix.rust-target }}
           fi
 
       - name: Package and publish npm platform package


### PR DESCRIPTION
## Description

The CLI generator emits `.github/workflows/ci.yml` into generated CLI repos with `cargo build --release --locked` in the publish job. The `Cargo.lock` is produced at generation time inside the generator image, **before** any user customizations (custom commands, dev-dependencies for tests, etc.) are applied. When users add dependencies post-generation, the lockfile becomes stale and `--locked` rejects the build.

This is the root cause of https://github.com/fern-api/petstore-cli/actions/runs/27142969865/job/80131354603 — the verification suite added `petstore_api_types` as a dev-dependency but the committed `Cargo.lock` wasn't fully re-resolved.

## Changes Made

- Remove `--locked` from both `cargo build` commands in the generated publish workflow (`emitPublishWorkflow.ts` lines 235/238)
- Update comment in `writeGitignore.ts` to reflect the new behavior
- Regenerate seed snapshot for `query-parameters-openapi/github-npm`
- Add changelog entry

## Testing

- [x] All 129 CLI generator unit tests pass (`vitest --run`)
- [x] Seed test regenerated for `query-parameters-openapi` fixture (3/3 passed)


Link to Devin session: https://app.devin.ai/sessions/b1fdb8bd7a3a487dababfe3177c77c4e
Requested by: @jsklan