### PR TITLE
fix(typescript): offset pager hasNextPage no longer depends on requested page-size [FER-11160]

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/fix-offset-hasnextpage.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-offset-hasnextpage.yml
@@ -2,9 +2,12 @@
 
 - summary: |
     Fix `hasNextPage` for offset pagination so it no longer compares `items.length`
-    against the requested page-size. When the caller omitted the page-size parameter
-    the check fell back to a fabricated default and wrongly reported `hasNextPage` as
-    `false` on a short page (and a false positive on a full last page). The pager now
-    reports a next page whenever the current page returned any items, matching the
-    offset pagers in the other Fern SDK generators.
+    against a fabricated default when the caller omits the page-size parameter
+    (FER-11160). The previous logic substituted a generator-chosen default (often
+    `1`), which produced false-positive continuation on short pages and false-negative
+    termination when the default was non-trivial. The pager now gates the size
+    comparison on whether the caller actually provided a page-size: when supplied,
+    a short page still short-circuits (saves one round-trip at the tail); when
+    omitted, it falls back to an items-driven check. Explicit `response.hasNextPage`
+    from the API continues to take priority.
   type: fix

--- a/generators/typescript/sdk/changes/unreleased/fix-offset-hasnextpage.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-offset-hasnextpage.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix `hasNextPage` for offset pagination so it no longer compares `items.length`
+    against the requested page-size. When the caller omitted the page-size parameter
+    the check fell back to a fabricated default and wrongly reported `hasNextPage` as
+    `false` on a short page (and a false positive on a full last page). The pager now
+    reports a next page whenever the current page returned any items, matching the
+    offset pagers in the other Fern SDK generators.
+  type: fix

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedEndpointResponse.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedEndpointResponse.test.ts
@@ -525,6 +525,13 @@ describe("GeneratedThrowingEndpointResponse", () => {
                 expect(info).toBeDefined();
                 // biome-ignore lint/style/noNonNullAssertion: Safe - value asserted above
                 expect(info!.type).toBe("offset-step");
+                // hasNextPage must be items-driven (matching the Python/Go offset pagers) and must NOT
+                // compare items.length against the requested page-size, which breaks when page-size is
+                // omitted (FER-11160).
+                // biome-ignore lint/style/noNonNullAssertion: Safe - value asserted above
+                expect(getTextOfTsNode(info!.hasNextPage)).not.toContain("Math.floor");
+                // biome-ignore lint/style/noNonNullAssertion: Safe - value asserted above
+                expect(getTextOfTsNode(info!.hasNextPage)).toBe("(response?.items ?? []).length > 0");
                 // biome-ignore lint/style/noNonNullAssertion: Safe - value asserted above
                 expect(getTextOfTsNode(info!.hasNextPage)).toMatchSnapshot();
             });

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedEndpointResponse.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedEndpointResponse.test.ts
@@ -525,13 +525,15 @@ describe("GeneratedThrowingEndpointResponse", () => {
                 expect(info).toBeDefined();
                 // biome-ignore lint/style/noNonNullAssertion: Safe - value asserted above
                 expect(info!.type).toBe("offset-step");
-                // hasNextPage must be items-driven (matching the Python/Go offset pagers) and must NOT
-                // compare items.length against the requested page-size, which breaks when page-size is
-                // omitted (FER-11160).
+                // When step is provided, compare items.length against the runtime step value — but
+                // gate the comparison on `step != null` so we never fall back to a fabricated default
+                // (FER-11160). Must NOT use Math.floor (regression guard for the pre-fix shape).
                 // biome-ignore lint/style/noNonNullAssertion: Safe - value asserted above
                 expect(getTextOfTsNode(info!.hasNextPage)).not.toContain("Math.floor");
                 // biome-ignore lint/style/noNonNullAssertion: Safe - value asserted above
-                expect(getTextOfTsNode(info!.hasNextPage)).toBe("(response?.items ?? []).length > 0");
+                expect(getTextOfTsNode(info!.hasNextPage)).toBe(
+                    "(response?.items ?? []).length > 0 && (request?.limit == null || (response?.items ?? []).length >= request?.limit)"
+                );
                 // biome-ignore lint/style/noNonNullAssertion: Safe - value asserted above
                 expect(getTextOfTsNode(info!.hasNextPage)).toMatchSnapshot();
             });

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedEndpointResponse.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedEndpointResponse.test.ts.snap
@@ -47,7 +47,7 @@ exports[`GeneratedThrowingEndpointResponse > getPaginationInfo > offset paginati
 
 exports[`GeneratedThrowingEndpointResponse > getPaginationInfo > offset pagination > returns offset pagination info without step 2`] = `"response?.items ?? []"`;
 
-exports[`GeneratedThrowingEndpointResponse > getPaginationInfo > offset pagination > returns offset-step pagination info with step and item-index semantics 1`] = `"(response?.items ?? []).length > 0"`;
+exports[`GeneratedThrowingEndpointResponse > getPaginationInfo > offset pagination > returns offset-step pagination info with step and item-index semantics 1`] = `"(response?.items ?? []).length > 0 && (request?.limit == null || (response?.items ?? []).length >= request?.limit)"`;
 
 exports[`GeneratedThrowingEndpointResponse > getPaginationInfo > offset pagination > uses hasNextPage property when available 1`] = `"response?.hasMore ?? (response?.items ?? []).length > 0"`;
 

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedEndpointResponse.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/GeneratedEndpointResponse.test.ts.snap
@@ -47,7 +47,7 @@ exports[`GeneratedThrowingEndpointResponse > getPaginationInfo > offset paginati
 
 exports[`GeneratedThrowingEndpointResponse > getPaginationInfo > offset pagination > returns offset pagination info without step 2`] = `"response?.items ?? []"`;
 
-exports[`GeneratedThrowingEndpointResponse > getPaginationInfo > offset pagination > returns offset-step pagination info with step and item-index semantics 1`] = `"(response?.items ?? []).length >= Math.floor((request?.limit ?? 1))"`;
+exports[`GeneratedThrowingEndpointResponse > getPaginationInfo > offset pagination > returns offset-step pagination info with step and item-index semantics 1`] = `"(response?.items ?? []).length > 0"`;
 
 exports[`GeneratedThrowingEndpointResponse > getPaginationInfo > offset pagination > uses hasNextPage property when available 1`] = `"response?.hasMore ?? (response?.items ?? []).length > 0"`;
 

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
@@ -323,66 +323,26 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
             noOptionalChaining: true
         });
 
-        // Use offset.step if available to ensure that page is full before returning true
-        const baseHasNextPage: ts.Expression =
-            offset.step != null
-                ? // If step is defined, check if items.length >= step (got full page)
-                  (() => {
-                      const stepPropertyAccess = context.type.generateGetterForRequestProperty({
-                          property: offset.step,
-                          variable: "request",
-                          isVariableOptional: true
-                      });
-                      return ts.factory.createBinaryExpression(
-                          ts.factory.createPropertyAccessExpression(
-                              ts.factory.createParenthesizedExpression(
-                                  ts.factory.createBinaryExpression(
-                                      itemsPropertyAccess,
-                                      ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
-                                      ts.factory.createArrayLiteralExpression([], false)
-                                  )
-                              ),
-                              ts.factory.createIdentifier("length")
-                          ),
-                          ts.factory.createToken(ts.SyntaxKind.GreaterThanEqualsToken),
-                          // access to stepPropertyAccess should be an integer so that it compares correctly to items.length
-                          ts.factory.createCallExpression(
-                              ts.factory.createPropertyAccessExpression(
-                                  ts.factory.createIdentifier("Math"),
-                                  ts.factory.createIdentifier("floor")
-                              ),
-                              undefined,
-                              [
-                                  ts.factory.createParenthesizedExpression(
-                                      ts.factory.createBinaryExpression(
-                                          stepPropertyAccess,
-                                          ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
-                                          ts.factory.createNumericLiteral(
-                                              this.getDefaultPaginationValue({
-                                                  type: offset.step.property.valueType
-                                              })
-                                          )
-                                      )
-                                  )
-                              ]
-                          )
-                      );
-                  })()
-                : // Fallback: check if items.length > 0 (got something)
-                  ts.factory.createBinaryExpression(
-                      ts.factory.createPropertyAccessExpression(
-                          ts.factory.createParenthesizedExpression(
-                              ts.factory.createBinaryExpression(
-                                  itemsPropertyAccess,
-                                  ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
-                                  ts.factory.createArrayLiteralExpression([], false)
-                              )
-                          ),
-                          ts.factory.createIdentifier("length")
-                      ),
-                      ts.factory.createToken(ts.SyntaxKind.GreaterThanToken),
-                      ts.factory.createNumericLiteral("0")
-                  );
+        // Has-next is items-driven: there may be another page as long as this page returned items.
+        // This matches the offset pagers in the other Fern SDK generators (e.g. Python, Go). We
+        // intentionally do NOT compare items.length against the requested `step`/page-size: when the
+        // caller omits page-size that comparison falls back to a fabricated default and wrongly reports
+        // `false` on a short page (and false positives on a full last page). `offset.step` still drives
+        // the offset increment below; it just doesn't gate has-next.
+        const baseHasNextPage: ts.Expression = ts.factory.createBinaryExpression(
+            ts.factory.createPropertyAccessExpression(
+                ts.factory.createParenthesizedExpression(
+                    ts.factory.createBinaryExpression(
+                        itemsPropertyAccess,
+                        ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                        ts.factory.createArrayLiteralExpression([], false)
+                    )
+                ),
+                ts.factory.createIdentifier("length")
+            ),
+            ts.factory.createToken(ts.SyntaxKind.GreaterThanToken),
+            ts.factory.createNumericLiteral("0")
+        );
 
         // If explicit hasNextPage property exists, it takes priority (?? to fallback to base check)
         const hasNextPage: ts.Expression =

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/default/endpoint-response/GeneratedThrowingEndpointResponse.ts
@@ -323,13 +323,14 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
             noOptionalChaining: true
         });
 
-        // Has-next is items-driven: there may be another page as long as this page returned items.
-        // This matches the offset pagers in the other Fern SDK generators (e.g. Python, Go). We
-        // intentionally do NOT compare items.length against the requested `step`/page-size: when the
-        // caller omits page-size that comparison falls back to a fabricated default and wrongly reports
-        // `false` on a short page (and false positives on a full last page). `offset.step` still drives
-        // the offset increment below; it just doesn't gate has-next.
-        const baseHasNextPage: ts.Expression = ts.factory.createBinaryExpression(
+        // TS-only: when the caller supplies the page-size parameter, treat a short page as the last
+        // page (saves one round-trip at the tail). When the caller omits it, fall back to items-driven
+        // so we never compare against a fabricated default — that fabrication caused both false-negative
+        // termination on short pages and false-positive continuation on full last pages (FER-11160).
+        // Other Fern SDKs are uniformly items-driven; we accept the divergence to keep the optimization
+        // when the caller provides a page-size. `response.hasNextPage` from the API still takes priority
+        // via the `??` wrapper below.
+        const itemsLengthAccess = (): ts.Expression =>
             ts.factory.createPropertyAccessExpression(
                 ts.factory.createParenthesizedExpression(
                     ts.factory.createBinaryExpression(
@@ -339,10 +340,44 @@ export class GeneratedThrowingEndpointResponse implements GeneratedEndpointRespo
                     )
                 ),
                 ts.factory.createIdentifier("length")
-            ),
+            );
+        const itemsLengthGtZero = ts.factory.createBinaryExpression(
+            itemsLengthAccess(),
             ts.factory.createToken(ts.SyntaxKind.GreaterThanToken),
             ts.factory.createNumericLiteral("0")
         );
+        const baseHasNextPage: ts.Expression =
+            offset.step != null
+                ? (() => {
+                      const stepPropertyAccess = context.type.generateGetterForRequestProperty({
+                          property: offset.step,
+                          variable: "request",
+                          isVariableOptional: true
+                      });
+                      const stepIsNull = ts.factory.createBinaryExpression(
+                          stepPropertyAccess,
+                          ts.factory.createToken(ts.SyntaxKind.EqualsEqualsToken),
+                          ts.factory.createNull()
+                      );
+                      const itemsLengthGteStep = ts.factory.createBinaryExpression(
+                          itemsLengthAccess(),
+                          ts.factory.createToken(ts.SyntaxKind.GreaterThanEqualsToken),
+                          stepPropertyAccess
+                      );
+                      const stepGate = ts.factory.createParenthesizedExpression(
+                          ts.factory.createBinaryExpression(
+                              stepIsNull,
+                              ts.factory.createToken(ts.SyntaxKind.BarBarToken),
+                              itemsLengthGteStep
+                          )
+                      );
+                      return ts.factory.createBinaryExpression(
+                          itemsLengthGtZero,
+                          ts.factory.createToken(ts.SyntaxKind.AmpersandAmpersandToken),
+                          stepGate
+                      );
+                  })()
+                : itemsLengthGtZero;
 
         // If explicit hasNextPage property exists, it takes priority (?? to fallback to base check)
         const hasNextPage: ts.Expression =

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
@@ -607,7 +607,9 @@ export class InlineUsersClient {
         >({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data.users ?? []).length > 0,
+            hasNextPage: (response) =>
+                (response?.data.users ?? []).length > 0 &&
+                (request?.limit == null || (response?.data.users ?? []).length >= request?.limit),
             getItems: (response) => response?.data.users ?? [],
             loadPage: (response) => {
                 _offset += response?.data.users != null ? response.data.users.length : 1;
@@ -693,7 +695,10 @@ export class InlineUsersClient {
         >({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => response?.hasNextPage ?? (response?.data.users ?? []).length > 0,
+            hasNextPage: (response) =>
+                response?.hasNextPage ??
+                ((response?.data.users ?? []).length > 0 &&
+                    (request?.limit == null || (response?.data.users ?? []).length >= request?.limit)),
             getItems: (response) => response?.data.users ?? [],
             loadPage: (response) => {
                 _offset += response?.data.users != null ? response.data.users.length : 1;

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
@@ -607,7 +607,7 @@ export class InlineUsersClient {
         >({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data.users ?? []).length >= Math.floor(request?.limit ?? 1),
+            hasNextPage: (response) => (response?.data.users ?? []).length > 0,
             getItems: (response) => response?.data.users ?? [],
             loadPage: (response) => {
                 _offset += response?.data.users != null ? response.data.users.length : 1;
@@ -693,8 +693,7 @@ export class InlineUsersClient {
         >({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) =>
-                response?.hasNextPage ?? (response?.data.users ?? []).length >= Math.floor(request?.limit ?? 1),
+            hasNextPage: (response) => response?.hasNextPage ?? (response?.data.users ?? []).length > 0,
             getItems: (response) => response?.data.users ?? [],
             loadPage: (response) => {
                 _offset += response?.data.users != null ? response.data.users.length : 1;

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
@@ -630,7 +630,9 @@ export class UsersClient {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data ?? []).length > 0,
+            hasNextPage: (response) =>
+                (response?.data ?? []).length > 0 &&
+                (request?.limit == null || (response?.data ?? []).length >= request?.limit),
             getItems: (response) => response?.data ?? [],
             loadPage: (response) => {
                 _offset += response?.data != null ? response.data.length : 1;
@@ -715,7 +717,10 @@ export class UsersClient {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => response?.hasNextPage ?? (response?.data ?? []).length > 0,
+            hasNextPage: (response) =>
+                response?.hasNextPage ??
+                ((response?.data ?? []).length > 0 &&
+                    (request?.limit == null || (response?.data ?? []).length >= request?.limit)),
             getItems: (response) => response?.data ?? [],
             loadPage: (response) => {
                 _offset += response?.data != null ? response.data.length : 1;

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
@@ -630,7 +630,7 @@ export class UsersClient {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data ?? []).length >= Math.floor(request?.limit ?? 123),
+            hasNextPage: (response) => (response?.data ?? []).length > 0,
             getItems: (response) => response?.data ?? [],
             loadPage: (response) => {
                 _offset += response?.data != null ? response.data.length : 1;
@@ -715,8 +715,7 @@ export class UsersClient {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) =>
-                response?.hasNextPage ?? (response?.data ?? []).length >= Math.floor(request?.limit ?? 1),
+            hasNextPage: (response) => response?.hasNextPage ?? (response?.data ?? []).length > 0,
             getItems: (response) => response?.data ?? [],
             loadPage: (response) => {
                 _offset += response?.data != null ? response.data.length : 1;

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
@@ -607,7 +607,7 @@ export class InlineUsersClient {
         >({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data.users ?? []).length >= Math.floor(request?.limit ?? 1),
+            hasNextPage: (response) => (response?.data.users ?? []).length > 0,
             getItems: (response) => response?.data.users ?? [],
             loadPage: (_response) => {
                 _offset += 1;
@@ -693,8 +693,7 @@ export class InlineUsersClient {
         >({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) =>
-                response?.hasNextPage ?? (response?.data.users ?? []).length >= Math.floor(request?.limit ?? 1),
+            hasNextPage: (response) => response?.hasNextPage ?? (response?.data.users ?? []).length > 0,
             getItems: (response) => response?.data.users ?? [],
             loadPage: (_response) => {
                 _offset += 1;

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/inlineUsers/resources/inlineUsers/client/Client.ts
@@ -607,7 +607,9 @@ export class InlineUsersClient {
         >({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data.users ?? []).length > 0,
+            hasNextPage: (response) =>
+                (response?.data.users ?? []).length > 0 &&
+                (request?.limit == null || (response?.data.users ?? []).length >= request?.limit),
             getItems: (response) => response?.data.users ?? [],
             loadPage: (_response) => {
                 _offset += 1;
@@ -693,7 +695,10 @@ export class InlineUsersClient {
         >({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => response?.hasNextPage ?? (response?.data.users ?? []).length > 0,
+            hasNextPage: (response) =>
+                response?.hasNextPage ??
+                ((response?.data.users ?? []).length > 0 &&
+                    (request?.limit == null || (response?.data.users ?? []).length >= request?.limit)),
             getItems: (response) => response?.data.users ?? [],
             loadPage: (_response) => {
                 _offset += 1;

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
@@ -630,7 +630,9 @@ export class UsersClient {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data ?? []).length > 0,
+            hasNextPage: (response) =>
+                (response?.data ?? []).length > 0 &&
+                (request?.limit == null || (response?.data ?? []).length >= request?.limit),
             getItems: (response) => response?.data ?? [],
             loadPage: (_response) => {
                 _offset += 1;
@@ -715,7 +717,10 @@ export class UsersClient {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => response?.hasNextPage ?? (response?.data ?? []).length > 0,
+            hasNextPage: (response) =>
+                response?.hasNextPage ??
+                ((response?.data ?? []).length > 0 &&
+                    (request?.limit == null || (response?.data ?? []).length >= request?.limit)),
             getItems: (response) => response?.data ?? [],
             loadPage: (_response) => {
                 _offset += 1;

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
@@ -630,7 +630,7 @@ export class UsersClient {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) => (response?.data ?? []).length >= Math.floor(request?.limit ?? 123),
+            hasNextPage: (response) => (response?.data ?? []).length > 0,
             getItems: (response) => response?.data ?? [],
             loadPage: (_response) => {
                 _offset += 1;
@@ -715,8 +715,7 @@ export class UsersClient {
         return new core.Page<SeedPagination.User, SeedPagination.ListUsersPaginationResponse>({
             response: dataWithRawResponse.data,
             rawResponse: dataWithRawResponse.rawResponse,
-            hasNextPage: (response) =>
-                response?.hasNextPage ?? (response?.data ?? []).length >= Math.floor(request?.limit ?? 1),
+            hasNextPage: (response) => response?.hasNextPage ?? (response?.data ?? []).length > 0,
             getItems: (response) => response?.data ?? [],
             loadPage: (_response) => {
                 _offset += 1;


### PR DESCRIPTION
## Problem

For offset-based `x-fern-pagination`, the generated **TypeScript** pager computed `hasNextPage` (when a `step`/page-size is configured) as:

```ts
hasNextPage: (response) => (response?.items ?? []).length >= Math.floor(request?.pageSize ?? <default>)
```

When the caller **omits the page-size** request param, `request?.pageSize` is `undefined`, so it falls back to a fabricated default (the field's declared `default`, else `1`). A page with fewer than that many items then reports `hasNextPage = false` even when more pages exist — and a full last page yields a false positive.

Repro (FER-11160): `channel3-ts-sdk` `categories.list` (offset pagination, page-size omitted) — the generated `tests/wire/categories.test.ts` asserts `page.hasNextPage() === true` and got `false`.

## Root cause: TypeScript was the only divergent generator

| Generator | Offset has-next logic |
|---|---|
| **TS** (before) | `items.length >= Math.floor(request.pageSize ?? <default>)` — broken when page-size omitted |
| **Python** (`pagination/offset.py`) | `len(items or []) > 0` |
| **Go** (`getPaginationInfo.ts`) | offset branch sets no `Done` field → items-driven core pager |

Python and Go never compared `items.length` to the requested page-size; TS added that comparison and that was the entire bug. Their CI wire tests pass without any patch.

## Fix

In `GeneratedThrowingEndpointResponse.getOffsetPaginationInfo`, the base `hasNextPage` is now unconditionally:

```ts
(response?.items ?? []).length > 0
```

matching the Python/Go offset pagers. Unchanged:
- the explicit `has-next-page` boolean response property still takes priority (`response?.hasNextPage ?? <base>`);
- `offset.step` still drives the offset increment (item-index semantics).

This accepts one extra (empty) final request to detect the end, exactly as Python/Go already do — in exchange for correctness when page-size is omitted.

## Tests

- `GeneratedEndpointResponse.test.ts`: updated the offset-step snapshot and added explicit regression assertions that the generated has-next contains no `Math.floor` and equals `(response?.items ?? []).length > 0`. **39/39 unit tests pass.**
- Regenerated the affected `seed/ts-sdk/pagination/{no-custom-config,page-index-semantics}` snapshots (validator-verified). The only diffs are `>= Math.floor(...)` → `> 0` in the generated `Client.ts` files.

## Notes

- Scoped to the TypeScript generator (the only affected one), per discussion. The other generators are already correct.
- Channel3's `categories.list` uses page-*number* offset, so for its `_offset` increment to be correct it also needs `offsetSemantics: page-index` in the generator config — that's a separate config concern; this PR fixes `hasNextPage`.

Fixes FER-11160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Update — refined strategy (commit `dc0f2624cb0`)

The initial fix above dropped the step comparison entirely, matching the items-driven Python/Go pagers. After discussion we refined the approach: **keep the step optimization but gate it on whether the caller actually provided a page-size**. That fixes the fabricated-default bug without losing the short-page short-circuit.

The base `hasNextPage` when `offset.step` is in the IR is now:

```ts
hasNextPage: (response) =>
  (response?.items ?? []).length > 0 &&
  (request?.pageSize == null || (response?.items ?? []).length >= request?.pageSize)
```

When `offset.step` is *not* in the IR, the generator emits the simpler items-driven form. Explicit `response.hasNextPage` continues to take priority via `??`. `Math.floor` is gone; `getDefaultPaginationValue` is no longer called from `hasNextPage` at all, so the fabricated-default failure mode is eliminated by construction.

### Why this shape

| `request.pageSize` | items returned | result | comment |
|---|---|---|---|
| 10 | 10 | true | may be last page; one wasted req — same as items-driven |
| 10 | 5 | false | **short-page short-circuit** — the optimization win |
| 10 | 0 | false | empty page |
| omitted | 5 | true | no info, fall back to items-driven |
| omitted | 0 | false | empty page |

### Cross-SDK divergence is now intentional

The earlier framing ("matches Python/Go") no longer applies: TS keeps the step optimization that the other generators don't have. The divergence buys callers who pass a page-size one fewer round-trip at the tail. The known limitation of this heuristic — APIs whose server caps the response size below the requested step will terminate early — is unchanged from PR #10225 and is mitigated the same way: API authors should populate `response.hasNextPage`, which still wins via `??`.

### Diff vs the prior commit on this branch

- `GeneratedThrowingEndpointResponse.ts` — `baseHasNextPage` emits the gated expression when `offset.step != null`; items-driven otherwise.
- `GeneratedEndpointResponse.test.ts` — assertion updated to the new gated string; the `not.toContain("Math.floor")` regression guard stays.
- `__snapshots__/GeneratedEndpointResponse.test.ts.snap` — regenerated.
- `seed/ts-sdk/pagination/{no-custom-config,page-index-semantics}` — 4 `Client.ts` files regenerated.
- `changes/unreleased/fix-offset-hasnextpage.yml` — rewritten to describe the gated strategy.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
