### PR TITLE
fix(rust): always wrap IR-derived error fields in Option and fix thiserror format strings

### DIFF
--- a/generators/rust/sdk/changes/unreleased/fix-error-option-wrapping-and-thiserror.yml
+++ b/generators/rust/sdk/changes/unreleased/fix-error-option-wrapping-and-thiserror.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Always wrap IR-derived error fields in `Option` to match constructor code
+    that assigns `None` for missing fields, preventing struct/constructor type
+    mismatches. Fix thiserror format strings: `{{message}}` → `{message}` so
+    field values are actually interpolated.
+  type: fix

--- a/generators/rust/sdk/src/__test__/snapshots/api-specific-variants.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/api-specific-variants.rs
@@ -2,11 +2,11 @@ use thiserror::{Error};
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("ValidationError: Unprocessable entity - {{message}}")]
+    #[error("ValidationError: Unprocessable entity - {message}")]
     ValidationError { message: String, field: Option<String>, validation_error: Option<String> },
-    #[error("RateLimitError: Rate limit exceeded - {{message}}")]
+    #[error("RateLimitError: Rate limit exceeded - {message}")]
     RateLimitError { message: String, retry_after_seconds: Option<u64>, limit_type: Option<String> },
-    #[error("InternalServerError: Internal server error - {{message}}")]
+    #[error("InternalServerError: Internal server error - {message}")]
     InternalServerError { message: String, error_id: Option<String> },
     #[error("HTTP error {status}: {message}")]
     Http { status: u16, message: String },

--- a/generators/rust/sdk/src/__test__/snapshots/basic-error-enum.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/basic-error-enum.rs
@@ -2,9 +2,9 @@ use thiserror::{Error};
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("UnauthorizedError: Authentication failed - {{message}}")]
+    #[error("UnauthorizedError: Authentication failed - {message}")]
     UnauthorizedError { message: String, auth_type: Option<String> },
-    #[error("NotFoundError: Resource not found - {{message}}")]
+    #[error("NotFoundError: Resource not found - {message}")]
     NotFoundError { message: String, resource_id: Option<String>, resource_type: Option<String> },
     #[error("HTTP error {status}: {message}")]
     Http { status: u16, message: String },

--- a/generators/rust/sdk/src/__test__/snapshots/context-rich-fields.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/context-rich-fields.rs
@@ -2,15 +2,15 @@ use thiserror::{Error};
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("UnauthorizedError: Authentication failed - {{message}}")]
+    #[error("UnauthorizedError: Authentication failed - {message}")]
     UnauthorizedError { message: String, auth_type: Option<String> },
-    #[error("NotFoundError: Resource not found - {{message}}")]
+    #[error("NotFoundError: Resource not found - {message}")]
     NotFoundError { message: String, resource_id: Option<String>, resource_type: Option<String> },
-    #[error("ValidationError: Unprocessable entity - {{message}}")]
+    #[error("ValidationError: Unprocessable entity - {message}")]
     ValidationError { message: String, field: Option<String>, validation_error: Option<String> },
-    #[error("RateLimitError: Rate limit exceeded - {{message}}")]
+    #[error("RateLimitError: Rate limit exceeded - {message}")]
     RateLimitError { message: String, retry_after_seconds: Option<u64>, limit_type: Option<String> },
-    #[error("InternalServerError: Internal server error - {{message}}")]
+    #[error("InternalServerError: Internal server error - {message}")]
     InternalServerError { message: String, error_id: Option<String> },
     #[error("HTTP error {status}: {message}")]
     Http { status: u16, message: String },

--- a/generators/rust/sdk/src/__test__/snapshots/default-field-values.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/default-field-values.rs
@@ -2,9 +2,9 @@ use thiserror::{Error};
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("RateLimitError: Rate limit exceeded - {{message}}")]
+    #[error("RateLimitError: Rate limit exceeded - {message}")]
     RateLimitError { message: String, retry_after_seconds: Option<u64>, limit_type: Option<String> },
-    #[error("MaintenanceError: {{message}}")]
+    #[error("MaintenanceError: {message}")]
     MaintenanceError { message: String },
     #[error("HTTP error {status}: {message}")]
     Http { status: u16, message: String },

--- a/generators/rust/sdk/src/__test__/snapshots/different-error-messages.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/different-error-messages.rs
@@ -2,15 +2,15 @@ use thiserror::{Error};
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("UnauthorizedError: Authentication failed - {{message}}")]
+    #[error("UnauthorizedError: Authentication failed - {message}")]
     UnauthorizedError { message: String, auth_type: Option<String> },
-    #[error("ForbiddenError: Access forbidden - {{message}}")]
+    #[error("ForbiddenError: Access forbidden - {message}")]
     ForbiddenError { message: String, resource: Option<String>, required_permission: Option<String> },
-    #[error("NotFoundError: Resource not found - {{message}}")]
+    #[error("NotFoundError: Resource not found - {message}")]
     NotFoundError { message: String, resource_id: Option<String>, resource_type: Option<String> },
-    #[error("ConflictError: Conflict - {{message}}")]
+    #[error("ConflictError: Conflict - {message}")]
     ConflictError { message: String, conflict_type: Option<String> },
-    #[error("ValidationError: Unprocessable entity - {{message}}")]
+    #[error("ValidationError: Unprocessable entity - {message}")]
     ValidationError { message: String, field: Option<String>, validation_error: Option<String> },
     #[error("HTTP error {status}: {message}")]
     Http { status: u16, message: String },

--- a/generators/rust/sdk/src/__test__/snapshots/json-parsing.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/json-parsing.rs
@@ -2,9 +2,9 @@ use thiserror::{Error};
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("ValidationError: Unprocessable entity - {{message}}")]
+    #[error("ValidationError: Unprocessable entity - {message}")]
     ValidationError { message: String, field: Option<String>, validation_error: Option<String> },
-    #[error("ConflictError: Conflict - {{message}}")]
+    #[error("ConflictError: Conflict - {message}")]
     ConflictError { message: String, conflict_type: Option<String> },
     #[error("HTTP error {status}: {message}")]
     Http { status: u16, message: String },

--- a/generators/rust/sdk/src/__test__/snapshots/status-code-mapping.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/status-code-mapping.rs
@@ -2,13 +2,13 @@ use thiserror::{Error};
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("BadRequestError: Bad request - {{message}}")]
+    #[error("BadRequestError: Bad request - {message}")]
     BadRequestError { message: String, field: Option<String>, details: Option<String> },
-    #[error("UnauthorizedError: Authentication failed - {{message}}")]
+    #[error("UnauthorizedError: Authentication failed - {message}")]
     UnauthorizedError { message: String, auth_type: Option<String> },
-    #[error("ForbiddenError: Access forbidden - {{message}}")]
+    #[error("ForbiddenError: Access forbidden - {message}")]
     ForbiddenError { message: String, resource: Option<String>, required_permission: Option<String> },
-    #[error("NotFoundError: Resource not found - {{message}}")]
+    #[error("NotFoundError: Resource not found - {message}")]
     NotFoundError { message: String, resource_id: Option<String>, resource_type: Option<String> },
     #[error("HTTP error {status}: {message}")]
     Http { status: u16, message: String },

--- a/generators/rust/sdk/src/__test__/snapshots/text-only-errors.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/text-only-errors.rs
@@ -2,9 +2,9 @@ use thiserror::{Error};
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("SimpleError: Bad request - {{message}}")]
+    #[error("SimpleError: Bad request - {message}")]
     SimpleError { message: String, field: Option<String>, details: Option<String> },
-    #[error("GenericError: Internal server error - {{message}}")]
+    #[error("GenericError: Internal server error - {message}")]
     GenericError { message: String, error_id: Option<String> },
     #[error("HTTP error {status}: {message}")]
     Http { status: u16, message: String },

--- a/generators/rust/sdk/src/error/ErrorGenerator.ts
+++ b/generators/rust/sdk/src/error/ErrorGenerator.ts
@@ -155,12 +155,18 @@ export class ErrorGenerator {
             if (typeDecl?.shape.type === "object") {
                 return typeDecl.shape.properties
                     .filter((p) => getWireValue(p.name) !== "message")
-                    .map((p) => ({
-                        name: this.context.case.snakeSafe(p.name),
-                        wireName: getWireValue(p.name),
-                        type: generateRustTypeForTypeReference(p.valueType, this.context),
-                        extractionKind: this.isU64TypeReference(p.valueType) ? ("u64" as const) : ("string" as const)
-                    }));
+                    .map((p) => {
+                        const isAlreadyOptional =
+                            p.valueType.type === "container" &&
+                            (p.valueType.container.type === "optional" || p.valueType.container.type === "nullable");
+                        const rustType = generateRustTypeForTypeReference(p.valueType, this.context);
+                        return {
+                            name: this.context.case.snakeSafe(p.name),
+                            wireName: getWireValue(p.name),
+                            type: isAlreadyOptional ? rustType : Type.option(rustType),
+                            extractionKind: this.isU64TypeReference(p.valueType) ? ("u64" as const) : ("string" as const)
+                        };
+                    });
             }
         }
         return this.getStatusCodeFields(errorDeclaration.statusCode).map(({ name, wireName, type }) => ({
@@ -565,17 +571,17 @@ export class ErrorGenerator {
         const statusCode = errorDeclaration.statusCode;
 
         const messageTemplates: Record<number, string> = {
-            400: "Bad request - {{message}}",
-            401: "Authentication failed - {{message}}",
-            403: "Access forbidden - {{message}}",
-            404: "Resource not found - {{message}}",
-            409: "Conflict - {{message}}",
-            422: "Unprocessable entity - {{message}}",
-            429: "Rate limit exceeded - {{message}}",
-            500: "Internal server error - {{message}}"
+            400: "Bad request - {message}",
+            401: "Authentication failed - {message}",
+            403: "Access forbidden - {message}",
+            404: "Resource not found - {message}",
+            409: "Conflict - {message}",
+            422: "Unprocessable entity - {message}",
+            429: "Rate limit exceeded - {message}",
+            500: "Internal server error - {message}"
         };
 
-        const template = messageTemplates[statusCode] || "{{message}}";
+        const template = messageTemplates[statusCode] || "{message}";
         return `${errorName}: ${template}`;
     }
 }

--- a/seed/rust-sdk/accept-header/.fern/metadata.json
+++ b/seed/rust-sdk/accept-header/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/accept-header/src/error.rs
+++ b/seed/rust-sdk/accept-header/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("NotFoundError: Resource not found - {{message}}")]
+    #[error("NotFoundError: Resource not found - {message}")]
     NotFoundError {
         message: String,
         resource_id: Option<String>,

--- a/seed/rust-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/rust-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/basic-auth-environment-variables/src/error.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/error.rs
@@ -2,9 +2,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("UnauthorizedRequest: Authentication failed - {{message}}")]
+    #[error("UnauthorizedRequest: Authentication failed - {message}")]
     UnauthorizedRequest { message: String },
-    #[error("BadRequest: Bad request - {{message}}")]
+    #[error("BadRequest: Bad request - {message}")]
     BadRequest {
         message: String,
         field: Option<String>,

--- a/seed/rust-sdk/basic-auth-pw-omitted/.fern/metadata.json
+++ b/seed/rust-sdk/basic-auth-pw-omitted/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/basic-auth-pw-omitted/src/error.rs
+++ b/seed/rust-sdk/basic-auth-pw-omitted/src/error.rs
@@ -2,9 +2,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("UnauthorizedRequest: Authentication failed - {{message}}")]
+    #[error("UnauthorizedRequest: Authentication failed - {message}")]
     UnauthorizedRequest { message: String },
-    #[error("BadRequest: Bad request - {{message}}")]
+    #[error("BadRequest: Bad request - {message}")]
     BadRequest {
         message: String,
         field: Option<String>,

--- a/seed/rust-sdk/basic-auth/.fern/metadata.json
+++ b/seed/rust-sdk/basic-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/basic-auth/src/error.rs
+++ b/seed/rust-sdk/basic-auth/src/error.rs
@@ -2,9 +2,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("UnauthorizedRequest: Authentication failed - {{message}}")]
+    #[error("UnauthorizedRequest: Authentication failed - {message}")]
     UnauthorizedRequest { message: String },
-    #[error("BadRequest: Bad request - {{message}}")]
+    #[error("BadRequest: Bad request - {message}")]
     BadRequest {
         message: String,
         field: Option<String>,

--- a/seed/rust-sdk/error-property/.fern/metadata.json
+++ b/seed/rust-sdk/error-property/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/error-property/src/error.rs
+++ b/seed/rust-sdk/error-property/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("PropertyBasedErrorTest: Bad request - {{message}}")]
+    #[error("PropertyBasedErrorTest: Bad request - {message}")]
     PropertyBasedErrorTest { message: String },
     #[error("HTTP error {status}: {message}")]
     Http { status: u16, message: String },

--- a/seed/rust-sdk/errors/.fern/metadata.json
+++ b/seed/rust-sdk/errors/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/errors/src/error.rs
+++ b/seed/rust-sdk/errors/src/error.rs
@@ -2,16 +2,16 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("NotFoundError: Resource not found - {{message}}")]
-    NotFoundError { message: String, code: i64 },
-    #[error("BadRequestError: Bad request - {{message}}")]
-    BadRequestError { message: String, code: i64 },
-    #[error("InternalServerError: Internal server error - {{message}}")]
-    InternalServerError { message: String, code: i64 },
-    #[error("FooTooMuch: Rate limit exceeded - {{message}}")]
-    FooTooMuch { message: String, code: i64 },
-    #[error("FooTooLittle: Internal server error - {{message}}")]
-    FooTooLittle { message: String, code: i64 },
+    #[error("NotFoundError: Resource not found - {message}")]
+    NotFoundError { message: String, code: Option<i64> },
+    #[error("BadRequestError: Bad request - {message}")]
+    BadRequestError { message: String, code: Option<i64> },
+    #[error("InternalServerError: Internal server error - {message}")]
+    InternalServerError { message: String, code: Option<i64> },
+    #[error("FooTooMuch: Rate limit exceeded - {message}")]
+    FooTooMuch { message: String, code: Option<i64> },
+    #[error("FooTooLittle: Internal server error - {message}")]
+    FooTooLittle { message: String, code: Option<i64> },
     #[error("HTTP error {status}: {message}")]
     Http { status: u16, message: String },
     #[error("Network error: {0}")]

--- a/seed/rust-sdk/exhaustive/.fern/metadata.json
+++ b/seed/rust-sdk/exhaustive/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/exhaustive/src/error.rs
+++ b/seed/rust-sdk/exhaustive/src/error.rs
@@ -2,15 +2,15 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("BadRequestBody: Bad request - {{message}}")]
+    #[error("BadRequestBody: Bad request - {message}")]
     BadRequestBody { message: String },
-    #[error("ErrorWithEnumBody: Bad request - {{message}}")]
+    #[error("ErrorWithEnumBody: Bad request - {message}")]
     ErrorWithEnumBody {
         message: String,
         field: Option<String>,
         details: Option<String>,
     },
-    #[error("ObjectWithOptionalFieldError: Bad request - {{message}}")]
+    #[error("ObjectWithOptionalFieldError: Bad request - {message}")]
     ObjectWithOptionalFieldError {
         message: String,
         string: Option<String>,
@@ -27,21 +27,24 @@ pub enum ApiError {
         map: Option<HashMap<i64, String>>,
         bigint: Option<num_bigint::BigInt>,
     },
-    #[error("ObjectWithRequiredFieldError: Bad request - {{message}}")]
-    ObjectWithRequiredFieldError { message: String, string: String },
-    #[error("NestedObjectWithOptionalFieldError: Bad request - {{message}}")]
+    #[error("ObjectWithRequiredFieldError: Bad request - {message}")]
+    ObjectWithRequiredFieldError {
+        message: String,
+        string: Option<String>,
+    },
+    #[error("NestedObjectWithOptionalFieldError: Bad request - {message}")]
     NestedObjectWithOptionalFieldError {
         message: String,
         string: Option<String>,
         nested_object: Option<ObjectWithOptionalField>,
     },
-    #[error("NestedObjectWithRequiredFieldError: Bad request - {{message}}")]
+    #[error("NestedObjectWithRequiredFieldError: Bad request - {message}")]
     NestedObjectWithRequiredFieldError {
         message: String,
-        string: String,
-        nested_object: ObjectWithOptionalField,
+        string: Option<String>,
+        nested_object: Option<ObjectWithOptionalField>,
     },
-    #[error("ErrorWithUnionBody: Bad request - {{message}}")]
+    #[error("ErrorWithUnionBody: Bad request - {message}")]
     ErrorWithUnionBody {
         message: String,
         field: Option<String>,

--- a/seed/rust-sdk/folders/.fern/metadata.json
+++ b/seed/rust-sdk/folders/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/folders/src/error.rs
+++ b/seed/rust-sdk/folders/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("NotFoundError: Resource not found - {{message}}")]
+    #[error("NotFoundError: Resource not found - {message}")]
     NotFoundError {
         message: String,
         resource_id: Option<String>,

--- a/seed/rust-sdk/nullable-request-body/.fern/metadata.json
+++ b/seed/rust-sdk/nullable-request-body/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/nullable-request-body/src/error.rs
+++ b/seed/rust-sdk/nullable-request-body/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("UnprocessableEntityError: Unprocessable entity - {{message}}")]
+    #[error("UnprocessableEntityError: Unprocessable entity - {message}")]
     UnprocessableEntityError {
         message: String,
         id: Option<String>,

--- a/seed/rust-sdk/trace/.fern/metadata.json
+++ b/seed/rust-sdk/trace/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/trace/src/error.rs
+++ b/seed/rust-sdk/trace/src/error.rs
@@ -2,13 +2,13 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("PlaylistIdNotFoundError: Resource not found - {{message}}")]
+    #[error("PlaylistIdNotFoundError: Resource not found - {message}")]
     PlaylistIdNotFoundError {
         message: String,
         resource_id: Option<String>,
         resource_type: Option<String>,
     },
-    #[error("UnauthorizedError: Authentication failed - {{message}}")]
+    #[error("UnauthorizedError: Authentication failed - {message}")]
     UnauthorizedError {
         message: String,
         auth_type: Option<String>,


### PR DESCRIPTION
## Description

Fixes the Rust SDK build failure seen in [lattice-sdk-rust CI](https://github.com/fern-support/lattice-sdk-rust/actions/runs/27231235108/job/80411641685?pr=2). Replaces #16414 with a minimal fix targeting only the two bugs.

## Changes Made

- **Wrap IR-derived error fields in `Option`**: In `resolveErrorFields`, non-optional (and non-nullable) fields from IR type declarations are now wrapped in `Type.option()`. This matches `buildFallbackConstruction` which assigns `None` for missing fields — previously the struct declared `field: String` but the constructor passed `None`, causing a Rust type mismatch.
- **Fix thiserror format strings**: `{{message}}` → `{message}` in `getErrorMessage`. In Rust's thiserror, `{{` is an escape producing literal `{`, so `{{message}}` rendered as the literal text `{message}` instead of interpolating the field value.

## Testing

- [x] All 9 ErrorGenerator unit tests pass, 8 snapshots updated
- [x] All 10 affected seed fixtures regenerated and pass (`exhaustive`, `errors`, `accept-header`, `basic-auth`, `basic-auth-environment-variables`, `basic-auth-pw-omitted`, `error-property`, `folders`, `nullable-request-body`, `trace`)
- [x] `pnpm run check` (biome) passes

Link to Devin session: https://app.devin.ai/sessions/5a695386909b4542b5f5f5b6fe011b2d
Requested by: @iamnamananand996