### PR TITLE
feat(cli): add npm version badge to generated CLI README header

### DIFF
--- a/generators/cli/changes/unreleased/add-npm-badge-to-readme.yml
+++ b/generators/cli/changes/unreleased/add-npm-badge-to-readme.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Add npm version badge to the generated CLI README header when npm
+    publish info is configured, matching the badge behavior of generated
+    TypeScript SDKs.
+  type: feat

--- a/generators/cli/src/__test__/emitReadme.test.ts
+++ b/generators/cli/src/__test__/emitReadme.test.ts
@@ -74,6 +74,34 @@ describe("emitReadme", () => {
         expect(readme).toContain("reference.md");
     });
 
+    // ── npm badge in header ─────────────────────────────────────────
+
+    it("includes npm version badge when npmPublishInfo is present", async () => {
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "petstore-api",
+            apiDisplayName: "Petstore",
+            authBindings: [bearerBinding],
+            npmPublishInfo
+        });
+
+        expect(readme).toContain("[![npm shield](https://img.shields.io/npm/v/@petstore/cli)]");
+        expect(readme).toContain("(https://www.npmjs.com/package/@petstore/cli)");
+    });
+
+    it("omits npm badge when npmPublishInfo is absent", async () => {
+        const readme = await emitAndRead({
+            outputDir,
+            binaryName: "acme",
+            apiDisplayName: "Acme",
+            authBindings: [bearerBinding],
+            npmPublishInfo: undefined
+        });
+
+        expect(readme).not.toContain("npm shield");
+        expect(readme).not.toContain("img.shields.io");
+    });
+
     // ── Build from source when npmPublishInfo absent ────────────────
 
     it("shows build-from-source when npmPublishInfo is absent", async () => {

--- a/generators/cli/src/emitReadme.ts
+++ b/generators/cli/src/emitReadme.ts
@@ -30,7 +30,7 @@ export async function emitReadme(args: {
     const { outputDir, binaryName, apiDisplayName, authBindings, npmPublishInfo } = args;
     const displayName = apiDisplayName ?? binaryName;
 
-    const header = generateHeader(displayName);
+    const header = generateHeader({ displayName, npmPublishInfo });
     const blocks = generateBlocks({ binaryName, displayName, authBindings, npmPublishInfo });
 
     const readmePath = path.join(outputDir, "README.md");
@@ -46,8 +46,25 @@ export async function emitReadme(args: {
 // Header
 // ---------------------------------------------------------------------------
 
-function generateHeader(displayName: string): string {
+function generateHeader(args: { displayName: string; npmPublishInfo: ResolvedNpmPublishInfo | undefined }): string {
+    const { displayName, npmPublishInfo } = args;
     const suffix = displayName.toUpperCase().endsWith("API") ? "" : " API";
+    const shieldLines: string[] = [];
+    if (npmPublishInfo != null) {
+        shieldLines.push(
+            `[![npm shield](https://img.shields.io/npm/v/${npmPublishInfo.packageName})](https://www.npmjs.com/package/${npmPublishInfo.packageName})`
+        );
+    }
+    if (shieldLines.length > 0) {
+        return lines(
+            `# ${displayName} CLI`,
+            "",
+            shieldLines.join("\n"),
+            "",
+            `Command-line interface for the ${displayName}${suffix}.`,
+            ""
+        );
+    }
     return lines(`# ${displayName} CLI`, "", `Command-line interface for the ${displayName}${suffix}.`, "");
 }
 


### PR DESCRIPTION
## Description

The CLI generator's `emitReadme.ts` now emits an npm version badge in the README header when `npmPublishInfo` is configured — matching the badge behavior of generated TypeScript SDKs.

Before: `# Petstore CLI\n\nCommand-line interface for the Petstore API.`

After:
```
# Petstore CLI

[![npm shield](https://img.shields.io/npm/v/@fern-api/example-cli-petstore)](https://www.npmjs.com/package/@fern-api/example-cli-petstore)

Command-line interface for the Petstore API.
```

When `npmPublishInfo` is absent (no npm publishing configured), no badge is emitted — behavior is unchanged.

## Changes Made
- Extended `generateHeader` in `generators/cli/src/emitReadme.ts` to accept `npmPublishInfo` and emit an npm shield when present
- Added two unit tests in `emitReadme.test.ts` covering badge presence/absence
- Added unreleased changelog entry (`feat`)

## Testing
- [x] Unit tests added/updated (137 tests pass including 2 new badge tests)
- [x] Lint passes (`pnpm run check`)


Link to Devin session: https://app.devin.ai/sessions/fc39474436db4e97bebb421a0cf7662a
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->