### PR TITLE
fix(go): generate compiling dynamic snippets for bytes request bodies

### DIFF
--- a/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -700,15 +700,23 @@ export class EndpointSnippetGenerator {
 
     private getBytesBodyRequestArg({ value }: { value: unknown }): go.TypeInstantiation {
         const bytesValue = typeof value === "string" ? (value as string) : "";
-        return go.TypeInstantiation.reference(
-            go.invokeFunc({
-                func: go.typeReference({
-                    name: "NewReader",
-                    importPath: "bytes"
-                }),
-                arguments_: [go.TypeInstantiation.bytes(bytesValue)]
-            })
-        );
+        // The bytes request parameter is generated as an io.Reader unless
+        // useReaderForBytesRequest is explicitly disabled, in which case it is a
+        // plain []byte (see BytesRequest.getRequestParameterType). The default
+        // matches the SDK generator's default (defaultBaseGoCustomConfigSchema),
+        // and the snippet argument must match that type or it will not compile.
+        if (this.context.customConfig?.useReaderForBytesRequest ?? true) {
+            return go.TypeInstantiation.reference(
+                go.invokeFunc({
+                    func: go.typeReference({
+                        name: "NewReader",
+                        importPath: "bytes"
+                    }),
+                    arguments_: [go.TypeInstantiation.bytes(bytesValue)]
+                })
+            );
+        }
+        return go.TypeInstantiation.bytes(bytesValue);
     }
 
     private getMethodArgsForInlinedRequest({
@@ -898,7 +906,12 @@ export class EndpointSnippetGenerator {
     }): go.TypeInstantiation {
         switch (body.type) {
             case "bytes":
-                return this.getBytesBodyRequestArg({ value });
+                // A bytes body referenced as a property of a request wrapper is
+                // generated as a []byte struct field (the request wrapper type
+                // comes from v1, which does not apply useReaderForBytesRequest).
+                // The standalone bytes parameter, by contrast, may be an
+                // io.Reader; that case is handled by getBytesBodyRequestArg.
+                return go.TypeInstantiation.bytes(typeof value === "string" ? value : "");
             case "typeReference":
                 return this.context.dynamicTypeInstantiationMapper.convert({ typeReference: body.value, value });
             default:

--- a/generators/go/sdk/changes/unreleased/fix-bytes-upload-snippet-type.yml
+++ b/generators/go/sdk/changes/unreleased/fix-bytes-upload-snippet-type.yml
@@ -1,0 +1,9 @@
+- summary: |
+    Fixed the generated dynamic code snippets for endpoints with a bytes request
+    body so that they compile. A bytes body referenced as a property of a request
+    wrapper is now instantiated as a `[]byte`, matching the generated struct
+    field, and a standalone bytes parameter now defaults to `io.Reader` (matching
+    the SDK's `useReaderForBytesRequest` default) instead of being keyed off an
+    unset config value. Previously the snippet wrapped the wrapped-request body in
+    `bytes.NewReader`, producing code that did not match the `[]byte` field type.
+  type: fix

--- a/seed/go-sdk/bytes-upload/dynamic-snippets/example1/snippet.go
+++ b/seed/go-sdk/bytes-upload/dynamic-snippets/example1/snippet.go
@@ -1,7 +1,6 @@
 package example
 
 import (
-    bytes "bytes"
     context "context"
 
     fern "github.com/bytes-upload/fern"
@@ -17,9 +16,7 @@ func do() {
     )
     request := &fern.UploadWithQueryParamsRequest{
         Model: "nova-2",
-        Body: bytes.NewReader(
-            []byte(""),
-        ),
+        Body: []byte(""),
     }
     client.Service.UploadWithQueryParams(
         context.TODO(),

--- a/seed/go-sdk/bytes-upload/reference.md
+++ b/seed/go-sdk/bytes-upload/reference.md
@@ -44,9 +44,7 @@ client.Service.Upload(
 ```go
 request := &fern.UploadWithQueryParamsRequest{
         Model: "nova-2",
-        Body: bytes.NewReader(
-            []byte(""),
-        ),
+        Body: []byte(""),
     }
 client.Service.UploadWithQueryParams(
         context.TODO(),

--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -359,7 +359,6 @@ allowedFailures:
   # "not supported yet" or a nil-pointer panic). These need feature work.
   - alias-extends # object/request body extends an alias; v1 assumes extends are objects
   - bytes-download
-  - bytes-upload
   - streaming-parameter
   - pagination
   - pagination-uri-path


### PR DESCRIPTION
## Description
Fixes the `bytes-upload` go-sdk seed fixture (removed from `allowedFailures`).

The generated dynamic code snippets for endpoints with a bytes request body did not compile. The snippet generator always wrapped a bytes value in `bytes.NewReader(...)` (an `io.Reader`), but the type the snippet must match differs by context:

- **Wrapped request body** (a bytes body that is a property of a request wrapper, e.g. `UploadWithQueryParamsRequest`): v1 generates the struct field as `[]byte` (v1 does not implement `useReaderForBytesRequest`). The snippet emitted `Body: bytes.NewReader([]byte(""))`, which does not match `Body []byte`:
  ```
  dynamic-snippets/example1/snippet.go:20:15: cannot use bytes.NewReader([]byte("")) (value of type *bytes.Reader) as []byte value in struct literal
  ```
- **Standalone bytes parameter**: the SDK method parameter type follows `useReaderForBytesRequest` (`BytesRequest.getRequestParameterType`), which defaults to `io.Reader` via `defaultBaseGoCustomConfigSchema`. The dynamic-snippets generator context does not apply that default, so keying the snippet off an unset config value produced `[]byte`, mismatching the `io.Reader` parameter.

## Changes Made
- `EndpointSnippetGenerator.getReferencedRequestBodyPropertyTypeInstantiation`: a `bytes` body referenced as a request-wrapper property is now instantiated as `[]byte`, matching the v1-generated struct field.
- `EndpointSnippetGenerator.getBytesBodyRequestArg` (standalone bytes parameter): defaults `useReaderForBytesRequest` to `true` (`?? true`), matching the SDK generator default and the `?? true` convention already used in this file, so the standalone snippet matches the `io.Reader` parameter.
- Removed `bytes-upload` from `seed/go-sdk/seed.yml` `allowedFailures`.
- Regenerated `seed/go-sdk/bytes-upload` output (wrapped body snippet + reference.md).
- Added a go-sdk changelog entry.

## Testing
- [x] `pnpm seed test --generator go-sdk --fixture bytes-upload --local` → `1/1 test cases passed` (generation + build + wire tests).
- [x] Manual testing completed


Link to Devin session: https://app.devin.ai/sessions/6ba63e4405694aa8ab8875f0dbfd9afc
Requested by: @iamnamananand996