### PR TITLE
fix(ci): replace classic PAT with fine-grained PAT in write-changelogs-to-docs

### DIFF
--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -51,6 +51,7 @@ jobs:
           repository: fern-api/docs
           ref: main
           path: docs
+          token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
 
       - name: update csharp-sdk changelog
         run: rsync -av --delete "changelogs/csharp-sdk/" "docs/fern/products/sdks/generators/csharp/changelog"
@@ -86,7 +87,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "update changelogs"
           title: "Update changelogs from fern repo"
           branch: update-changelogs
@@ -102,11 +103,8 @@ jobs:
           repository: fern-api/docs
           merge-method: squash
 
-      - name: Trigger approval workflow in docs repo
+      - name: Approve PR
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
-        run: |
-          gh api repos/fern-api/docs/dispatches \
-            -f event_type=approve-changelog-pr \
-            -f "client_payload[pull_number]=${{ steps.cpr.outputs.pull-request-number }}"
+        run: gh pr review ${{ steps.cpr.outputs.pull-request-number }} --repo fern-api/docs --approve

--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -105,5 +105,5 @@ jobs:
       - name: Approve PR
         if: steps.cpr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
         run: gh pr review ${{ steps.cpr.outputs.pull-request-number }} --repo fern-api/docs --approve

--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -51,7 +51,6 @@ jobs:
           repository: fern-api/docs
           ref: main
           path: docs
-          token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
 
       - name: update csharp-sdk changelog
         run: rsync -av --delete "changelogs/csharp-sdk/" "docs/fern/products/sdks/generators/csharp/changelog"
@@ -87,7 +86,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
           commit-message: "update changelogs"
           title: "Update changelogs from fern repo"
           branch: update-changelogs
@@ -103,8 +102,12 @@ jobs:
           repository: fern-api/docs
           merge-method: squash
 
-      - name: Approve PR
+      - name: Trigger approval workflow in docs repo
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
-        run: gh pr review ${{ steps.cpr.outputs.pull-request-number }} --repo fern-api/docs --approve
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          gh api repos/fern-api/docs/dispatches \
+            -f event_type=approve-changelog-pr \
+            -f "client_payload[pull_number]=$PR_NUMBER"

--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -102,8 +102,11 @@ jobs:
           repository: fern-api/docs
           merge-method: squash
 
-      - name: Approve PR
+      - name: Trigger approval workflow in docs repo
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
-        run: gh pr review ${{ steps.cpr.outputs.pull-request-number }} --repo fern-api/docs --approve
+        run: |
+          gh api repos/fern-api/docs/dispatches \
+            -f event_type=approve-changelog-pr \
+            -f "client_payload[pull_number]=${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
## Description

The `write-changelogs-to-docs.yml` workflow fails at the "Approve PR" step because `FERN_GITHUB_TOKEN` is a classic PAT, which the `fern-api` org now blocks. Same root cause as #16433, but this cross-repo workflow was missed.

## Changes Made

- Replaced direct `gh pr review --approve` (which used `FERN_GITHUB_TOKEN`) with a `repository_dispatch` to fern-api/docs
- The docs repo's new `approve-changelog-pr` workflow (https://github.com/fern-api/docs/pull/5744) approves using its own `GITHUB_TOKEN` (github-actions[bot] — different identity from the PR creator)
- Used env var for PR number instead of template expansion (fixes potential injection)
- Kept `FERN_SUPPORT_GH_ACTIONS_PAT` for PR creation and automerge (cross-repo access)

**Security:**
- `repository_dispatch` requires `contents: write` on docs repo to trigger
- Docs workflow validates PR number is numeric and branch is in an allowlist (`update-changelogs`, `update-self-hosted-changelog`)

## Testing

- [ ] Manual testing — merge docs PR first, then trigger this workflow via `workflow_dispatch`

Companion PR: https://github.com/fern-api/docs/pull/5744 (merge first)

Link to Devin session: https://app.devin.ai/sessions/38e3b601d27244bdb0777d0dbaf0f8b7
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->