### PR TITLE
fix(cli): enable local seed tests by passing specs and SDK template paths in native mode

### DIFF
--- a/generators/cli/changes/unreleased/fix-local-seed-specs.yml
+++ b/generators/cli/changes/unreleased/fix-local-seed-specs.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Fix local (native) seed test execution by correctly passing OpenAPI specs
+    and SDK template directory to the CLI generator via environment variables.
+  type: fix

--- a/generators/cli/src/cli.ts
+++ b/generators/cli/src/cli.ts
@@ -61,7 +61,9 @@ async function generate(configPath: string): Promise<void> {
                 customConfig: getCustomConfig(config),
                 ir,
                 irFilepath: config.irFilepath,
-                outputConfig
+                outputConfig,
+                specsDir: process.env.FERN_SPECS_DIR,
+                sdkTemplateDir: process.env.FERN_SDK_TEMPLATE_DIR
             });
 
             if (outcome.status === "skipped") {

--- a/packages/cli/cli/changes/unreleased/fix-native-specs-mounting.yml
+++ b/packages/cli/cli/changes/unreleased/fix-native-specs-mounting.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix native generator execution to correctly pass raw API specs directory
+    via FERN_SPECS_DIR environment variable, enabling local seed tests for
+    generators that consume OpenAPI specs (e.g. CLI generator).
+  type: fix

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/NativeExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/NativeExecutionEnvironment.ts
@@ -1,7 +1,8 @@
 import { loggingExeca } from "@fern-api/logging-execa";
 import { CliError } from "@fern-api/task-context";
 import { copyFile, rm } from "fs/promises";
-import { ExecutionEnvironment } from "./ExecutionEnvironment.js";
+import { CONTAINER_SPECS_DIRECTORY } from "./constants.js";
+import { ExecutionEnvironment, SourceMount } from "./ExecutionEnvironment.js";
 
 const LICENSE_MOUNT_PATH = "/tmp/LICENSE";
 
@@ -35,6 +36,7 @@ export class NativeExecutionEnvironment implements ExecutionEnvironment {
         snippetPath,
         snippetTemplatePath,
         licenseFilePath,
+        sourceMounts,
         context,
         inspect
     }: ExecutionEnvironment.ExecuteArgs): Promise<void> {
@@ -55,6 +57,12 @@ export class NativeExecutionEnvironment implements ExecutionEnvironment {
                 );
             }
         }
+
+        // Resolve source-mount env vars for native execution. In container mode these
+        // become Docker volume mounts; natively we expose them as environment variables
+        // so generators can locate mounted directories (e.g. FERN_SPECS_DIR).
+        const specsMount = sourceMounts?.find((m: SourceMount) => m.containerPath === CONTAINER_SPECS_DIRECTORY);
+        const specsEnv = specsMount != null ? { FERN_SPECS_DIR: specsMount.hostPath } : {};
 
         try {
             for (const command of this.commands) {
@@ -79,6 +87,7 @@ export class NativeExecutionEnvironment implements ExecutionEnvironment {
                     env: {
                         ...process.env,
                         ...this.env,
+                        ...specsEnv,
                         IR_PATH: irPath,
                         CONFIG_PATH: configPath,
                         OUTPUT_PATH: outputPath,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
@@ -257,7 +257,9 @@ export async function writeFilesToDiskAndRunGenerator({
         const rawSpecsDir = join(workspaceTempDir.path, SPECS_DIRECTORY_NAME);
         await mkdir(rawSpecsDir, { recursive: true });
 
-        const containerSpecsDir = CONTAINER_SPECS_DIRECTORY;
+        // In native (non-container) mode, the manifest's specPath entries must reference
+        // the actual host paths since there is no Docker volume mount to remap them.
+        const containerSpecsDir = environment.usesContainerPaths ? CONTAINER_SPECS_DIRECTORY : rawSpecsDir;
 
         const manifest = await collectRawSpecs({
             specs: rawApiSpecs,

--- a/seed/cli/seed.yml
+++ b/seed/cli/seed.yml
@@ -30,6 +30,10 @@ test:
       # rust-model-cli.cjs into its own dist/ for subprocess invocation.
       - pnpm turbo run dist:cli --filter @fern-api/rust-model && pnpm turbo run dist:cli --filter @fern-api/cli-generator
     runCommand: node --enable-source-maps dist/cli.cjs {CONFIG_PATH}
+    env:
+      # In native (non-Docker) mode, the SDK template lives in the local
+      # build output rather than the Docker image's /dist/sdk.
+      FERN_SDK_TEMPLATE_DIR: dist/sdk
 
 scripts:
   - image: fernapi/cli-seed


### PR DESCRIPTION
## Description

Fixes the CLI generator's local (`--local`) seed test runner so that OpenAPI specs and the SDK template directory are correctly resolved when running natively (without Docker).

Previously, running `pnpm seed test --generator cli --fixture query-parameters-openapi --skip-scripts --local` would either:
1. Skip generation entirely ("No OpenAPI specs mounted") because specs written to a temp dir used container paths (`/fern/specs`) in the manifest but `/fern/specs` doesn't exist on the host, or
2. Crash with `ENOENT: /dist/sdk` because the SDK template path is Docker-image-specific.

## Changes Made

- **`runGenerator.ts`**: When `!environment.usesContainerPaths`, use the actual host path (instead of `/fern/specs`) as the base directory for spec manifest entries so file paths resolve correctly without Docker volume mounts.
- **`NativeExecutionEnvironment.ts`**: Extract source mounts targeting `/fern/specs` and expose the host path as `FERN_SPECS_DIR` env var to the child generator process.
- **`generators/cli/src/cli.ts`**: Read `FERN_SPECS_DIR` and `FERN_SDK_TEMPLATE_DIR` env vars and forward them to `runPipeline()`.
- **`seed/cli/seed.yml`**: Add `env: { FERN_SDK_TEMPLATE_DIR: dist/sdk }` to the local test config so the generator finds the SDK template at the build output path instead of `/dist/sdk`.

## Testing

- [x] `pnpm seed test --generator cli --fixture query-parameters-openapi --skip-scripts --local` — all 3 variants pass
- [x] `pnpm seed test --generator cli --skip-scripts --local` — full fixture suite passes (112/128 succeed, remaining 16 are in `allowedFailures`)
- [x] No snapshot diffs — generated output matches committed snapshots exactly


Link to Devin session: https://app.devin.ai/sessions/cde1bd191d68405381f0f7134894c5f7
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->