### PR TITLE
fix(python): skip pydantic v1 test for deps_with_min_python_version fixture

### DIFF
--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -235,6 +235,8 @@ fixtures:
         extra_dependencies:
           boto3: 1.35.76
       outputFolder: deps_with_min_python_version
+      skipScripts:
+        - test-pydantic-v1
     - customConfig:
         extra_dev_dependencies:
           requests_mock: 1.12.1
@@ -499,7 +501,6 @@ scripts:
         - poetry run pytest -rP -n auto -m aiohttp .
 allowedFailures:
   - examples:legacy-wire-tests
-  - exhaustive:deps_with_min_python_version
   - oauth-client-credentials-custom
   - streaming-parameter
   - trace


### PR DESCRIPTION
## Description

Removes `exhaustive:deps_with_min_python_version` from `allowedFailures`.

## Changes Made

- Added `skipScripts: [test-pydantic-v1]` to `deps_with_min_python_version` output folder config in `seed.yml`
- Removed `exhaustive:deps_with_min_python_version` from `allowedFailures`

**Root cause:** The `test-pydantic-v1` script runs `poetry add pydantic=^1.10` which constrains pydantic to v1.x. But this fixture has `langchain: ^1.2.15` and `langchain-openai: ^1.1.14` as dev dependencies, which transitively require `pydantic >=2.7.4`. Poetry cannot resolve this conflict.

Same pattern as the existing `pydantic-v2-wrapped` fixture which already uses `skipScripts: [test-pydantic-v1]`.

## Testing

- `pnpm seed:local test --generator python-sdk --fixture exhaustive --outputFolder deps_with_min_python_version` → `1/1 test cases passed`
- `poetry run mypy .` → `Success: no issues found in 142 source files`
- `poetry run pytest -rP -n auto .` → `66 passed, 4 skipped`

Link to Devin session: https://app.devin.ai/sessions/4e0c080d0e2a40bbb153fa05e4dd653d
Requested by: @iamnamananand996