### PR TITLE
fix(deps): bump net-imap to 0.5.15 to fix 3 June 2026 CVEs in ruby-sdk-generator container

### DIFF
--- a/generators/ruby-v2/sdk/Dockerfile
+++ b/generators/ruby-v2/sdk/Dockerfile
@@ -29,19 +29,24 @@ RUN apk --no-cache upgrade && \
         libc-dev && \
     # Update the remaining vulnerable Ruby gems shipped with the base image:
     # - erb 4.0.3 -> 4.0.3.1 (GHSA-q339-8rmv-2mhv: deserialization guard bypass)
-    # - net-imap 0.4.21 -> 0.4.24 (GHSA-vcgp-9326-pqcp STARTTLS stripping,
-    #   GHSA-75xq-5h9v-w6px command injection, GHSA-87pf-fpwv-p7m7 SCRAM DoS,
-    #   GHSA-hm49-wcqc-g2xg "raw" command injection, GHSA-q2mw-fvj9-vvcw response DoS)
+    # - net-imap 0.4.21 -> 0.5.15 (0.4.24 fixed GHSA-vcgp-9326-pqcp STARTTLS
+    #   stripping, GHSA-75xq-5h9v-w6px command injection, GHSA-87pf-fpwv-p7m7
+    #   SCRAM DoS, GHSA-hm49-wcqc-g2xg "raw" command injection,
+    #   GHSA-q2mw-fvj9-vvcw response DoS; 0.5.15 additionally fixes
+    #   GHSA-46q3-7gv7-qmgg ID/ENABLE command injection,
+    #   GHSA-8p34-64r3-mwg8 non-sync literal command injection,
+    #   GHSA-c4fp-cxrr-mj66 incomplete raw argument validation DoS.
+    #   No 0.4.x patch exists for the June 2026 CVEs, so we jump to 0.5.15.)
     # Ruby ships erb as a default gem and net-imap as a preinstalled gem; simply
     # running `gem install` leaves the original gemspec on disk and SBOM scanners
     # (grype) still report the old version, so remove the stale gemspecs after
     # installing the patched versions.
     gem install --no-document \
         erb:4.0.3.1 \
-        net-imap:0.4.24 && \
+        net-imap:0.5.15 && \
     # Remove both the stale gemspecs and the legacy gem directories. Without
     # removing the directories, grype reports the unpatched versions even
-    # though Ruby is loading the patched 4.0.3.1 / 0.4.24 copies.
+    # though Ruby is loading the patched 4.0.3.1 / 0.5.15 copies.
     rm -f /usr/local/lib/ruby/gems/3.3.0/specifications/default/erb-*.gemspec \
           /usr/local/lib/ruby/gems/3.3.0/specifications/net-imap-0.4.21.gemspec && \
     rm -rf /usr/local/lib/ruby/gems/3.3.0/gems/erb-4.0.3 \


### PR DESCRIPTION
## Description

Bumps `net-imap` from `0.4.24` to `0.5.15` in the Ruby SDK generator Dockerfile to fix three CVEs published on June 9, 2026. No 0.4.x patch exists for these advisories — the 0.4.x branch only receives critical security fixes for Ruby 3.3's bundled version and was not patched this round — so we jump to the 0.5.15 release line.

## Changes Made

- Bumped `net-imap` from `0.4.24` → `0.5.15` in `generators/ruby-v2/sdk/Dockerfile`
- Updated comments documenting the CVEs addressed by this gem version

### CVEs fixed (all three require `>= 0.5.15` or `>= 0.6.4.1`):
| GHSA | CVE | Summary |
|------|-----|---------|
| GHSA-46q3-7gv7-qmgg | CVE-2026-47242 | Command Injection via unvalidated `#id` and `#enable` arguments |
| GHSA-8p34-64r3-mwg8 | CVE-2026-47240 | Command Injection via non-synchronizing literal in "raw" argument |
| GHSA-c4fp-cxrr-mj66 | CVE-2026-47241 | Denial of Service via incomplete raw argument validation |

## Testing

- [ ] Docker build of the ruby-sdk-generator image (CI)
- The gem version change is a drop-in security patch; `net-imap` 0.5.x is API-compatible with 0.4.x and requires Ruby >= 3.2.0 (the image runs Ruby 3.3)

Link to Devin session: https://app.devin.ai/sessions/6a563d47992242f496b122c35689ab81
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->