### PR TITLE
fix(cli): prevent duplicate type declarations when multiple endpoints share request body schema

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/shared-request-body.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/shared-request-body.json
@@ -1,0 +1,383 @@
+{
+  "title": "Shared Request Body Test",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [
+    {
+      "summary": "Send a chat message",
+      "audiences": [],
+      "operationId": "chat",
+      "tags": [
+        "Chat"
+      ],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "ChatBody",
+      "request": {
+        "schema": {
+          "generatedName": "ChatRequest",
+          "schema": "ChatRequest",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Success",
+        "schema": {
+          "generatedName": "ChatResponse",
+          "schema": "ChatResponse",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/chat",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {
+              "message": {
+                "value": {
+                  "value": "message",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "id": {
+                  "value": {
+                    "value": "id",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "text": {
+                  "value": {
+                    "value": "text",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    },
+    {
+      "summary": "Get the prompt for a chat message",
+      "audiences": [],
+      "operationId": "chatPrompt",
+      "tags": [
+        "Chat"
+      ],
+      "pathParameters": [],
+      "queryParameters": [],
+      "headers": [],
+      "generatedRequestName": "ChatPromptRequest",
+      "request": {
+        "schema": {
+          "generatedName": "ChatPromptRequest",
+          "schema": "ChatRequest",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "contentType": "application/json",
+        "fullExamples": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "json"
+      },
+      "response": {
+        "description": "Success",
+        "schema": {
+          "generatedName": "ChatPromptResponse",
+          "schema": "PromptResponse",
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "reference"
+        },
+        "fullExamples": [],
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "statusCode": 200,
+        "type": "json"
+      },
+      "errors": {},
+      "servers": [],
+      "authed": false,
+      "method": "POST",
+      "path": "/chat/prompt",
+      "examples": [
+        {
+          "pathParameters": [],
+          "queryParameters": [],
+          "headers": [],
+          "request": {
+            "properties": {
+              "message": {
+                "value": {
+                  "value": "message",
+                  "type": "string"
+                },
+                "type": "primitive"
+              }
+            },
+            "type": "object"
+          },
+          "response": {
+            "value": {
+              "properties": {
+                "prompt": {
+                  "value": {
+                    "value": "prompt",
+                    "type": "string"
+                  },
+                  "type": "primitive"
+                },
+                "token_count": {
+                  "value": {
+                    "value": 1,
+                    "type": "int"
+                  },
+                  "type": "primitive"
+                }
+              },
+              "type": "object"
+            },
+            "type": "withoutStreaming"
+          },
+          "codeSamples": [],
+          "type": "full"
+        }
+      ],
+      "source": {
+        "file": "../openapi.yml",
+        "type": "openapi"
+      }
+    }
+  ],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "ChatRequest": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "chatRequestMessage",
+            "key": "message",
+            "schema": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "ChatRequestMessage",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "chatRequestModel",
+            "key": "model",
+            "schema": {
+              "generatedName": "ChatRequestModel",
+              "value": {
+                "schema": {
+                  "type": "string"
+                },
+                "generatedName": "ChatRequestModel",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "chatRequestTemperature",
+            "key": "temperature",
+            "schema": {
+              "generatedName": "ChatRequestTemperature",
+              "value": {
+                "schema": {
+                  "type": "double"
+                },
+                "generatedName": "ChatRequestTemperature",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "ChatRequest",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "ChatResponse": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "chatResponseId",
+            "key": "id",
+            "schema": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "ChatResponseId",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "chatResponseText",
+            "key": "text",
+            "schema": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "ChatResponseText",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "ChatResponse",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "PromptResponse": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "promptResponsePrompt",
+            "key": "prompt",
+            "schema": {
+              "schema": {
+                "type": "string"
+              },
+              "generatedName": "PromptResponsePrompt",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "promptResponseTokenCount",
+            "key": "token_count",
+            "schema": {
+              "generatedName": "PromptResponseTokenCount",
+              "value": {
+                "schema": {
+                  "type": "int"
+                },
+                "generatedName": "PromptResponseTokenCount",
+                "groupName": [],
+                "type": "primitive"
+              },
+              "groupName": [],
+              "type": "optional"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "PromptResponse",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/shared-request-body.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/shared-request-body.json
@@ -1,0 +1,221 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "Chat": {
+              "auth": undefined,
+              "display-name": "Send a chat message",
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "message": "message",
+                  },
+                  "response": {
+                    "body": {
+                      "id": "id",
+                      "text": "text",
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/chat",
+              "request": "ChatRequest",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "ChatResponse",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+        "types": {
+          "ChatRequest": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "message": "string",
+              "model": "optional<string>",
+              "temperature": "optional<double>",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "ChatResponse": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "id": "string",
+              "text": "string",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "PromptResponse": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "prompt": "string",
+              "token_count": "optional<integer>",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+        },
+      },
+      "rawContents": "service:
+  auth: false
+  base-path: ''
+  endpoints:
+    Chat:
+      path: /chat
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      display-name: Send a chat message
+      request: ChatRequest
+      response:
+        docs: Success
+        type: ChatResponse
+        status-code: 200
+      examples:
+        - request:
+            message: message
+          response:
+            body:
+              id: id
+              text: text
+  source:
+    openapi: ../openapi.yml
+types:
+  ChatRequest:
+    properties:
+      message: string
+      model: optional<string>
+      temperature: optional<double>
+    source:
+      openapi: ../openapi.yml
+  ChatResponse:
+    properties:
+      id: string
+      text: string
+    source:
+      openapi: ../openapi.yml
+  PromptResponse:
+    properties:
+      prompt: string
+      token_count: optional<integer>
+    source:
+      openapi: ../openapi.yml
+",
+    },
+    "chat.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "imports": {
+          "root": "__package__.yml",
+        },
+        "service": {
+          "auth": false,
+          "base-path": "",
+          "endpoints": {
+            "prompt": {
+              "auth": undefined,
+              "display-name": "Get the prompt for a chat message",
+              "docs": undefined,
+              "examples": [
+                {
+                  "request": {
+                    "message": "message",
+                  },
+                  "response": {
+                    "body": {
+                      "prompt": "prompt",
+                      "token_count": 1,
+                    },
+                  },
+                },
+              ],
+              "method": "POST",
+              "pagination": undefined,
+              "path": "/chat/prompt",
+              "request": "root.ChatRequest",
+              "response": {
+                "docs": "Success",
+                "status-code": 200,
+                "type": "root.PromptResponse",
+              },
+              "source": {
+                "openapi": "../openapi.yml",
+              },
+            },
+          },
+          "source": {
+            "openapi": "../openapi.yml",
+          },
+        },
+      },
+      "rawContents": "imports:
+  root: __package__.yml
+service:
+  auth: false
+  base-path: ''
+  endpoints:
+    prompt:
+      path: /chat/prompt
+      method: POST
+      source:
+        openapi: ../openapi.yml
+      display-name: Get the prompt for a chat message
+      request: root.ChatRequest
+      response:
+        docs: Success
+        type: root.PromptResponse
+        status-code: 200
+      examples:
+        - request:
+            message: message
+          response:
+            body:
+              prompt: prompt
+              token_count: 1
+  source:
+    openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Shared Request Body Test",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Shared Request Body Test
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/shared-request-body/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/shared-request-body/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/shared-request-body/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/shared-request-body/fern/generators.yml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ../openapi.yml

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/shared-request-body/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/shared-request-body/openapi.yml
@@ -1,0 +1,79 @@
+openapi: 3.0.3
+info:
+  title: Shared Request Body Test
+  version: 1.0.0
+paths:
+  /chat:
+    post:
+      operationId: chat
+      tags:
+        - Chat
+      summary: Send a chat message
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChatRequest"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChatResponse"
+
+  /chat/prompt:
+    post:
+      operationId: chatPrompt
+      tags:
+        - Chat
+      summary: Get the prompt for a chat message
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChatRequest"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PromptResponse"
+
+components:
+  schemas:
+    ChatRequest:
+      type: object
+      properties:
+        message:
+          type: string
+        model:
+          type: string
+        temperature:
+          type: number
+      required:
+        - message
+
+    ChatResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        text:
+          type: string
+      required:
+        - id
+        - text
+
+    PromptResponse:
+      type: object
+      properties:
+        prompt:
+          type: string
+        token_count:
+          type: integer
+      required:
+        - prompt

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/OpenApiIrConverterContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/OpenApiIrConverterContext.ts
@@ -372,6 +372,15 @@ export class OpenApiIrConverterContext {
     }
 
     /**
+     * Returns true if the given schema is directly referenced as a request body
+     * by two or more endpoints. Such schemas should not be inlined because
+     * inlining would produce duplicate type declarations with the same name.
+     */
+    public isMultiRequestSchema(id: SchemaId): boolean {
+        return this.reachability?.multiRequestSchemas.has(id) ?? false;
+    }
+
+    /**
      * Returns true if the given schema is only reachable from request contexts
      * (not from responses, errors, parameters, webhooks, or channels).
      */

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/buildEndpoint.ts
@@ -532,11 +532,15 @@ function getRequest({
         const resolvedSchema =
             request.schema.type === "reference" ? context.getSchema(request.schema.schema, namespace) : request.schema;
 
-        // the request body is referenced if it is not an object or if other parts of the spec
-        // refer to the same type
+        // The request body is kept as a reference (not inlined) when:
+        //   - the resolved schema is not an object, OR
+        //   - the schema is also used outside of request bodies (response reachable), OR
+        //   - the same schema is referenced as a request body by multiple endpoints
+        //     (inlining would produce duplicate type declarations with the same name)
         if (
             resolvedSchema?.type !== "object" ||
-            (maybeSchemaId != null && context.isResponseReachable(maybeSchemaId))
+            (maybeSchemaId != null &&
+                (context.isResponseReachable(maybeSchemaId) || context.isMultiRequestSchema(maybeSchemaId)))
         ) {
             // When respectReadonlySchemas is enabled on a write endpoint, resolve schema
             // references to the write variant (without readOnly properties)

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/computeSchemaReachability.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern/src/computeSchemaReachability.ts
@@ -4,6 +4,8 @@ import { OneOfSchema, OpenApiIntermediateRepresentation, Schema, SchemaId, Schem
 export interface SchemaReachability {
     requestReachable: Set<SchemaId>;
     responseReachable: Set<SchemaId>;
+    /** Schema IDs directly referenced as request body by 2+ endpoints. */
+    multiRequestSchemas: Set<SchemaId>;
 }
 
 export interface SchemaVariantPlan {
@@ -108,6 +110,10 @@ export function computeSchemaReachability(ir: OpenApiIntermediateRepresentation)
     const responseReachable = new Set<SchemaId>();
     const { groupedSchemas } = ir;
 
+    // Track how many endpoints directly reference each schema as their request body.
+    // Schemas referenced by 2+ endpoints should not be inlined (would cause duplicate type declarations).
+    const requestBodyRefCount = new Map<SchemaId, number>();
+
     for (const endpoint of ir.endpoints) {
         // Request roots
         if (endpoint.request != null) {
@@ -115,6 +121,10 @@ export function computeSchemaReachability(ir: OpenApiIntermediateRepresentation)
                 case "json":
                 case "formUrlEncoded":
                     seedReachable(endpoint.request.schema, groupedSchemas, requestReachable);
+                    if (endpoint.request.schema.type === "reference") {
+                        const id = endpoint.request.schema.schema;
+                        requestBodyRefCount.set(id, (requestBodyRefCount.get(id) ?? 0) + 1);
+                    }
                     break;
                 case "multipart":
                     for (const prop of endpoint.request.properties) {
@@ -189,7 +199,14 @@ export function computeSchemaReachability(ir: OpenApiIntermediateRepresentation)
         }
     }
 
-    return { requestReachable, responseReachable };
+    const multiRequestSchemas = new Set<SchemaId>();
+    for (const [id, count] of requestBodyRefCount) {
+        if (count >= 2) {
+            multiRequestSchemas.add(id);
+        }
+    }
+
+    return { requestReachable, responseReachable, multiRequestSchemas };
 }
 
 /**

--- a/packages/cli/cli/changes/unreleased/fix-shared-request-body-inlining.yml
+++ b/packages/cli/cli/changes/unreleased/fix-shared-request-body-inlining.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix duplicate type declarations when multiple endpoints share the same request body schema via $ref.
+    Previously, request-only schemas referenced by 2+ endpoints were inlined into each endpoint's request
+    wrapper, producing types with the same name and causing "already declared" errors in generated SDKs.
+    Shared request body schemas are now kept as references instead of being inlined.
+  type: fix

--- a/test-definitions/fern/apis/openapi-request-body-ref/openapi.yml
+++ b/test-definitions/fern/apis/openapi-request-body-ref/openapi.yml
@@ -6,6 +6,8 @@ info:
     Tests that when an operation's request body $refs a top-level
     components.schemas.X schema, the importer does NOT synthesize a
     duplicate auto-named request wrapper with the same name.
+    Also tests that when multiple endpoints share the same request body
+    schema, a single shared type is generated instead of duplicates.
 paths:
   /vendors/{vendor_id}:
     put:
@@ -133,6 +135,46 @@ paths:
               schema:
                 $ref: "#/components/schemas/TeamMember"
 
+  /chat:
+    post:
+      operationId: chat
+      tags:
+        - Chat
+      summary: Send a chat message
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChatRequest"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChatResponse"
+
+  /chat/prompt:
+    post:
+      operationId: chatPrompt
+      tags:
+        - Chat
+      summary: Get the prompt for a chat message (shares request body with /chat)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChatRequest"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PromptResponse"
+
 components:
   schemas:
     UpdateVendorRequest:
@@ -221,3 +263,36 @@ components:
           type: string
       required:
         - id
+
+    ChatRequest:
+      type: object
+      properties:
+        message:
+          type: string
+        model:
+          type: string
+        temperature:
+          type: number
+      required:
+        - message
+
+    ChatResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        text:
+          type: string
+      required:
+        - id
+        - text
+
+    PromptResponse:
+      type: object
+      properties:
+        prompt:
+          type: string
+        token_count:
+          type: integer
+      required:
+        - prompt


### PR DESCRIPTION
## Description
When multiple endpoints reference the same component schema as their request body via \$ref, and that schema is only used in request bodies (not in responses), Fern's inlining logic would inline the properties into each endpoint's request wrapper. Both wrappers got the same type name from the schema, causing 'already declared' errors in generated SDKs (e.g., Go).

## Changes Made
- Track schemas referenced as request body by 2+ endpoints in `computeSchemaReachability`
- In `buildEndpoint`, treat multi-request schemas the same as response-reachable schemas — keep them as shared references instead of inlining
- Add `OpenApiIrConverterContext` support for tracking multi-request schemas
- Add test fixture and snapshots validating the fix

## Testing
- [x] Unit tests added/updated (test fixture `shared-request-body` with snapshots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->