### PR TITLE
fix(rust): error.rs codegen for named/non-primitive error-body fields [FER-11169]

### DIFF
--- a/generators/rust/sdk/src/__test__/ErrorGenerator.test.ts
+++ b/generators/rust/sdk/src/__test__/ErrorGenerator.test.ts
@@ -7,7 +7,10 @@ import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 const caseConverter = new CaseConverter({ generationLanguage: "rust", keywords: undefined, smartCasing: true });
 
 // Mock function to create IR with specific error definitions
-function createMockIR(errors: Record<string, FernIr.ErrorDeclaration>): FernIr.IntermediateRepresentation {
+function createMockIR(
+    errors: Record<string, FernIr.ErrorDeclaration>,
+    types: Record<string, FernIr.TypeDeclaration> = {}
+): FernIr.IntermediateRepresentation {
     return {
         apiName: {
             originalName: "TestAPI",
@@ -18,9 +21,37 @@ function createMockIR(errors: Record<string, FernIr.ErrorDeclaration>): FernIr.I
         },
         apiVersion: "1.0.0",
         errors,
-        types: {},
+        types,
         services: {}
     } as unknown as FernIr.IntermediateRepresentation;
+}
+
+function createName(value: string): unknown {
+    return {
+        originalName: value,
+        camelCase: { unsafeName: value, safeName: value },
+        snakeCase: { unsafeName: value, safeName: value },
+        screamingSnakeCase: { unsafeName: value.toUpperCase(), safeName: value.toUpperCase() },
+        pascalCase: { unsafeName: value, safeName: value }
+    };
+}
+
+function createProperty(wireValue: string, valueType: FernIr.TypeReference): FernIr.ObjectProperty {
+    return {
+        name: { wireValue, name: createName(wireValue) },
+        valueType
+    } as unknown as FernIr.ObjectProperty;
+}
+
+function createObjectTypeDeclaration(properties: FernIr.ObjectProperty[]): FernIr.TypeDeclaration {
+    return {
+        shape: { type: "object", properties, extends: [] }
+    } as unknown as FernIr.TypeDeclaration;
+}
+
+const INTEGER_TYPE = { type: "primitive", primitive: { v1: "INTEGER" } } as unknown as FernIr.TypeReference;
+function namedType(typeId: string): FernIr.TypeReference {
+    return { type: "named", typeId, name: createName(typeId) } as unknown as FernIr.TypeReference;
 }
 
 // Mock function to create error declarations
@@ -68,8 +99,10 @@ function createMockContext(ir: FernIr.IntermediateRepresentation): SdkGeneratorC
         case: caseConverter,
         getClientName: () => "TestClient",
         customConfig: {},
-        hasWebSocketChannels: () => false
-    } as SdkGeneratorContext;
+        hasWebSocketChannels: () => false,
+        getUniqueTypeNameForReference: (reference: FernIr.DeclaredTypeName) => reference.typeId,
+        getDateTimeType: () => "offset"
+    } as unknown as SdkGeneratorContext;
 }
 
 describe("ErrorGenerator", () => {
@@ -197,6 +230,61 @@ describe("ErrorGenerator", () => {
 
             const result = generator.generateErrorRs();
             await expect(result).toMatchFileSnapshot("snapshots/default-field-values.rs");
+        });
+    });
+
+    describe("named error body types", () => {
+        it("emits matching field types, serde extraction, and a prelude import for non-primitive body fields", async () => {
+            // ServerError's body type carries a non-string primitive (`code: i64`)
+            // and a named type (`detail: ErrorResponseDetail`). Both must compile:
+            // the field types must match how `from_response` extracts them, and the
+            // named type must be brought into scope.
+            const errors = {
+                ServerError: createErrorDeclaration("ServerError", 500, "json")
+            };
+            const types = {
+                ServerErrorBody: createObjectTypeDeclaration([
+                    createProperty("message", { type: "primitive", primitive: { v1: "STRING" } } as unknown as FernIr.TypeReference),
+                    createProperty("code", INTEGER_TYPE),
+                    createProperty("detail", namedType("ErrorResponseDetail"))
+                ])
+            };
+            const ir = createMockIR(errors, types);
+            const context = createMockContext(ir);
+            const generator = new ErrorGenerator(context);
+
+            const result = generator.generateErrorRs();
+
+            // Bug #1: the named type must be imported.
+            expect(result).toContain("use crate::prelude::*;");
+            // Bug #2: field types match the values extracted in `from_response`.
+            expect(result).toContain("code: Option<i64>");
+            expect(result).toContain("detail: Option<ErrorResponseDetail>");
+            expect(result).toContain("serde_json::from_value::<i64>(v.clone()).ok()");
+            expect(result).toContain("serde_json::from_value::<ErrorResponseDetail>(v.clone()).ok()");
+            // `message` is lifted to the shared variant field, not duplicated.
+            expect(result).not.toContain("message: Option<String>");
+
+            await expect(result).toMatchFileSnapshot("snapshots/named-error-body.rs");
+        });
+
+        it("does not import the prelude when all error body fields are primitives", async () => {
+            const errors = {
+                SimpleError: createErrorDeclaration("SimpleError", 400, "json")
+            };
+            const types = {
+                SimpleErrorBody: createObjectTypeDeclaration([
+                    createProperty("message", { type: "primitive", primitive: { v1: "STRING" } } as unknown as FernIr.TypeReference),
+                    createProperty("reason", { type: "primitive", primitive: { v1: "STRING" } } as unknown as FernIr.TypeReference)
+                ])
+            };
+            const ir = createMockIR(errors, types);
+            const context = createMockContext(ir);
+            const generator = new ErrorGenerator(context);
+
+            const result = generator.generateErrorRs();
+            expect(result).not.toContain("use crate::prelude::*;");
+            expect(result).toContain("reason: Option<String>");
         });
     });
 });

--- a/generators/rust/sdk/src/__test__/snapshots/named-error-body.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/named-error-body.rs
@@ -1,0 +1,77 @@
+use thiserror::{Error};
+use crate::prelude::*;
+
+#[derive(Error, Debug)]
+pub enum ApiError {
+    #[error("ServerError: Internal server error - {message}")]
+    ServerError { message: String, code: Option<i64>, detail: Option<ErrorResponseDetail> },
+    #[error("HTTP error {status}: {message}")]
+    Http { status: u16, message: String },
+    #[error("Network error: {0}")]
+    Network(reqwest::Error),
+    #[error("Request executor error: {0}")]
+    Executor(Box<dyn std::error::Error + Send + Sync>),
+    #[error("Serialization error: {0}")]
+    Serialization(serde_json::Error),
+    #[error("Configuration error: {0}")]
+    Configuration(String),
+    #[error("Invalid header value")]
+    InvalidHeader,
+    #[error("Could not clone request for retry")]
+    RequestClone,
+    #[error("SSE stream terminated")]
+    StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
+    #[error("SSE parse error: {0}")]
+    SseParseError(String),
+}
+
+impl ApiError {
+    pub fn from_response(status_code: u16, body: Option<&str>) -> Self {
+    match status_code {
+        500 => {
+            // Parse error body for ServerError;
+            if let Some(body_str) = body {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body_str) {
+                    return Self::ServerError {
+                        message: parsed.get("message").and_then(|v| v.as_str()).unwrap_or("Unknown error").to_string(),
+                        code: parsed.get("code").and_then(|v| serde_json::from_value::<i64>(v.clone()).ok()),
+                        detail: parsed.get("detail").and_then(|v| serde_json::from_value::<ErrorResponseDetail>(v.clone()).ok())
+                    };
+                }
+            }
+            return Self::ServerError {
+                message: body.unwrap_or("Unknown error").to_string(),
+                code: None,
+                detail: None
+            };
+        },
+        _ => Self::Http {
+            status: status_code,
+            message: body.unwrap_or("Unknown error").to_string()
+        },
+    }
+}
+}
+
+
+/// Error returned when a required field was not set on a builder.
+#[derive(Debug)]
+pub struct BuildError {
+    field: &'static str,
+}
+
+impl BuildError {
+    pub fn missing_field(field: &'static str) -> Self {
+        Self { field }
+    }
+}
+
+impl std::fmt::Display for BuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "`{}` was not set but is required", self.field)
+    }
+}
+
+impl std::error::Error for BuildError {}

--- a/generators/rust/sdk/src/error/ErrorGenerator.ts
+++ b/generators/rust/sdk/src/error/ErrorGenerator.ts
@@ -1,4 +1,5 @@
 import { GeneratorError, getWireValue } from "@fern-api/base-generator";
+import { assertNever } from "@fern-api/core-utils";
 import { generateRustTypeForTypeReference } from "@fern-api/rust-model";
 import { FernIr } from "@fern-fern/ir-sdk";
 import {
@@ -22,17 +23,48 @@ import {
 import { BUILD_ERROR_RS } from "@fern-api/rust-base";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
+/** How `from_response` reads a field's value out of the parsed JSON error body. */
+type ExtractionKind = "string" | "u64" | "json";
+
+interface ResolvedErrorField {
+    /** Rust field name (snake_case). */
+    name: string;
+    /** JSON key the value is read from (wire name). */
+    wireName: string;
+    /** Rust type of the variant field. */
+    type: Type;
+    extractionKind: ExtractionKind;
+    /** For `extractionKind === "json"`: the Rust type to deserialize into. */
+    jsonType?: string;
+    /** True when the field's Rust type only resolves with the crate prelude in scope. */
+    requiresPrelude?: boolean;
+}
+
 export class ErrorGenerator {
     constructor(private readonly context: SdkGeneratorContext) {}
 
     public generateErrorRs(): string {
-        const errorModule = new Module({
-            useStatements: [
+        const useStatements = [
+            new UseStatement({
+                path: "thiserror",
+                items: ["Error"]
+            })
+        ];
+
+        // Error variants whose body fields reference named (non-primitive) types
+        // emit those types by bare name (e.g. `ErrorResponseDetail`) and
+        // deserialize them with `serde_json::from_value`. Bring every generated
+        // type into scope via the crate prelude so those references resolve.
+        if (this.requiresPreludeImport()) {
+            useStatements.push(
                 new UseStatement({
-                    path: "thiserror",
-                    items: ["Error"]
+                    path: "crate::prelude::*"
                 })
-            ],
+            );
+        }
+
+        const errorModule = new Module({
+            useStatements,
             enums: [this.buildErrorEnum()],
             implBlocks: [this.buildErrorImpl()]
         });
@@ -144,37 +176,136 @@ export class ErrorGenerator {
      * hardcoded status-code fields otherwise. Returns fields with both the Rust field
      * name (snake_case) and the JSON wire name (camelCase from the spec).
      */
-    private resolveErrorFields(errorDeclaration: FernIr.ErrorDeclaration): Array<{
-        name: string;
-        wireName: string;
-        type: Type;
-        extractionKind: "string" | "u64";
-    }> {
+    private resolveErrorFields(errorDeclaration: FernIr.ErrorDeclaration): ResolvedErrorField[] {
         if (errorDeclaration.type?.type === "named") {
             const typeDecl = this.context.ir.types[errorDeclaration.type.typeId];
             if (typeDecl?.shape.type === "object") {
                 return typeDecl.shape.properties
                     .filter((p) => getWireValue(p.name) !== "message")
-                    .map((p) => {
-                        const isAlreadyOptional =
-                            p.valueType.type === "container" &&
-                            (p.valueType.container.type === "optional" || p.valueType.container.type === "nullable");
-                        const rustType = generateRustTypeForTypeReference(p.valueType, this.context);
-                        return {
-                            name: this.context.case.snakeSafe(p.name),
-                            wireName: getWireValue(p.name),
-                            type: isAlreadyOptional ? rustType : Type.option(rustType),
-                            extractionKind: this.isU64TypeReference(p.valueType) ? ("u64" as const) : ("string" as const)
-                        };
-                    });
+                    .map((p) => this.resolveNamedBodyField(p));
             }
         }
         return this.getStatusCodeFields(errorDeclaration.statusCode).map(({ name, wireName, type }) => ({
             name,
             wireName,
             type,
-            extractionKind: (name === "retry_after_seconds" ? "u64" : "string") as "string" | "u64"
+            extractionKind: (name === "retry_after_seconds" ? "u64" : "string") as ExtractionKind
         }));
+    }
+
+    /**
+     * Resolves a single property of a named error-body type into a variant field.
+     *
+     * The field is always `Option<_>`: both the parse-failure path and the no-body
+     * fallback construct the variant with `None`, so a required property still needs
+     * an optional field. The extraction kind selects how `from_response` reads the
+     * value back out of the parsed JSON so it matches the field's Rust type:
+     *   - `string` / `u64`: read directly via `Value::as_str` / `Value::as_u64`
+     *   - `json`: deserialize the value into its Rust type via `serde_json::from_value`,
+     *     which is the only option that works for named (non-primitive) and other
+     *     primitive types (e.g. `i64`, `bool`). Without it the generated code would
+     *     try to read, say, an `i64` field via `as_str()` and fail to compile.
+     */
+    private resolveNamedBodyField(property: FernIr.ObjectProperty): ResolvedErrorField {
+        const innerTypeReference = this.dereferenceOptional(property.valueType);
+        const innerType = generateRustTypeForTypeReference(innerTypeReference, this.context);
+        const field = {
+            name: this.context.case.snakeSafe(property.name),
+            wireName: getWireValue(property.name),
+            type: Type.option(innerType)
+        };
+        if (this.isStringTypeReference(innerTypeReference)) {
+            return { ...field, extractionKind: "string" };
+        }
+        if (this.isU64TypeReference(innerTypeReference)) {
+            return { ...field, extractionKind: "u64" };
+        }
+        return {
+            ...field,
+            extractionKind: "json",
+            jsonType: innerType.toString(),
+            requiresPrelude: this.typeReferenceNeedsPrelude(innerTypeReference)
+        };
+    }
+
+    /**
+     * True when the field's Rust type names an identifier that only resolves with the
+     * crate prelude in scope: named types and `HashMap`/`HashSet` (re-exported via
+     * `crate::api::*` / `std::collections`), and the `chrono`/`uuid` types behind the
+     * date and uuid primitives. Built-in primitives (`i64`, `bool`, `String`, `Vec`)
+     * and the fully-qualified `serde_json::Value` / `num_bigint::BigInt` resolve without it.
+     */
+    private typeReferenceNeedsPrelude(typeRef: FernIr.TypeReference): boolean {
+        switch (typeRef.type) {
+            case "named":
+                return true;
+            case "container":
+                return typeRef.container._visit({
+                    list: (inner) => this.typeReferenceNeedsPrelude(inner),
+                    optional: (inner) => this.typeReferenceNeedsPrelude(inner),
+                    nullable: (inner) => this.typeReferenceNeedsPrelude(inner),
+                    map: () => true,
+                    set: () => true,
+                    literal: () => false,
+                    _other: () => false
+                });
+            case "primitive":
+                return FernIr.PrimitiveTypeV1._visit(typeRef.primitive.v1, {
+                    date: () => true,
+                    dateTime: () => true,
+                    dateTimeRfc2822: () => true,
+                    uuid: () => true,
+                    integer: () => false,
+                    long: () => false,
+                    uint: () => false,
+                    uint64: () => false,
+                    float: () => false,
+                    double: () => false,
+                    boolean: () => false,
+                    string: () => false,
+                    base64: () => false,
+                    bigInteger: () => false,
+                    _other: () => false
+                });
+            case "unknown":
+                return false;
+            default:
+                return assertNever(typeRef);
+        }
+    }
+
+    /** Strips `optional`/`nullable` container wrappers to reach the underlying type. */
+    private dereferenceOptional(typeRef: FernIr.TypeReference): FernIr.TypeReference {
+        if (typeRef.type === "container") {
+            if (typeRef.container.type === "optional") {
+                return this.dereferenceOptional(typeRef.container.optional);
+            }
+            if (typeRef.container.type === "nullable") {
+                return this.dereferenceOptional(typeRef.container.nullable);
+            }
+        }
+        return typeRef;
+    }
+
+    private isStringTypeReference(typeRef: FernIr.TypeReference): boolean {
+        if (typeRef.type === "primitive") {
+            return typeRef.primitive.v1 === "STRING";
+        }
+        if (typeRef.type === "container" && typeRef.container.type === "optional") {
+            return this.isStringTypeReference(typeRef.container.optional);
+        }
+        return false;
+    }
+
+    /**
+     * True when any error variant has a body field whose Rust type only resolves
+     * with the crate prelude in scope (named types, `HashMap`/`HashSet`), which
+     * `generateErrorRs` then imports.
+     */
+    private requiresPreludeImport(): boolean {
+        return Object.values(this.context.ir.errors).some((errorDeclaration) =>
+            this.resolveErrorFields(errorDeclaration).some((field) => field.requiresPrelude === true)
+        );
     }
 
     private isU64TypeReference(typeRef: FernIr.TypeReference): boolean {
@@ -327,11 +458,9 @@ export class ErrorGenerator {
 
     private buildSuccessConstruction(errorName: string, errorDeclaration: FernIr.ErrorDeclaration): Expression {
         const fields = this.resolveErrorFields(errorDeclaration);
-        const fieldAssignments = fields.map(({ name, wireName, extractionKind }) => ({
-            name,
-            value: extractionKind === "u64"
-                ? this.buildU64FieldExtraction(wireName)
-                : this.buildStringFieldExtraction(wireName)
+        const fieldAssignments = fields.map((field) => ({
+            name: field.name,
+            value: this.buildFieldExtraction(field)
         }));
 
         return Expression.structConstruction(`Self::${errorName}`, [
@@ -453,16 +582,17 @@ export class ErrorGenerator {
         if (!firstError) {
             throw GeneratorError.internalError("Unexpected: errors array should not be empty");
         }
-        const fields = this.buildDynamicFieldAssignments(firstError);
 
-        // Create match arms for each error type
+        // Each variant must be constructed with its OWN body fields — errors that
+        // share a status code can have different body shapes, so the field set is
+        // derived per error rather than reused from the first one.
         const matchArms = errors.map((error) => {
             const errorName = this.getErrorVariantName(error);
             return MatchArm.withExpression(
                 Pattern.some(Pattern.literal(errorName)),
                 Expression.structConstruction(`Self::${errorName}`, [
                     { name: "message", value: Expression.variable("message") },
-                    ...fields
+                    ...this.buildDynamicFieldAssignments(error)
                 ])
             );
         });
@@ -474,7 +604,7 @@ export class ErrorGenerator {
                 Pattern.wildcard(),
                 Expression.structConstruction(`Self::${fallbackName}`, [
                     { name: "message", value: Expression.variable("message") },
-                    ...fields
+                    ...this.buildDynamicFieldAssignments(firstError)
                 ])
             )
         );
@@ -484,12 +614,23 @@ export class ErrorGenerator {
     }
 
     private buildDynamicFieldAssignments(errorDeclaration: FernIr.ErrorDeclaration): Expression.FieldAssignment[] {
-        return this.resolveErrorFields(errorDeclaration).map(({ name, wireName, extractionKind }) => ({
-            name,
-            value: extractionKind === "u64"
-                ? this.buildU64FieldExtraction(wireName)
-                : this.buildStringFieldExtraction(wireName)
+        return this.resolveErrorFields(errorDeclaration).map((field) => ({
+            name: field.name,
+            value: this.buildFieldExtraction(field)
         }));
+    }
+
+    private buildFieldExtraction(field: ResolvedErrorField): Expression {
+        switch (field.extractionKind) {
+            case "string":
+                return this.buildStringFieldExtraction(field.wireName);
+            case "u64":
+                return this.buildU64FieldExtraction(field.wireName);
+            case "json":
+                return this.buildJsonFieldExtraction(field.wireName, field.jsonType ?? "serde_json::Value");
+            default:
+                return assertNever(field.extractionKind);
+        }
     }
 
     private buildStringFieldExtraction(fieldName: string): Expression {
@@ -517,6 +658,23 @@ export class ErrorGenerator {
                 args: [Expression.literal(fieldName)]
             }),
             Expression.closure([{ name: "v" }], Expression.raw("v.as_u64()"))
+        );
+    }
+
+    /**
+     * Deserializes the JSON value at `fieldName` directly into `rustType` via
+     * `serde_json::from_value`, yielding `Option<rustType>` (the closure returns
+     * `None` on a type mismatch). Used for named and non-string/non-u64 primitive
+     * fields, whose Rust types `as_str()`/`as_u64()` cannot produce.
+     */
+    private buildJsonFieldExtraction(fieldName: string, rustType: string): Expression {
+        return Expression.andThen(
+            Expression.methodCall({
+                target: Expression.variable("parsed"),
+                method: "get",
+                args: [Expression.literal(fieldName)]
+            }),
+            Expression.closure([{ name: "v" }], Expression.raw(`serde_json::from_value::<${rustType}>(v.clone()).ok()`))
         );
     }
 

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.40.5
+  changelogEntry:
+    - summary: |
+        Fix `error.rs` failing to compile when an error body has a property whose type is
+        a named (non-primitive) type or a non-string/non-u64 primitive (e.g. `i64`). Error
+        body fields are now deserialized with `serde_json::from_value` into their actual Rust
+        type (instead of always reading `as_str()`/`as_u64()`), and the crate prelude is
+        imported when a field references a generated type so it resolves in scope. Also fixes
+        a latent bug where errors sharing a status code all reused the first error's body
+        fields; each variant is now constructed with its own fields.
+      type: fix
+  createdAt: "2026-06-09"
+  irVersion: 66
 - version: 0.40.4
   changelogEntry:
     - summary: |

--- a/seed/rust-sdk/errors/src/error.rs
+++ b/seed/rust-sdk/errors/src/error.rs
@@ -49,7 +49,7 @@ impl ApiError {
                                 .to_string(),
                             code: parsed
                                 .get("code")
-                                .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                .and_then(|v| serde_json::from_value::<i64>(v.clone()).ok()),
                         };
                     }
                 }
@@ -70,7 +70,7 @@ impl ApiError {
                                 .to_string(),
                             code: parsed
                                 .get("code")
-                                .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                .and_then(|v| serde_json::from_value::<i64>(v.clone()).ok()),
                         };
                     }
                 }
@@ -93,19 +93,19 @@ impl ApiError {
                                 message: message,
                                 code: parsed
                                     .get("code")
-                                    .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                    .and_then(|v| serde_json::from_value::<i64>(v.clone()).ok()),
                             },
                             Some("FooTooLittle") => Self::FooTooLittle {
                                 message: message,
                                 code: parsed
                                     .get("code")
-                                    .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                    .and_then(|v| serde_json::from_value::<i64>(v.clone()).ok()),
                             },
                             _ => Self::InternalServerError {
                                 message: message,
                                 code: parsed
                                     .get("code")
-                                    .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                    .and_then(|v| serde_json::from_value::<i64>(v.clone()).ok()),
                             },
                         };
                     }
@@ -131,7 +131,7 @@ impl ApiError {
                                 .to_string(),
                             code: parsed
                                 .get("code")
-                                .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                .and_then(|v| serde_json::from_value::<i64>(v.clone()).ok()),
                         };
                     }
                 }

--- a/seed/rust-sdk/examples/no-custom-config/src/error.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("NotFoundError: Resource not found - {{message}}")]
+    #[error("NotFoundError: Resource not found - {message}")]
     NotFoundError {
         message: String,
         resource_id: Option<String>,

--- a/seed/rust-sdk/examples/readme-config/src/error.rs
+++ b/seed/rust-sdk/examples/readme-config/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("NotFoundError: Resource not found - {{message}}")]
+    #[error("NotFoundError: Resource not found - {message}")]
     NotFoundError {
         message: String,
         resource_id: Option<String>,

--- a/seed/rust-sdk/exhaustive/src/error.rs
+++ b/seed/rust-sdk/exhaustive/src/error.rs
@@ -1,3 +1,4 @@
+use crate::prelude::*;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -86,24 +87,102 @@ impl ApiError {
                         let error_type = parsed.get("error_type").and_then(|v| v.as_str());
                         return match error_type {
                             Some("BadRequestBody") => Self::BadRequestBody { message: message },
-                            Some("ErrorWithEnumBody") => {
-                                Self::ErrorWithEnumBody { message: message }
-                            }
+                            Some("ErrorWithEnumBody") => Self::ErrorWithEnumBody {
+                                message: message,
+                                field: parsed
+                                    .get("field")
+                                    .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                details: parsed
+                                    .get("details")
+                                    .and_then(|v| v.as_str().map(|s| s.to_string())),
+                            },
                             Some("ObjectWithOptionalFieldError") => {
-                                Self::ObjectWithOptionalFieldError { message: message }
+                                Self::ObjectWithOptionalFieldError {
+                                    message: message,
+                                    string: parsed
+                                        .get("string")
+                                        .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                    integer: parsed.get("integer").and_then(|v| {
+                                        serde_json::from_value::<i64>(v.clone()).ok()
+                                    }),
+                                    long: parsed.get("long").and_then(|v| {
+                                        serde_json::from_value::<i64>(v.clone()).ok()
+                                    }),
+                                    double: parsed.get("double").and_then(|v| {
+                                        serde_json::from_value::<f64>(v.clone()).ok()
+                                    }),
+                                    bool_: parsed.get("bool").and_then(|v| {
+                                        serde_json::from_value::<bool>(v.clone()).ok()
+                                    }),
+                                    datetime: parsed.get("datetime").and_then(|v| {
+                                        serde_json::from_value::<DateTime<FixedOffset>>(v.clone())
+                                            .ok()
+                                    }),
+                                    date: parsed.get("date").and_then(|v| {
+                                        serde_json::from_value::<NaiveDate>(v.clone()).ok()
+                                    }),
+                                    uuid: parsed.get("uuid").and_then(|v| {
+                                        serde_json::from_value::<Uuid>(v.clone()).ok()
+                                    }),
+                                    base64: parsed.get("base64").and_then(|v| {
+                                        serde_json::from_value::<Vec<u8>>(v.clone()).ok()
+                                    }),
+                                    list: parsed.get("list").and_then(|v| {
+                                        serde_json::from_value::<Vec<String>>(v.clone()).ok()
+                                    }),
+                                    set: parsed.get("set").and_then(|v| {
+                                        serde_json::from_value::<HashSet<String>>(v.clone()).ok()
+                                    }),
+                                    map: parsed.get("map").and_then(|v| {
+                                        serde_json::from_value::<HashMap<i64, String>>(v.clone())
+                                            .ok()
+                                    }),
+                                    bigint: parsed.get("bigint").and_then(|v| {
+                                        serde_json::from_value::<num_bigint::BigInt>(v.clone()).ok()
+                                    }),
+                                }
                             }
                             Some("ObjectWithRequiredFieldError") => {
-                                Self::ObjectWithRequiredFieldError { message: message }
+                                Self::ObjectWithRequiredFieldError {
+                                    message: message,
+                                    string: parsed
+                                        .get("string")
+                                        .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                }
                             }
                             Some("NestedObjectWithOptionalFieldError") => {
-                                Self::NestedObjectWithOptionalFieldError { message: message }
+                                Self::NestedObjectWithOptionalFieldError {
+                                    message: message,
+                                    string: parsed
+                                        .get("string")
+                                        .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                    nested_object: parsed.get("NestedObject").and_then(|v| {
+                                        serde_json::from_value::<ObjectWithOptionalField>(v.clone())
+                                            .ok()
+                                    }),
+                                }
                             }
                             Some("NestedObjectWithRequiredFieldError") => {
-                                Self::NestedObjectWithRequiredFieldError { message: message }
+                                Self::NestedObjectWithRequiredFieldError {
+                                    message: message,
+                                    string: parsed
+                                        .get("string")
+                                        .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                    nested_object: parsed.get("NestedObject").and_then(|v| {
+                                        serde_json::from_value::<ObjectWithOptionalField>(v.clone())
+                                            .ok()
+                                    }),
+                                }
                             }
-                            Some("ErrorWithUnionBody") => {
-                                Self::ErrorWithUnionBody { message: message }
-                            }
+                            Some("ErrorWithUnionBody") => Self::ErrorWithUnionBody {
+                                message: message,
+                                field: parsed
+                                    .get("field")
+                                    .and_then(|v| v.as_str().map(|s| s.to_string())),
+                                details: parsed
+                                    .get("details")
+                                    .and_then(|v| v.as_str().map(|s| s.to_string())),
+                            },
                             _ => Self::BadRequestBody { message: message },
                         };
                     }

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/error.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("NotFoundError: Resource not found - {{message}}")]
+    #[error("NotFoundError: Resource not found - {message}")]
     NotFoundError {
         message: String,
         resource_id: Option<String>,

--- a/seed/rust-sdk/imdb/imdb-custom-features/src/error.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-features/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("NotFoundError: Resource not found - {{message}}")]
+    #[error("NotFoundError: Resource not found - {message}")]
     NotFoundError {
         message: String,
         resource_id: Option<String>,

--- a/seed/rust-sdk/imdb/imdb/src/error.rs
+++ b/seed/rust-sdk/imdb/imdb/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("NotFoundError: Resource not found - {{message}}")]
+    #[error("NotFoundError: Resource not found - {message}")]
     NotFoundError {
         message: String,
         resource_id: Option<String>,

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/error.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("BadRequestError: Bad request - {{message}}")]
+    #[error("BadRequestError: Bad request - {message}")]
     BadRequestError {
         message: String,
         field: Option<String>,


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-11169

The rust-sdk `ErrorGenerator` derives `ApiError` variant fields from an error's named body type, but `from_response` always extracted them via `as_str()`/`as_u64()` and `generateErrorRs` only imported `thiserror::Error`. An error body with a named-type property (e.g. `ErrorResponseDetail`) or a non-string/non-u64 primitive (e.g. `code: i64`) produced an `error.rs` that did not compile:

1. **Missing imports** — a named-type field had no `use` bringing it into scope → `cannot find type ... in this scope`.
2. **Extraction mismatch** — `code: i64` was read via `as_str()` (`Option<String>`), a type mismatch against the field.

This never failed CI because rust-sdk seed tests run snapshot-only (`--skip-scripts`) and never compile the generated code — the broken output was the committed snapshot. (`0.40.4` wrapped fields in `Option` and fixed the thiserror format strings, but left the `as_str`/`as_u64` extraction and missing import in place, so `errors`/`exhaustive` still don't compile on `main`.)

## Changes Made
- New `"json"` extraction deserializes via `serde_json::from_value::<T>(v.clone()).ok()` into the field's actual Rust type — works for named, collection, and other primitive types. `string`/`u64` keep their direct reads.
- `use crate::prelude::*;` is emitted **only** when a field's type needs it (named/collection/date/uuid), bringing those types into scope without an `unused_imports` warning for pure-primitive bodies.
- Fixed a latent bug in the multi-error-per-status-code path that reused the first error's fields for every variant; each variant now uses its own fields (this blocked `exhaustive`, whose errors all share status 400).
- `versions.yml`: `0.40.5` (fix).
- Regenerated affected seed fixtures. `errors` and `exhaustive` carry the real fix; the other 6 (`examples/*`, `imdb/*`, `server-sent-event-examples/*`) are format-string-only regenerations (`{{message}}` → `{message}`) that `0.40.4` introduced in the generator but didn't fully propagate to snapshots — required for the branch to be self-consistent.
- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [x] Unit tests added/updated — 2 new `ErrorGenerator` tests (named-type body + primitive-only body) plus a new snapshot; full rust-sdk vitest suite green (35 tests).
- [x] Manual testing completed — regenerated fixtures and ran `cargo build` in a Rust container: `errors` compiles clean; `exhaustive`'s `error.rs` compiles. (`exhaustive`'s crate still has a separate, pre-existing rust-**model** bug — `DocumentedUnknownType` newtype lacks `#[derive(Default)]` — out of scope here.)

> Note: the systemic gap is that `--skip-scripts` means rust generated code is never compiled in CI. Wiring `cargo build` into the rust-sdk seed flow would catch this class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)