### PR TITLE
feat(internal): auto-propagate Rust SDK changelog entries to CLI Generator

### DIFF
--- a/.claude/release-versioning.md
+++ b/.claude/release-versioning.md
@@ -35,6 +35,7 @@ If a path falls under **`softwareDirectory`**, use the matching **`changelogFold
 | `rust` | `generators/rust` | `generators/rust/sdk/changes/unreleased/` |
 | `swift` | `generators/swift` | `generators/swift/sdk/changes/unreleased/` |
 | `typescript` | `generators/typescript` | `generators/typescript/sdk/changes/unreleased/` |
+| `cli-generator` | `generators/cli` | `generators/cli/changes/unreleased/` |
 
 Pick the narrowest matching **`softwareDirectory`** when several could apply (e.g. generator-only work under `generators/python/...` uses the Python generator row, not CLI). If a single PR spans multiple **`softwareDirectory`** trees, add a changelog file in **each** corresponding **`changelogFolder/unreleased/`**.
 

--- a/.claude/release-versioning.md
+++ b/.claude/release-versioning.md
@@ -47,3 +47,17 @@ Pick the narrowest matching **`softwareDirectory`** when several could apply (e.
    - **`type`**: `fix` | `chore` | `feat` | `internal`
 
 Those types drive semver bumps when releases run (`fix`/`chore` → patch, `feat`/`internal` → minor). The automated release flow does **not** produce major version bumps. To ship a major release, a human edits the relevant `versions.yml` directly so the breaking change is explicitly acknowledged in review. The validator rejects `type: break` in `unreleased/`.
+
+## Cross-product propagation (`propagatesTo`)
+
+Some products embed another product's output. For example, the CLI Generator bundles the Rust SDK Generator's generated code. When the Rust SDK ships a fix, the CLI Generator must also release a new version with that fix.
+
+**`propagatesTo`** in `release-config.json` automates this. When a software entry with `propagatesTo` is released, the release script creates an auto-generated changelog entry (`auto-propagated-from-<source>.yml`) in each target's `unreleased/` folder. The entry inherits the highest severity type from the source so the target receives at least a matching semver bump.
+
+Current propagation relationships:
+
+| Source | Propagates to |
+|--------|--------------|
+| `rust` | `cli-generator` |
+
+**You do not need to manually add a CLI Generator changelog entry when only the Rust SDK changes.** The automation handles it. If your PR also changes CLI Generator code (under `generators/cli/`), add a separate changelog entry as usual — the propagated entry will be combined with it during release.

--- a/.claude/release-versioning.md
+++ b/.claude/release-versioning.md
@@ -30,7 +30,6 @@ If a path falls under **`softwareDirectory`**, use the matching **`changelogFold
 | `java` | `generators/java` | `generators/java/sdk/changes/unreleased/` |
 | `php` | `generators/php` | `generators/php/sdk/changes/unreleased/` |
 | `python` | `generators/python` | `generators/python/sdk/changes/unreleased/` |
-| `ruby` | `generators/ruby` | `generators/ruby/sdk/changes/unreleased/` |
 | `ruby-v2` | `generators/ruby-v2` | `generators/ruby-v2/sdk/changes/unreleased/` |
 | `rust` | `generators/rust` | `generators/rust/sdk/changes/unreleased/` |
 | `swift` | `generators/swift` | `generators/swift/sdk/changes/unreleased/` |

--- a/release-config.json
+++ b/release-config.json
@@ -47,7 +47,8 @@
       "name": "Rust SDK Generator",
       "versionsFile": "generators/rust/sdk/versions.yml",
       "changelogFolder": "generators/rust/sdk/changes",
-      "softwareDirectory": "generators/rust"
+      "softwareDirectory": "generators/rust",
+      "propagatesTo": ["cli-generator"]
     },
     "swift": {
       "name": "Swift SDK Generator",

--- a/release-config.schema.json
+++ b/release-config.schema.json
@@ -25,6 +25,11 @@
           "softwareDirectory": {
             "type": "string",
             "description": "Path to software directory - changes here require changelog entries (defaults to same directory as versions.yml)"
+          },
+          "propagatesTo": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Other software keys whose unreleased changelog should receive a propagated entry when this software is released. Used when one product embeds another (e.g. Rust SDK → CLI Generator)."
           }
         },
         "required": ["name", "versionsFile"]

--- a/scripts/release-config.ts
+++ b/scripts/release-config.ts
@@ -8,6 +8,7 @@ export interface SoftwareConfig {
     versionsFile: string;
     changelogFolder?: string;
     softwareDirectory?: string;
+    propagatesTo?: string[];
 }
 
 export interface ReleaseConfig {

--- a/scripts/release-workflow.ts
+++ b/scripts/release-workflow.ts
@@ -1,7 +1,60 @@
 #!/usr/bin/env tsx
 // biome-ignore-all lint/suspicious/noConsole: CLI script requires console output for user feedback
 import { spawnSync } from "child_process";
-import { listConfiguredSoftware } from "./release-config.js";
+import { listConfiguredSoftware, loadReleaseConfig } from "./release-config.js";
+
+/**
+ * Topologically sorts the software list so that sources with `propagatesTo`
+ * are processed before their dependents. This guarantees a source's release
+ * commit (which includes a propagated changelog entry for the dependent) is
+ * pushed to main before the dependent's release runs and pulls it.
+ */
+function topologicalSort(softwareList: string[]): string[] {
+    const config = loadReleaseConfig();
+    const setList = new Set(softwareList);
+
+    // Build in-degree map (target → number of sources that propagate to it)
+    const inDegree = new Map<string, number>();
+    const edges = new Map<string, string[]>();
+    for (const sw of softwareList) {
+        inDegree.set(sw, inDegree.get(sw) ?? 0);
+        const targets = config.software[sw]?.propagatesTo ?? [];
+        for (const target of targets) {
+            if (setList.has(target)) {
+                inDegree.set(target, (inDegree.get(target) ?? 0) + 1);
+                const existing = edges.get(sw) ?? [];
+                existing.push(target);
+                edges.set(sw, existing);
+            }
+        }
+    }
+
+    // Kahn's algorithm
+    const queue = softwareList.filter((sw) => (inDegree.get(sw) ?? 0) === 0);
+    const sorted: string[] = [];
+
+    while (queue.length > 0) {
+        const sw = queue.shift();
+        if (sw === undefined) {
+            break;
+        }
+        sorted.push(sw);
+        for (const target of edges.get(sw) ?? []) {
+            const newDegree = (inDegree.get(target) ?? 1) - 1;
+            inDegree.set(target, newDegree);
+            if (newDegree === 0) {
+                queue.push(target);
+            }
+        }
+    }
+
+    if (sorted.length !== softwareList.length) {
+        console.error("❌ Circular dependency detected in propagatesTo configuration");
+        process.exit(1);
+    }
+
+    return sorted;
+}
 
 function main(): void {
     const softwareArg = process.argv[2] ?? "all";
@@ -19,6 +72,9 @@ function main(): void {
             }
         }
     }
+
+    // Ensure sources are released before their dependents
+    softwareList = topologicalSort(softwareList);
 
     console.log(`Software configured for release: ${softwareList.join(", ")}`);
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -361,7 +361,12 @@ function moveUnreleasedFiles(unreleasedDir: string, versionDir: string, changes:
  * Returns the list of file paths that were written (relative to the repo
  * root) so the caller can stage them in the same git commit.
  */
-function propagateToDownstream(softwareName: string, config: SoftwareConfig, changes: UnreleasedChange[]): string[] {
+function propagateToDownstream(
+    softwareName: string,
+    sourceVersion: string,
+    config: SoftwareConfig,
+    changes: UnreleasedChange[]
+): string[] {
     const targets = config.propagatesTo;
     if (!targets || targets.length === 0) {
         return [];
@@ -395,10 +400,10 @@ function propagateToDownstream(softwareName: string, config: SoftwareConfig, cha
             mkdirSync(targetUnreleasedDir, { recursive: true });
         }
 
-        const filename = `auto-propagated-from-${softwareName}.yml`;
+        const filename = `auto-propagated-from-${softwareName}-${sourceVersion}.yml`;
         const filePath = join(targetUnreleasedDir, filename);
 
-        const content = `- summary: |\n    Includes ${config.name} updates.\n  type: ${highestType}\n`;
+        const content = `- summary: |\n    Includes ${config.name} ${sourceVersion} updates.\n  type: ${highestType}\n`;
         writeFileSync(filePath, content);
 
         const relativePath = join(getUnreleasedDir(targetConfig), filename);
@@ -480,7 +485,7 @@ function prepareRelease(softwareName: string, config: SoftwareConfig): void {
     console.log(`   ✅ Files moved to ${getChangelogFolder(config)}/${nextVersion}/\n`);
 
     // Propagate changelog entries to downstream dependents (e.g. rust → cli-generator)
-    const propagatedPaths = propagateToDownstream(softwareName, config, changes);
+    const propagatedPaths = propagateToDownstream(softwareName, nextVersion, config, changes);
 
     // Commit changes
     console.log("💾 Committing changes...");

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -10,6 +10,7 @@ import {
     getSoftwareConfig,
     getUnreleasedDir,
     listConfiguredSoftware,
+    loadReleaseConfig,
     type SoftwareConfig
 } from "./release-config.js";
 import { setupSoftware } from "./release-setup.js";
@@ -350,6 +351,61 @@ function moveUnreleasedFiles(unreleasedDir: string, versionDir: string, changes:
     }
 }
 
+/**
+ * When a software entry declares `propagatesTo`, this function creates an
+ * auto-generated changelog entry in each target's unreleased folder. The
+ * entry uses the highest severity type from the source's changes so that
+ * the dependent receives at least a matching semver bump (e.g. a `feat`
+ * in the Rust SDK produces a `feat` entry for the CLI Generator).
+ *
+ * Returns the list of file paths that were written (relative to the repo
+ * root) so the caller can stage them in the same git commit.
+ */
+function propagateToDownstream(softwareName: string, config: SoftwareConfig, changes: UnreleasedChange[]): string[] {
+    const targets = config.propagatesTo;
+    if (!targets || targets.length === 0) {
+        return [];
+    }
+
+    const allConfigs = loadReleaseConfig();
+    const writtenPaths: string[] = [];
+
+    // Determine the highest severity type from the source changes.
+    let highestType: ChangelogEntry["type"] = "chore";
+    for (const change of changes) {
+        for (const entry of change.entries) {
+            if (getSeverityFromType(entry.type) === "minor") {
+                highestType = entry.type;
+            }
+        }
+    }
+
+    for (const targetKey of targets) {
+        const targetConfig = allConfigs.software[targetKey];
+        if (!targetConfig) {
+            console.warn(`⚠️  propagatesTo target "${targetKey}" not found in release-config.json — skipping`);
+            continue;
+        }
+
+        const targetUnreleasedDir = join(__dirname, "..", getUnreleasedDir(targetConfig));
+        if (!existsSync(targetUnreleasedDir)) {
+            mkdirSync(targetUnreleasedDir, { recursive: true });
+        }
+
+        const filename = `auto-propagated-from-${softwareName}.yml`;
+        const filePath = join(targetUnreleasedDir, filename);
+
+        const content = `- summary: |\n    Includes ${config.name} updates.\n  type: ${highestType}\n`;
+        writeFileSync(filePath, content);
+
+        const relativePath = join(getUnreleasedDir(targetConfig), filename);
+        writtenPaths.push(relativePath);
+        console.log(`   📡 Propagated ${softwareName} → ${targetKey} (${relativePath})`);
+    }
+
+    return writtenPaths;
+}
+
 function prepareRelease(softwareName: string, config: SoftwareConfig): void {
     const versionsFile = join(__dirname, "..", config.versionsFile);
     const changelogFolder = join(__dirname, "..", getChangelogFolder(config));
@@ -420,11 +476,17 @@ function prepareRelease(softwareName: string, config: SoftwareConfig): void {
     moveUnreleasedFiles(fullUnreleasedDir, versionDir, changes);
     console.log(`   ✅ Files moved to ${getChangelogFolder(config)}/${nextVersion}/\n`);
 
+    // Propagate changelog entries to downstream dependents (e.g. rust → cli-generator)
+    const propagatedPaths = propagateToDownstream(softwareName, config, changes);
+
     // Commit changes
     console.log("💾 Committing changes...");
     try {
         execSync(`git add ${config.versionsFile}`, { stdio: "inherit" });
         execSync(`git add ${getChangelogFolder(config)}`, { stdio: "inherit" });
+        for (const propagatedPath of propagatedPaths) {
+            execSync(`git add ${propagatedPath}`, { stdio: "inherit" });
+        }
         execSync(`git commit -m "chore(${softwareName}): release ${nextVersion}"`, { stdio: "inherit" });
         console.log("   ✅ Changes committed\n");
     } catch (error) {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -371,14 +371,17 @@ function propagateToDownstream(softwareName: string, config: SoftwareConfig, cha
     const writtenPaths: string[] = [];
 
     // Determine the highest severity type from the source changes.
-    let highestType: ChangelogEntry["type"] = "chore";
+    // Initialize from the first entry so patch-level types propagate
+    // faithfully (fix → fix, not fix → chore).
+    let highestType: ChangelogEntry["type"] | undefined;
     for (const change of changes) {
         for (const entry of change.entries) {
-            if (getSeverityFromType(entry.type) === "minor") {
+            if (highestType === undefined || getSeverityFromType(entry.type) === "minor") {
                 highestType = entry.type;
             }
         }
     }
+    highestType = highestType ?? "chore";
 
     for (const targetKey of targets) {
         const targetConfig = allConfigs.software[targetKey];


### PR DESCRIPTION
## Description

When the Rust SDK Generator ships a release, the CLI Generator (which embeds Rust SDK output) must also ship a new version. Currently this requires manually duplicating changelog entries, which is error-prone. This PR automates the propagation.

## Changes Made

**New `propagatesTo` field in `release-config.json`:**

```json
"rust": {
  ...
  "propagatesTo": ["cli-generator"]
}
```

When `release.ts` processes the Rust SDK release, it now:
1. Writes `generators/cli/changes/unreleased/auto-propagated-from-rust-<version>.yml` with a summary like "Includes Rust SDK Generator 0.41.0 updates" and the highest severity type from the source changes (`feat` → `feat`, `fix` → `fix`)
2. Stages the propagated file in the same commit as the source release
3. Each release creates a unique file (versioned filename) so multiple source releases accumulate without overwriting each other

**Topological ordering in `release-workflow.ts`:**

Kahn's algorithm ensures sources (e.g. `rust`) are always processed before their dependents (e.g. `cli-generator`) regardless of JSON key order. The dependent's `pnpm release` run pulls the source's commit (which includes the propagated file) and processes it normally.

**Updated docs:** `.claude/release-versioning.md` documents the new `propagatesTo` mechanism, adds the missing `cli-generator` row to the mapping table, and removes a stale `ruby` entry.

- Schema: `release-config.schema.json` — added `propagatesTo` array
- Config: `release-config.json` — `rust.propagatesTo: ["cli-generator"]`
- Types: `release-config.ts` — `propagatesTo?: string[]` on `SoftwareConfig`
- Logic: `release.ts` — `propagateToDownstream()` writes versioned entries during source release
- Ordering: `release-workflow.ts` — `topologicalSort()` before iterating

## Testing
- [x] `pnpm run check` (biome lint + format) passes
- [x] All CI checks pass
- [ ] Manual testing completed — the propagation logic is straightforward file-writing that will be exercised on the next Rust SDK release to main

Link to Devin session: https://app.devin.ai/sessions/4373901806b34beba6123dbb60a1edb7
Requested by: @jsklan