### PR TITLE
fix(typescript): fix anySignal() race condition between aborted check and addEventListener

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/fix-anysignal-race-condition.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-anysignal-race-condition.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix race condition in anySignal() where abort events could be silently
+    dropped when a source signal aborts between the aborted check and
+    addEventListener registration.
+  type: fix

--- a/generators/typescript/utils/core-utilities/src/core/fetcher/signals.ts
+++ b/generators/typescript/utils/core-utilities/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/generators/typescript/utils/core-utilities/tests/unit/fetcher/signals.test.ts
+++ b/generators/typescript/utils/core-utilities/tests/unit/fetcher/signals.test.ts
@@ -66,4 +66,49 @@ describe("Test anySignal", () => {
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
     });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
+    });
 });

--- a/seed/ts-sdk/accept-header/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/accept-header/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/accept-header/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/accept-header/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/accept-header/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/accept-header/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/alias-extends/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/alias-extends/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/alias-extends/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/alias-extends/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/alias-extends/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/alias-extends/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/alias/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/alias/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/alias/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/alias/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/alias/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/alias/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/allof-inline/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/allof-inline/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/allof-inline/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/allof-inline/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/allof-inline/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/allof-inline/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/allof/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/allof/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/allof/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/allof/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/allof/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/allof/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/any-auth/always-send-auth/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/any-auth/always-send-auth/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/any-auth/always-send-auth/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/any-auth/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/any-auth/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/any-auth/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/api-wide-base-path-with-default/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/api-wide-base-path-with-default/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/api-wide-base-path-with-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/api-wide-base-path-with-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/api-wide-base-path-with-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/api-wide-base-path-with-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/api-wide-base-path/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/api-wide-base-path/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/basic-auth-pw-omitted/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/basic-auth-pw-omitted/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/basic-auth-pw-omitted/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/basic-auth/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/basic-auth/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/basic-auth/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/basic-auth/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/basic-auth/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/basic-auth/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/bytes-download/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/bytes-download/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/bytes-download/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/bytes-download/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/bytes-download/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/bytes-download/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/bytes-upload/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/bytes-upload/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/bytes-upload/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/bytes-upload/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/bytes-upload/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/bytes-upload/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/bytes-upload/tests/unit/fetcher/signals.test.ts
@@ -66,4 +66,49 @@ describe("Test anySignal", () => {
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
     });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
+    });
 });

--- a/seed/ts-sdk/circular-references-advanced/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/circular-references-advanced/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/circular-references-extends/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/circular-references-extends/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/circular-references-extends/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/circular-references-extends/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/circular-references-extends/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/circular-references-extends/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/circular-references/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/circular-references/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/circular-references/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/circular-references/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/circular-references/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/circular-references/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/cli-multi-spec-namespaced/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/cli-multi-spec-namespaced/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/cli-multi-spec-namespaced/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/cli-multi-spec-namespaced/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/cli-multi-spec-namespaced/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/cli-multi-spec-namespaced/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/cli-multi-spec/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/cli-multi-spec/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/cli-multi-spec/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/cli-multi-spec/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/cli-multi-spec/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/cli-multi-spec/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/client-side-params/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/client-side-params/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/client-side-params/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/client-side-params/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/client-side-params/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/client-side-params/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/content-type/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/content-type/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/content-type/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/content-type/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/content-type/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/content-type/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/dollar-string-examples/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/dollar-string-examples/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/dollar-string-examples/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/dollar-string-examples/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/dollar-string-examples/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/dollar-string-examples/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/empty-clients/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/empty-clients/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/empty-clients/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/empty-clients/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/empty-clients/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/empty-clients/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/endpoint-security-auth/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/endpoint-security-auth/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/endpoint-security-auth/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/endpoint-security-auth/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/endpoint-security-auth/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/enum/forward-compatible-enums/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/enum/forward-compatible-enums/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/enum/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/enum/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/enum/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/enum/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/enum/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/enum/serde/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/enum/serde/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/enum/serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/enum/serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/enum/serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/enum/serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/error-property/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/error-property/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/error-property/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/error-property/union-utils/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/error-property/union-utils/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/errors/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/errors/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/errors/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/errors/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/errors/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/errors/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/tests/unit/fetcher/signals.test.ts
@@ -66,4 +66,49 @@ describe("Test anySignal", () => {
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
     });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
+    });
 });

--- a/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/bigint/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/unit/fetcher/signals.test.ts
@@ -66,4 +66,49 @@ describe("Test anySignal", () => {
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
     });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
+    });
 });

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/local-files/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/output-src-only/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/signals.test.ts
@@ -1,12 +1,12 @@
-import { anySignal, getTimeoutSignal } from "../../../core/fetcher/signals";
+import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/use-jest/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/use-jest/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/unit/fetcher/signals.test.ts
@@ -66,4 +66,49 @@ describe("Test anySignal", () => {
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
     });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
+    });
 });

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/extends/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/extends/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/extends/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/extends/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/extends/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/extends/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/extra-properties/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/extra-properties/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/extra-properties/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/extra-properties/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/extra-properties/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/extra-properties/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/file-download/stream-wrapper/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/file-download/stream-wrapper/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/tests/unit/fetcher/signals.test.ts
@@ -66,4 +66,49 @@ describe("Test anySignal", () => {
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
     });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
+    });
 });

--- a/seed/ts-sdk/file-upload-openapi/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/file-upload-openapi/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/file-upload-openapi/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-upload-openapi/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/file-upload-openapi/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-upload-openapi/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/file-upload/inline/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-upload/inline/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/file-upload/serde/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-upload/serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/file-upload/use-jest/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/file-upload/use-jest/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/file-upload/use-jest/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-upload/use-jest/tests/unit/fetcher/signals.test.ts
@@ -66,4 +66,49 @@ describe("Test anySignal", () => {
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
     });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
+    });
 });

--- a/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/file-upload/wrapper/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/file-upload/wrapper/tests/unit/fetcher/signals.test.ts
@@ -66,4 +66,49 @@ describe("Test anySignal", () => {
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
     });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
+    });
 });

--- a/seed/ts-sdk/folders/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/folders/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/folders/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/folders/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/folders/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/folders/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/header-auth-environment-variable/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/header-auth-environment-variable/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/header-auth-environment-variable/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/header-auth/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/header-auth/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/header-auth/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/header-auth/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/header-auth/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/header-auth/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/http-head/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/http-head/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/http-head/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/http-head/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/http-head/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/http-head/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/idempotency-headers/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/idempotency-headers/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/inferred-auth-explicit/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/inferred-auth-explicit/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/inferred-auth-implicit-reference/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/inferred-auth-implicit-reference/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/inferred-auth-implicit/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/inferred-auth-implicit/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/license/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/license/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/license/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/license/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/license/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/license/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/literal-user-agent/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/literal-user-agent/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/literal-user-agent/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/literal-user-agent/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/literal-user-agent/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/literal-user-agent/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/literal/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/literal/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/literal/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/literal/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/literal/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/literal/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/literals-unions/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/literals-unions/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/literals-unions/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/literals-unions/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/literals-unions/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/literals-unions/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/mixed-file-directory/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/mixed-file-directory/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/multi-line-docs/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/multi-line-docs/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/multi-url-environment-reference/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/multi-url-environment-reference/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/multi-url-environment-reference/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/multi-url-environment/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/multi-url-environment/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/multiple-request-bodies/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/multiple-request-bodies/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/multiple-request-bodies/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/multiple-request-bodies/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/multiple-request-bodies/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/no-content-response/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/no-content-response/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/no-content-response/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/no-content-response/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/no-content-response/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/no-content-response/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/no-environment/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/no-environment/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/no-environment/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/no-environment/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/no-environment/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/no-environment/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/no-retries/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/no-retries/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/no-retries/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/no-retries/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/no-retries/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/no-retries/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/null-type/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/null-type/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/null-type/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/null-type/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/null-type/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/null-type/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/nullable-allof-extends/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/nullable-allof-extends/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/nullable-allof-extends/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/nullable-allof-extends/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/nullable-allof-extends/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/nullable-allof-extends/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/nullable-optional/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/nullable-optional/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/nullable-optional/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/nullable-optional/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/nullable-optional/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/nullable-optional/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/nullable-request-body/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/nullable-request-body/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/nullable-request-body/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/nullable-request-body/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/nullable-request-body/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/nullable-request-body/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/nullable/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/nullable/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/nullable/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/nullable/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/nullable/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/nullable/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/oauth-client-credentials-openapi/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-openapi/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/oauth-client-credentials-reference/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-reference/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/object/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/object/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/object/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/object/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/object/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/object/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/objects-with-imports/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/objects-with-imports/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/optional/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/optional/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/optional/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/optional/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/optional/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/optional/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/package-yml/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/package-yml/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/package-yml/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/package-yml/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/package-yml/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/package-yml/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/pagination-custom/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/pagination-custom/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/pagination-custom/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/pagination-custom/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/pagination-custom/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/pagination-uri-path/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/pagination-uri-path/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/pagination-uri-path/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/pagination-uri-path/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/pagination-uri-path/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/pagination/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/pagination/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/pagination/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/pagination/page-index-semantics/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/pagination/page-index-semantics/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/pagination/page-index-semantics/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/path-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/path-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/plain-text/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/plain-text/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/plain-text/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/plain-text/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/plain-text/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/plain-text/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/property-access/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/property-access/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/property-access/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/public-object/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/public-object/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/public-object/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/public-object/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/public-object/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/public-object/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/query-param-name-conflict/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/query-param-name-conflict/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/query-param-name-conflict/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-param-name-conflict/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/query-param-name-conflict/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-param-name-conflict/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/query-parameters-openapi/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/query-parameters-openapi/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/query-parameters-openapi/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/query-parameters-openapi/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters-openapi/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/query-parameters/serde/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/query-parameters/serde/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/query-parameters/serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters/serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/query-parameters/serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/query-parameters/serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/tests/unit/fetcher/signals.test.ts
@@ -66,4 +66,49 @@ describe("Test anySignal", () => {
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
     });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
+    });
 });

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/required-nullable/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/required-nullable/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/required-nullable/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/required-nullable/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/required-nullable/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/required-nullable/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/reserved-keywords/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/reserved-keywords/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/response-property/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/response-property/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/response-property/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/response-property/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/response-property/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/response-property/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/schemaless-request-body-examples/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/schemaless-request-body-examples/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/schemaless-request-body-examples/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/schemaless-request-body-examples/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/schemaless-request-body-examples/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/schemaless-request-body-examples/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/server-sent-events-resumable/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/server-sent-events-resumable/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/server-sent-events-resumable/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/server-sent-events-resumable/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/server-sent-events/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/server-sent-events/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/server-sent-events/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/server-url-templating/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/server-url-templating/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/server-url-templating/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/server-url-templating/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/server-url-templating/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/server-url-templating/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/allow-extra-fields/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/allow-extra-fields/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/bundle/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/bundle/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/bundle/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/bundle/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/bundle/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/custom-package-json/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/custom-package-json/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/custom-package-json/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/jsr/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/jsr/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/jsr/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/jsr/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/jsr/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/legacy-exports/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/legacy-exports/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/legacy-exports/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/naming-shorthand/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/naming-shorthand/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/naming-shorthand/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/naming/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/naming/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/naming/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/naming/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/naming/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/naming/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/no-scripts/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/no-scripts/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/no-scripts/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/oidc-token/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/oidc-token/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/oidc-token/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/omit-fern-headers/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/omit-fern-headers/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/use-oxc/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/use-oxc/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/use-oxc/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/use-oxfmt/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/use-oxfmt/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/use-oxlint/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/use-oxlint/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/use-oxlint/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/use-prettier/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/use-prettier/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/use-prettier/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-api/use-yarn/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-api/use-yarn/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-api/use-yarn/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/simple-fhir/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/simple-fhir/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-fhir/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/simple-fhir/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/simple-fhir/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/single-url-environment-default/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/single-url-environment-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/streaming-parameter/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/streaming-parameter/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/streaming/serde-layer/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/streaming/serde-layer/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/streaming/serde-layer/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/streaming/wrapper/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/streaming/wrapper/tests/unit/fetcher/signals.test.ts
@@ -66,4 +66,49 @@ describe("Test anySignal", () => {
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
     });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
+    });
 });

--- a/seed/ts-sdk/trace/exhaustive/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/trace/exhaustive/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/trace/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/trace/serde/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/trace/serde/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/trace/serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/trace/serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/trace/serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/trace/serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/ts-express-casing/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/ts-express-casing/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/ts-extra-properties/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/ts-extra-properties/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/ts-extra-properties/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/ts-extra-properties/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/ts-extra-properties/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/ts-extra-properties/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/union-query-parameters/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/union-query-parameters/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/union-query-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/union-query-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/union-query-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/union-query-parameters/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/unions-with-local-date/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/unions-with-local-date/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/unions-with-local-date/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/unions-with-local-date/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/unions-with-local-date/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/unions/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/unions/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/unions/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/unions/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/unions/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/unions/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/unions/serde-layer/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/unions/serde-layer/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/unions/serde-layer/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/unions/serde-layer/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/unions/serde-layer/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/unions/serde-layer/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/url-form-encoded/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/url-form-encoded/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/url-form-encoded/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/url-form-encoded/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/url-form-encoded/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/url-form-encoded/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/validation/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/validation/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/validation/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/validation/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/validation/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/validation/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/variables/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/variables/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/variables/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/variables/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/variables/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/variables/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/version-no-default/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/version-no-default/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/version-no-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/version-no-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/version-no-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/version-no-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/version/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/version/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/version/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/version/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/version/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/version/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/webhook-audience/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/webhook-audience/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/webhook-audience/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/webhook-audience/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/webhook-audience/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/webhook-audience/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/webhooks/no-custom-config/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/webhooks/no-custom-config/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/webhooks/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/webhooks/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/webhooks/no-custom-config/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/webhooks/no-custom-config/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/websocket-multi-url/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/websocket-multi-url/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/websocket-multi-url/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/websocket-multi-url/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/websocket-multi-url/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/websocket-multi-url/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/websocket/no-serde/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/websocket/no-serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/websocket/serde/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/websocket/serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/websocket/serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/websocket/serde/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/websocket/serde/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });

--- a/seed/ts-sdk/x-fern-default/src/core/fetcher/signals.ts
+++ b/seed/ts-sdk/x-fern-default/src/core/fetcher/signals.ts
@@ -14,12 +14,21 @@ export function anySignal(...args: AbortSignal[] | [AbortSignal[]]): AbortSignal
     for (const signal of signals) {
         if (signal.aborted) {
             controller.abort((signal as any)?.reason);
-            break;
+            return controller.signal;
         }
 
         signal.addEventListener("abort", () => controller.abort((signal as any)?.reason), {
             signal: controller.signal,
         });
+
+        // Re-check after adding listener: the signal may have aborted
+        // between the initial `signal.aborted` check and the `addEventListener`
+        // call above. If it did, the abort event was already dispatched and
+        // the listener will never fire — we must manually abort.
+        if (signal.aborted) {
+            controller.abort((signal as any)?.reason);
+            return controller.signal;
+        }
     }
 
     return controller.signal;

--- a/seed/ts-sdk/x-fern-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/x-fern-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        jest.useFakeTimers();
+        vi.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(timeoutMs - 1);
+        vi.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        jest.advanceTimersByTime(1);
+        vi.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });

--- a/seed/ts-sdk/x-fern-default/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/x-fern-default/tests/unit/fetcher/signals.test.ts
@@ -2,11 +2,11 @@ import { anySignal, getTimeoutSignal } from "../../../src/core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {
-        vi.useFakeTimers();
+        jest.useFakeTimers();
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        jest.useRealTimers();
     });
 
     it("should return an object with signal and abortId", () => {
@@ -24,10 +24,10 @@ describe("Test getTimeoutSignal", () => {
 
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(timeoutMs - 1);
+        jest.advanceTimersByTime(timeoutMs - 1);
         expect(signal.aborted).toBe(false);
 
-        vi.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1);
         expect(signal.aborted).toBe(true);
     });
 });
@@ -65,5 +65,50 @@ describe("Test anySignal", () => {
 
         const signal = anySignal(controller1.signal, controller2.signal);
         expect(signal.aborted).toBe(true);
+    });
+
+    it("should detect a signal that aborts between the initial aborted check and the event listener registration", () => {
+        const ctrlA = new AbortController();
+        const ctrlB = new AbortController();
+
+        const originalAddEventListener = ctrlA.signal.addEventListener.bind(ctrlA.signal);
+        const originalRemoveEventListener = ctrlA.signal.removeEventListener.bind(ctrlA.signal);
+
+        let abortedAccessCount = 0;
+        const proxy = new Proxy(ctrlA.signal, {
+            get(target, prop, receiver) {
+                if (prop === "aborted") {
+                    abortedAccessCount++;
+                    if (abortedAccessCount === 1) return false;
+                    return Reflect.get(target, prop, receiver);
+                }
+                if (prop === "addEventListener") {
+                    return (...args: Parameters<typeof originalAddEventListener>) => {
+                        if (abortedAccessCount >= 1 && args[0] === "abort") {
+                            ctrlA.abort("too-late");
+                        }
+                        return originalAddEventListener(...args);
+                    };
+                }
+                if (prop === "removeEventListener") {
+                    return originalRemoveEventListener;
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+
+        const combined = anySignal(proxy, ctrlB.signal);
+
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("too-late");
+    });
+
+    it("should forward the abort reason from a source signal", () => {
+        const controller = new AbortController();
+        const combined = anySignal(controller.signal);
+
+        controller.abort("test-reason");
+        expect(combined.aborted).toBe(true);
+        expect(combined.reason).toBe("test-reason");
     });
 });


### PR DESCRIPTION
## Description
Closes #16151

Fix race condition in generated `anySignal()` where abort events are silently dropped when a source signal aborts between the `signal.aborted` check and `addEventListener("abort", ...)` registration.

Supersedes #16153 — this PR adds the missing seed snapshot updates and changelog entry.

## Changes Made
- Re-check `signal.aborted` immediately after `addEventListener` to catch signals that aborted during the registration window
- Replace `break` with `return controller.signal` to avoid useless iteration after combined signal is already aborted
- Add unit tests: race condition reproducer via Proxy, abort reason forwarding
- Update all ~214 seed ts-sdk fixtures with the new `signals.ts` and `signals.test.ts`
- Add unreleased changelog entry

## Testing
- [x] Unit tests added/updated — 2 new test cases including the exact race condition scenario
- [x] All seed ts-sdk snapshots updated (428 files)


Link to Devin session: https://app.devin.ai/sessions/4dada59a7cef4f5691cec8e1e8ca587c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->