### PR TITLE
fix(cli-generator): trigger release to bundle rust-sdk 0.40.5 error.rs fix

### DIFF
--- a/generators/cli/changes/unreleased/bump-embedded-rust-sdk-error-fix.yml
+++ b/generators/cli/changes/unreleased/bump-embedded-rust-sdk-error-fix.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Rebuild embedded SDK generation to pick up rust-sdk 0.40.5 error.rs
+    codegen fix — named/non-primitive error body fields now emit correct
+    imports and use serde_json::from_value() instead of as_str().
+  type: fix


### PR DESCRIPTION
## Description
Refs FER-11169

The CLI generator (0.17.2) was released before the rust-sdk 0.40.5 error.rs codegen fix landed on main. Since the CLI generator invokes the rust-sdk generator as a child process (`generateEmbeddedSdk.ts`) and bundles its compiled CLI at Docker image build time, a new release is needed to pick up the fix.

## Changes Made
- Add unreleased changelog entry under `generators/cli/changes/unreleased/` to trigger 0.17.3 release
- No code changes — the fix is already on main in `generators/rust/sdk/src/error/ErrorGenerator.ts` (PR #16421)

When this merges, the release automation will:
1. Bump CLI generator to 0.17.3
2. Build the Docker image (which bundles the current rust-sdk code from main)
3. Publish `fernapi/fern-cli-generator:0.17.3`

## Testing
- No new tests needed — the rust-sdk fix already has unit tests and seed fixtures (PR #16421)
- After release, downstream projects (e.g. sarvam-cli) can bump to 0.17.3 and remove their `.fernignore`/hand-patched `error.rs`

Link to Devin session: https://app.devin.ai/sessions/956981812c87459193e538773ebee01c
Requested by: @cade-fern