### PR TITLE
fix(cli): preserve relative symlinks when copying generator output

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-symlink-copy.yml
+++ b/packages/cli/cli/changes/unreleased/fix-symlink-copy.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix `fs.cp` resolving relative symlinks to absolute temp-directory paths
+    during local generation. Adds `verbatimSymlinks: true` so symlinks like
+    `.claude -> .agents` are preserved as-is when copying generator output.
+  type: fix

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -790,7 +790,7 @@ export class LocalTaskHandler {
         const pathsToPreserve = await this.getPathsToPreserve(fernIgnorePaths);
 
         // Copy files from local output to tmp directory
-        await cp(this.absolutePathToLocalOutput, tmpOutputResolutionDir, { recursive: true });
+        await cp(this.absolutePathToLocalOutput, tmpOutputResolutionDir, { recursive: true, verbatimSymlinks: true });
 
         // Initialize a throwaway git repo in the temp directory. This is only used to
         // leverage git's file-tracking for resolving .fernignore paths. We inline the
@@ -839,7 +839,7 @@ export class LocalTaskHandler {
 
         // Delete local output directory and copy all files from the generated directory
         await rm(this.absolutePathToLocalOutput, { recursive: true });
-        await cp(tmpOutputResolutionDir, this.absolutePathToLocalOutput, { recursive: true });
+        await cp(tmpOutputResolutionDir, this.absolutePathToLocalOutput, { recursive: true, verbatimSymlinks: true });
     }
 
     private async copyGeneratedFilesNoFernIgnorePreservingGit(): Promise<void> {
@@ -893,11 +893,11 @@ export class LocalTaskHandler {
                 await cp(
                     join(this.absolutePathToTmpOutputDirectory, RelativeFilePath.of(localOutputItem)),
                     join(outputPath, RelativeFilePath.of(localOutputItem)),
-                    { recursive: true }
+                    { recursive: true, verbatimSymlinks: true }
                 );
             }
         } else {
-            await cp(this.absolutePathToTmpOutputDirectory, outputPath, { recursive: true });
+            await cp(this.absolutePathToTmpOutputDirectory, outputPath, { recursive: true, verbatimSymlinks: true });
         }
     }
 

--- a/seed/cli/allof-inline/.claude
+++ b/seed/cli/allof-inline/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3131-8Cah1W2x2OvM/output/.agents
+.agents

--- a/seed/cli/allof/.claude
+++ b/seed/cli/allof/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3064-fXp4qGBvqZiF/output/.agents
+.agents

--- a/seed/cli/api-wide-base-path-with-default/.claude
+++ b/seed/cli/api-wide-base-path-with-default/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3105-a9AQZS98pNX1/output/.agents
+.agents

--- a/seed/cli/cli-multi-spec-namespaced/no-custom-config/.claude
+++ b/seed/cli/cli-multi-spec-namespaced/no-custom-config/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3082-olcO6aO55mlE/output/.agents
+.agents

--- a/seed/cli/cli-multi-spec/no-custom-config/.claude
+++ b/seed/cli/cli-multi-spec/no-custom-config/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3097-9TXbqMAqmypn/output/.agents
+.agents

--- a/seed/cli/file-upload-openapi/.claude
+++ b/seed/cli/file-upload-openapi/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3069-UIfFldAXNZSd/output/.agents
+.agents

--- a/seed/cli/imdb/.claude
+++ b/seed/cli/imdb/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3097-3XhI18Hbkf3E/output/.agents
+.agents

--- a/seed/cli/multi-url-environment-reference/.claude
+++ b/seed/cli/multi-url-environment-reference/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3058-aNXQA0iG2F6c/output/.agents
+.agents

--- a/seed/cli/no-content-response/.claude
+++ b/seed/cli/no-content-response/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3088-0yY3jR3deGGq/output/.agents
+.agents

--- a/seed/cli/null-type/.claude
+++ b/seed/cli/null-type/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3069-WViu63sCjMg1/output/.agents
+.agents

--- a/seed/cli/nullable-allof-extends/.claude
+++ b/seed/cli/nullable-allof-extends/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3131-T3jbGKqwlj00/output/.agents
+.agents

--- a/seed/cli/nullable-request-body/.claude
+++ b/seed/cli/nullable-request-body/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3084-diaVGCZBmbR7/output/.agents
+.agents

--- a/seed/cli/oauth-client-credentials-openapi/.claude
+++ b/seed/cli/oauth-client-credentials-openapi/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3063-XUt16aYeechQ/output/.agents
+.agents

--- a/seed/cli/openapi-request-body-ref/.claude
+++ b/seed/cli/openapi-request-body-ref/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3027-i5UtkCpqY2bc/output/.agents
+.agents

--- a/seed/cli/query-param-name-conflict/.claude
+++ b/seed/cli/query-param-name-conflict/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3069-X2aVnOpMQNpY/output/.agents
+.agents

--- a/seed/cli/query-parameters-openapi-as-objects/.claude
+++ b/seed/cli/query-parameters-openapi-as-objects/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3131-Z5P8O5fQMOfn/output/.agents
+.agents

--- a/seed/cli/query-parameters-openapi/github-no-publish/.claude
+++ b/seed/cli/query-parameters-openapi/github-no-publish/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3088-vLix4OvLoOEn/output/.agents
+.agents

--- a/seed/cli/query-parameters-openapi/github-npm/.claude
+++ b/seed/cli/query-parameters-openapi/github-npm/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3078-kFj9QH7Nh26D/output/.agents
+.agents

--- a/seed/cli/query-parameters-openapi/no-custom-config/.claude
+++ b/seed/cli/query-parameters-openapi/no-custom-config/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3058-125legg0BVRM/output/.agents
+.agents

--- a/seed/cli/schemaless-request-body-examples/.claude
+++ b/seed/cli/schemaless-request-body-examples/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3082-dZBlYpq0R9U2/output/.agents
+.agents

--- a/seed/cli/server-sent-events-openapi/.claude
+++ b/seed/cli/server-sent-events-openapi/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3088-hEyL1OQWDWno/output/.agents
+.agents

--- a/seed/cli/server-url-templating/.claude
+++ b/seed/cli/server-url-templating/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3072-IwOPqkjcLwZz/output/.agents
+.agents

--- a/seed/cli/url-form-encoded/.claude
+++ b/seed/cli/url-form-encoded/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3069-uavT0xvIGOf6/output/.agents
+.agents

--- a/seed/cli/webhook-audience/.claude
+++ b/seed/cli/webhook-audience/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3105-70tWRYklD4g1/output/.agents
+.agents

--- a/seed/cli/x-fern-default/.claude
+++ b/seed/cli/x-fern-default/.claude
@@ -1,1 +1,1 @@
-/tmp/fern-3063-SdhyD3VeydcQ/output/.agents
+.agents


### PR DESCRIPTION
## Description

Fixes the root cause of ~94 nonsense `chore(seed): update all seed snapshots` commits in June that only changed `.claude` symlink targets to different random temp-directory paths.

## Changes Made

- Add `verbatimSymlinks: true` to all recursive `fs.cp()` calls in `LocalTaskHandler.copyGeneratedFilesToDirectory` and related copy methods
- Fix all 25 existing broken `.claude` symlinks in `seed/cli/` back to the correct relative `.agents` target

**Root cause:** Node.js `fs.cp({ recursive: true })` resolves relative symlinks to absolute paths by default. The CLI generator creates `.claude -> .agents` (relative), but after `LocalTaskHandler` copies from the temp output dir, it becomes `.claude -> /tmp/fern-XXXX/output/.agents` (absolute). Since the temp dir name is random, every `update-seed` run produces a diff, triggering a new PR+merge cycle.

```
// Before (default verbatimSymlinks: false)
source: .claude -> .agents
copied: .claude -> /tmp/fern-3043-Wb3WIlsAGCcX/output/.agents  // absolute!

// After (verbatimSymlinks: true)
source: .claude -> .agents
copied: .claude -> .agents  // preserved
```

## Testing
- [x] Verified fix with Node.js repro: `fs.cpSync(src, dst, { recursive: true, verbatimSymlinks: true })` preserves relative symlink targets
- [x] All 25 `.claude` symlinks in `seed/cli/` now correctly point to `.agents` (relative)

Link to Devin session: https://app.devin.ai/sessions/0bee19cec2e64ddf8570bdddf5bfff70
Requested by: @Swimburger