### PR TITLE
fix(cli): populate repository.url in generated npm package.json for provenance

### DIFF
--- a/generators/cli/changes/unreleased/fix-npm-provenance-repository-url.yml
+++ b/generators/cli/changes/unreleased/fix-npm-provenance-repository-url.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Populate `repository.url` in generated npm `package.json` files from
+    the GitHub output mode's `repoUrl`. Fixes npm provenance verification
+    failures (E422) when publishing with `--provenance`.
+  type: fix

--- a/generators/cli/src/__test__/emitPublishWorkflow.test.ts
+++ b/generators/cli/src/__test__/emitPublishWorkflow.test.ts
@@ -24,8 +24,12 @@ describe("emitPublishWorkflow", () => {
         await rm(tmpDir, { recursive: true, force: true });
     });
 
-    async function emitAndRead(npmPublishInfo: ResolvedNpmPublishInfo, binaryName = "acme"): Promise<string> {
-        await emitPublishWorkflow({ outputDir, binaryName, npmPublishInfo });
+    async function emitAndRead(
+        npmPublishInfo: ResolvedNpmPublishInfo,
+        binaryName = "acme",
+        repoUrl: string | undefined = undefined
+    ): Promise<string> {
+        await emitPublishWorkflow({ outputDir, binaryName, npmPublishInfo, repoUrl });
         return readFile(path.join(outputDir, ".github", "workflows", "ci.yml"), "utf-8");
     }
 
@@ -161,6 +165,19 @@ describe("emitPublishWorkflow", () => {
         expect(yaml).toContain("musl-tools");
         expect(yaml).toContain("--no-default-features --features rustls");
         expect(yaml).not.toContain("gcc-aarch64-linux-gnu");
+    });
+
+    it("includes repository.url in package.json when repoUrl is provided", async () => {
+        const yaml = await emitAndRead(baseInfo, "acme", "https://github.com/acme/acme-cli");
+
+        expect(yaml).toContain('"repository"');
+        expect(yaml).toContain('"url": "https://github.com/acme/acme-cli"');
+    });
+
+    it("omits repository field from package.json when repoUrl is undefined", async () => {
+        const yaml = await emitAndRead(baseInfo, "acme", undefined);
+
+        expect(yaml).not.toContain('"repository"');
     });
 
     it("both publish steps define a publish() helper and backport logic", async () => {

--- a/generators/cli/src/__test__/resolveOutputConfig.test.ts
+++ b/generators/cli/src/__test__/resolveOutputConfig.test.ts
@@ -58,6 +58,7 @@ describe("resolveOutputConfig", () => {
 
         expect(result.version).toBe("1.0.0");
         expect(result.isGithubOutput).toBe(true);
+        expect(result.repoUrl).toBe("https://github.com/acme/cli");
         expect(result.npmPublishInfo).toBeUndefined();
     });
 

--- a/generators/cli/src/__test__/runPipeline.test.ts
+++ b/generators/cli/src/__test__/runPipeline.test.ts
@@ -108,18 +108,21 @@ describe("runPipeline", () => {
     const localFilesConfig: ResolvedOutputConfig = {
         version: "0.0.0",
         isGithubOutput: false,
+        repoUrl: undefined,
         npmPublishInfo: undefined
     };
 
     const githubConfigNoNpm: ResolvedOutputConfig = {
         version: "1.0.0",
         isGithubOutput: true,
+        repoUrl: "https://github.com/acme/cli",
         npmPublishInfo: undefined
     };
 
     const githubConfig: ResolvedOutputConfig = {
         version: "1.5.0",
         isGithubOutput: true,
+        repoUrl: "https://github.com/acme/cli",
         npmPublishInfo: {
             packageName: "@acme/cli",
             registryUrl: "https://registry.npmjs.org",
@@ -271,6 +274,7 @@ describe("runPipeline", () => {
         const versionedConfig: ResolvedOutputConfig = {
             version: "2.3.1",
             isGithubOutput: false,
+            repoUrl: undefined,
             npmPublishInfo: undefined
         };
         await runPipeline({

--- a/generators/cli/src/emitPublishWorkflow.ts
+++ b/generators/cli/src/emitPublishWorkflow.ts
@@ -53,11 +53,12 @@ export async function emitPublishWorkflow(args: {
     outputDir: string;
     binaryName: string;
     npmPublishInfo: ResolvedNpmPublishInfo;
+    repoUrl: string | undefined;
 }): Promise<void> {
-    const { outputDir, binaryName, npmPublishInfo } = args;
+    const { outputDir, binaryName, npmPublishInfo, repoUrl } = args;
     const workflowsDir = path.join(outputDir, ".github", "workflows");
     await mkdir(workflowsDir, { recursive: true });
-    const yaml = constructWorkflowYaml({ binaryName, npmPublishInfo });
+    const yaml = constructWorkflowYaml({ binaryName, npmPublishInfo, repoUrl });
     await writeFile(path.join(workflowsDir, "ci.yml"), yaml);
 }
 
@@ -116,8 +117,12 @@ jobs:
 `;
 }
 
-function constructWorkflowYaml(args: { binaryName: string; npmPublishInfo: ResolvedNpmPublishInfo }): string {
-    const { binaryName, npmPublishInfo } = args;
+function constructWorkflowYaml(args: {
+    binaryName: string;
+    npmPublishInfo: ResolvedNpmPublishInfo;
+    repoUrl: string | undefined;
+}): string {
+    const { binaryName, npmPublishInfo, repoUrl } = args;
     const { useOidc } = npmPublishInfo;
     const tokenVar = npmPublishInfo.tokenEnvironmentVariable;
 
@@ -260,7 +265,15 @@ ${matrixIncludes}
           {
             "name": "\${PLATFORM_PKG}",
             "version": "\${VERSION}",
-            "description": "Platform-specific binary for ${binaryName} (\${{ matrix.npm-platform-suffix }})",
+            "description": "Platform-specific binary for ${binaryName} (\${{ matrix.npm-platform-suffix }})",${
+                repoUrl != null
+                    ? `
+            "repository": {
+              "type": "git",
+              "url": "${repoUrl}"
+            },`
+                    : ""
+            }
             "os": ["\$(echo \${{ matrix.npm-platform-suffix }} | cut -d- -f1)"],
             "cpu": ["\$(echo \${{ matrix.npm-platform-suffix }} | cut -d- -f2)"],
             "main": "\${BINARY_NAME}",
@@ -324,7 +337,15 @@ ${optionalDepsLines}
           {
             "name": "${npmPublishInfo.packageName}",
             "version": "\${VERSION}",
-            "description": "CLI for ${binaryName}",
+            "description": "CLI for ${binaryName}",${
+                repoUrl != null
+                    ? `
+            "repository": {
+              "type": "git",
+              "url": "${repoUrl}"
+            },`
+                    : ""
+            }
             "bin": {
               "${binaryName}": "bin/cli.js"
             },

--- a/generators/cli/src/resolveOutputConfig.ts
+++ b/generators/cli/src/resolveOutputConfig.ts
@@ -22,6 +22,12 @@ export interface ResolvedOutputConfig {
      */
     isGithubOutput: boolean;
     /**
+     * The full GitHub repository URL (e.g. `https://github.com/fern-api/petstore-cli`).
+     * Present only in github output mode. Used to populate `repository.url`
+     * in generated npm `package.json` files for provenance verification.
+     */
+    repoUrl: string | undefined;
+    /**
      * Non-null only when output mode is `github` and the upstream
      * config includes `publishInfo` of type `npm`. When set, the
      * emitted `ci.yml` also includes publish + publish-launcher jobs.
@@ -59,6 +65,7 @@ export function resolveOutputConfig(output: GeneratorConfig["output"]): Resolved
             return {
                 version: mode.version,
                 isGithubOutput: true,
+                repoUrl: mode.repoUrl,
                 npmPublishInfo: resolveNpmPublishInfo(mode.publishInfo)
             };
         }
@@ -66,12 +73,14 @@ export function resolveOutputConfig(output: GeneratorConfig["output"]): Resolved
             return {
                 version: mode.version,
                 isGithubOutput: false,
+                repoUrl: undefined,
                 npmPublishInfo: undefined
             };
         case "downloadFiles":
             return {
                 version: DEFAULT_VERSION,
                 isGithubOutput: false,
+                repoUrl: undefined,
                 npmPublishInfo: undefined
             };
         default:
@@ -80,6 +89,7 @@ export function resolveOutputConfig(output: GeneratorConfig["output"]): Resolved
             return {
                 version: DEFAULT_VERSION,
                 isGithubOutput: false,
+                repoUrl: undefined,
                 npmPublishInfo: undefined
             };
     }

--- a/generators/cli/src/runPipeline.ts
+++ b/generators/cli/src/runPipeline.ts
@@ -161,7 +161,8 @@ export async function runPipeline(args: {
             await emitPublishWorkflow({
                 outputDir,
                 binaryName,
-                npmPublishInfo: outputConfig.npmPublishInfo
+                npmPublishInfo: outputConfig.npmPublishInfo,
+                repoUrl: outputConfig.repoUrl
             });
         } else {
             await emitCiWorkflow({ outputDir, binaryName });


### PR DESCRIPTION
## Description

Fixes npm provenance verification failure (E422) when publishing CLI packages with `--provenance`. npm requires `package.json`'s `repository.url` to match the GitHub repo the action runs from, but the CLI generator was emitting `package.json` files without this field.

## Changes Made

- Added `repoUrl` field to `ResolvedOutputConfig` (extracted from `GithubOutputMode.repoUrl`)
- `emitPublishWorkflow` now accepts `repoUrl` and conditionally emits a `"repository": {"type": "git", "url": "..."}` block in both the platform and launcher `package.json` files
- When `repoUrl` is undefined (non-github output modes), no repository field is emitted

## Testing

- [x] Unit tests added: `includes repository.url in package.json when repoUrl is provided` and `omits repository field from package.json when repoUrl is undefined`
- [x] Existing `resolveOutputConfig` test updated to verify `repoUrl` passthrough
- [x] All 139 tests pass

Link to Devin session: https://app.devin.ai/sessions/b7adf0e8af4744fa851ef5984b4fe422
Requested by: @cade-fern