### PR TITLE
chore(csharp): upgrade CSharpier to 1.3.0

### DIFF
--- a/docker/seed/Dockerfile.csharp
+++ b/docker/seed/Dockerfile.csharp
@@ -82,7 +82,7 @@ WORKDIR /
 #   - System.Formats.Asn1
 #       5.0.0 (transitively pulled by signing/cryptography deps) -> 10.0.5
 #       (GHSA-447r-wph3-92pm)
-RUN dotnet tool install -g csharpier --version "1.2.6" && \
+RUN dotnet tool install -g csharpier --version "1.3.0" && \
     echo '<Project Sdk="Microsoft.NET.Sdk"> \
   <PropertyGroup> \
       <TargetFrameworks>net462;net8.0;net9.0;netstandard2.0</TargetFrameworks> \

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -175,7 +175,7 @@ export class CsharpProject extends AbstractProject<GeneratorContext> {
         await loggingExeca(
             this.context.logger,
             csharpier,
-            ["format", ".", "--no-msbuild-check", "--skip-validation", "--compilation-errors-as-warnings"],
+            ["format", ".", "--no-msbuild-check", "--skip-validation", "--syntax-errors-as-warnings"],
             {
                 doNotPipeOutput: false,
                 cwd: absolutePathToSrcDirectory

--- a/generators/csharp/formatter/src/CsharpFormatter.ts
+++ b/generators/csharp/formatter/src/CsharpFormatter.ts
@@ -113,7 +113,7 @@ export class CsharpFormatter extends AbstractFormatter {
 
         const { stdout } = execa.sync(
             this.csharpierPath,
-            ["format", "--no-msbuild-check", "--skip-validation", "--compilation-errors-as-warnings"],
+            ["format", "--no-msbuild-check", "--skip-validation", "--syntax-errors-as-warnings"],
             {
                 input: content,
                 encoding: "utf-8",

--- a/generators/csharp/model/Dockerfile
+++ b/generators/csharp/model/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /usr/local/lib/node_modules/npm/node_modules && \
     tar -xzf brace-expansion-5.0.6.tgz --strip-components=1 -C brace-expansion/ && \
     rm brace-expansion-5.0.6.tgz
 
-RUN dotnet tool install -g csharpier --version "1.2.6"
+RUN dotnet tool install -g csharpier --version "1.3.0"
 
 COPY generators/csharp/model/dist /dist
 

--- a/generators/csharp/sdk/Dockerfile
+++ b/generators/csharp/sdk/Dockerfile
@@ -30,7 +30,7 @@ RUN apk --no-cache upgrade && \
 # itself.
 RUN rm -rf /usr/share/powershell /usr/bin/pwsh
 
-RUN dotnet tool install -g csharpier --version "1.2.6"
+RUN dotnet tool install -g csharpier --version "1.3.0"
 
 # Copy over node contents to be able to run the compiled CLI
 COPY --from=node /usr/local/bin/node /usr/local/bin/

--- a/generators/csharp/sdk/changes/unreleased/upgrade-csharpier-1.3.0.yml
+++ b/generators/csharp/sdk/changes/unreleased/upgrade-csharpier-1.3.0.yml
@@ -1,0 +1,3 @@
+- type: chore
+  summary: |
+    Upgrade CSharpier formatter to 1.3.0.


### PR DESCRIPTION
## Description

Upgrade CSharpier formatter from 1.2.6 to [1.3.0](https://github.com/belav/csharpier/releases/tag/1.3.0).

## Changes Made

- Bumped CSharpier version from `1.2.6` → `1.3.0` in all three Dockerfiles (`generators/csharp/sdk/Dockerfile`, `generators/csharp/model/Dockerfile`, `docker/seed/Dockerfile.csharp`)
- Updated `--compilation-errors-as-warnings` → `--syntax-errors-as-warnings` in `CsharpFormatter.ts` (renamed flag in 1.3.0 breaking changes)

## Testing

- [ ] CI seed tests for csharp-sdk and csharp-model will validate no formatting regressions

Link to Devin session: https://app.devin.ai/sessions/91e2a7b1a0a94cb9a8e03f5dd8ac4aa1
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->