### PR TITLE
fix(cli): remove --locked from generated CI workflows

### DIFF
--- a/generators/cli/changes/unreleased/remove-locked-from-ci.yml
+++ b/generators/cli/changes/unreleased/remove-locked-from-ci.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Remove `--locked` from `cargo check`, `cargo build`, and `cargo test`
+    commands in generated CI workflows. The lockfile produced at generation
+    time can become stale when the cli-sdk runtime is updated or users add
+    custom code, causing `--locked` builds to reject the lockfile.
+  type: fix

--- a/generators/cli/src/emitPublishWorkflow.ts
+++ b/generators/cli/src/emitPublishWorkflow.ts
@@ -88,7 +88,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Check
-        run: cargo check --locked
+        run: cargo check
 
   compile:
     runs-on: ubuntu-latest
@@ -100,7 +100,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Compile
-        run: cargo build --locked
+        run: cargo build
 
   test:
     runs-on: ubuntu-latest
@@ -112,7 +112,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Test
-        run: cargo test --locked
+        run: cargo test
 `;
 }
 
@@ -168,7 +168,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Check
-        run: cargo check --locked
+        run: cargo check
 
   compile:
     runs-on: ubuntu-latest
@@ -180,7 +180,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Compile
-        run: cargo build --locked
+        run: cargo build
 
   test:
     runs-on: ubuntu-latest
@@ -192,7 +192,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Test
-        run: cargo test --locked
+        run: cargo test
 
   publish:
     needs: [check, compile, test]

--- a/seed/cli/query-parameters-openapi/github-no-publish/.github/workflows/ci.yml
+++ b/seed/cli/query-parameters-openapi/github-no-publish/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Check
-        run: cargo check --locked
+        run: cargo check
 
   compile:
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Compile
-        run: cargo build --locked
+        run: cargo build
 
   test:
     runs-on: ubuntu-latest
@@ -44,4 +44,4 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Test
-        run: cargo test --locked
+        run: cargo test

--- a/seed/cli/query-parameters-openapi/github-npm/.github/workflows/ci.yml
+++ b/seed/cli/query-parameters-openapi/github-npm/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Check
-        run: cargo check --locked
+        run: cargo check
 
   compile:
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Compile
-        run: cargo build --locked
+        run: cargo build
 
   test:
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Test
-        run: cargo test --locked
+        run: cargo test
 
   publish:
     needs: [check, compile, test]


### PR DESCRIPTION
## Description

The CLI generator's emitted CI workflows use `cargo check --locked`, `cargo build --locked`, and `cargo test --locked`. The lockfile produced at generation time becomes stale when the cli-sdk runtime is updated (e.g. the 0.6.2 → 1.0.0 bump) or users add custom code/dependencies, causing all three CI jobs to fail with:

```
error: cannot update the lock file because --locked was passed to prevent this
```

This was already partially addressed in v0.14.1 (which removed `--locked` from publish build steps) but v0.14.2 re-added `--locked` to the check/compile/test jobs.

## Changes Made

- Removed `--locked` from `cargo check`, `cargo build`, `cargo test` in `constructBuildTestYaml` (github-no-publish mode)
- Removed `--locked` from `cargo check`, `cargo build`, `cargo test` in `constructWorkflowYaml` (github-npm publish mode)
- Updated seed fixtures (`query-parameters-openapi/github-npm` and `github-no-publish`) to match
- Added unreleased changelog entry

## Testing

- [x] `pnpm run check` passes (biome lint)
- [x] Seed fixtures updated to reflect the new generated output

Link to Devin session: https://app.devin.ai/sessions/bc0ede63bf8c4ea293c69e77ecac8b93
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->