### PR TITLE
fix(ci): fix publish-generator re-runs and upgrade oxc tooling

### DIFF
--- a/.github/workflows/publish-generator-csharp-model.yml
+++ b/.github/workflows/publish-generator-csharp-model.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-csharp-sdk.yml
+++ b/.github/workflows/publish-generator-csharp-sdk.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-fern-cli.yml
+++ b/.github/workflows/publish-generator-fern-cli.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-go-model.yml
+++ b/.github/workflows/publish-generator-go-model.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-go-sdk.yml
+++ b/.github/workflows/publish-generator-go-sdk.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-java-model.yml
+++ b/.github/workflows/publish-generator-java-model.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-java-sdk.yml
+++ b/.github/workflows/publish-generator-java-sdk.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-openapi.yml
+++ b/.github/workflows/publish-generator-openapi.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-php-model.yml
+++ b/.github/workflows/publish-generator-php-model.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-php-sdk.yml
+++ b/.github/workflows/publish-generator-php-sdk.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-python-pydantic.yml
+++ b/.github/workflows/publish-generator-python-pydantic.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-python-sdk.yml
+++ b/.github/workflows/publish-generator-python-sdk.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-ruby-sdk.yml
+++ b/.github/workflows/publish-generator-ruby-sdk.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-rust-model.yml
+++ b/.github/workflows/publish-generator-rust-model.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-rust-sdk.yml
+++ b/.github/workflows/publish-generator-rust-sdk.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-swift-sdk.yml
+++ b/.github/workflows/publish-generator-swift-sdk.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
       - name: automated publish
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/publish-generator-ts-sdk.yml
+++ b/.github/workflows/publish-generator-ts-sdk.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Checkout repo at current ref
         uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 10
 
       # Pre-flight: build the validator image locally (single-arch, no push)

--- a/generators/typescript/sdk/changes/unreleased/upgrade-tsgolint.yml
+++ b/generators/typescript/sdk/changes/unreleased/upgrade-tsgolint.yml
@@ -1,6 +1,6 @@
 - summary: |
-    Upgrade oxlint-tsgolint from 0.22.1 to 0.23.0 and use the prebuilt
-    binary directly (built with go1.26.3, clearing go/stdlib CVEs).
-    Removes the rebuild-from-source stage, cutting Docker build time by
-    ~5 minutes.
+    Upgrade oxc tooling: oxlint 1.63.0 → 1.69.0, oxfmt 0.48.0 → 0.54.0,
+    oxlint-tsgolint 0.22.1 → 0.23.0. tsgolint 0.23.0 ships with go1.26.3
+    (clearing go/stdlib CVEs), so the rebuild-from-source Docker stage is
+    removed entirely.
   type: chore

--- a/generators/typescript/sdk/changes/unreleased/upgrade-tsgolint.yml
+++ b/generators/typescript/sdk/changes/unreleased/upgrade-tsgolint.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Upgrade oxlint-tsgolint from 0.22.1 to 0.23.0 and use the prebuilt
+    binary directly (built with go1.26.3, clearing go/stdlib CVEs).
+    Removes the rebuild-from-source stage, cutting Docker build time by
+    ~5 minutes.
+  type: chore

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -1,8 +1,10 @@
 # Stage 1: Rebuild oxlint-tsgolint from source under go1.26.4 so the embedded
 # go/stdlib clears vulnerability scanners. The published binaries are still
 # compiled with an older upstream Go toolchain.
-FROM golang:1.26.4-trixie AS tsgolint-rebuild
+FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS tsgolint-rebuild
 ARG TSGOLINT_VERSION=0.22.1
+ARG TARGETOS
+ARG TARGETARCH
 ENV GOTOOLCHAIN=go1.26.4
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/*
 RUN git config --global user.email "build@example.com" && \
@@ -21,7 +23,7 @@ RUN git config --global user.email "build@example.com" && \
     cd .. && \
     mkdir -p internal/collections && \
     find ./typescript-go/internal/collections -type f ! -name '*_test.go' -exec cp {} internal/collections/ \; && \
-    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/tsgolint ./cmd/tsgolint && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags "-s -w" -o /out/tsgolint ./cmd/tsgolint && \
     ls -la /out/tsgolint
 
 FROM node:24.16-trixie-slim

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -62,9 +62,9 @@ RUN npm install -g pnpm@10.33.3 --force
 RUN npm install -g yarn@1.22.22 --force
 RUN pnpm add -g typescript@~5.9.3 \
   prettier@3.8.1 \
-  oxfmt@0.48.0 \
+  oxfmt@0.54.0 \
   @biomejs/biome@2.4.10 \
-  oxlint@1.63.0 \
+  oxlint@1.69.0 \
   oxlint-tsgolint@0.23.0 \
   @types/node@^20.0.0 \
   ts-loader@^9.5.4 \

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -1,31 +1,3 @@
-# Stage 1: Rebuild oxlint-tsgolint from source under go1.26.4 so the embedded
-# go/stdlib clears vulnerability scanners. The published binaries are still
-# compiled with an older upstream Go toolchain.
-FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS tsgolint-rebuild
-ARG TSGOLINT_VERSION=0.22.1
-ARG TARGETOS
-ARG TARGETARCH
-ENV GOTOOLCHAIN=go1.26.4
-RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/*
-RUN git config --global user.email "build@example.com" && \
-    git config --global user.name "Build" && \
-    git clone --depth 1 --branch v${TSGOLINT_VERSION} \
-        https://github.com/oxc-project/tsgolint.git /src/tsgolint && \
-    cd /src/tsgolint && \
-    # Equivalent of `just init`: init the typescript-go submodule
-    # (NOT recursively — typescript-go's own microsoft/TypeScript
-    # sub-submodule is huge and not needed for tsgolint's build),
-    # apply patches, copy internal/collections so internal/utils can
-    # import it (the file comment explains the duplication).
-    git submodule update --init --depth 1 typescript-go && \
-    cd typescript-go && \
-    git am --3way --no-gpg-sign ../patches/*.patch && \
-    cd .. && \
-    mkdir -p internal/collections && \
-    find ./typescript-go/internal/collections -type f ! -name '*_test.go' -exec cp {} internal/collections/ \; && \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags "-s -w" -o /out/tsgolint ./cmd/tsgolint && \
-    ls -la /out/tsgolint
-
 FROM node:24.16-trixie-slim
 
 # Apply latest Debian security updates so that grype-tracked OS package
@@ -93,30 +65,12 @@ RUN pnpm add -g typescript@~5.9.3 \
   oxfmt@0.48.0 \
   @biomejs/biome@2.4.10 \
   oxlint@1.63.0 \
-  oxlint-tsgolint@0.22.1 \
+  oxlint-tsgolint@0.23.0 \
   @types/node@^20.0.0 \
   ts-loader@^9.5.4 \
   webpack@^5.105.4 \
   msw@2.12.14 \
   vitest@^4.1.1
-
-# Replace the prebuilt @oxlint-tsgolint/linux-* binary with the locally
-# rebuilt one so it embeds the patched Go stdlib.
-COPY --from=tsgolint-rebuild /out/tsgolint /tmp/tsgolint-rebuilt
-RUN chmod +x /tmp/tsgolint-rebuilt && \
-    set -eux; \
-    found=0; \
-    for f in $(find / -type f -name tsgolint -path '*@oxlint-tsgolint*' 2>/dev/null); do \
-        cp /tmp/tsgolint-rebuilt "$f"; \
-        chmod +x "$f"; \
-        found=1; \
-        echo "Replaced tsgolint binary at $f"; \
-    done; \
-    if [ "$found" = "0" ]; then \
-        echo "::error::Could not find any tsgolint binary to replace"; \
-        exit 1; \
-    fi; \
-    rm /tmp/tsgolint-rebuilt
 
 COPY generators/typescript/sdk/cli/dist/ /
 

--- a/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
@@ -51,9 +51,9 @@ type COMMON_SCRIPTS = (typeof COMMON_SCRIPTS)[keyof typeof COMMON_SCRIPTS];
 const TOOL_VERSIONS = {
     BIOME: "2.4.10",
     PRETTIER: "3.8.1",
-    OXFMT: "0.48.0",
-    OXLINT: "1.63.0",
-    OXLINT_TSGOLINT: "0.22.1"
+    OXFMT: "0.54.0",
+    OXLINT: "1.69.0",
+    OXLINT_TSGOLINT: "0.23.0"
 } as const;
 
 export abstract class TypescriptProject {

--- a/seed/ts-sdk/simple-api/use-oxc/package.json
+++ b/seed/ts-sdk/simple-api/use-oxc/package.json
@@ -67,9 +67,9 @@
     "devDependencies": {
         "@types/node": "^20.0.0",
         "msw": "2.11.2",
-        "oxfmt": "0.48.0",
-        "oxlint": "1.63.0",
-        "oxlint-tsgolint": "0.22.1",
+        "oxfmt": "0.54.0",
+        "oxlint": "1.69.0",
+        "oxlint-tsgolint": "0.23.0",
         "ts-loader": "^9.5.4",
         "typescript": "~5.9.3",
         "vitest": "^4.1.1",

--- a/seed/ts-sdk/simple-api/use-oxfmt/package.json
+++ b/seed/ts-sdk/simple-api/use-oxfmt/package.json
@@ -68,7 +68,7 @@
         "@biomejs/biome": "2.4.10",
         "@types/node": "^20.0.0",
         "msw": "2.11.2",
-        "oxfmt": "0.48.0",
+        "oxfmt": "0.54.0",
         "ts-loader": "^9.5.4",
         "typescript": "~5.9.3",
         "vitest": "^4.1.1",

--- a/seed/ts-sdk/simple-api/use-oxlint/package.json
+++ b/seed/ts-sdk/simple-api/use-oxlint/package.json
@@ -64,8 +64,8 @@
         "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10",
-        "oxlint": "1.63.0",
-        "oxlint-tsgolint": "0.22.1"
+        "oxlint": "1.69.0",
+        "oxlint-tsgolint": "0.23.0"
     },
     "browser": {
         "fs": false,


### PR DESCRIPTION
## Description

Fixes two CI issues with generator Docker image publishing and upgrades oxc tooling to latest.

1. **Re-runs silently skip publishing** — `ref: main` in checkout resolves to current HEAD (not the triggering commit), so with `fetch-depth: 10` the release commit falls outside the shallow window and the version-diff finds nothing to publish
2. **TS SDK Docker build takes 5+ hours** — tsgolint 0.22.1 was rebuilt from source to clear go/stdlib CVEs; tsgolint 0.23.0 ships with go1.26.3 which already clears them

## Changes Made

- Remove `ref: main` from all 17 `publish-generator-*.yml` workflows — checkout now defaults to `github.sha` (stable across re-runs)
- Upgrade oxc tooling to latest across the repo:
  - `oxlint` 1.63.0 → 1.69.0
  - `oxfmt` 0.48.0 → 0.54.0
  - `oxlint-tsgolint` 0.22.1 → 0.23.0
- Delete the entire `tsgolint-rebuild` Go build stage from the TS SDK Dockerfile — the prebuilt 0.23.0 binary is already compiled with go1.26.3, clearing the CVEs that required the rebuild
- Update `TOOL_VERSIONS` in `TypescriptProject.ts` (controls versions in generated SDKs)
- Update seed test snapshots (`use-oxc`, `use-oxlint`, `use-oxfmt`)

## Testing

- [x] Empirically verified shallow-clone behavior: without `ref: main`, re-runs correctly find the release commit
- [x] Verified tsgolint 0.23.0 npm binary embeds go1.26.3 via `readelf -p .go.buildinfo`
- [x] Seed test snapshots updated to match new versions
- [x] CI checks

Link to Devin session: https://app.devin.ai/sessions/9d0120bca08b4f23a880ab12968be08b
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->