### PR TITLE
feat(cli): track validation rules fired in fern check PostHog event

### DIFF
--- a/packages/cli/cli/changes/unreleased/track-validation-rules-in-posthog.yml
+++ b/packages/cli/cli/changes/unreleased/track-validation-rules-in-posthog.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Track which validation rules fired during `fern check` as part of the PostHog CLI telemetry event.
+    The event now includes `validationRules` (array of rule names that produced violations),
+    `numErrors`, `numWarnings`, and `passed` properties.
+  type: feat

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1359,10 +1359,6 @@ function addValidateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     default: false
                 }),
         async (argv) => {
-            cliContext.instrumentPostHogEvent({
-                command: "fern check"
-            });
-
             // Docs validation may reference APIs outside `--api`; apply the filter
             // only to API-level validation.
             const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1359,6 +1359,10 @@ function addValidateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     default: false
                 }),
         async (argv) => {
+            cliContext.instrumentPostHogEvent({
+                command: "fern check"
+            });
+
             // Docs validation may reference APIs outside `--api`; apply the filter
             // only to API-level validation.
             const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -51,6 +51,7 @@ import { hideBin } from "yargs/helpers";
 import yargs from "yargs/yargs";
 import { CliContext } from "./cli-context/CliContext.js";
 import { getLatestVersionOfCli } from "./cli-context/upgrade-utils/getLatestVersionOfCli.js";
+import { type Project } from "@fern-api/project-loader";
 import { GlobalCliOptions, loadProjectAndRegisterWorkspacesWithContext } from "./cliCommons.js";
 import { addGeneratorCommands, addGetOrganizationCommand } from "./cliV2.js";
 import { addGeneratorToWorkspaces } from "./commands/add-generator/addGeneratorToWorkspaces.js";
@@ -1359,28 +1360,51 @@ function addValidateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     default: false
                 }),
         async (argv) => {
-            // Docs validation may reference APIs outside `--api`; apply the filter
-            // only to API-level validation.
-            const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
-                commandLineApiWorkspace: undefined,
-                defaultToAllApiWorkspaces: true
-            });
-
-            if (argv.api != null && !project.apiWorkspaces.some((ws) => ws.workspaceName === argv.api)) {
-                cliContext.failAndThrow(`API does not exist: ${argv.api}`, undefined, {
-                    code: CliError.Code.ConfigError
+            let project: Project | undefined;
+            try {
+                // Docs validation may reference APIs outside `--api`; apply the filter
+                // only to API-level validation.
+                project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
+                    commandLineApiWorkspace: undefined,
+                    defaultToAllApiWorkspaces: true
                 });
-            }
 
-            await validateWorkspaces({
-                project,
-                cliContext,
-                logWarnings: argv.warnings,
-                brokenLinks: argv.brokenLinks,
-                errorOnBrokenLinks: argv.strictBrokenLinks,
-                directFromOpenapi: argv.fromOpenapi,
-                commandLineApiWorkspace: argv.api
-            });
+                if (argv.api != null && !project.apiWorkspaces.some((ws) => ws.workspaceName === argv.api)) {
+                    cliContext.instrumentPostHogEvent({
+                        command: "fern check",
+                        properties: {
+                            passed: false,
+                            abortReason: `API does not exist: ${argv.api}`
+                        }
+                    });
+                    cliContext.failAndThrow(`API does not exist: ${argv.api}`, undefined, {
+                        code: CliError.Code.ConfigError
+                    });
+                }
+
+                await validateWorkspaces({
+                    project,
+                    cliContext,
+                    logWarnings: argv.warnings,
+                    brokenLinks: argv.brokenLinks,
+                    errorOnBrokenLinks: argv.strictBrokenLinks,
+                    directFromOpenapi: argv.fromOpenapi,
+                    commandLineApiWorkspace: argv.api
+                });
+            } catch (error) {
+                if (project == null) {
+                    const reason =
+                        error instanceof Error ? error.message.slice(0, 100) : "project load failed";
+                    cliContext.instrumentPostHogEvent({
+                        command: "fern check",
+                        properties: {
+                            passed: false,
+                            abortReason: reason
+                        }
+                    });
+                }
+                throw error;
+            }
         }
     );
 }

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -42,6 +42,7 @@ import {
 } from "@fern-api/init";
 import { LOG_LEVELS, LogLevel } from "@fern-api/logger";
 import { askToLogin, getDashboardBaseUrl, login, logout } from "@fern-api/login";
+import { type Project } from "@fern-api/project-loader";
 import { protocGenFern } from "@fern-api/protoc-gen-fern";
 import { CliError } from "@fern-api/task-context";
 import chalk from "chalk";
@@ -51,7 +52,6 @@ import { hideBin } from "yargs/helpers";
 import yargs from "yargs/yargs";
 import { CliContext } from "./cli-context/CliContext.js";
 import { getLatestVersionOfCli } from "./cli-context/upgrade-utils/getLatestVersionOfCli.js";
-import { type Project } from "@fern-api/project-loader";
 import { GlobalCliOptions, loadProjectAndRegisterWorkspacesWithContext } from "./cliCommons.js";
 import { addGeneratorCommands, addGetOrganizationCommand } from "./cliV2.js";
 import { addGeneratorToWorkspaces } from "./commands/add-generator/addGeneratorToWorkspaces.js";
@@ -1393,8 +1393,7 @@ function addValidateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 });
             } catch (error) {
                 if (project == null) {
-                    const reason =
-                        error instanceof Error ? error.message.slice(0, 100) : "project load failed";
+                    const reason = error instanceof Error ? error.message.slice(0, 100) : "project load failed";
                     cliContext.instrumentPostHogEvent({
                         command: "fern check",
                         properties: {

--- a/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
+++ b/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
@@ -172,8 +172,7 @@ export async function validateWorkspaces({
         }
     } catch (error) {
         if (abortReason == null) {
-            abortReason =
-                error instanceof Error ? error.message.slice(0, 100) : "unexpected error";
+            abortReason = error instanceof Error ? error.message.slice(0, 100) : "unexpected error";
         }
         throw error;
     } finally {
@@ -181,9 +180,7 @@ export async function validateWorkspaces({
         const firedRules = [
             ...new Set(allViolations.map((v) => v.name).filter((name): name is string => name != null))
         ];
-        const numErrors = allViolations.filter(
-            (v) => v.severity === "fatal" || v.severity === "error"
-        ).length;
+        const numErrors = allViolations.filter((v) => v.severity === "fatal" || v.severity === "error").length;
         const numWarnings = allViolations.filter((v) => v.severity === "warning").length;
         cliContext.instrumentPostHogEvent({
             command: "fern check",

--- a/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
+++ b/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
@@ -151,6 +151,21 @@ export async function validateWorkspaces({
         });
     });
 
+    // Emit telemetry with which validation rules produced violations
+    const allViolations = [...apiResults.flatMap((r) => r.violations), ...(docsResult?.violations ?? [])];
+    const firedRules = [...new Set(allViolations.map((v) => v.name).filter((name): name is string => name != null))];
+    const numErrors = allViolations.filter((v) => v.severity === "fatal" || v.severity === "error").length;
+    const numWarnings = allViolations.filter((v) => v.severity === "warning").length;
+    cliContext.instrumentPostHogEvent({
+        command: "fern check",
+        properties: {
+            validationRules: firedRules,
+            numErrors,
+            numWarnings,
+            passed: !hasErrors && !hasAnyErrors
+        }
+    });
+
     if (cliContext.isJsonMode) {
         const showApiNames = apiResults.length > 1;
         cliContext.writeJsonToStdout(

--- a/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
+++ b/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
@@ -38,142 +38,162 @@ export async function validateWorkspaces({
     const apiResults: ApiValidationResult[] = [];
     let docsResult: DocsValidationResult | undefined;
     let hasAnyErrors = false;
+    let abortReason: string | undefined;
 
     const apiWorkspacesToValidate =
         commandLineApiWorkspace != null
             ? project.apiWorkspaces.filter((workspace) => workspace.workspaceName === commandLineApiWorkspace)
             : project.apiWorkspaces;
 
-    // Collect docs violations first (using runTaskForWorkspace to preserve [docs]: prefix for fatal errors)
-    const docsWorkspace = project.docsWorkspaces;
-    if (docsWorkspace != null) {
-        const excludeRules = brokenLinks || errorOnBrokenLinks ? [] : ["valid-markdown-links"];
-        const ossWorkspaces = await filterOssWorkspaces(project);
+    let hasErrors = false;
 
-        let collected: Awaited<ReturnType<typeof collectDocsWorkspaceViolations>> | undefined;
-        await cliContext.runTaskForWorkspace(docsWorkspace, async (context) => {
-            collected = await collectDocsWorkspaceViolations({
-                workspace: docsWorkspace,
-                context,
-                apiWorkspaces: project.apiWorkspaces,
-                ossWorkspaces,
-                errorOnBrokenLinks,
-                excludeRules
-            });
-        });
+    try {
+        // Collect docs violations first (using runTaskForWorkspace to preserve [docs]: prefix for fatal errors)
+        const docsWorkspace = project.docsWorkspaces;
+        if (docsWorkspace != null) {
+            const excludeRules = brokenLinks || errorOnBrokenLinks ? [] : ["valid-markdown-links"];
+            const ossWorkspaces = await filterOssWorkspaces(project);
 
-        if (collected != null) {
-            docsResult = {
-                violations: collected.violations,
-                elapsedMillis: collected.elapsedMillis
-            };
-
-            if (collected.hasErrors) {
-                hasAnyErrors = true;
-            }
-        }
-    }
-
-    // Collect API violations (using runTaskForWorkspace to preserve [api]: prefix for fatal errors)
-    await Promise.all(
-        apiWorkspacesToValidate.map(async (workspace) => {
-            if (workspace.generatorsConfiguration?.groups.length === 0 && workspace.type !== "fern") {
-                return;
-            }
-
-            if (workspace instanceof OSSWorkspace && directFromOpenapi) {
-                // For --from-openapi, run IR generation which logs its own errors
-                await cliContext.runTaskForWorkspace(workspace, async (context) => {
-                    await workspace.getIntermediateRepresentation({
-                        context,
-                        audiences: { type: "all" },
-                        enableUniqueErrorsPerEndpoint: false,
-                        generateV1Examples: false,
-                        logWarnings: logWarnings
-                    });
-                });
-                return;
-            }
-
-            // For LazyFernWorkspace, check if api.yml exists before running validation.
-            // If it doesn't exist, we want to log the error WITHOUT the [api]: prefix.
-            // All other errors (including dependency errors) should have the [api]: prefix.
-            if (workspace instanceof LazyFernWorkspace) {
-                const absolutePathToApiYml = join(
-                    workspace.absoluteFilePath,
-                    RelativeFilePath.of(DEFINITION_DIRECTORY),
-                    RelativeFilePath.of(ROOT_API_FILENAME)
-                );
-                const apiYmlExists = await doesPathExist(absolutePathToApiYml);
-                if (!apiYmlExists) {
-                    // Log the missing file error without the [api]: prefix
-                    await cliContext.runTask(async (context) => {
-                        context.logger.error(`Missing file: ${ROOT_API_FILENAME}`);
-                        return context.failAndThrow(undefined, undefined, { code: CliError.Code.ValidationError });
-                    });
-                    return;
-                }
-            }
-
-            // Run toFernWorkspace and validation inside runTaskForWorkspace so that
-            // dependency errors and other validation errors get the [api]: prefix
-            let collected: Awaited<ReturnType<typeof collectAPIWorkspaceViolations>> | undefined;
-            await cliContext.runTaskForWorkspace(workspace, async (context) => {
-                const fernWorkspace = await workspace.toFernWorkspace({ context });
-                collected = await collectAPIWorkspaceViolations({
-                    workspace: fernWorkspace,
+            let collected: Awaited<ReturnType<typeof collectDocsWorkspaceViolations>> | undefined;
+            await cliContext.runTaskForWorkspace(docsWorkspace, async (context) => {
+                collected = await collectDocsWorkspaceViolations({
+                    workspace: docsWorkspace,
                     context,
-                    ossWorkspace: workspace instanceof OSSWorkspace ? workspace : undefined
+                    apiWorkspaces: project.apiWorkspaces,
+                    ossWorkspaces,
+                    errorOnBrokenLinks,
+                    excludeRules
                 });
             });
 
             if (collected != null) {
-                apiResults.push({
-                    apiName: collected.apiName,
+                docsResult = {
                     violations: collected.violations,
                     elapsedMillis: collected.elapsedMillis
-                });
+                };
 
                 if (collected.hasErrors) {
                     hasAnyErrors = true;
                 }
             }
-        })
-    );
-
-    // Print the aggregated report (using runTask to get a proper TaskContext)
-    const { hasErrors } = await cliContext.runTask((context) => {
-        return printCheckReport({
-            apiResults,
-            docsResult,
-            logWarnings,
-            context
-        });
-    });
-
-    // Emit telemetry with which validation rules produced violations
-    const allViolations = [...apiResults.flatMap((r) => r.violations), ...(docsResult?.violations ?? [])];
-    const firedRules = [...new Set(allViolations.map((v) => v.name).filter((name): name is string => name != null))];
-    const numErrors = allViolations.filter((v) => v.severity === "fatal" || v.severity === "error").length;
-    const numWarnings = allViolations.filter((v) => v.severity === "warning").length;
-    cliContext.instrumentPostHogEvent({
-        command: "fern check",
-        properties: {
-            validationRules: firedRules,
-            numErrors,
-            numWarnings,
-            passed: !hasErrors && !hasAnyErrors
         }
-    });
 
-    if (cliContext.isJsonMode) {
-        const showApiNames = apiResults.length > 1;
-        cliContext.writeJsonToStdout(
-            buildCheckJsonResult({ apiResults, docsResult, hasErrors: hasErrors || hasAnyErrors, showApiNames })
+        // Collect API violations (using runTaskForWorkspace to preserve [api]: prefix for fatal errors)
+        await Promise.all(
+            apiWorkspacesToValidate.map(async (workspace) => {
+                if (workspace.generatorsConfiguration?.groups.length === 0 && workspace.type !== "fern") {
+                    return;
+                }
+
+                if (workspace instanceof OSSWorkspace && directFromOpenapi) {
+                    // For --from-openapi, run IR generation which logs its own errors
+                    await cliContext.runTaskForWorkspace(workspace, async (context) => {
+                        await workspace.getIntermediateRepresentation({
+                            context,
+                            audiences: { type: "all" },
+                            enableUniqueErrorsPerEndpoint: false,
+                            generateV1Examples: false,
+                            logWarnings: logWarnings
+                        });
+                    });
+                    return;
+                }
+
+                // For LazyFernWorkspace, check if api.yml exists before running validation.
+                // If it doesn't exist, we want to log the error WITHOUT the [api]: prefix.
+                // All other errors (including dependency errors) should have the [api]: prefix.
+                if (workspace instanceof LazyFernWorkspace) {
+                    const absolutePathToApiYml = join(
+                        workspace.absoluteFilePath,
+                        RelativeFilePath.of(DEFINITION_DIRECTORY),
+                        RelativeFilePath.of(ROOT_API_FILENAME)
+                    );
+                    const apiYmlExists = await doesPathExist(absolutePathToApiYml);
+                    if (!apiYmlExists) {
+                        abortReason = "missing api.yml";
+                        // Log the missing file error without the [api]: prefix
+                        await cliContext.runTask(async (context) => {
+                            context.logger.error(`Missing file: ${ROOT_API_FILENAME}`);
+                            return context.failAndThrow(undefined, undefined, {
+                                code: CliError.Code.ValidationError
+                            });
+                        });
+                        return;
+                    }
+                }
+
+                // Run toFernWorkspace and validation inside runTaskForWorkspace so that
+                // dependency errors and other validation errors get the [api]: prefix
+                let collected: Awaited<ReturnType<typeof collectAPIWorkspaceViolations>> | undefined;
+                await cliContext.runTaskForWorkspace(workspace, async (context) => {
+                    const fernWorkspace = await workspace.toFernWorkspace({ context });
+                    collected = await collectAPIWorkspaceViolations({
+                        workspace: fernWorkspace,
+                        context,
+                        ossWorkspace: workspace instanceof OSSWorkspace ? workspace : undefined
+                    });
+                });
+
+                if (collected != null) {
+                    apiResults.push({
+                        apiName: collected.apiName,
+                        violations: collected.violations,
+                        elapsedMillis: collected.elapsedMillis
+                    });
+
+                    if (collected.hasErrors) {
+                        hasAnyErrors = true;
+                    }
+                }
+            })
         );
-    }
 
-    if (hasErrors || hasAnyErrors) {
-        cliContext.failAndThrow(undefined, undefined, { code: CliError.Code.ValidationError });
+        // Print the aggregated report (using runTask to get a proper TaskContext)
+        const reportResult = await cliContext.runTask((context) => {
+            return printCheckReport({
+                apiResults,
+                docsResult,
+                logWarnings,
+                context
+            });
+        });
+        hasErrors = reportResult.hasErrors;
+
+        if (cliContext.isJsonMode) {
+            const showApiNames = apiResults.length > 1;
+            cliContext.writeJsonToStdout(
+                buildCheckJsonResult({ apiResults, docsResult, hasErrors: hasErrors || hasAnyErrors, showApiNames })
+            );
+        }
+
+        if (hasErrors || hasAnyErrors) {
+            abortReason = "validation errors";
+            cliContext.failAndThrow(undefined, undefined, { code: CliError.Code.ValidationError });
+        }
+    } catch (error) {
+        if (abortReason == null) {
+            abortReason =
+                error instanceof Error ? error.message.slice(0, 100) : "unexpected error";
+        }
+        throw error;
+    } finally {
+        const allViolations = [...apiResults.flatMap((r) => r.violations), ...(docsResult?.violations ?? [])];
+        const firedRules = [
+            ...new Set(allViolations.map((v) => v.name).filter((name): name is string => name != null))
+        ];
+        const numErrors = allViolations.filter(
+            (v) => v.severity === "fatal" || v.severity === "error"
+        ).length;
+        const numWarnings = allViolations.filter((v) => v.severity === "warning").length;
+        cliContext.instrumentPostHogEvent({
+            command: "fern check",
+            properties: {
+                validationRules: firedRules,
+                numErrors,
+                numWarnings,
+                passed: !hasErrors && !hasAnyErrors,
+                abortReason
+            }
+        });
     }
 }

--- a/packages/cli/yaml/docs-validator/src/createDocsConfigFileAstVisitorForRules.ts
+++ b/packages/cli/yaml/docs-validator/src/createDocsConfigFileAstVisitorForRules.ts
@@ -40,7 +40,7 @@ export function createDocsConfigFileAstVisitorForRules({
                     const severityOverride = severityOverrides?.get(ruleName);
                     addViolations(
                         ruleViolations.map((violation) => ({
-                            name: violation.name,
+                            name: violation.name ?? ruleName,
                             severity: severityOverride ?? violation.severity,
                             relativeFilepath: violation.relativeFilepath ?? RelativeFilePath.of(""),
                             nodePath: violation.nodePath ?? nodePath,


### PR DESCRIPTION
## Description

Adds telemetry to the `fern check` command so PostHog captures which validation rules produced violations, and ensures the metric is always emitted — even when the run aborts early.

## Changes Made

- After validation completes (or aborts), emits a PostHog event with:
  - `validationRules`: deduplicated array of rule names that produced violations
  - `numErrors`: count of fatal/error-severity violations
  - `numWarnings`: count of warning-severity violations
  - `passed`: boolean indicating whether the check passed
  - `abortReason`: string describing why the run didn't complete (e.g. `"missing api.yml"`, `"validation errors"`, `"project load failed"`, or the error message on unexpected crashes). `undefined` when the run completes normally with no violations.
- Wrapped validation logic in try/finally so the metric fires regardless of how the run terminates
- Handles pre-validation failures (project loading, invalid `--api` filter) with their own abort events
- Fixed docs-validator `createDocsConfigFileAstVisitorForRules` to fall back to the rule name when a violation doesn't explicitly set its own `name` field — ensures rules like `missing-redirects` are always identified in telemetry
- Added unreleased changelog entry

## Testing

- [x] All 172 docs-validator unit tests pass
- [x] Full compilation of all 94 packages succeeds with 0 errors
- [x] Biome lint passes with no issues

Link to Devin session: https://app.devin.ai/sessions/56d3717fb23e4295afbcd7d1347d788f
Requested by: @dannysheridan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->