### PR TITLE
fix(cli): tolerate array-valued property entries in OpenAPI schemas

### DIFF
--- a/generators/cli/sdk/changes/unreleased/tolerant-property-deserialization.yml
+++ b/generators/cli/sdk/changes/unreleased/tolerant-property-deserialization.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Tolerate malformed property entries in OpenAPI schemas where the value is a
+    YAML/JSON array instead of a schema object (e.g. ElevenLabs 3.1 spec emits
+    `"state": [{"x-fern-type-name": "…"}]`). Previously this caused a fatal
+    parse error; now the entry is silently dropped so the rest of the spec loads.
+  type: fix

--- a/generators/cli/sdk/src/openapi/parser.rs
+++ b/generators/cli/sdk/src/openapi/parser.rs
@@ -973,7 +973,7 @@ where
 /// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
 /// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
 /// JSON Schema property but must not prevent the rest of the spec from
-/// loading.  Entries with non-object values are silently dropped.
+/// loading.  Entries with non-object values are logged as warnings and dropped.
 fn deserialize_tolerant_properties<'de, D>(
     deserializer: D,
 ) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
@@ -1003,12 +1003,28 @@ where
                         if val.is_mapping() {
                             match OpenApiSchemaObject::deserialize(val) {
                                 Ok(schema) => { out.insert(key, schema); }
-                                Err(_) => { /* skip malformed schema */ }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
                             }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
                         }
-                        // else: sequence, scalar, null → silently dropped
                     }
-                    Err(_) => { /* skip unparseable value */ }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
                 }
             }
             Ok(out)

--- a/generators/cli/sdk/src/openapi/parser.rs
+++ b/generators/cli/sdk/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,60 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are silently dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(_) => { /* skip malformed schema */ }
+                            }
+                        }
+                        // else: sequence, scalar, null → silently dropped
+                    }
+                    Err(_) => { /* skip unparseable value */ }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9969,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }


### PR DESCRIPTION
## Description

Fixes the ElevenLabs CLI crash: `Failed to parse OpenAPI spec: invalid type: sequence, expected struct OpenApiSchemaObject`.

The ElevenLabs OpenAPI 3.1 spec has `SpeechHistoryItemResponseModel.properties.state` set to a YAML/JSON **array** `[{"x-fern-type-name": "SpeechHistoryState"}]` instead of a schema object. The Rust parser's `properties: HashMap<String, OpenApiSchemaObject>` cannot deserialize a sequence as a struct, which aborts the entire spec parse at CLI runtime.

## Changes Made

- Added `deserialize_tolerant_properties` custom serde deserializer that intercepts each map entry, checks whether the value is a YAML mapping (object), and silently drops non-mapping entries (sequences, scalars, nulls)
- Applied to `OpenApiSchemaObject.properties` — the direct fix for the reported crash
- Applied to `OpenApiComponents.schemas` — same resilience for top-level component schemas
- Added regression test `test_properties_with_array_value_are_skipped` exercising the exact pattern from the ElevenLabs spec

## Testing
- [x] Unit tests added — new regression test passes
- [x] All 1248 Rust SDK tests pass (1247 existing + 1 new)
- [x] `cargo check` clean
- [x] `pnpm run check` (biome) clean

Link to Devin session: https://app.devin.ai/sessions/975e77a9af2244aa86d472332c906af8
Requested by: @jon-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->