### PR TITLE
fix(rust): use camelCase wire names in error field parsing; fix empty-body handling

### DIFF
--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -544,6 +544,12 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
             return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
@@ -562,6 +568,12 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
             return serde_json::from_value(serde_json::Value::Null)
                 .map(|body| RawResponse { body, status_code, headers })
                 .map_err(|_| ApiError::Http { status: status_code, message: String::new() });

--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -543,9 +543,8 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -563,10 +562,9 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/generators/rust/sdk/changes/unreleased/fix-error-field-parsing.yml
+++ b/generators/rust/sdk/changes/unreleased/fix-error-field-parsing.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Fix error field parsing to use camelCase JSON wire names matching REST conventions
+    (e.g. `resourceId`, `authType`, `errorId`) and derive error fields from the IR type
+    definition when available. Fix empty-body response handling: `parse_response` and
+    `parse_response_raw` now return `Ok` for empty 2xx bodies (unit/HEAD/204 responses)
+    and `Err` for empty 4xx/5xx bodies, preventing auth failures from being silently
+    swallowed on the `with_executor` path.
+  type: fix

--- a/generators/rust/sdk/src/__test__/snapshots/api-specific-variants.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/api-specific-variants.rs
@@ -40,7 +40,7 @@ impl ApiError {
                     return Self::ValidationError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
                         field: parsed.get("field").and_then(|v| v.as_str().map(|s| s.to_string())),
-                        validation_error: parsed.get("validation_error").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        validation_error: parsed.get("validationError").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -56,8 +56,8 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::RateLimitError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        retry_after_seconds: parsed.get("retry_after_seconds").and_then(|v| v.as_u64()),
-                        limit_type: parsed.get("limit_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        retry_after_seconds: parsed.get("retryAfterSeconds").and_then(|v| v.as_u64()),
+                        limit_type: parsed.get("limitType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -73,7 +73,7 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::InternalServerError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        error_id: parsed.get("error_id").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        error_id: parsed.get("errorId").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }

--- a/generators/rust/sdk/src/__test__/snapshots/basic-error-enum.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/basic-error-enum.rs
@@ -37,7 +37,7 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::UnauthorizedError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        auth_type: parsed.get("auth_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        auth_type: parsed.get("authType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -52,8 +52,8 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::NotFoundError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        resource_id: parsed.get("resource_id").and_then(|v| v.as_str().map(|s| s.to_string())),
-                        resource_type: parsed.get("resource_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        resource_id: parsed.get("resourceId").and_then(|v| v.as_str().map(|s| s.to_string())),
+                        resource_type: parsed.get("resourceType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }

--- a/generators/rust/sdk/src/__test__/snapshots/context-rich-fields.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/context-rich-fields.rs
@@ -43,7 +43,7 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::UnauthorizedError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        auth_type: parsed.get("auth_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        auth_type: parsed.get("authType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -58,8 +58,8 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::NotFoundError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        resource_id: parsed.get("resource_id").and_then(|v| v.as_str().map(|s| s.to_string())),
-                        resource_type: parsed.get("resource_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        resource_id: parsed.get("resourceId").and_then(|v| v.as_str().map(|s| s.to_string())),
+                        resource_type: parsed.get("resourceType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -76,7 +76,7 @@ impl ApiError {
                     return Self::ValidationError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
                         field: parsed.get("field").and_then(|v| v.as_str().map(|s| s.to_string())),
-                        validation_error: parsed.get("validation_error").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        validation_error: parsed.get("validationError").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -92,8 +92,8 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::RateLimitError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        retry_after_seconds: parsed.get("retry_after_seconds").and_then(|v| v.as_u64()),
-                        limit_type: parsed.get("limit_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        retry_after_seconds: parsed.get("retryAfterSeconds").and_then(|v| v.as_u64()),
+                        limit_type: parsed.get("limitType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -109,7 +109,7 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::InternalServerError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        error_id: parsed.get("error_id").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        error_id: parsed.get("errorId").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }

--- a/generators/rust/sdk/src/__test__/snapshots/default-field-values.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/default-field-values.rs
@@ -37,8 +37,8 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::RateLimitError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        retry_after_seconds: parsed.get("retry_after_seconds").and_then(|v| v.as_u64()),
-                        limit_type: parsed.get("limit_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        retry_after_seconds: parsed.get("retryAfterSeconds").and_then(|v| v.as_u64()),
+                        limit_type: parsed.get("limitType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }

--- a/generators/rust/sdk/src/__test__/snapshots/different-error-messages.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/different-error-messages.rs
@@ -43,7 +43,7 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::UnauthorizedError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        auth_type: parsed.get("auth_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        auth_type: parsed.get("authType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -59,7 +59,7 @@ impl ApiError {
                     return Self::ForbiddenError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
                         resource: parsed.get("resource").and_then(|v| v.as_str().map(|s| s.to_string())),
-                        required_permission: parsed.get("required_permission").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        required_permission: parsed.get("requiredPermission").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -75,8 +75,8 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::NotFoundError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        resource_id: parsed.get("resource_id").and_then(|v| v.as_str().map(|s| s.to_string())),
-                        resource_type: parsed.get("resource_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        resource_id: parsed.get("resourceId").and_then(|v| v.as_str().map(|s| s.to_string())),
+                        resource_type: parsed.get("resourceType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -92,7 +92,7 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::ConflictError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        conflict_type: parsed.get("conflict_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        conflict_type: parsed.get("conflictType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -108,7 +108,7 @@ impl ApiError {
                     return Self::ValidationError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
                         field: parsed.get("field").and_then(|v| v.as_str().map(|s| s.to_string())),
-                        validation_error: parsed.get("validation_error").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        validation_error: parsed.get("validationError").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -544,6 +544,12 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
             return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
@@ -562,6 +568,12 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
             return serde_json::from_value(serde_json::Value::Null)
                 .map(|body| RawResponse { body, status_code, headers })
                 .map_err(|_| ApiError::Http { status: status_code, message: String::new() });

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -543,9 +543,8 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -563,10 +562,9 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/generators/rust/sdk/src/__test__/snapshots/json-parsing.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/json-parsing.rs
@@ -38,7 +38,7 @@ impl ApiError {
                     return Self::ValidationError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
                         field: parsed.get("field").and_then(|v| v.as_str().map(|s| s.to_string())),
-                        validation_error: parsed.get("validation_error").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        validation_error: parsed.get("validationError").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -54,7 +54,7 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::ConflictError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        conflict_type: parsed.get("conflict_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        conflict_type: parsed.get("conflictType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }

--- a/generators/rust/sdk/src/__test__/snapshots/status-code-mapping.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/status-code-mapping.rs
@@ -58,7 +58,7 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::UnauthorizedError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        auth_type: parsed.get("auth_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        auth_type: parsed.get("authType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -74,7 +74,7 @@ impl ApiError {
                     return Self::ForbiddenError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
                         resource: parsed.get("resource").and_then(|v| v.as_str().map(|s| s.to_string())),
-                        required_permission: parsed.get("required_permission").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        required_permission: parsed.get("requiredPermission").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }
@@ -90,8 +90,8 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::NotFoundError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        resource_id: parsed.get("resource_id").and_then(|v| v.as_str().map(|s| s.to_string())),
-                        resource_type: parsed.get("resource_type").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        resource_id: parsed.get("resourceId").and_then(|v| v.as_str().map(|s| s.to_string())),
+                        resource_type: parsed.get("resourceType").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }

--- a/generators/rust/sdk/src/__test__/snapshots/text-only-errors.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/text-only-errors.rs
@@ -54,7 +54,7 @@ impl ApiError {
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
                     return Self::GenericError {
                         message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
-                        error_id: parsed.get("error_id").and_then(|v| v.as_str().map(|s| s.to_string()))
+                        error_id: parsed.get("errorId").and_then(|v| v.as_str().map(|s| s.to_string()))
                     };
                 }
             }

--- a/generators/rust/sdk/src/error/ErrorGenerator.ts
+++ b/generators/rust/sdk/src/error/ErrorGenerator.ts
@@ -398,14 +398,14 @@ export class ErrorGenerator {
                             Expression.toString(Expression.literal("Unknown error"))
                         )
                     }),
-                    // Extract error_type field if present
+                    // Extract error discriminant field if present
                     Statement.let({
                         name: "error_type",
                         value: Expression.andThen(
                             Expression.methodCall({
                                 target: Expression.variable("parsed"),
                                 method: "get",
-                                args: [Expression.literal("error_type")]
+                                args: [Expression.literal(this.getErrorDiscriminantWireName())]
                             }),
                             Expression.closure([{ name: "v" }], Expression.raw("v.as_str()"))
                         )
@@ -541,6 +541,14 @@ export class ErrorGenerator {
             name: "error",
             args: [`"${message}"`]
         });
+    }
+
+    private getErrorDiscriminantWireName(): string {
+        const strategy = this.context.ir.errorDiscriminationStrategy;
+        if (strategy.type === "property") {
+            return getWireValue(strategy.discriminant);
+        }
+        return "error_type";
     }
 
     // Helper methods

--- a/generators/rust/sdk/src/error/ErrorGenerator.ts
+++ b/generators/rust/sdk/src/error/ErrorGenerator.ts
@@ -1,4 +1,5 @@
-import { GeneratorError } from "@fern-api/base-generator";
+import { GeneratorError, getWireValue } from "@fern-api/base-generator";
+import { generateRustTypeForTypeReference } from "@fern-api/rust-model";
 import { FernIr } from "@fern-fern/ir-sdk";
 import {
     Attribute,
@@ -135,13 +136,49 @@ export class ErrorGenerator {
     }
 
     private buildErrorFields(errorDeclaration: FernIr.ErrorDeclaration): Array<{ name: string; type: Type }> {
-        const fields = [{ name: "message", type: Type.string() }];
+        return [{ name: "message", type: Type.string() }, ...this.resolveErrorFields(errorDeclaration)];
+    }
 
-        // Add semantic fields based on status code
-        const statusFields = this.getStatusCodeFields(errorDeclaration.statusCode);
-        fields.push(...statusFields);
+    /**
+     * Derives error fields from the IR type definition when available, falling back to
+     * hardcoded status-code fields otherwise. Returns fields with both the Rust field
+     * name (snake_case) and the JSON wire name (camelCase from the spec).
+     */
+    private resolveErrorFields(errorDeclaration: FernIr.ErrorDeclaration): Array<{
+        name: string;
+        wireName: string;
+        type: Type;
+        extractionKind: "string" | "u64";
+    }> {
+        if (errorDeclaration.type?.type === "named") {
+            const typeDecl = this.context.ir.types[errorDeclaration.type.typeId];
+            if (typeDecl?.shape.type === "object") {
+                return typeDecl.shape.properties
+                    .filter((p) => getWireValue(p.name) !== "message")
+                    .map((p) => ({
+                        name: this.context.case.snakeSafe(p.name),
+                        wireName: getWireValue(p.name),
+                        type: generateRustTypeForTypeReference(p.valueType, this.context),
+                        extractionKind: this.isU64TypeReference(p.valueType) ? ("u64" as const) : ("string" as const)
+                    }));
+            }
+        }
+        return this.getStatusCodeFields(errorDeclaration.statusCode).map(({ name, wireName, type }) => ({
+            name,
+            wireName,
+            type,
+            extractionKind: (name === "retry_after_seconds" ? "u64" : "string") as "string" | "u64"
+        }));
+    }
 
-        return fields;
+    private isU64TypeReference(typeRef: FernIr.TypeReference): boolean {
+        if (typeRef.type === "primitive") {
+            return typeRef.primitive.v1 === "UINT_64";
+        }
+        if (typeRef.type === "container" && typeRef.container.type === "optional") {
+            return this.isU64TypeReference(typeRef.container.optional);
+        }
+        return false;
     }
 
     private getStatusCodeFields(statusCode: number): Array<{ name: string; wireName: string; type: Type }> {
@@ -283,13 +320,12 @@ export class ErrorGenerator {
     }
 
     private buildSuccessConstruction(errorName: string, errorDeclaration: FernIr.ErrorDeclaration): Expression {
-        const statusFields = this.getStatusCodeFields(errorDeclaration.statusCode);
-        const fieldAssignments = statusFields.map(({ name, wireName }) => ({
+        const fields = this.resolveErrorFields(errorDeclaration);
+        const fieldAssignments = fields.map(({ name, wireName, extractionKind }) => ({
             name,
-            value:
-                name === "retry_after_seconds"
-                    ? this.buildU64FieldExtraction(wireName)
-                    : this.buildStringFieldExtraction(wireName)
+            value: extractionKind === "u64"
+                ? this.buildU64FieldExtraction(wireName)
+                : this.buildStringFieldExtraction(wireName)
         }));
 
         return Expression.structConstruction(`Self::${errorName}`, [
@@ -315,8 +351,7 @@ export class ErrorGenerator {
     }
 
     private buildFallbackConstruction(errorName: string, errorDeclaration: FernIr.ErrorDeclaration): Expression {
-        const statusFields = this.getStatusCodeFields(errorDeclaration.statusCode);
-        const defaultFields = statusFields.map(({ name }) => ({
+        const defaultFields = this.resolveErrorFields(errorDeclaration).map(({ name }) => ({
             name,
             value: Expression.reference("None")
         }));
@@ -376,7 +411,7 @@ export class ErrorGenerator {
                         )
                     }),
                     // Build the match statement for error_type
-                    Statement.return(Expression.raw(this.buildErrorTypeMatchExpression(errors, statusCode)))
+                    Statement.return(Expression.raw(this.buildErrorTypeMatchExpression(errors)))
                 ]
             )
         );
@@ -396,7 +431,7 @@ export class ErrorGenerator {
             Statement.return(
                 Expression.structConstruction(`Self::${this.getErrorVariantName(firstError)}`, [
                     { name: "message", value: Expression.toString(Expression.literal("Unknown error")) },
-                    ...this.getStatusCodeFields(statusCode).map(({ name }) => ({
+                    ...this.resolveErrorFields(firstError).map(({ name }) => ({
                         name,
                         value: Expression.reference("None")
                     }))
@@ -407,8 +442,12 @@ export class ErrorGenerator {
         return MatchArm.withStatements(Pattern.literal(statusCode), parseBodyStatements);
     }
 
-    private buildErrorTypeMatchExpression(errors: FernIr.ErrorDeclaration[], statusCode: number): string {
-        const fields = this.buildDynamicFieldAssignments(statusCode);
+    private buildErrorTypeMatchExpression(errors: FernIr.ErrorDeclaration[]): string {
+        const [firstError] = errors;
+        if (!firstError) {
+            throw GeneratorError.internalError("Unexpected: errors array should not be empty");
+        }
+        const fields = this.buildDynamicFieldAssignments(firstError);
 
         // Create match arms for each error type
         const matchArms = errors.map((error) => {
@@ -423,10 +462,6 @@ export class ErrorGenerator {
         });
 
         // Add default fallback to first error type
-        const [firstError] = errors;
-        if (!firstError) {
-            throw GeneratorError.internalError("Unexpected: errors array should not be empty");
-        }
         const fallbackName = this.getErrorVariantName(firstError);
         matchArms.push(
             MatchArm.withExpression(
@@ -442,17 +477,13 @@ export class ErrorGenerator {
         return matchStatement.toString();
     }
 
-    private buildDynamicFieldAssignments(statusCode: number): Expression.FieldAssignment[] {
-        const fields = this.getStatusCodeFields(statusCode);
-
-        return fields.map(({ name, wireName }) => {
-            const fieldValue =
-                name === "retry_after_seconds"
-                    ? this.buildU64FieldExtraction(wireName)
-                    : this.buildStringFieldExtraction(wireName);
-
-            return { name, value: fieldValue };
-        });
+    private buildDynamicFieldAssignments(errorDeclaration: FernIr.ErrorDeclaration): Expression.FieldAssignment[] {
+        return this.resolveErrorFields(errorDeclaration).map(({ name, wireName, extractionKind }) => ({
+            name,
+            value: extractionKind === "u64"
+                ? this.buildU64FieldExtraction(wireName)
+                : this.buildStringFieldExtraction(wireName)
+        }));
     }
 
     private buildStringFieldExtraction(fieldName: string): Expression {

--- a/generators/rust/sdk/src/error/ErrorGenerator.ts
+++ b/generators/rust/sdk/src/error/ErrorGenerator.ts
@@ -144,31 +144,31 @@ export class ErrorGenerator {
         return fields;
     }
 
-    private getStatusCodeFields(statusCode: number): Array<{ name: string; type: Type }> {
-        const fieldMap: Record<number, Array<{ name: string; type: Type }>> = {
+    private getStatusCodeFields(statusCode: number): Array<{ name: string; wireName: string; type: Type }> {
+        const fieldMap: Record<number, Array<{ name: string; wireName: string; type: Type }>> = {
             400: [
-                { name: "field", type: Type.option(Type.string()) },
-                { name: "details", type: Type.option(Type.string()) }
+                { name: "field", wireName: "field", type: Type.option(Type.string()) },
+                { name: "details", wireName: "details", type: Type.option(Type.string()) }
             ],
-            401: [{ name: "auth_type", type: Type.option(Type.string()) }],
+            401: [{ name: "auth_type", wireName: "authType", type: Type.option(Type.string()) }],
             403: [
-                { name: "resource", type: Type.option(Type.string()) },
-                { name: "required_permission", type: Type.option(Type.string()) }
+                { name: "resource", wireName: "resource", type: Type.option(Type.string()) },
+                { name: "required_permission", wireName: "requiredPermission", type: Type.option(Type.string()) }
             ],
             404: [
-                { name: "resource_id", type: Type.option(Type.string()) },
-                { name: "resource_type", type: Type.option(Type.string()) }
+                { name: "resource_id", wireName: "resourceId", type: Type.option(Type.string()) },
+                { name: "resource_type", wireName: "resourceType", type: Type.option(Type.string()) }
             ],
-            409: [{ name: "conflict_type", type: Type.option(Type.string()) }],
+            409: [{ name: "conflict_type", wireName: "conflictType", type: Type.option(Type.string()) }],
             422: [
-                { name: "field", type: Type.option(Type.string()) },
-                { name: "validation_error", type: Type.option(Type.string()) }
+                { name: "field", wireName: "field", type: Type.option(Type.string()) },
+                { name: "validation_error", wireName: "validationError", type: Type.option(Type.string()) }
             ],
             429: [
-                { name: "retry_after_seconds", type: Type.option(Type.primitive(PrimitiveType.U64)) },
-                { name: "limit_type", type: Type.option(Type.string()) }
+                { name: "retry_after_seconds", wireName: "retryAfterSeconds", type: Type.option(Type.primitive(PrimitiveType.U64)) },
+                { name: "limit_type", wireName: "limitType", type: Type.option(Type.string()) }
             ],
-            500: [{ name: "error_id", type: Type.option(Type.string()) }]
+            500: [{ name: "error_id", wireName: "errorId", type: Type.option(Type.string()) }]
         };
 
         return fieldMap[statusCode] || [];
@@ -284,12 +284,12 @@ export class ErrorGenerator {
 
     private buildSuccessConstruction(errorName: string, errorDeclaration: FernIr.ErrorDeclaration): Expression {
         const statusFields = this.getStatusCodeFields(errorDeclaration.statusCode);
-        const fieldAssignments = statusFields.map(({ name }) => ({
+        const fieldAssignments = statusFields.map(({ name, wireName }) => ({
             name,
             value:
                 name === "retry_after_seconds"
-                    ? this.buildU64FieldExtraction(name)
-                    : this.buildStringFieldExtraction(name)
+                    ? this.buildU64FieldExtraction(wireName)
+                    : this.buildStringFieldExtraction(wireName)
         }));
 
         return Expression.structConstruction(`Self::${errorName}`, [
@@ -445,11 +445,11 @@ export class ErrorGenerator {
     private buildDynamicFieldAssignments(statusCode: number): Expression.FieldAssignment[] {
         const fields = this.getStatusCodeFields(statusCode);
 
-        return fields.map(({ name }) => {
+        return fields.map(({ name, wireName }) => {
             const fieldValue =
                 name === "retry_after_seconds"
-                    ? this.buildU64FieldExtraction(name)
-                    : this.buildStringFieldExtraction(name);
+                    ? this.buildU64FieldExtraction(wireName)
+                    : this.buildStringFieldExtraction(wireName);
 
             return { name, value: fieldValue };
         });

--- a/seed/rust-sdk/accept-header/src/core/http_client.rs
+++ b/seed/rust-sdk/accept-header/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/alias-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/alias-extends/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/alias/src/core/http_client.rs
+++ b/seed/rust-sdk/alias/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/allof-inline/src/core/http_client.rs
+++ b/seed/rust-sdk/allof-inline/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/allof/src/core/http_client.rs
+++ b/seed/rust-sdk/allof/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/any-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/any-auth/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/api-wide-base-path-with-default/src/core/http_client.rs
+++ b/seed/rust-sdk/api-wide-base-path-with-default/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/audiences/src/core/http_client.rs
+++ b/seed/rust-sdk/audiences/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/basic-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/bytes-download/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-download/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/bytes-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/http_client.rs
@@ -581,9 +581,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -601,10 +606,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/circular-references/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/cli-multi-spec-namespaced/src/core/http_client.rs
+++ b/seed/rust-sdk/cli-multi-spec-namespaced/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/cli-multi-spec/src/core/http_client.rs
+++ b/seed/rust-sdk/cli-multi-spec/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/client-side-params/src/core/http_client.rs
+++ b/seed/rust-sdk/client-side-params/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/content-type/src/core/http_client.rs
+++ b/seed/rust-sdk/content-type/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/empty-clients/src/core/http_client.rs
+++ b/seed/rust-sdk/empty-clients/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/enum/src/core/http_client.rs
+++ b/seed/rust-sdk/enum/src/core/http_client.rs
@@ -618,9 +618,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -638,10 +643,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/error-property/src/core/http_client.rs
+++ b/seed/rust-sdk/error-property/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/errors/src/core/http_client.rs
+++ b/seed/rust-sdk/errors/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
@@ -546,9 +546,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -566,10 +571,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
@@ -546,9 +546,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -566,10 +571,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/exhaustive/src/core/http_client.rs
+++ b/seed/rust-sdk/exhaustive/src/core/http_client.rs
@@ -583,9 +583,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -603,10 +608,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/extends/src/core/http_client.rs
+++ b/seed/rust-sdk/extends/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/extra-properties/src/core/http_client.rs
+++ b/seed/rust-sdk/extra-properties/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/file-download/src/core/http_client.rs
+++ b/seed/rust-sdk/file-download/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
@@ -618,9 +618,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -638,10 +643,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/file-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload/src/core/http_client.rs
@@ -618,9 +618,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -638,10 +643,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/folders/src/core/http_client.rs
+++ b/seed/rust-sdk/folders/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/header-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/http-head/src/core/http_client.rs
+++ b/seed/rust-sdk/http-head/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/license/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/license/basic/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
+++ b/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/literal-user-agent/src/core/http_client.rs
+++ b/seed/rust-sdk/literal-user-agent/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/literal/src/core/http_client.rs
+++ b/seed/rust-sdk/literal/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/literals-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/literals-unions/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/mixed-case/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-case/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
@@ -581,9 +581,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -601,10 +606,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/no-content-response/src/core/http_client.rs
+++ b/seed/rust-sdk/no-content-response/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/no-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/no-environment/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/no-retries/src/core/http_client.rs
+++ b/seed/rust-sdk/no-retries/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/null-type/src/core/http_client.rs
+++ b/seed/rust-sdk/null-type/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/nullable-optional/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/object/src/core/http_client.rs
+++ b/seed/rust-sdk/object/src/core/http_client.rs
@@ -546,9 +546,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -566,10 +571,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/openapi-request-body-ref/src/core/http_client.rs
+++ b/seed/rust-sdk/openapi-request-body-ref/src/core/http_client.rs
@@ -618,9 +618,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -638,10 +643,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/optional/src/core/http_client.rs
+++ b/seed/rust-sdk/optional/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/package-yml/src/core/http_client.rs
+++ b/seed/rust-sdk/package-yml/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/pagination-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/path-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/path-parameters/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/plain-text/src/core/http_client.rs
+++ b/seed/rust-sdk/plain-text/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/property-access/src/core/http_client.rs
+++ b/seed/rust-sdk/property-access/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/public-object/src/core/http_client.rs
+++ b/seed/rust-sdk/public-object/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
+++ b/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/query-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters/src/core/http_client.rs
@@ -546,9 +546,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -566,10 +571,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/request-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/request-parameters/src/core/http_client.rs
@@ -546,9 +546,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -566,10 +571,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/required-nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/required-nullable/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/response-property/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/server-sent-events-resumable/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events-resumable/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/server-url-templating/src/core/http_client.rs
+++ b/seed/rust-sdk/server-url-templating/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/simple-fhir/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/streaming/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/trace/src/core/http_client.rs
+++ b/seed/rust-sdk/trace/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/union-query-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/union-query-parameters/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/unions/src/core/http_client.rs
+++ b/seed/rust-sdk/unions/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/unknown/src/core/http_client.rs
+++ b/seed/rust-sdk/unknown/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
+++ b/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/validation/src/core/http_client.rs
+++ b/seed/rust-sdk/validation/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/variables/src/core/http_client.rs
+++ b/seed/rust-sdk/variables/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/version-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/version-no-default/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/version/src/core/http_client.rs
+++ b/seed/rust-sdk/version/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/webhook-audience/src/core/http_client.rs
+++ b/seed/rust-sdk/webhook-audience/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/webhooks/src/core/http_client.rs
+++ b/seed/rust-sdk/webhooks/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/websocket/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket/src/core/http_client.rs
@@ -543,9 +543,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -563,10 +568,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;

--- a/seed/rust-sdk/x-fern-default/src/core/http_client.rs
+++ b/seed/rust-sdk/x-fern-default/src/core/http_client.rs
@@ -544,9 +544,14 @@ impl HttpClient {
         let status = response.status().as_u16();
         let text = response.text().await.map_err(ApiError::Network)?;
 
-        // Handle empty response bodies (e.g., 202 Accepted for deferred requests)
         if text.is_empty() {
-            return Err(ApiError::Http {
+            if status >= 400 {
+                return Err(ApiError::Http {
+                    status,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null).map_err(|_| ApiError::Http {
                 status,
                 message: String::new(),
             });
@@ -564,10 +569,15 @@ impl HttpClient {
         let text = response.text().await.map_err(ApiError::Network)?;
 
         if text.is_empty() {
-            return Err(ApiError::Http {
-                status: status_code,
-                message: String::new(),
-            });
+            if status_code >= 400 {
+                return Err(ApiError::Http {
+                    status: status_code,
+                    message: String::new(),
+                });
+            }
+            return serde_json::from_value(serde_json::Value::Null)
+                .map(|body| RawResponse { body, status_code, headers })
+                .map_err(|_| ApiError::Http { status: status_code, message: String::new() });
         }
 
         let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;


### PR DESCRIPTION
## Description

Reopens #16388 (closed due to stale fork-based branch with merge conflicts — rebased onto main).

Two bugs in the Rust SDK generator discovered while testing against a live mock server:

### Bug 1 — `parse_response` / `parse_response_raw` fail on empty bodies

Both functions returned `Err(ApiError::Http { status, "" })` for any empty response body, breaking HEAD requests, DELETE 204 No Content, and `()` return types.

**Fix:** Check HTTP status first — 4xx/5xx returns error immediately. For 2xx, attempt `serde_json::from_value(Value::Null)` which succeeds for `()` and `Option<_>`, falling through to the existing `Serialization` error path for concrete types.

### Bug 2 — Error field parsing uses snake_case IR names as JSON wire keys

`getStatusCodeFields()` passed snake_case IR field names directly to `parsed.get(name)`, so fields like `"auth_type"` were never found in camelCase JSON responses (`"authType"`).

**Fix:** Derive error fields from IR type definition when available (`resolveErrorFields`), using `getWireValue()` for JSON key lookup. Falls back to hardcoded status-code fields with proper camelCase `wireName`.

## Changes Made

- `generators/rust/base/src/asIs/http_client.rs`: Guard empty-body responses with status check before attempting null deserialization
- `generators/rust/sdk/src/error/ErrorGenerator.ts`: Add `resolveErrorFields()` that derives fields from IR type definition; use `wireName` (camelCase) for JSON extraction
- Updated all seed snapshots for `http_client.rs` changes
- Updated error generator test snapshots
- Added unreleased changelog entry

## Testing

- [x] All existing `ErrorGenerator` tests pass
- [x] Seed snapshots updated to reflect corrected wire names and empty-body handling
- [x] Rebased cleanly onto latest main

Link to Devin session: https://app.devin.ai/sessions/1bac35f4e667495cb0ae0919a6bf0c41
Requested by: @iamnamananand996