### PR TITLE
fix(cli-generator): three codegen bugs (multipart dep, mod.rs registration, nested glue)

### DIFF
--- a/generators/cli/changes/unreleased/fix-types-crate-reqwest-dep.yml
+++ b/generators/cli/changes/unreleased/fix-types-crate-reqwest-dep.yml
@@ -8,4 +8,7 @@
     groups (2+ levels). The glue now recursively discovers sub-client
     structs from the generated SDK's resource tree and emits correct
     nested struct literals instead of assuming a flat client hierarchy.
+    Nested sub-clients are qualified through `api::resources::<group>`
+    (where the group modules actually live) rather than `api::<group>`,
+    which is not re-exported at the crate's `api` root.
   type: fix

--- a/generators/cli/changes/unreleased/fix-types-crate-reqwest-dep.yml
+++ b/generators/cli/changes/unreleased/fix-types-crate-reqwest-dep.yml
@@ -1,0 +1,11 @@
+- summary: |
+    Add `reqwest` dependency to the embedded types crate when file-upload
+    (multipart/form-data) request types are generated. Previously the types
+    crate referenced `reqwest::multipart::Form` without declaring the dep.
+  type: fix
+- summary: |
+    Fix SDK glue generation for APIs with nested `x-fern-sdk-group-name`
+    groups (2+ levels). The glue now recursively discovers sub-client
+    structs from the generated SDK's resource tree and emits correct
+    nested struct literals instead of assuming a flat client hierarchy.
+  type: fix

--- a/generators/cli/src/generateEmbeddedTypes.ts
+++ b/generators/cli/src/generateEmbeddedTypes.ts
@@ -106,8 +106,23 @@ async function patchTypesCrate(args: { typesOutputDir: string; typesCrateName: s
     const { typesOutputDir, typesCrateName } = args;
     const crateName = typesCrateName.replace(/-/g, "_");
 
+    // Scan generated source files for reqwest::multipart usage (emitted
+    // by the model generator's FileUploadRequestGenerator).
+    const needsReqwest = await sourceFilesContain(path.join(typesOutputDir, "src"), "reqwest::multipart");
+
     // 1. Cargo.toml — minimal lib crate with serde derives and
     //    the extra deps required by the core serde helper modules.
+    const deps = [
+        'serde = { version = "1", features = ["derive"] }',
+        'serde_json = "1"',
+        'chrono = { version = "0.4", features = ["serde"] }',
+        'base64 = "0.22"',
+        'num-bigint = { version = "0.4", features = ["serde"] }',
+        'ordered-float = { version = "4.5", features = ["serde"] }'
+    ];
+    if (needsReqwest) {
+        deps.push('reqwest = { version = "0.12", features = ["multipart"], default-features = false }');
+    }
     const cargoToml = [
         "[package]",
         `name = "${crateName}"`,
@@ -118,12 +133,7 @@ async function patchTypesCrate(args: { typesOutputDir: string; typesCrateName: s
         "doctest = false",
         "",
         "[dependencies]",
-        'serde = { version = "1", features = ["derive"] }',
-        'serde_json = "1"',
-        'chrono = { version = "0.4", features = ["serde"] }',
-        'base64 = "0.22"',
-        'num-bigint = { version = "0.4", features = ["serde"] }',
-        'ordered-float = { version = "4.5", features = ["serde"] }',
+        ...deps,
         ""
     ].join("\n");
     await writeFile(path.join(typesOutputDir, "Cargo.toml"), cargoToml);
@@ -294,6 +304,32 @@ function resolveAsIsDir(): string {
             "Ensure `pnpm turbo run dist:cli --filter @fern-api/rust-model` has been run, " +
             "or that @fern-api/rust-base is installed in the workspace."
     );
+}
+
+/**
+ * Recursively check whether any `.rs` file under `dir` contains `needle`.
+ */
+async function sourceFilesContain(dir: string, needle: string): Promise<boolean> {
+    let entries;
+    try {
+        entries = await readdir(dir, { withFileTypes: true });
+    } catch (_e: unknown) {
+        return false;
+    }
+    for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (await sourceFilesContain(full, needle)) {
+                return true;
+            }
+        } else if (entry.name.endsWith(".rs")) {
+            const content = await readFile(full, "utf-8");
+            if (content.includes(needle)) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 /**

--- a/generators/cli/src/generateSdkGlue.ts
+++ b/generators/cli/src/generateSdkGlue.ts
@@ -123,7 +123,7 @@ async function discoverClientTree(
  *
  *     sdk::api::AgentsClient {
  *         http_client: http_client.clone(),
- *         drive: sdk::api::agents::DriveClient { http_client: http_client.clone() },
+ *         drive: sdk::api::resources::agents::DriveClient { http_client: http_client.clone() },
  *     }
  */
 function renderClientInit(sdkCrate: string, node: ClientNode, indent: string): string {
@@ -148,15 +148,19 @@ function renderClientInit(sdkCrate: string, node: ClientNode, indent: string): s
  * Build the qualified type path for a client node.
  *
  * Top-level sub-clients are re-exported at `sdk::api::TypeName`.
- * Nested sub-clients live at `sdk::api::<parent_modules>::TypeName`.
+ * Nested sub-clients are NOT re-exported at the `api` root — they live
+ * under their group module beneath `api::resources`, i.e.
+ * `sdk::api::resources::<parent_modules>::TypeName`. `modulePath` is
+ * relative to `api::resources`, so the `resources::` prefix is required.
  */
 function qualifyType(sdkCrate: string, node: ClientNode): string {
     if (node.modulePath.length <= 1) {
         return `${sdkCrate}::api::${node.typeName}`;
     }
-    // For nested clients, use the parent modules (all but last segment).
+    // For nested clients, use the parent modules (all but last segment),
+    // rooted at `api::resources` where the group modules actually live.
     const parentModules = node.modulePath.slice(0, -1).join("::");
-    return `${sdkCrate}::api::${parentModules}::${node.typeName}`;
+    return `${sdkCrate}::api::resources::${parentModules}::${node.typeName}`;
 }
 
 /**

--- a/generators/cli/src/generateSdkGlue.ts
+++ b/generators/cli/src/generateSdkGlue.ts
@@ -10,62 +10,153 @@
  *   - `block_on(future)` — run an async SDK call from synchronous
  *     handler context (bridges `ApiError` → `CliError`).
  *
- * The generated code reads the SDK crate's `src/api/resources/mod.rs`
- * to discover the root client struct and its sub-client fields, so the
- * construction code is always in sync with the generated SDK.
+ * The generated code reads the SDK crate's `src/api/resources/` tree
+ * to discover client structs and their sub-client fields recursively,
+ * so the construction code is always in sync with the generated SDK —
+ * including specs with nested `x-fern-sdk-group-name` groups.
  */
 
 import { readFile, writeFile } from "fs/promises";
 import path from "path";
 
-/** A sub-client field parsed from the root client struct. */
+/** A sub-client field parsed from a client struct (possibly nested). */
 export interface SubClientField {
     fieldName: string;
     typeName: string;
 }
 
+/** Recursive tree of client fields discovered from the generated SDK. */
+interface ClientNode {
+    fieldName: string;
+    typeName: string;
+    /** Module path segments relative to `api::resources` (e.g. `["agents"]`). */
+    modulePath: string[];
+    children: ClientNode[];
+}
+
 /** Root client info parsed from the generated SDK. */
 export interface RootClientInfo {
     name: string;
-    subClients: SubClientField[];
+    subClients: ClientNode[];
 }
 
+// ---------------------------------------------------------------------------
+// Struct parsing
+// ---------------------------------------------------------------------------
+
+/** Fields that are not sub-clients — skip these when discovering sub-clients. */
+const SKIP_TYPES = new Set(["ClientConfig", "HttpClient"]);
+
 /**
- * Parse `src/api/resources/mod.rs` to extract the root client struct
- * definition and its sub-client fields.
+ * Parse a client struct from Rust source to extract its typed fields.
  *
- * Expected pattern:
- * ```rust
- * pub struct ApiClient {
- *     pub config: ClientConfig,
- *     pub pets: PetsClient,
- *     pub auth: AuthClient,
- * }
- * ```
+ * Returns the struct name and all `pub <field>: <Type>` entries,
+ * filtering out config/http_client infrastructure fields.
  */
-function parseRootClient(modRsContent: string): RootClientInfo {
-    const structMatch = modRsContent.match(/pub struct (\w+Client)\s*\{([^}]+)\}/);
+function parseClientStruct(source: string): { name: string; fields: SubClientField[] } | undefined {
+    const structMatch = source.match(/pub struct (\w+Client)\s*\{([^}]+)\}/);
     if (structMatch == null) {
-        throw new Error("Could not find root client struct in SDK's api/resources/mod.rs");
+        return undefined;
     }
 
     const name = structMatch[1] ?? "";
     const body = structMatch[2] ?? "";
-    const subClients: SubClientField[] = [];
+    const fields: SubClientField[] = [];
 
-    // Match each `pub <field>: <Type>,` line, skipping `config: ClientConfig`
     const fieldRegex = /pub\s+(\w+)\s*:\s*(\w+)\s*,?/g;
     let match;
     while ((match = fieldRegex.exec(body)) !== null) {
         const fieldName = match[1] ?? "";
         const typeName = match[2] ?? "";
-        if (typeName === "ClientConfig") {
-            continue; // skip the config field
+        if (SKIP_TYPES.has(typeName)) {
+            continue;
         }
-        subClients.push({ fieldName, typeName });
+        fields.push({ fieldName, typeName });
     }
 
-    return { name, subClients };
+    return { name, fields };
+}
+
+/**
+ * Recursively discover the client tree starting from `resources/mod.rs`.
+ *
+ * For each sub-client field, attempts to read
+ * `resources/<fieldName>/mod.rs` to discover nested sub-clients.
+ * Leaf clients (no sub-directory or no nested struct) have empty children.
+ */
+async function discoverClientTree(
+    resourcesDir: string,
+    fields: SubClientField[],
+    parentModulePath: string[]
+): Promise<ClientNode[]> {
+    const nodes: ClientNode[] = [];
+
+    for (const { fieldName, typeName } of fields) {
+        const modulePath = [...parentModulePath, fieldName];
+        let children: ClientNode[] = [];
+
+        // Try to read the sub-client's mod.rs for nested sub-clients.
+        const subModRsPath = path.join(resourcesDir, fieldName, "mod.rs");
+        try {
+            const subModRs = await readFile(subModRsPath, "utf-8");
+            const subStruct = parseClientStruct(subModRs);
+            if (subStruct != null && subStruct.fields.length > 0) {
+                children = await discoverClientTree(path.join(resourcesDir, fieldName), subStruct.fields, modulePath);
+            }
+        } catch (_e: unknown) {
+            // No sub-directory — leaf client.
+        }
+
+        nodes.push({ fieldName, typeName, modulePath, children });
+    }
+
+    return nodes;
+}
+
+// ---------------------------------------------------------------------------
+// Code generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the Rust struct literal for a single client node, recursing into
+ * children.  Returns a multi-line string like:
+ *
+ *     sdk::api::AgentsClient {
+ *         http_client: http_client.clone(),
+ *         drive: sdk::api::agents::DriveClient { http_client: http_client.clone() },
+ *     }
+ */
+function renderClientInit(sdkCrate: string, node: ClientNode, indent: string): string {
+    const qualifiedType = qualifyType(sdkCrate, node);
+
+    if (node.children.length === 0) {
+        return `${qualifiedType} { http_client: http_client.clone() }`;
+    }
+
+    const lines: string[] = [];
+    lines.push(`${qualifiedType} {`);
+    lines.push(`${indent}    http_client: http_client.clone(),`);
+    for (const child of node.children) {
+        const childInit = renderClientInit(sdkCrate, child, indent + "    ");
+        lines.push(`${indent}    ${child.fieldName}: ${childInit},`);
+    }
+    lines.push(`${indent}}`);
+    return lines.join("\n");
+}
+
+/**
+ * Build the qualified type path for a client node.
+ *
+ * Top-level sub-clients are re-exported at `sdk::api::TypeName`.
+ * Nested sub-clients live at `sdk::api::<parent_modules>::TypeName`.
+ */
+function qualifyType(sdkCrate: string, node: ClientNode): string {
+    if (node.modulePath.length <= 1) {
+        return `${sdkCrate}::api::${node.typeName}`;
+    }
+    // For nested clients, use the parent modules (all but last segment).
+    const parentModules = node.modulePath.slice(0, -1).join("::");
+    return `${sdkCrate}::api::${parentModules}::${node.typeName}`;
 }
 
 /**
@@ -73,10 +164,10 @@ function parseRootClient(modRsContent: string): RootClientInfo {
  */
 function renderSdkGlue(sdkCrateSnake: string, rootClient: RootClientInfo): string {
     const subClientInits = rootClient.subClients
-        .map(
-            (sc) =>
-                `        ${sc.fieldName}: ${sdkCrateSnake}::api::${sc.typeName} { http_client: http_client.clone() },`
-        )
+        .map((node) => {
+            const init = renderClientInit(sdkCrateSnake, node, "        ");
+            return `        ${node.fieldName}: ${init},`;
+        })
         .join("\n");
 
     return `\
@@ -209,14 +300,33 @@ export async function generateSdkGlue(args: {
     const sdkCrateSnake = sdkCrateName.replace(/-/g, "_");
 
     // Read the SDK's root client definition.
-    const modRsPath = path.join(outputDir, sdkCrateName, "src", "api", "resources", "mod.rs");
+    const resourcesDir = path.join(outputDir, sdkCrateName, "src", "api", "resources");
+    const modRsPath = path.join(resourcesDir, "mod.rs");
     const modRsContent = await readFile(modRsPath, "utf-8");
-    const rootClient = parseRootClient(modRsContent);
+    const rootStruct = parseClientStruct(modRsContent);
+    if (rootStruct == null) {
+        throw new Error("Could not find root client struct in SDK's api/resources/mod.rs");
+    }
+
+    // Recursively discover nested sub-clients from the SDK's resource tree.
+    const subClients = await discoverClientTree(resourcesDir, rootStruct.fields, []);
+    const rootClient: RootClientInfo = { name: rootStruct.name, subClients };
 
     // Write the glue module.
     const binDir = path.join(outputDir, "cli", binaryName);
     const content = renderSdkGlue(sdkCrateSnake, rootClient);
     await writeFile(path.join(binDir, "sdk_glue.rs"), content);
 
-    return rootClient.subClients;
+    // Return flat sub-client list for agent skill generation.
+    return flattenSubClients(subClients);
+}
+
+/** Flatten the recursive tree into a flat list (preserves the public interface). */
+function flattenSubClients(nodes: ClientNode[]): SubClientField[] {
+    const result: SubClientField[] = [];
+    for (const node of nodes) {
+        result.push({ fieldName: node.fieldName, typeName: node.typeName });
+        result.push(...flattenSubClients(node.children));
+    }
+    return result;
 }

--- a/generators/rust/model/src/ModelGeneratorCli.ts
+++ b/generators/rust/model/src/ModelGeneratorCli.ts
@@ -211,6 +211,24 @@ export class ModelGeneratorCli extends AbstractRustGeneratorCli<ModelCustomConfi
             }
         }
 
+        // Add request types for endpoints with referenced body AND query parameters
+        for (const service of Object.values(context.ir.services)) {
+            for (const endpoint of service.endpoints) {
+                if (endpoint.requestBody?.type === "reference" && endpoint.queryParameters.length > 0) {
+                    const filename = context.getFilenameForReferencedRequestWithQuery(endpoint.id);
+                    const rawModuleName = filename.replace(".rs", "");
+                    const escapedModuleName = context.escapeRustKeyword(rawModuleName);
+                    const typeName = context.getReferencedRequestWithQueryTypeName(endpoint.id);
+
+                    if (!uniqueModuleNames.has(escapedModuleName)) {
+                        uniqueModuleNames.add(escapedModuleName);
+                        moduleExports.push({ moduleName: escapedModuleName, typeName });
+                        requestTypeCount++;
+                    }
+                }
+            }
+        }
+
         // Add bytes request body types
         for (const service of Object.values(context.ir.services)) {
             for (const endpoint of service.endpoints) {

--- a/generators/rust/sdk/changes/unreleased/fix-referenced-request-mod-registration.yml
+++ b/generators/rust/sdk/changes/unreleased/fix-referenced-request-mod-registration.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Register synthesized request-envelope types for endpoints with a
+    referenced request body AND query parameters in the model generator's
+    `types/mod.rs`. Previously these types were generated but never
+    declared as modules, causing unresolved-type errors in the SDK crate.
+  type: fix


### PR DESCRIPTION
## Description

Fixes three independent codegen bugs in the CLI generator that prevent generated Rust workspaces from compiling when the input spec has:
1. `multipart/form-data` file-upload operations
2. DELETE endpoints with both a request body and query parameters
3. Nested `x-fern-sdk-group-name` groups (2+ levels)

All three bugs reproduce on any spec with the same shapes — not specific to any particular API.

## Changes Made

### Issue 1 — Types crate missing `reqwest` dep for multipart
**File:** `generators/cli/src/generateEmbeddedTypes.ts`

The model generator emits `to_multipart() -> reqwest::multipart::Form` on file-upload request types, but `patchTypesCrate()` wrote a static `Cargo.toml` that never included `reqwest`.

Fix: after the model generator runs, scan generated `.rs` files for `reqwest::multipart` usage. When found, add `reqwest = { version = "0.12", features = ["multipart"], default-features = false }` to the types crate's `Cargo.toml`.

### Issue 2 — Synthesized request envelope not registered in `mod.rs`
**File:** `generators/rust/model/src/ModelGeneratorCli.ts`

`generateTypesModFile()` registers inlined request bodies, file-upload bodies, query-only requests, and bytes requests — but was missing the case for endpoints with a *referenced* body AND query parameters (the "envelope" struct). The `ReferencedRequestWithQueryGenerator` generates the file, but `mod.rs` never declared the module.

Fix: add the missing registration loop matching `endpoint.requestBody?.type === "reference" && endpoint.queryParameters.length > 0`, mirroring how `SdkGeneratorCli.ts` already handles it.

### Issue 3 — SDK glue assumes flat client tree
**File:** `generators/cli/src/generateSdkGlue.ts`

`renderSdkGlue()` constructed every sub-client as `{ http_client: http_client.clone() }`, which is wrong for clients with nested sub-clients (e.g. `AgentsClient { http_client, drive, general, research, sql }`).

Fix: replaced the flat `parseRootClient` + flat template with a recursive approach:
- `parseClientStruct()` extracts typed fields from any client struct
- `discoverClientTree()` recursively reads `resources/<field>/mod.rs` to find nested sub-client structs
- `renderClientInit()` emits correct nested struct literals with proper module-qualified type paths

## Testing
- [x] `pnpm turbo run compile` passes for `@fern-api/cli-generator` and `@fern-api/rust-model`
- [x] `pnpm turbo run test` — all 16 rust-model tests pass, all CLI generator tests pass
- [x] `pnpm format:check` and `pnpm lint:biome` clean on all changed files
- [ ] Updated README.md generator (if applicable) — N/A

Link to Devin session: https://app.devin.ai/sessions/ef1ebb84bab848a79fcabfb375d49c88
Requested by: @cade-fern