### PR TITLE
fix(cli-generator): fix union body params and path encoding

### DIFF
--- a/generators/cli/changes/unreleased/fix-cli-sdk-parser-encoding.yml
+++ b/generators/cli/changes/unreleased/fix-cli-sdk-parser-encoding.yml
@@ -4,10 +4,6 @@
     union type recognition in the OpenAPI parser.
   type: fix
 - summary: |
-    Normalize x-fern-sdk-method-name overlay values to kebab-case,
-    matching the existing normalization applied to group names.
-  type: fix
-- summary: |
     Stop percent-encoding '.' and '~' in URL path segments — both are
     unreserved characters per RFC 3986 §2.3.
   type: fix

--- a/generators/cli/changes/unreleased/fix-cli-sdk-parser-encoding.yml
+++ b/generators/cli/changes/unreleased/fix-cli-sdk-parser-encoding.yml
@@ -1,0 +1,13 @@
+- summary: |
+    Fix array-typed body params (oneOf [string, array<string>]) being
+    serialized as literal strings by adding $ref chain resolution and
+    union type recognition in the OpenAPI parser.
+  type: fix
+- summary: |
+    Normalize x-fern-sdk-method-name overlay values to kebab-case,
+    matching the existing normalization applied to group names.
+  type: fix
+- summary: |
+    Stop percent-encoding '.' and '~' in URL path segments — both are
+    unreserved characters per RFC 3986 §2.3.
+  type: fix

--- a/generators/cli/sdk/src/openapi/executor.rs
+++ b/generators/cli/sdk/src/openapi/executor.rs
@@ -2522,13 +2522,17 @@ fn serialize_path_param(
     let explode = param_def.and_then(|p| p.explode).unwrap_or(false);
 
     let enc = |v: &Value| crate::validate::encode_path_segment(&value_to_path_string(v));
+    let label_enc =
+        |v: &Value| crate::validate::encode_label_path_segment(&value_to_path_string(v));
 
     match style {
         "label" => match value {
             Value::Array(arr) => {
                 // RFC 6570: explode=true -> dot-separated; explode=false -> comma-separated.
+                // Use label_enc so `.` in values is encoded and won't be
+                // confused with the `.` structural separator.
                 let joiner = if explode { "." } else { "," };
-                let body = arr.iter().map(&enc).collect::<Vec<_>>().join(joiner);
+                let body = arr.iter().map(&label_enc).collect::<Vec<_>>().join(joiner);
                 format!(".{body}")
             }
             Value::Object(map) => {
@@ -2537,7 +2541,11 @@ fn serialize_path_param(
                     let body = map
                         .iter()
                         .map(|(k, v)| {
-                            format!("{}={}", crate::validate::encode_path_segment(k), enc(v))
+                            format!(
+                                "{}={}",
+                                crate::validate::encode_label_path_segment(k),
+                                label_enc(v)
+                            )
                         })
                         .collect::<Vec<_>>()
                         .join(".");
@@ -2547,14 +2555,14 @@ fn serialize_path_param(
                     let body = map
                         .iter()
                         .flat_map(|(k, v)| {
-                            [crate::validate::encode_path_segment(k), enc(v)]
+                            [crate::validate::encode_label_path_segment(k), label_enc(v)]
                         })
                         .collect::<Vec<_>>()
                         .join(",");
                     format!(".{body}")
                 }
             }
-            _ => format!(".{}", enc(value)),
+            _ => format!(".{}", label_enc(value)),
         },
         "matrix" => match value {
             Value::Array(arr) if explode => arr

--- a/generators/cli/sdk/src/openapi/parser.rs
+++ b/generators/cli/sdk/src/openapi/parser.rs
@@ -2488,7 +2488,7 @@ pub fn load_openapi_spec_from_value(
             // + `customersList` operation → method `list` rather than
             // `customers-list`. Mirrors Fern's OpenAPI importer.
             let method_name = match &operation.x_fern_sdk_method_name {
-                Some(m) => m.clone(),
+                Some(m) => camel_to_kebab(m),
                 None => match &operation.operation_id {
                     Some(id) => {
                         let stripped = if operation.x_fern_sdk_group_name.is_none() {
@@ -3154,6 +3154,88 @@ fn resolve_branch_scalar_type(
     }
 }
 
+/// Maximum depth of `$ref` chain resolution. Prevents infinite loops from
+/// cyclic `$ref` chains (e.g. `A: {$ref: B}`, `B: {$ref: A}`).
+const MAX_REF_CHAIN_DEPTH: u8 = 8;
+
+/// Follow a `$ref` chain through `component_schemas` until reaching a
+/// terminal schema (one without a `$ref`). Returns `None` if the chain
+/// is unresolvable or exceeds `MAX_REF_CHAIN_DEPTH`.
+fn resolve_ref_chain<'a>(
+    schema: &'a OpenApiSchemaObject,
+    component_schemas: &'a HashMap<String, OpenApiSchemaObject>,
+) -> Option<&'a OpenApiSchemaObject> {
+    let mut current = schema;
+    for _ in 0..MAX_REF_CHAIN_DEPTH {
+        match &current.schema_ref {
+            Some(ref_path) => {
+                let name = strip_ref_prefix(ref_path);
+                current = component_schemas.get(&name)?;
+            }
+            None => return Some(current),
+        }
+    }
+    tracing::warn!("$ref chain exceeded {MAX_REF_CHAIN_DEPTH} levels; likely cyclic");
+    None
+}
+
+/// Recognize a `oneOf` / `anyOf` union where one branch is `type: string`
+/// and another is `type: array` with `items.type: string`. This pattern
+/// (e.g. `Addresses: oneOf [string, array<string>]`) should surface as a
+/// repeated string flag so the CLI accepts both single values and JSON
+/// arrays. Returns `true` when the union matches this shape.
+fn is_string_or_string_array_union(
+    obj: &OpenApiSchemaObject,
+    component_schemas: &HashMap<String, OpenApiSchemaObject>,
+) -> bool {
+    let branches: &[OpenApiSchemaObject] = if !obj.one_of.is_empty() {
+        &obj.one_of
+    } else if !obj.any_of.is_empty() {
+        &obj.any_of
+    } else {
+        return false;
+    };
+
+    if branches.len() < 2 {
+        return false;
+    }
+
+    let mut has_string = false;
+    let mut has_string_array = false;
+
+    for branch in branches {
+        let resolved = if let Some(ref_path) = &branch.schema_ref {
+            let name = strip_ref_prefix(ref_path);
+            match component_schemas.get(&name) {
+                Some(s) => s,
+                None => continue,
+            }
+        } else {
+            branch
+        };
+
+        if is_null_sentinel(resolved) {
+            continue;
+        }
+
+        match resolved.schema_type() {
+            Some("string") => has_string = true,
+            Some("array") => {
+                let items_are_string = resolved
+                    .items
+                    .as_ref()
+                    .map_or(false, |it| it.schema_type() == Some("string"));
+                if items_are_string {
+                    has_string_array = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    has_string && has_string_array
+}
+
 /// Maximum depth of consecutive `allOf` recursion. Cyclic `$ref` chains
 /// (`Foo: {allOf: [{$ref: Foo}, ...]}`) are degenerate but legal; this cap
 /// stops the walk before it explodes. Distinct from `MAX_BODY_DEPTH`,
@@ -3274,9 +3356,12 @@ fn flatten_body_params_prefix(
         };
 
         // $ref property: resolve from component_schemas before checking type.
+        // Follow ref chains (A → B → C) to reach the terminal schema.
         if let Some(ref_path) = &prop.schema_ref {
             let ref_name = strip_ref_prefix(ref_path);
-            if let Some(resolved) = component_schemas.get(&ref_name) {
+            let direct_resolved = component_schemas.get(&ref_name);
+            let resolved = direct_resolved.and_then(|s| resolve_ref_chain(s, component_schemas));
+            if let Some(resolved) = resolved {
                 // Recurse for object-shaped *or* allOf-shaped resolved
                 // schemas — the latter is the inheritance pattern
                 // (`Mixin: {allOf: [Base, extras]}`) Box uses heavily.
@@ -3299,6 +3384,27 @@ fn flatten_body_params_prefix(
                         );
                         continue;
                     }
+                }
+                // Recognize oneOf/anyOf [string, array<string>] unions and
+                // emit as a repeated string flag so the executor JSON-parses
+                // array inputs instead of passing them as literal strings.
+                if is_string_or_string_array_union(resolved, component_schemas) {
+                    let const_default = const_default_value(resolved);
+                    out.insert(
+                        full_key,
+                        MethodParameter {
+                            param_type: Some("string".to_string()),
+                            description: prop.description.clone().or_else(|| resolved.description.clone()),
+                            location: Some("body".to_string()),
+                            required: required.contains(name.as_str()) && const_default.is_none(),
+                            format: resolved.format.clone(),
+                            default_value: const_default,
+                            repeated: true,
+                            nullable: resolved.is_nullable(),
+                            ..Default::default()
+                        },
+                    );
+                    continue;
                 }
                 // Non-object ref or empty recursion — emit with resolved type.
                 // Promote nullable-union compositions to a scalar flag
@@ -3357,6 +3463,26 @@ fn flatten_body_params_prefix(
                 );
                 continue;
             }
+        }
+
+        // Recognize inline oneOf/anyOf [string, array<string>] unions.
+        if is_string_or_string_array_union(prop, component_schemas) {
+            let const_default = const_default_value(prop);
+            out.insert(
+                full_key,
+                MethodParameter {
+                    param_type: Some("string".to_string()),
+                    description: prop.description.clone(),
+                    location: Some("body".to_string()),
+                    required: required.contains(name.as_str()) && const_default.is_none(),
+                    format: prop.format.clone(),
+                    default_value: const_default,
+                    repeated: true,
+                    nullable: prop.is_nullable(),
+                    ..Default::default()
+                },
+            );
+            continue;
         }
 
         // Promote nullable-union compositions (`anyOf: [scalar, null]`
@@ -9226,6 +9352,166 @@ paths:
         )
         .unwrap();
         assert_eq!(recognize_nullable_union(&obj, &HashMap::new()), None);
+    }
+
+    #[test]
+    fn test_resolve_ref_chain_single_hop() {
+        let schema: OpenApiSchemaObject =
+            serde_yaml::from_str(r##"$ref: "#/components/schemas/Foo""##).unwrap();
+        let foo: OpenApiSchemaObject = serde_yaml::from_str("type: string\n").unwrap();
+        let mut components = HashMap::new();
+        components.insert("Foo".to_string(), foo);
+        let resolved = resolve_ref_chain(&schema, &components).unwrap();
+        assert_eq!(resolved.schema_type(), Some("string"));
+    }
+
+    #[test]
+    fn test_resolve_ref_chain_multi_hop() {
+        // A -> B -> C (terminal: type: array, items.type: string)
+        let a: OpenApiSchemaObject =
+            serde_yaml::from_str(r##"$ref: "#/components/schemas/B""##).unwrap();
+        let b: OpenApiSchemaObject =
+            serde_yaml::from_str(r##"$ref: "#/components/schemas/C""##).unwrap();
+        let c: OpenApiSchemaObject =
+            serde_yaml::from_str("type: array\nitems:\n  type: string\n").unwrap();
+        let mut components = HashMap::new();
+        components.insert("B".to_string(), b);
+        components.insert("C".to_string(), c);
+        let resolved = resolve_ref_chain(&a, &components).unwrap();
+        assert_eq!(resolved.schema_type(), Some("array"));
+    }
+
+    #[test]
+    fn test_resolve_ref_chain_already_terminal() {
+        let schema: OpenApiSchemaObject = serde_yaml::from_str("type: integer\n").unwrap();
+        let components = HashMap::new();
+        let resolved = resolve_ref_chain(&schema, &components).unwrap();
+        assert_eq!(resolved.schema_type(), Some("integer"));
+    }
+
+    #[test]
+    fn test_resolve_ref_chain_broken_ref() {
+        let schema: OpenApiSchemaObject =
+            serde_yaml::from_str(r##"$ref: "#/components/schemas/Missing""##).unwrap();
+        assert!(resolve_ref_chain(&schema, &HashMap::new()).is_none());
+    }
+
+    #[test]
+    fn test_is_string_or_string_array_union_one_of() {
+        let obj: OpenApiSchemaObject = serde_yaml::from_str(
+            r#"
+            oneOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+            "#,
+        )
+        .unwrap();
+        assert!(is_string_or_string_array_union(&obj, &HashMap::new()));
+    }
+
+    #[test]
+    fn test_is_string_or_string_array_union_any_of() {
+        let obj: OpenApiSchemaObject = serde_yaml::from_str(
+            r#"
+            anyOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+            "#,
+        )
+        .unwrap();
+        assert!(is_string_or_string_array_union(&obj, &HashMap::new()));
+    }
+
+    #[test]
+    fn test_is_string_or_string_array_union_with_null() {
+        // oneOf [string, array<string>, null] should still match
+        let obj: OpenApiSchemaObject = serde_yaml::from_str(
+            r#"
+            oneOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+              - type: "null"
+            "#,
+        )
+        .unwrap();
+        assert!(is_string_or_string_array_union(&obj, &HashMap::new()));
+    }
+
+    #[test]
+    fn test_is_string_or_string_array_union_not_matching() {
+        // oneOf [string, integer] should NOT match
+        let obj: OpenApiSchemaObject = serde_yaml::from_str(
+            r#"
+            oneOf:
+              - type: string
+              - type: integer
+            "#,
+        )
+        .unwrap();
+        assert!(!is_string_or_string_array_union(&obj, &HashMap::new()));
+    }
+
+    #[test]
+    fn test_flatten_promotes_string_or_string_array_union() {
+        // End-to-end: a body property with `oneOf: [string, array<string>]`
+        // becomes a `repeated: true` string MethodParameter.
+        let schema: OpenApiSchemaObject = serde_yaml::from_str(
+            r#"
+            type: object
+            properties:
+              to:
+                oneOf:
+                  - type: string
+                  - type: array
+                    items:
+                      type: string
+            "#,
+        )
+        .unwrap();
+        let params = flatten_body_params(&schema, &HashMap::new(), 0);
+        let to = &params["to"];
+        assert_eq!(to.param_type.as_deref(), Some("string"));
+        assert!(to.repeated, "should be repeated for array union: {to:?}");
+    }
+
+    #[test]
+    fn test_flatten_resolves_ref_chain_to_union() {
+        // Simulates: to -> $ref SendMessageTo -> $ref Addresses ->
+        // oneOf [string, array<string>]
+        let schema: OpenApiSchemaObject = serde_yaml::from_str(
+            r##"
+            type: object
+            properties:
+              to:
+                $ref: "#/components/schemas/SendMessageTo"
+            "##,
+        )
+        .unwrap();
+        let send_msg_to: OpenApiSchemaObject =
+            serde_yaml::from_str(r##"$ref: "#/components/schemas/Addresses""##).unwrap();
+        let addresses: OpenApiSchemaObject = serde_yaml::from_str(
+            r#"
+            oneOf:
+              - type: string
+              - type: array
+                items:
+                  type: string
+            "#,
+        )
+        .unwrap();
+        let mut components = HashMap::new();
+        components.insert("SendMessageTo".to_string(), send_msg_to);
+        components.insert("Addresses".to_string(), addresses);
+        let params = flatten_body_params(&schema, &components, 0);
+        let to = &params["to"];
+        assert_eq!(to.param_type.as_deref(), Some("string"));
+        assert!(to.repeated, "ref-chain to union should produce repeated: {to:?}");
     }
 
     #[test]

--- a/generators/cli/sdk/src/openapi/parser.rs
+++ b/generators/cli/sdk/src/openapi/parser.rs
@@ -2488,7 +2488,7 @@ pub fn load_openapi_spec_from_value(
             // + `customersList` operation → method `list` rather than
             // `customers-list`. Mirrors Fern's OpenAPI importer.
             let method_name = match &operation.x_fern_sdk_method_name {
-                Some(m) => camel_to_kebab(m),
+                Some(m) => m.clone(),
                 None => match &operation.operation_id {
                     Some(id) => {
                         let stripped = if operation.x_fern_sdk_group_name.is_none() {

--- a/generators/cli/sdk/src/validate.rs
+++ b/generators/cli/sdk/src/validate.rs
@@ -251,22 +251,20 @@ fn normalize_non_existing(path: &Path) -> Result<PathBuf, CliError> {
     Ok(resolved)
 }
 
-/// Characters to encode in a single URL path segment. Keeps RFC 3986 §2.3
-/// unreserved characters that commonly appear in resource IDs (`-` and `_`)
-/// unencoded; encodes everything else including `.` (dots appear in email-style
-/// calendar IDs and should not carry path semantics).
+/// Characters to encode in a single URL path segment. All RFC 3986 §2.3
+/// unreserved characters (`A-Z a-z 0-9 - . _ ~`) are left unencoded;
+/// everything else is percent-encoded.
 use percent_encoding::{AsciiSet, CONTROLS};
 const PATH_SEGMENT: &AsciiSet = &CONTROLS
     .add(b' ').add(b'!').add(b'"').add(b'#').add(b'$').add(b'%')
     .add(b'&').add(b'\'').add(b'(').add(b')').add(b'*').add(b'+')
-    .add(b',').add(b'.').add(b'/').add(b':').add(b';').add(b'<')
+    .add(b',').add(b'/').add(b':').add(b';').add(b'<')
     .add(b'=').add(b'>').add(b'?').add(b'@').add(b'[').add(b'\\')
-    .add(b']').add(b'^').add(b'`').add(b'{').add(b'|').add(b'}')
-    .add(b'~');
+    .add(b']').add(b'^').add(b'`').add(b'{').add(b'|').add(b'}');
 
 /// Percent-encode a value for use as a single URL path segment (e.g., file ID,
-/// calendar ID, message ID). Hyphens and underscores are left unencoded since
-/// they are unreserved per RFC 3986 and ubiquitous in resource IDs.
+/// calendar ID, message ID). All RFC 3986 §2.3 unreserved characters
+/// (`A-Z a-z 0-9 - . _ ~`) are left unencoded.
 pub fn encode_path_segment(s: &str) -> String {
     use percent_encoding::utf8_percent_encode;
     utf8_percent_encode(s, PATH_SEGMENT).to_string()
@@ -515,10 +513,25 @@ mod tests {
 
     #[test]
     fn test_encode_path_segment_email() {
-        // Calendar IDs are often email addresses
+        // Calendar IDs are often email addresses. `@` is a reserved
+        // character and must be encoded; `.` is unreserved per RFC 3986
+        // §2.3 and must NOT be encoded.
         let encoded = encode_path_segment("user@gmail.com");
-        assert!(!encoded.contains('@'));
-        assert!(!encoded.contains('.'));
+        assert!(!encoded.contains('@'), "@ must be percent-encoded");
+        assert!(encoded.contains('.'), ". is unreserved and must not be encoded");
+        assert_eq!(encoded, "user%40gmail.com");
+    }
+
+    #[test]
+    fn test_encode_path_segment_dot_and_tilde_unreserved() {
+        // `.` and `~` are RFC 3986 §2.3 unreserved characters and must
+        // not be percent-encoded in path segments.
+        assert_eq!(encode_path_segment("file.txt"), "file.txt");
+        assert_eq!(encode_path_segment("user~archive"), "user~archive");
+        assert_eq!(
+            encode_path_segment("codex-test@agentmail.to"),
+            "codex-test%40agentmail.to"
+        );
     }
 
     #[test]

--- a/generators/cli/sdk/src/validate.rs
+++ b/generators/cli/sdk/src/validate.rs
@@ -262,12 +262,26 @@ const PATH_SEGMENT: &AsciiSet = &CONTROLS
     .add(b'=').add(b'>').add(b'?').add(b'@').add(b'[').add(b'\\')
     .add(b']').add(b'^').add(b'`').add(b'{').add(b'|').add(b'}');
 
+/// Extended encode set for OpenAPI label-style path parameter values.
+/// Adds `.` on top of `PATH_SEGMENT` so that literal dots in values are
+/// distinguished from the `.` structural separator used by label-style
+/// (RFC 6570) serialization.
+const LABEL_PATH_SEGMENT: &AsciiSet = &PATH_SEGMENT.add(b'.');
+
 /// Percent-encode a value for use as a single URL path segment (e.g., file ID,
 /// calendar ID, message ID). All RFC 3986 §2.3 unreserved characters
 /// (`A-Z a-z 0-9 - . _ ~`) are left unencoded.
 pub fn encode_path_segment(s: &str) -> String {
     use percent_encoding::utf8_percent_encode;
     utf8_percent_encode(s, PATH_SEGMENT).to_string()
+}
+
+/// Percent-encode a value for use in OpenAPI label-style path parameters.
+/// Same as [`encode_path_segment`] but also encodes `.` so it cannot be
+/// confused with the `.` separator used by label-style serialization.
+pub fn encode_label_path_segment(s: &str) -> String {
+    use percent_encoding::utf8_percent_encode;
+    utf8_percent_encode(s, LABEL_PATH_SEGMENT).to_string()
 }
 
 /// Percent-encode a value for use in URI path templates where `/` should stay
@@ -550,10 +564,11 @@ mod tests {
 
     #[test]
     fn test_encode_path_segment_path_traversal() {
-        // Encoding makes traversal segments harmless
+        // Encoding `/` makes traversal harmless — the path cannot escape
+        // the segment even though `.` is left unencoded (unreserved).
         let encoded = encode_path_segment("../../etc/passwd");
-        assert!(!encoded.contains('/'));
-        assert!(!encoded.contains(".."));
+        assert!(!encoded.contains('/'), "slashes must be encoded");
+        assert_eq!(encoded, "..%2F..%2Fetc%2Fpasswd");
     }
 
     #[test]
@@ -595,6 +610,25 @@ mod tests {
         let encoded = encode_path_preserving_slashes("タイムライン 1/列 A");
         assert!(!encoded.contains(' '));
         assert!(encoded.contains('/'));
+    }
+
+    // -- label path segment encoding ------------------------------------------
+
+    #[test]
+    fn test_encode_label_path_segment_encodes_dot() {
+        // Label-style serialization uses `.` as a separator, so dots in
+        // values must be encoded to avoid ambiguity.
+        assert_eq!(encode_label_path_segment("1.0"), "1%2E0");
+        assert_eq!(
+            encode_label_path_segment("codex-test@agentmail.to"),
+            "codex-test%40agentmail%2Eto"
+        );
+    }
+
+    #[test]
+    fn test_encode_label_path_segment_preserves_tilde() {
+        // `~` is unreserved and not a label separator — no need to encode.
+        assert_eq!(encode_label_path_segment("user~archive"), "user~archive");
     }
 
     // -- validate_resource_name -----------------------------------------------


### PR DESCRIPTION
## Description

Fixes two CLI SDK issues surfaced during AgentMail CLI generation:

## Changes Made

### 1. Array-typed body params serialized as strings (highest priority)

The OpenAPI parser had two compounding gaps:
- **$ref chains not followed**: `to → $ref SendMessageTo → $ref Addresses` stopped at the first hop
- **True `oneOf` unions unhandled**: `oneOf [string, array<string>]` (no null branch) fell through to `param_type: None`, causing the executor to pass JSON arrays as literal strings

Added `resolve_ref_chain()` to follow `$ref` → `$ref` → terminal schema, and `is_string_or_string_array_union()` to recognize `oneOf`/`anyOf` unions of `[string, array<string>]` and emit them as `repeated: true, param_type: "string"`.

### 2. `.` and `~` over-encoded in URL path segments

The `PATH_SEGMENT` encode set included `.` and `~`, both RFC 3986 §2.3 unreserved characters. This caused `codex-test@agentmail.to` to encode as `codex-test%40agentmail%2Eto` instead of `codex-test%40agentmail.to`. Removed both from the encode set.

Added a separate `LABEL_PATH_SEGMENT` set (= `PATH_SEGMENT` + `.`) and `encode_label_path_segment()` for OpenAPI label-style path parameter serialization, where `.` is a structural separator that must remain distinguishable from literal dots in values.

## Testing

- [x] Unit tests added for `resolve_ref_chain` (single hop, multi hop, terminal, broken ref)
- [x] Unit tests added for `is_string_or_string_array_union` (oneOf, anyOf, with null, non-matching)
- [x] End-to-end `flatten_body_params` tests for inline unions and ref-chain-to-union
- [x] Updated `encode_path_segment` tests for `.` and `~` as unreserved chars
- [x] Added `encode_label_path_segment` tests for label-style encoding
- [x] Updated path traversal test for new `.` behavior
- [x] `cargo check --tests` passes

Link to Devin session: https://app.devin.ai/sessions/a67c73a6b2fc4cf785755041fdfb434f
Requested by: @cade-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->