### PR TITLE
chore(ci): skip CI and seed matrix computation on seed-labeled PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,19 +29,32 @@ env:
   TURBO_DAEMON: "false"
 
 jobs:
-  # Detect whether this push only touched seed snapshot files.
+  # Detect whether this push/PR only touched seed snapshot files.
   # If so, skip all CI jobs — seed changes cannot break the build.
   changes-filter:
     runs-on: ubuntu-latest
     outputs:
       should-skip-ci: ${{ steps.check.outputs.should-skip }}
     steps:
-      - name: Check if push only touches seed files
+      - name: Check if change only touches seed files
         id: check
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          # Only consider skipping for pushes to main. PRs and dispatches always run CI.
+          # Skip CI for PRs with the 'seed' label (automated seed snapshot updates).
+          # Seed PRs only touch files under seed/ and cannot break the build.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            PR_LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+            if echo "$PR_LABELS" | jq -e 'index("seed")' > /dev/null 2>&1; then
+              echo "should-skip=true" >> $GITHUB_OUTPUT
+              echo "Seed-labeled PR detected — skipping CI."
+              exit 0
+            fi
+            echo "should-skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Skip CI for pushes to main with seed commit messages.
           if [[ "${{ github.event_name }}" != "push" || "${{ github.ref }}" != "refs/heads/main" ]]; then
             echo "should-skip=false" >> $GITHUB_OUTPUT
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,11 @@ jobs:
         id: check
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           # Skip CI for PRs with the 'seed' label (automated seed snapshot updates).
           # Seed PRs only touch files under seed/ and cannot break the build.
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            PR_LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
             if echo "$PR_LABELS" | jq -e 'index("seed")' > /dev/null 2>&1; then
               echo "should-skip=true" >> $GITHUB_OUTPUT
               echo "Seed-labeled PR detected — skipping CI."

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -34,6 +34,7 @@ jobs:
     timeout-minutes: 2
     outputs:
       post-metrics: ${{ steps.set-options.outputs.post-metrics }}
+      is-seed-pr: ${{ steps.set-options.outputs.is-seed-pr }}
     steps:
       - name: Set Options
         id: set-options
@@ -47,6 +48,20 @@ jobs:
           else
             echo "post-metrics=false" >> $GITHUB_OUTPUT
             echo "Will not collect metrics on this run"
+          fi
+
+          # Detect seed-labeled PRs to skip expensive matrix computation.
+          # Seed PRs only contain snapshot output changes — no generators are affected.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            PR_LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+            if echo "$PR_LABELS" | jq -e 'index("seed")' > /dev/null 2>&1; then
+              echo "is-seed-pr=true" >> $GITHUB_OUTPUT
+              echo "Seed-labeled PR detected — will skip matrix computation."
+            else
+              echo "is-seed-pr=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "is-seed-pr=false" >> $GITHUB_OUTPUT
           fi
 
   check-orphaned-seed-folders:
@@ -91,6 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup]
+    if: needs.setup.outputs.is-seed-pr != 'true'
     outputs:
       seed-infrastructure-changed: ${{ steps.detect-affected.outputs.seed-infrastructure-changed }}
       ruby-sdk-v2: ${{ steps.create-dynamic-matrix.outputs.ruby-sdk-v2-test-matrix }}

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Set Options
         id: set-options
         shell: bash
+        env:
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           echo "GitHub Event: ${{ github.event_name }}"
           echo "GitHub Event Action: ${{ github.event.action }}"
@@ -53,7 +55,6 @@ jobs:
           # Detect seed-labeled PRs to skip expensive matrix computation.
           # Seed PRs only contain snapshot output changes — no generators are affected.
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            PR_LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
             if echo "$PR_LABELS" | jq -e 'index("seed")' > /dev/null 2>&1; then
               echo "is-seed-pr=true" >> $GITHUB_OUTPUT
               echo "Seed-labeled PR detected — will skip matrix computation."


### PR DESCRIPTION
## Description

Automated seed snapshot PRs (e.g. #16400) only touch files under `seed/` and cannot break the build, but they currently run the full CI suite (compile, lint, test, test-ete, depcheck, etc.) and the expensive seed matrix computation (~5 min of `pnpm install` + `pnpm seed:build`).

With ~183 seed PRs in the last 40 days (~4-5/day), this wastes ~50+ hours/month of CI compute.

## Changes Made

**`ci.yml`**: Extended `changes-filter` to detect PRs with the `seed` label and set `should-skip=true`. All downstream CI jobs already gate on this output, so they'll be skipped. GitHub treats skipped required checks as passing for branch protection, so auto-merge continues to work.

**`seed.yml`**: Added `is-seed-pr` output to the `setup` job and gated `get-all-test-matrices` on it. When skipped, generator jobs are also skipped, and `seed-test-results` (which uses `always() && !cancelled()`) still runs and treats `skipped` dependencies as passing.

## Testing

- [x] Manual review of the skip logic against the existing `changes-filter` pattern
- [x] Verified that `seed-test-results` already handles `skipped` status as passing (line 1540 in seed.yml)
- [x] Confirmed GitHub branch protection treats skipped required checks as passing

Link to Devin session: https://app.devin.ai/sessions/360adc3e4dfe4c8b8739ad91e694f013
Requested by: @dannysheridan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->