### PR TITLE
fix(ci): replace classic PAT with GITHUB_TOKEN for auto-approve

### DIFF
--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+# These scope secrets.GITHUB_TOKEN
+permissions:
+  pull-requests: write
+  contents: write
+
 # Cancel previous workflows on previous push
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -63,6 +68,13 @@ jobs:
           GH_TOKEN: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
         run: |
           gh workflow run "CI" --ref automated-lint-fixes
+
+      # Give the dispatched workflow time to register check runs on the PR
+      # before the auto-approve action starts polling.
+      - name: Wait for CI checks to register
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
+        shell: bash
+        run: sleep 60
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'

--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -48,25 +48,35 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.ACTIONS_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "fix(lint): auto-fix lint issues"
           title: "fix(lint): auto-fix lint issues"
           branch: automated-lint-fixes
           delete-branch: true
 
+      # GITHUB_TOKEN does not trigger pull_request events, so we re-trigger
+      # CI on the PR branch using a PAT so required checks can run.
+      - name: Trigger CI on PR branch
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
+        run: |
+          gh workflow run "CI" --ref automated-lint-fixes
+
       - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.ACTIONS_PAT }}
+          token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: squash
 
       - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
         uses: ./.github/actions/auto-approve
         with:
-          approver-gh-token: ${{ secrets.FERN_GITHUB_TOKEN }}
+          approver-gh-token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           enforced-checks: lint
           enforce-checks: "true"

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -1109,7 +1109,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(seed): update all seed snapshots"
           title: "chore(seed): update all seed snapshots"
           branch: update-all-seed
@@ -1121,7 +1121,7 @@ jobs:
             seed
 
       - name: Log PR Creation Failure
-        if: steps.cpr.outputs.pull-request-operation != 'created'
+        if: steps.cpr.outputs.pull-request-operation != 'created' && steps.cpr.outputs.pull-request-operation != 'updated'
         shell: bash
         run: |
           echo "PR was not created, likely due to no diff for the generated seed output"
@@ -1132,8 +1132,19 @@ jobs:
         run: |
           echo "PR Created: ${{ steps.cpr.outputs.pull-request-url }}"
 
+      # GITHUB_TOKEN does not trigger pull_request events, so we re-trigger
+      # CI on the PR branch using a PAT so required checks can run.
+      - name: Trigger CI on PR branch
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
+        run: |
+          gh workflow run "CI" --ref update-all-seed
+          gh workflow run "Seed Snapshot Tests" --ref update-all-seed
+
       - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
@@ -1141,8 +1152,8 @@ jobs:
           merge-method: squash
 
       - name: Approve PR
-        if: steps.cpr.outputs.pull-request-operation == 'created'
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
         uses: ./.github/actions/auto-approve
         with:
-          approver-gh-token: ${{ secrets.FERN_GITHUB_TOKEN }}
+          approver-gh-token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Description

The `fern-api` org now forbids classic PATs. The auto-approve step in `update-seed.yml` and `fix-lint.yml` used `FERN_GITHUB_TOKEN` (a classic PAT), which fails with:

```
GraphQL: `fern-api` forbids access via a personal access token (classic).
Please use a GitHub App, OAuth App, or a personal access token with fine-grained permissions.
```

This is the root cause of https://github.com/fern-api/fern/pull/16431 not auto-merging — the approve step failed, so the PR has no approval and `mergeable_state` is `blocked`.

## Changes Made

**`update-seed.yml`:**
- PR creation token: `FERN_SUPPORT_GH_ACTIONS_PAT` → `GITHUB_TOKEN` (so the PR author differs from the approver)
- Approve token: `FERN_GITHUB_TOKEN` (classic, blocked) → `FERN_SUPPORT_GH_ACTIONS_PAT` (fine-grained)
- Automerge token: unchanged (`FERN_SUPPORT_GH_ACTIONS_PAT`)
- Added `workflow_dispatch` CI trigger step — `GITHUB_TOKEN` pushes don't trigger `pull_request` events, so we explicitly dispatch CI and Seed workflows on the PR branch via the PAT
- Automerge + approve now also fire on `updated` PRs (previously only `created`)

**`fix-lint.yml`:**
- Same token swap pattern (`GITHUB_TOKEN` for PR creation, `FERN_SUPPORT_GH_ACTIONS_PAT` for approve/automerge)
- Added `permissions` block (`contents: write`, `pull-requests: write`) required for `GITHUB_TOKEN` to push branches and create PRs
- Added 60s wait between `workflow_dispatch` CI trigger and auto-approve polling to prevent the approve action from racing ahead of check registration
- Same `updated` PR handling

**`dependabot.yml`:** No changes needed — already uses `GITHUB_TOKEN` (not a classic PAT).

## Testing
- [ ] Manual testing completed — this can only be verified by running the update-seed / fix-lint workflows after merge

Link to Devin session: https://app.devin.ai/sessions/6b2e9395b4f7415ebba357cce169bda5
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->