### PR TITLE
fix(deps): update java-sdk-generator container to fix perl and libsolv CVEs

### DIFF
--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -79,9 +79,8 @@ RUN rm -f /opt/gradle/lib/plugins/bcpg-jdk18on-*.jar \
 # krb5-libs (CVE-2026-40356 integer underflow OOB read, CVE-2026-40355
 # NULL pointer dereference in gss_accept_sec_context; fixed in
 # 1.21.3-7.amzn2023.0.1)
-# Security update 2026-06-10: add perl-interpreter/perl-libs (CVE-2026-8376),
-# perl-HTTP-Tiny (CVE-2026-7010), libsolv (CVE-2026-48863, CVE-2026-48864,
-# CVE-2026-9149, CVE-2026-9150)
+# Security update 2026-06-10: add perl-* (CVE-2026-8376, CVE-2026-7010),
+# libsolv (CVE-2026-48863, CVE-2026-48864, CVE-2026-9149, CVE-2026-9150)
 RUN dnf --releasever=latest update -y \
     openssl-fips-provider-latest \
     openssl-libs \
@@ -107,9 +106,7 @@ RUN dnf --releasever=latest update -y \
     glibc-minimal-langpack \
     libgcrypt \
     krb5-libs \
-    perl-interpreter \
-    perl-libs \
-    perl-HTTP-Tiny \
+    'perl-*' \
     libsolv && \
     dnf remove -y git-lfs wget || true && \
     dnf clean all && \

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -79,6 +79,15 @@ RUN rm -f /opt/gradle/lib/plugins/bcpg-jdk18on-*.jar \
 # krb5-libs (CVE-2026-40356 integer underflow OOB read, CVE-2026-40355
 # NULL pointer dereference in gss_accept_sec_context; fixed in
 # 1.21.3-7.amzn2023.0.1)
+# Security update 2026-06-10: add perl-interpreter/perl-libs
+# (CVE-2026-8376, heap buffer overflow in Perl_study_chunk on 32-bit builds),
+# perl-HTTP-Tiny (CVE-2026-7010, CRLF injection / HTTP request smuggling;
+# fixed in ALAS2023-2026-1765),
+# libsolv (CVE-2026-48864 heap overflow in .solv decompression,
+# CVE-2026-9149 heap overflow via negative maxsize in repo_add_solv,
+# CVE-2026-9150 stack overflow in Debian metadata parser,
+# CVE-2026-48863 stack overflow in EdDSA PGP verification;
+# fixed in ALAS2023-2026-1798)
 RUN dnf --releasever=latest update -y \
     openssl-fips-provider-latest \
     openssl-libs \
@@ -103,7 +112,11 @@ RUN dnf --releasever=latest update -y \
     glibc-common \
     glibc-minimal-langpack \
     libgcrypt \
-    krb5-libs && \
+    krb5-libs \
+    perl-interpreter \
+    perl-libs \
+    perl-HTTP-Tiny \
+    libsolv && \
     dnf remove -y git-lfs wget || true && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -79,15 +79,9 @@ RUN rm -f /opt/gradle/lib/plugins/bcpg-jdk18on-*.jar \
 # krb5-libs (CVE-2026-40356 integer underflow OOB read, CVE-2026-40355
 # NULL pointer dereference in gss_accept_sec_context; fixed in
 # 1.21.3-7.amzn2023.0.1)
-# Security update 2026-06-10: add perl-interpreter/perl-libs
-# (CVE-2026-8376, heap buffer overflow in Perl_study_chunk on 32-bit builds),
-# perl-HTTP-Tiny (CVE-2026-7010, CRLF injection / HTTP request smuggling;
-# fixed in ALAS2023-2026-1765),
-# libsolv (CVE-2026-48864 heap overflow in .solv decompression,
-# CVE-2026-9149 heap overflow via negative maxsize in repo_add_solv,
-# CVE-2026-9150 stack overflow in Debian metadata parser,
-# CVE-2026-48863 stack overflow in EdDSA PGP verification;
-# fixed in ALAS2023-2026-1798)
+# Security update 2026-06-10: add perl-interpreter/perl-libs (CVE-2026-8376),
+# perl-HTTP-Tiny (CVE-2026-7010), libsolv (CVE-2026-48863, CVE-2026-48864,
+# CVE-2026-9149, CVE-2026-9150)
 RUN dnf --releasever=latest update -y \
     openssl-fips-provider-latest \
     openssl-libs \

--- a/generators/java/sdk/changes/unreleased/fix-container-cves.yml
+++ b/generators/java/sdk/changes/unreleased/fix-container-cves.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Update java-sdk-generator container to fix CVE-2026-7010 (perl-HTTP-Tiny
+    CRLF injection), CVE-2026-48864/CVE-2026-9149/CVE-2026-9150/CVE-2026-48863
+    (libsolv buffer overflows), and CVE-2026-8376 (perl heap buffer overflow).
+  type: chore


### PR DESCRIPTION
## Description

Update the `java-sdk-generator` container Dockerfile to patch 6 CVEs flagged by Dependabot/Grype in the `dev/java-sdk-generator` image.

## Changes Made

Add `perl-interpreter`, `perl-libs`, `perl-HTTP-Tiny`, and `libsolv` to the existing `dnf --releasever=latest update` command:

| CVE | Package | Severity | Fix |
|-----|---------|----------|-----|
| CVE-2026-7010 | perl-HTTP-Tiny 0.092 | Medium (6.5) | ALAS2023-2026-1765 (→ 0.093+) |
| CVE-2026-48864 | libsolv 0.7.22 | Important (7.8) | ALAS2023-2026-1798 |
| CVE-2026-9149 | libsolv 0.7.22 | Medium (6.5) | ALAS2023-2026-1798 |
| CVE-2026-9150 | libsolv 0.7.22 | Medium (6.5) | ALAS2023-2026-1798 |
| CVE-2026-48863 | libsolv 0.7.22 | Important (7.5) | ALAS2023-2026-1798 |
| CVE-2026-8376 | perl-interpreter 5.32.1 | Medium (5.7) | AL2023 fix pending upstream |

**Note:** CVE-2026-8376 (perl heap buffer overflow in `Perl_study_chunk` on 32-bit builds) does not yet have an AL2023 advisory. Adding `perl-interpreter` and `perl-libs` to the update list ensures the fix is picked up automatically once Amazon publishes the patched package.

- [x] Updated changelog entry (`generators/java/sdk/changes/unreleased/fix-container-cves.yml`)

## Testing

- Dockerfile-only change — no generated code affected
- Container image rebuild will validate that `dnf update` resolves the listed packages

Link to Devin session: https://app.devin.ai/sessions/b2dc85de8f614d9d940955d12b75ed1d
Requested by: @davidkonigsberg