### PR TITLE
feat(cli): carry favicon path into ledger config for proper rendering

### DIFF
--- a/packages/cli/cli/changes/unreleased/ledger-favicon.yml
+++ b/packages/cli/cli/changes/unreleased/ledger-favicon.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Carry the configured favicon path into the docs ledger config so the
+    favicon renders on ledger-published sites. The favicon is now treated as
+    a config-referenced file (like the logo) and resolved from S3 at its real
+    extension (.svg/.png/.ico) instead of being dropped.
+  type: feat

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
@@ -141,6 +141,37 @@ describe("buildLedgerInput", () => {
         });
     });
 
+    it("carries the favicon FileId through to the LedgerConfig as a fullPath (any extension)", () => {
+        // Favicon is a config-referenced file (like logo/OG): its fullPath is
+        // resolved here and retained in the manifest files map so the read side
+        // can serve it from S3 at its real extension (.svg here, not .ico).
+        const docsDefinition = {
+            pages: {},
+            config: {
+                root: MINIMAL_ROOT,
+                favicon: "docs/assets/favicon.svg"
+            }
+        } as unknown as Parameters<typeof buildLedgerInput>[0]["docsDefinition"];
+
+        const { localeEntry } = buildLedgerInput({
+            docsDefinition,
+            apiDefinitions: new Map(),
+            // Identity map: fileId === sanitizedPath in the current FDR flow.
+            fileIdToPath: new Map([["docs/assets/favicon.svg", "docs/assets/favicon.svg"]])
+        });
+
+        expect(localeEntry.config?.favicon).toBe("docs/assets/favicon.svg");
+    });
+
+    it("omits the favicon from LedgerConfig when absent in DocsConfig", () => {
+        const { localeEntry } = buildLedgerInput({
+            docsDefinition: makeDocsDefinition(),
+            apiDefinitions: new Map()
+        });
+
+        expect(localeEntry.config?.favicon).toBeUndefined();
+    });
+
     it("drops a logo ImageRef when the file is not measured (no width/height in manifest)", () => {
         const docsDefinition = {
             pages: {},

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/mapDocsConfigToLedgerConfig.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/mapDocsConfigToLedgerConfig.ts
@@ -253,11 +253,16 @@ function mapIntegrations(integrations: DocsConfig["integrations"]): LedgerConfig
  * has no measured dimensions, the corresponding logo field is dropped rather
  * than emitted with placeholder values.
  *
- * Fields that exist only in DocsConfig (favicon, agents.llmsTxt,
- * languages, navigation, root, logoV2, colors, colorsV2, typography (v1),
- * hideNavLinks, globalTheme, backgroundImage at the top level, logo at the
- * top level) are intentionally omitted: LedgerConfig either exposes them by
- * convention (favicon, llms*) or has dropped them (legacy v1/v2 variants).
+ * Fields that exist only in DocsConfig (agents.llmsTxt, languages,
+ * navigation, root, logoV2, colors, colorsV2, typography (v1), hideNavLinks,
+ * globalTheme, backgroundImage at the top level, logo at the top level) are
+ * intentionally omitted: LedgerConfig either exposes them by convention
+ * (llms*) or has dropped them (legacy v1/v2 variants).
+ *
+ * The favicon IS carried: it's a config-referenced file (like the logo/OG
+ * images) whose fullPath is resolved here and retained in the ledger
+ * manifest's `files` map so the read side can resolve it from S3 at its
+ * real extension (.svg/.png/.ico).
  */
 export function mapDocsConfigToLedgerConfig({
     docsConfig,
@@ -278,6 +283,7 @@ export function mapDocsConfigToLedgerConfig({
         logoHeight: docsConfig.logoHeight,
         logoHref: docsConfig.logoHref,
         logoRightText: docsConfig.logoRightText,
+        favicon: resolveFileIdToPath(docsConfig.favicon, fileIdToPath),
         agents: mapAgents(docsConfig.agents),
         metadata: mapMetadata(docsConfig.metadata, fileIdToPath),
         redirects: docsConfig.redirects,


### PR DESCRIPTION
## Description
Linear ticket: Refs

Carry the configured favicon path into the docs ledger config so ledger-published sites render the favicon. This is the **producer** half of a coupled change; the **consumer** half is fern-platform PR https://github.com/fern-api/fern-platform/pull/11932 (schema field + files-map retention + favicon route cleanup).

Previously `mapDocsConfigToLedgerConfig` intentionally dropped `favicon` (the doc comment claimed it was "served by convention" as a well-known file artifact). The favicon *file* is uploaded to S3, but the *reference* to which file is the favicon was lost — so the read side had no way to emit `<link rel="icon">` or resolve the artifact at its real extension. Many projects use `favicon.svg`, but the read route hardcoded `favicon.ico`, so the favicon never resolved.

## Changes Made
- `mapDocsConfigToLedgerConfig.ts`: resolve and carry `favicon: resolveFileIdToPath(docsConfig.favicon, fileIdToPath)` into the returned `LedgerConfig` (mirrors how logo / OG / font paths are resolved). Updated the doc comment to document favicon as a config-referenced file rather than "intentionally omitted".
- Added changelog entry `packages/cli/cli/changes/unreleased/ledger-favicon.yml` (`type: feat`).
- [x] Updated README.md generator (if applicable) — N/A

## Testing
- [x] Unit tests added/updated — two new cases in `buildLedgerInput.test.ts`: (1) favicon FileId carried through to `LedgerConfig` as a fullPath at any extension (`.svg`), (2) favicon omitted from `LedgerConfig` when absent in `DocsConfig`. All 21 `buildLedgerInput` tests pass.
- [x] Manual testing completed — `remote-workspace-runner` compiles clean against the fern-platform SDK that adds the `favicon` schema field; biome clean.


Link to Devin session: https://app.devin.ai/sessions/ec72b39820204a31be764cd3d1e8f654
Requested by: @emjoseph