### PR TITLE
fix(csharp): always clone request before send to prevent ObjectDisposedException on retry

### DIFF
--- a/generators/csharp/base/src/asIs/RawClient.Template.cs
+++ b/generators/csharp/base/src/asIs/RawClient.Template.cs
@@ -151,21 +151,14 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
             return new global::<%= namespace%>.ApiResponse { StatusCode = (int)response.StatusCode, Raw = response };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/generators/csharp/base/src/asIs/RawClient.Template.cs
+++ b/generators/csharp/base/src/asIs/RawClient.Template.cs
@@ -166,27 +166,27 @@ internal partial class RawClient(ClientOptions clientOptions)
         // it sends, so sending the original would leave its Content disposed and cause
         // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
         // original Content alive across the entire retry loop.
-        HttpResponseMessage? response = null;
+        HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
             if (attempt > 0)
             {
-                var delayMs = GetRetryDelayFromHeaders(response!, attempt - 1);
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
                 await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
             using var attemptRequest = await CloneRequestAsync(request, cancellationToken).ConfigureAwait(false);
-            response = await httpClient
+            retryResponse = await httpClient
                 .SendAsync(attemptRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
 
-            if (!ShouldRetry(response))
+            if (!ShouldRetry(retryResponse))
             {
                 break;
             }
         }
 
-        return new global::<%= namespace%>.ApiResponse { StatusCode = (int)response!.StatusCode, Raw = response };
+        return new global::<%= namespace%>.ApiResponse { StatusCode = (int)retryResponse!.StatusCode, Raw = retryResponse };
     }
 
     private static bool ShouldRetry(HttpResponseMessage response)

--- a/generators/csharp/base/src/asIs/RawClient.Template.cs
+++ b/generators/csharp/base/src/asIs/RawClient.Template.cs
@@ -64,7 +64,10 @@ internal partial class RawClient(ClientOptions clientOptions)
         return await SendWithRetriesAsync(request, options, cts.Token).ConfigureAwait(false);
     }
 
-    private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage request)
+    private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
+    )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
         clonedRequest.Version = request.Version;
@@ -88,7 +91,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -103,7 +110,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request.Content.CopyToAsync(bodyStream, cancellationToken).ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -135,31 +146,47 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::<%= namespace%>.ApiResponse { StatusCode = (int)response.StatusCode, Raw = response };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? response = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
+            if (attempt > 0)
+            {
+                var delayMs = GetRetryDelayFromHeaders(response!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
+            }
+
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken).ConfigureAwait(false);
+            response = await httpClient
+                .SendAsync(attemptRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
+
             if (!ShouldRetry(response))
             {
                 break;
             }
-
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
-                .SendAsync(retryRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-                .ConfigureAwait(false);
         }
 
-        return new global::<%= namespace%>.ApiResponse { StatusCode = (int)response.StatusCode, Raw = response };
+        return new global::<%= namespace%>.ApiResponse { StatusCode = (int)response!.StatusCode, Raw = response };
     }
 
     private static bool ShouldRetry(HttpResponseMessage response)

--- a/generators/csharp/base/src/asIs/test/RawClientTests/RetriesTests.Template.cs
+++ b/generators/csharp/base/src/asIs/test/RawClientTests/RetriesTests.Template.cs
@@ -404,12 +404,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -458,10 +454,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/generators/csharp/base/src/asIs/test/RawClientTests/RetriesTests.Template.cs
+++ b/generators/csharp/base/src/asIs/test/RawClientTests/RetriesTests.Template.cs
@@ -401,10 +401,147 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(<%= retryStatusCodes === "recommended" ? 503 : 500 %>));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries<%= clientOptionsRequiredDefaults %> }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(<%= retryStatusCodes === "recommended" ? 503 : 500 %>));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(<%= retryStatusCodes === "recommended" ? 503 : 500 %>));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(<%= retryStatusCodes === "recommended" ? 503 : 500 %>));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries<%= clientOptionsRequiredDefaults %> }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner) : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/generators/csharp/sdk/changes/unreleased/fix-retry-object-disposed-exception.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-retry-object-disposed-exception.yml
@@ -1,0 +1,14 @@
+- summary: |
+    Fix `ObjectDisposedException` thrown from `RawClient.CloneRequestAsync` when retrying a request
+    with retryable content (JSON or buffered multipart). The retry loop previously sent the original
+    `HttpRequestMessage` for the initial attempt and only cloned for retries; under HTTP/2 (and some
+    other configurations) `HttpClient` disposes the Content of every request it sends, leaving the
+    original's Content disposed by the time the first retry tried to clone it. The loop now always
+    sends a clone — never the original — for retryable content with at least one retry budgeted.
+
+    Same fix also: clamps negative `MaxRetries` values to `0` (would have surfaced as
+    `NullReferenceException` under the new loop structure); short-circuits `MaxRetries == 0` and the
+    non-retryable content path through a fast lane that sends the original directly with no cloning
+    cost; and threads the caller's `CancellationToken` into `CloneRequestAsync`'s body-buffering so
+    cancellation requests during large-body clones are honoured promptly (.NET 5+).
+  type: fix

--- a/seed/csharp-sdk/accept-header/.fern/metadata.json
+++ b/seed/csharp-sdk/accept-header/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/accept-header/src/SeedAccept.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/accept-header/src/SeedAccept.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/RawClient.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedAccept.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedAccept.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/Core/RawClient.cs
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/alias-extends/.fern/metadata.json
+++ b/seed/csharp-sdk/alias-extends/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/RawClient.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/RawClient.cs
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedAliasExtends.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedAliasExtends.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/alias/.fern/metadata.json
+++ b/seed/csharp-sdk/alias/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/alias/src/SeedAlias.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/alias/src/SeedAlias.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/RawClient.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/alias/src/SeedAlias/Core/RawClient.cs
+++ b/seed/csharp-sdk/alias/src/SeedAlias/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedAlias.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedAlias.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/allof-inline/.fern/metadata.json
+++ b/seed/csharp-sdk/allof-inline/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/allof-inline/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/allof-inline/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/allof-inline/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/allof-inline/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/allof-inline/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/allof-inline/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/allof-inline/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/allof-inline/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/allof/.fern/metadata.json
+++ b/seed/csharp-sdk/allof/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/allof/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/allof/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/allof/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/allof/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/allof/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/allof/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/allof/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/allof/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/any-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/any-auth/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedAnyAuth.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedAnyAuth.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/api-wide-base-path-with-default/.fern/metadata.json
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path-with-default/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/api-wide-base-path/.fern/metadata.json
+++ b/seed/csharp-sdk/api-wide-base-path/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/RawClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/RawClient.cs
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApiWideBasePath.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApiWideBasePath.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/audiences/.fern/metadata.json
+++ b/seed/csharp-sdk/audiences/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/audiences/src/SeedAudiences.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/audiences/src/SeedAudiences.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/RawClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedAudiences.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedAudiences.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/Core/RawClient.cs
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedBasicAuthEnvironmentVariables.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedBasicAuthEnvironmentVariables.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/basic-auth-pw-omitted/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth-pw-omitted/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedBasicAuthPwOmitted.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedBasicAuthPwOmitted.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/basic-auth/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedBasicAuth.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedBasicAuth.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/basic-auth/unified-client-options/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "unified-client-options": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -405,12 +405,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -464,10 +460,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -402,10 +402,161 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions
+            {
+                HttpClient = disposingClient,
+                MaxRetries = MaxRetries,
+                BaseUrl = "http://localhost",
+            }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions
+            {
+                HttpClient = disposingClient,
+                MaxRetries = MaxRetries,
+                BaseUrl = "http://localhost",
+            }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedBasicAuth.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedBasicAuth.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/basic-auth/wire-tests/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth/wire-tests/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "enable-wire-tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedBasicAuth.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedBasicAuth.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedBearerTokenEnvironmentVariable.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedBearerTokenEnvironmentVariable.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/.fern/metadata.json
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "unified-client-options": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable.Test/Core/RawClientTests/RetriesTests.cs
@@ -405,12 +405,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -464,10 +460,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable.Test/Core/RawClientTests/RetriesTests.cs
@@ -402,10 +402,161 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions
+            {
+                HttpClient = disposingClient,
+                MaxRetries = MaxRetries,
+                BaseUrl = "http://localhost",
+            }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions
+            {
+                HttpClient = disposingClient,
+                MaxRetries = MaxRetries,
+                BaseUrl = "http://localhost",
+            }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedBearerTokenEnvironmentVariable.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedBearerTokenEnvironmentVariable.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/bytes-download/.fern/metadata.json
+++ b/seed/csharp-sdk/bytes-download/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/RawClient.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/RawClient.cs
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedBytesDownload.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedBytesDownload.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/bytes-upload/.fern/metadata.json
+++ b/seed/csharp-sdk/bytes-upload/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/RawClient.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/RawClient.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedBytesUpload.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedBytesUpload.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/csharp-sdk/circular-references-advanced/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/circular-references-extends/.fern/metadata.json
+++ b/seed/csharp-sdk/circular-references-extends/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/circular-references-extends/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/circular-references-extends/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/circular-references-extends/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/circular-references-extends/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/circular-references-extends/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/circular-references-extends/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/circular-references-extends/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/circular-references-extends/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/circular-references/.fern/metadata.json
+++ b/seed/csharp-sdk/circular-references/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/circular-references/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/circular-references/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/circular-references/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/cli-multi-spec-namespaced/.fern/metadata.json
+++ b/seed/csharp-sdk/cli-multi-spec-namespaced/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/cli-multi-spec-namespaced/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/cli-multi-spec-namespaced/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/cli-multi-spec-namespaced/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/cli-multi-spec-namespaced/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/cli-multi-spec-namespaced/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/cli-multi-spec-namespaced/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/cli-multi-spec-namespaced/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/cli-multi-spec-namespaced/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/cli-multi-spec/.fern/metadata.json
+++ b/seed/csharp-sdk/cli-multi-spec/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/cli-multi-spec/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/cli-multi-spec/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/cli-multi-spec/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/cli-multi-spec/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/cli-multi-spec/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/cli-multi-spec/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/cli-multi-spec/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/cli-multi-spec/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/client-side-params/.fern/metadata.json
+++ b/seed/csharp-sdk/client-side-params/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/RawClient.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/RawClient.cs
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedClientSideParams.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedClientSideParams.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/content-type/.fern/metadata.json
+++ b/seed/csharp-sdk/content-type/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/RawClient.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedContentTypes.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedContentTypes.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/RawClient.cs
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/cross-package-type-names/.fern/metadata.json
+++ b/seed/csharp-sdk/cross-package-type-names/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/RawClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/RawClient.cs
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedCrossPackageTypeNames.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedCrossPackageTypeNames.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/RawClient.cs
@@ -153,10 +153,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -167,11 +163,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/Core/RawClient.cs
@@ -64,7 +64,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -90,7 +91,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -105,7 +110,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -137,14 +148,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -152,29 +167,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -153,10 +153,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -167,11 +163,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -64,7 +64,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -90,7 +91,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -105,7 +110,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -137,14 +148,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -152,29 +167,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "package-id": "Seed.Client"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/RawClient.cs
@@ -153,10 +153,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -167,11 +163,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/Core/RawClient.cs
@@ -64,7 +64,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -90,7 +91,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -105,7 +110,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -137,14 +148,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -152,29 +167,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/.fern/metadata.json
@@ -1,15 +1,14 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "read-only-memory-types": [
       "float"
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/RawClient.cs
@@ -153,10 +153,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -167,11 +163,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/Core/RawClient.cs
@@ -64,7 +64,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -90,7 +91,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -105,7 +110,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -137,14 +148,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -152,29 +167,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -153,10 +153,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -167,11 +163,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -64,7 +64,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -90,7 +91,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -105,7 +110,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -137,14 +148,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -152,29 +167,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-inline-types/inline-types/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-inline-types/inline-types/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "enable-inline-types": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedObject.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedObject.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/.fern/metadata.json
@@ -1,15 +1,14 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "namespace": "Contoso.Net",
     "client-class-name": "Contoso",
     "explicit-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::Contoso.Net.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::Contoso.Net.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/.fern/metadata.json
@@ -1,14 +1,13 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "experimental-fully-qualified-namespaces": true,
     "experimental-dotnet-format": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Core/RawClientTests/RetriesTests.cs
@@ -396,10 +396,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/Core/RawClientTests/RetriesTests.cs
@@ -399,12 +399,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -453,10 +449,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/RawClient.cs
@@ -147,21 +147,14 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
             return new ApiResponse { StatusCode = (int)response.StatusCode, Raw = response };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/Core/RawClient.cs
@@ -55,7 +55,10 @@ internal partial class RawClient(ClientOptions clientOptions)
         return await SendWithRetriesAsync(request, options, cts.Token).ConfigureAwait(false);
     }
 
-    private static async Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage request)
+    private static async Task<HttpRequestMessage> CloneRequestAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
+    )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri)
         {
@@ -82,7 +85,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -97,7 +104,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -129,37 +142,52 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new ApiResponse { StatusCode = (int)response.StatusCode, Raw = response };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
-        return new ApiResponse { StatusCode = (int)response.StatusCode, Raw = response };
+        return new ApiResponse { StatusCode = (int)retryResponse!.StatusCode, Raw = retryResponse };
     }
 
     private static bool ShouldRetry(HttpResponseMessage response)

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/.fern/metadata.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "namespace": "Contoso.Net",
     "client-class-name": "Contoso",
@@ -9,8 +9,7 @@
     "experimental-fully-qualified-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::Contoso.Net.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::Contoso.Net.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/.fern/metadata.json
@@ -1,15 +1,14 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "namespace": "Contoso.Net",
     "client-class-name": "ContosoClient",
     "explicit-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::Contoso.Net.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::Contoso.Net.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/.fern/metadata.json
@@ -1,15 +1,14 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "namespace": "Seed.CsharpNamespaceConflict",
     "client-class-name": "Seed",
     "experimental-fully-qualified-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::Seed.CsharpNamespaceConflict.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::Seed.CsharpNamespaceConflict.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-readonly-request/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-readonly-request/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedCsharpReadonlyRequest.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedCsharpReadonlyRequest.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-system-collision/system-client/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "client-class-name": "System"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedCsharpSystemCollision.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedCsharpSystemCollision.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedCsharpXmlEntities.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedCsharpXmlEntities.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/RawClient.cs
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/dollar-string-examples/.fern/metadata.json
+++ b/seed/csharp-sdk/dollar-string-examples/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedDollarStringExamples.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedDollarStringExamples.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/empty-clients/.fern/metadata.json
+++ b/seed/csharp-sdk/empty-clients/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/RawClient.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/RawClient.cs
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedEmptyClients.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedEmptyClients.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/endpoint-security-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/endpoint-security-auth/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedEndpointSecurityAuth.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedEndpointSecurityAuth.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/enum/forward-compatible-enums/.fern/metadata.json
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/RawClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/RawClient.cs
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedEnum.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedEnum.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/enum/plain-enums/.fern/metadata.json
+++ b/seed/csharp-sdk/enum/plain-enums/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "enable-forward-compatible-enums": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/RawClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/RawClient.cs
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedEnum.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedEnum.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/error-property/.fern/metadata.json
+++ b/seed/csharp-sdk/error-property/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedErrorProperty.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedErrorProperty.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/errors/.fern/metadata.json
+++ b/seed/csharp-sdk/errors/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/errors/src/SeedErrors.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/errors/src/SeedErrors.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/RawClient.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/errors/src/SeedErrors/Core/RawClient.cs
+++ b/seed/csharp-sdk/errors/src/SeedErrors/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedErrors.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedErrors.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/examples/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/examples/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedExamples.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedExamples.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/examples/readme-config/.fern/metadata.json
+++ b/seed/csharp-sdk/examples/readme-config/.fern/metadata.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "custom-readme-sections": [
       {
@@ -15,8 +15,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedExamples.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedExamples.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/RawClient.cs
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "explicit-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedExhaustive.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedExhaustive.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedExhaustive.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedExhaustive.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "generate-error-types": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedExhaustive.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedExhaustive.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "root-namespace-for-core-classes": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedExhaustive.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedExhaustive.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "redact-response-body-on-error": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedExhaustive.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedExhaustive.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "use-undiscriminated-unions": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Core/RawClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedExhaustive.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedExhaustive.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/extends/.fern/metadata.json
+++ b/seed/csharp-sdk/extends/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/extends/src/SeedExtends.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/extends/src/SeedExtends.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/RawClient.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/extends/src/SeedExtends/Core/RawClient.cs
+++ b/seed/csharp-sdk/extends/src/SeedExtends/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedExtends.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedExtends.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/extra-properties/.fern/metadata.json
+++ b/seed/csharp-sdk/extra-properties/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/RawClient.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/RawClient.cs
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedExtraProperties.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedExtraProperties.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/file-download/.fern/metadata.json
+++ b/seed/csharp-sdk/file-download/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedFileDownload.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedFileDownload.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/file-upload-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/file-upload-openapi/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/file-upload/.fern/metadata.json
+++ b/seed/csharp-sdk/file-upload/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/RawClient.cs
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedFileUpload.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedFileUpload.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/folders/.fern/metadata.json
+++ b/seed/csharp-sdk/folders/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/folders/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/folders/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/folders/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/folders/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/header-auth-environment-variable/.fern/metadata.json
+++ b/seed/csharp-sdk/header-auth-environment-variable/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/RawClient.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedHeaderTokenEnvironmentVariable.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedHeaderTokenEnvironmentVariable.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/RawClient.cs
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/header-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/header-auth/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/RawClient.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/RawClient.cs
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedHeaderToken.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedHeaderToken.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/http-head/.fern/metadata.json
+++ b/seed/csharp-sdk/http-head/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/RawClient.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedHttpHead.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedHttpHead.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/RawClient.cs
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/idempotency-headers/.fern/metadata.json
+++ b/seed/csharp-sdk/idempotency-headers/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/RawClient.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedIdempotencyHeaders.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedIdempotencyHeaders.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/RawClient.cs
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/imdb/exception-class-names/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/exception-class-names/.fern/metadata.json
@@ -1,14 +1,13 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "base-api-exception-class-name": "CustomApiException",
     "base-exception-class-name": "CustomException"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/imdb/exported-client-class-name/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/.fern/metadata.json
@@ -1,15 +1,14 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "client-class-name": "BaseClient",
     "exported-client-class-name": "CustomClient",
     "maxRetries": 5
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/imdb/extra-dependencies-override/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/extra-dependencies-override/.fern/metadata.json
@@ -1,15 +1,14 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "extra-dependencies": {
       "PolySharp": "1.14.0"
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/imdb/extra-dependencies/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/extra-dependencies/.fern/metadata.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "extra-dependencies": {
       "Moq": "4.20.70",
@@ -9,8 +9,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/imdb/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/include-exception-handler/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/imdb/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/imdb/omit-fern-headers/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "omit-fern-headers": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/inferred-auth-explicit/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-explicit/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedInferredAuthExplicit.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedInferredAuthExplicit.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedInferredAuthImplicitApiKey.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedInferredAuthImplicitApiKey.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedInferredAuthImplicitNoExpiry.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedInferredAuthImplicitNoExpiry.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedInferredAuthImplicit.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedInferredAuthImplicit.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/inferred-auth-implicit/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-implicit/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/RawClient.cs
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedInferredAuthImplicit.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedInferredAuthImplicit.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/license/custom-license/.fern/metadata.json
+++ b/seed/csharp-sdk/license/custom-license/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/RawClient.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedLicense.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedLicense.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/RawClient.cs
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/license/mit-license/.fern/metadata.json
+++ b/seed/csharp-sdk/license/mit-license/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/RawClient.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedLicense.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedLicense.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/RawClient.cs
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/literal-user-agent/.fern/metadata.json
+++ b/seed/csharp-sdk/literal-user-agent/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent/Core/RawClient.cs
+++ b/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent/Core/RawClient.cs
+++ b/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedLiteralUserAgent.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedLiteralUserAgent.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/literal/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/literal/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/RawClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/RawClient.cs
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedLiteral.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedLiteral.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/literal/readonly-constants/.fern/metadata.json
+++ b/seed/csharp-sdk/literal/readonly-constants/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "generate-literals": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/RawClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/RawClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedLiteral.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedLiteral.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/literals-unions/.fern/metadata.json
+++ b/seed/csharp-sdk/literals-unions/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedLiteralsUnions.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedLiteralsUnions.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/mixed-case/.fern/metadata.json
+++ b/seed/csharp-sdk/mixed-case/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/RawClient.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/RawClient.cs
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedMixedCase.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedMixedCase.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/mixed-file-directory/.fern/metadata.json
+++ b/seed/csharp-sdk/mixed-file-directory/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/RawClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/RawClient.cs
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedMixedFileDirectory.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedMixedFileDirectory.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/multi-line-docs/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-line-docs/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedMultiLineDocs.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedMultiLineDocs.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/multi-url-environment-no-default/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-url-environment-no-default/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedMultiUrlEnvironmentNoDefault.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedMultiUrlEnvironmentNoDefault.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/multi-url-environment-reference/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-url-environment-reference/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "environment-class-name": "CustomEnvironment"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedMultiUrlEnvironment.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedMultiUrlEnvironment.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "pascal-case-environments": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedMultiUrlEnvironment.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedMultiUrlEnvironment.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/multiple-request-bodies/.fern/metadata.json
+++ b/seed/csharp-sdk/multiple-request-bodies/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/no-content-response/.fern/metadata.json
+++ b/seed/csharp-sdk/no-content-response/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/no-content-response/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/no-content-response/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/no-content-response/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/no-content-response/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/no-content-response/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/no-content-response/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/no-content-response/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/no-content-response/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/no-environment/.fern/metadata.json
+++ b/seed/csharp-sdk/no-environment/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedNoEnvironment.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedNoEnvironment.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/RawClient.cs
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/no-retries/.fern/metadata.json
+++ b/seed/csharp-sdk/no-retries/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/RawClient.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedNoRetries.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedNoRetries.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/RawClient.cs
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/null-type/.fern/metadata.json
+++ b/seed/csharp-sdk/null-type/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/null-type/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/null-type/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/null-type/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/null-type/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/null-type/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/null-type/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/null-type/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/null-type/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/nullable-allof-extends/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable-allof-extends/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "experimental-explicit-nullable-optional": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedNullableOptional.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedNullableOptional.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedNullableOptional.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedNullableOptional.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/nullable-request-body/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable-request-body/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "experimental-explicit-nullable-optional": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedNullable.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedNullable.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/nullable/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/RawClient.cs
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedNullable.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedNullable.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedOauthClientCredentials.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedOauthClientCredentials.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-default/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedOauthClientCredentialsDefault.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedOauthClientCredentialsDefault.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedOauthClientCredentialsEnvironmentVariables.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedOauthClientCredentialsEnvironmentVariables.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedOauthClientCredentialsMandatoryAuth.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedOauthClientCredentialsMandatoryAuth.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "unified-client-options": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -407,12 +407,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -468,10 +464,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -404,10 +404,165 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions
+            {
+                HttpClient = disposingClient,
+                MaxRetries = MaxRetries,
+                BaseUrl = "http://localhost",
+                ClientId = "test",
+                ClientSecret = "test",
+            }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions
+            {
+                HttpClient = disposingClient,
+                MaxRetries = MaxRetries,
+                BaseUrl = "http://localhost",
+                ClientId = "test",
+                ClientSecret = "test",
+            }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedOauthClientCredentialsMandatoryAuth.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedOauthClientCredentialsMandatoryAuth.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedOauthClientCredentials.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedOauthClientCredentials.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedOauthClientCredentialsReference.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedOauthClientCredentialsReference.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedOauthClientCredentialsWithVariables.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedOauthClientCredentialsWithVariables.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedOauthClientCredentials.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedOauthClientCredentials.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/RawClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedOauthClientCredentials.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedOauthClientCredentials.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/object/.fern/metadata.json
+++ b/seed/csharp-sdk/object/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/object/src/SeedObject.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/object/src/SeedObject.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/object/src/SeedObject.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/object/src/SeedObject.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/object/src/SeedObject/Core/RawClient.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/object/src/SeedObject/Core/RawClient.cs
+++ b/seed/csharp-sdk/object/src/SeedObject/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedObject.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedObject.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/objects-with-imports/.fern/metadata.json
+++ b/seed/csharp-sdk/objects-with-imports/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedObjectsWithImports.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedObjectsWithImports.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/openapi-request-body-ref/.fern/metadata.json
+++ b/seed/csharp-sdk/openapi-request-body-ref/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/optional/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/optional/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedObjectsWithImports.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedObjectsWithImports.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/.fern/metadata.json
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "simplify-object-dictionaries": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/RawClient.cs
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedObjectsWithImports.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedObjectsWithImports.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/package-yml/.fern/metadata.json
+++ b/seed/csharp-sdk/package-yml/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/RawClient.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/RawClient.cs
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedPackageYml.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedPackageYml.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/pagination-custom/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination-custom/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedPagination.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedPagination.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/pagination-uri-path/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination-uri-path/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedPaginationUriPath.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedPaginationUriPath.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/.fern/metadata.json
@@ -1,14 +1,13 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "custom-pager-name": "MyPager",
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedPagination.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedPagination.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/pagination/custom-pager/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination/custom-pager/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "custom-pager-name": "MyPager"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedPagination.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedPagination.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/pagination/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedPagination.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedPagination.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/pagination/page-index-semantics/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination/page-index-semantics/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "offset-semantics": "page-index"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination/Core/RawClient.cs
+++ b/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedPagination.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedPagination.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/path-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedPathParameters.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedPathParameters.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/.fern/metadata.json
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "inline-path-parameters": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedPathParameters.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedPathParameters.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/plain-text/.fern/metadata.json
+++ b/seed/csharp-sdk/plain-text/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/RawClient.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/RawClient.cs
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedPlainText.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedPlainText.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/property-access/.fern/metadata.json
+++ b/seed/csharp-sdk/property-access/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/RawClient.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/RawClient.cs
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedPropertyAccess.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedPropertyAccess.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/public-object/.fern/metadata.json
+++ b/seed/csharp-sdk/public-object/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/RawClient.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/RawClient.cs
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedPublicObject.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedPublicObject.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/query-param-name-conflict/.fern/metadata.json
+++ b/seed/csharp-sdk/query-param-name-conflict/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/query-param-name-conflict/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/query-param-name-conflict/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/query-param-name-conflict/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/query-param-name-conflict/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/query-param-name-conflict/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-param-name-conflict/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/query-param-name-conflict/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-param-name-conflict/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/query-parameters-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/query-parameters-openapi/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/query-parameters/.fern/metadata.json
+++ b/seed/csharp-sdk/query-parameters/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedQueryParameters.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedQueryParameters.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/request-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedRequestParameters.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedRequestParameters.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/request-parameters/with-defaults/.fern/metadata.json
+++ b/seed/csharp-sdk/request-parameters/with-defaults/.fern/metadata.json
@@ -1,15 +1,14 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "use-default-request-parameter-values": true,
     "experimental-explicit-nullable-optional": true,
     "use-undiscriminated-unions": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedRequestParameters.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedRequestParameters.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/.fern/metadata.json
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "experimental-explicit-nullable-optional": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/required-nullable/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/reserved-keywords/.fern/metadata.json
+++ b/seed/csharp-sdk/reserved-keywords/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedNurseryApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedNurseryApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/response-property/.fern/metadata.json
+++ b/seed/csharp-sdk/response-property/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedResponseProperty.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedResponseProperty.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/schemaless-request-body-examples/.fern/metadata.json
+++ b/seed/csharp-sdk/schemaless-request-body-examples/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/server-sent-event-examples/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-event-examples/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedServerSentEvents.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedServerSentEvents.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/server-sent-events-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-events-openapi/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/server-sent-events-resumable/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-events-resumable/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-events-resumable/src/SeedServerSentEventsResumable/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedServerSentEventsResumable.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedServerSentEventsResumable.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/server-sent-events/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-events/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedServerSentEvents.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedServerSentEvents.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/server-url-templating/.fern/metadata.json
+++ b/seed/csharp-sdk/server-url-templating/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/.fern/metadata.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "output-path": {
       "library": "lib/SeedApi",
@@ -11,8 +11,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedSimpleApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedSimpleApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/simple-api/custom-output-path/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-api/custom-output-path/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "output-path": "custom-src"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedSimpleApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedSimpleApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/simple-api/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-api/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedSimpleApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedSimpleApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/simple-api/use-sln-format/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-api/use-sln-format/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "sln-format": "sln"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedSimpleApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedSimpleApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/simple-fhir/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-fhir/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/single-url-environment-default/.fern/metadata.json
+++ b/seed/csharp-sdk/single-url-environment-default/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedSingleUrlEnvironmentDefault.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedSingleUrlEnvironmentDefault.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/single-url-environment-no-default/.fern/metadata.json
+++ b/seed/csharp-sdk/single-url-environment-no-default/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/RawClient.cs
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedSingleUrlEnvironmentNoDefault.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedSingleUrlEnvironmentNoDefault.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/csharp-sdk/streaming-parameter/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedStreaming.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedStreaming.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/streaming/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/streaming/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedStreaming.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedStreaming.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/.fern/metadata.json
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "redact-response-body-on-error": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/RawClient.cs
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedStreaming.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedStreaming.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/trace/.fern/metadata.json
+++ b/seed/csharp-sdk/trace/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/trace/src/SeedTrace.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/trace/src/SeedTrace.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/RawClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedTrace.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedTrace.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/trace/src/SeedTrace/Core/RawClient.cs
+++ b/seed/csharp-sdk/trace/src/SeedTrace/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedUndiscriminatedUnionWithResponseProperty.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedUndiscriminatedUnionWithResponseProperty.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedUndiscriminatedUnions.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedUndiscriminatedUnions.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/.fern/metadata.json
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "use-undiscriminated-unions": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedUndiscriminatedUnions.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedUndiscriminatedUnions.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/union-query-parameters/.fern/metadata.json
+++ b/seed/csharp-sdk/union-query-parameters/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/union-query-parameters/src/SeedUnionQueryParameters.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/union-query-parameters/src/SeedUnionQueryParameters.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/union-query-parameters/src/SeedUnionQueryParameters.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/union-query-parameters/src/SeedUnionQueryParameters.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/union-query-parameters/src/SeedUnionQueryParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/union-query-parameters/src/SeedUnionQueryParameters/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedUnionQueryParameters.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedUnionQueryParameters.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/union-query-parameters/src/SeedUnionQueryParameters/Core/RawClient.cs
+++ b/seed/csharp-sdk/union-query-parameters/src/SeedUnionQueryParameters/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/csharp-sdk/unions-with-local-date/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedUnions.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedUnions.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/unions/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedUnions.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedUnions.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/unions/no-discriminated-unions/.fern/metadata.json
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "use-discriminated-unions": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/RawClient.cs
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedUnions.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedUnions.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/unknown/.fern/metadata.json
+++ b/seed/csharp-sdk/unknown/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/RawClient.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedUnknownAsAny.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedUnknownAsAny.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/RawClient.cs
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/validation/.fern/metadata.json
+++ b/seed/csharp-sdk/validation/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/validation/src/SeedValidation.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/validation/src/SeedValidation.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/RawClient.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedValidation.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedValidation.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/validation/src/SeedValidation/Core/RawClient.cs
+++ b/seed/csharp-sdk/validation/src/SeedValidation/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/variables/.fern/metadata.json
+++ b/seed/csharp-sdk/variables/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/variables/src/SeedVariables.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/variables/src/SeedVariables.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/variables/src/SeedVariables/Core/RawClient.cs
+++ b/seed/csharp-sdk/variables/src/SeedVariables/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedVariables.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedVariables.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/version-no-default/.fern/metadata.json
+++ b/seed/csharp-sdk/version-no-default/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/RawClient.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/RawClient.cs
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedVersion.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedVersion.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/version/.fern/metadata.json
+++ b/seed/csharp-sdk/version/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/version/src/SeedVersion.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/version/src/SeedVersion.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/RawClient.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/version/src/SeedVersion/Core/RawClient.cs
+++ b/seed/csharp-sdk/version/src/SeedVersion/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedVersion.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedVersion.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/webhook-audience/.fern/metadata.json
+++ b/seed/csharp-sdk/webhook-audience/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/webhooks/.fern/metadata.json
+++ b/seed/csharp-sdk/webhooks/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/RawClient.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/RawClient.cs
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedWebhooks.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedWebhooks.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/websocket-bearer-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket-bearer-auth/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedWebsocketBearerAuth.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedWebsocketBearerAuth.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/websocket-inferred-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket-inferred-auth/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedWebsocketAuth.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedWebsocketAuth.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/.fern/metadata.json
@@ -1,13 +1,12 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "experimental-enable-websockets": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedWebsocketMultiUrl.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedWebsocketMultiUrl.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/websocket/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket/no-custom-config/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedWebsocket.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedWebsocket.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/websocket/with-websockets/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket/with-websockets/.fern/metadata.json
@@ -1,14 +1,13 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "generate-literals": true,
     "experimental-enable-websockets": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/RawClient.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedWebsocket.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedWebsocket.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 

--- a/seed/csharp-sdk/x-fern-default/.fern/metadata.json
+++ b/seed/csharp-sdk/x-fern-default/.fern/metadata.json
@@ -1,11 +1,10 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/x-fern-default/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/x-fern-default/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -397,10 +397,151 @@ public class RetriesTests
         }
     }
 
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
+    {
+        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
+        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
+        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
+        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
+        // production condition reliably and guards against regressing the retry loop into sending
+        // the original request instead of a clone.
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        var content = await response.Raw.Content.ReadAsStringAsync();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(content, Is.EqualTo("Success"));
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(2));
+
+            var retriedEntry = _server.LogEntries.ElementAt(1);
+            using var actualJson = JsonDocument.Parse(retriedEntry.RequestMessage.Body!);
+            Assert.That(actualJson.RootElement.GetProperty("key").GetString(), Is.EqualTo("value"));
+        }
+    }
+
+    [Test]
+    public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
+    {
+        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
+        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
+        // even if a regression breaks the second or third clone in the sequence (e.g., a content
+        // type whose CopyToAsync is not idempotent across reads).
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WillSetStateTo("Second")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Second")
+            .WillSetStateTo("Third")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Third")
+            .WillSetStateTo("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(500));
+
+        _server
+            .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
+            .InScenario("DisposeContentMultiRetry")
+            .WhenStateIs("Success")
+            .RespondWith(WireMockResponse.Create().WithStatusCode(200).WithBody("Success"));
+
+        using var disposingClient = new HttpClient(
+            new ContentDisposingHandler(new HttpClientHandler())
+        );
+        var rawClient = new RawClient(
+            new ClientOptions { HttpClient = disposingClient, MaxRetries = MaxRetries }
+        )
+        {
+            BaseRetryDelay = 0,
+        };
+
+        var request = new JsonRequest
+        {
+            BaseUrl = _baseUrl,
+            Method = HttpMethod.Post,
+            Path = "/test",
+            Body = new { key = "value" },
+        };
+
+        var response = await rawClient.SendRequestAsync(request);
+        Assert.That(response.StatusCode, Is.EqualTo(200));
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Initial attempt + 3 retries == 4 requests reaching the server.
+            Assert.That(_server.LogEntries, Has.Count.EqualTo(MaxRetries + 1));
+
+            // Every retried request must have preserved the original body.
+            foreach (var entry in _server.LogEntries)
+            {
+                using var actualJson = JsonDocument.Parse(entry.RequestMessage.Body!);
+                Assert.That(
+                    actualJson.RootElement.GetProperty("key").GetString(),
+                    Is.EqualTo("value")
+                );
+            }
+        }
+    }
+
     [TearDown]
     public void TearDown()
     {
         _server.Dispose();
         _httpClient.Dispose();
+    }
+
+    private sealed class ContentDisposingHandler : DelegatingHandler
+    {
+        public ContentDisposingHandler(HttpMessageHandler inner)
+            : base(inner) { }
+
+        protected override async global::System.Threading.Tasks.Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content?.Dispose();
+            return response;
+        }
     }
 }

--- a/seed/csharp-sdk/x-fern-default/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
+++ b/seed/csharp-sdk/x-fern-default/src/SeedApi.Test/Core/RawClientTests/RetriesTests.cs
@@ -400,12 +400,8 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent()
     {
-        // Production HttpClient (especially HTTP/2 via SocketsHttpHandler) disposes request.Content
-        // after sending. WireMock loopback HTTP/1.1 does not, so we MUST simulate the disposal in
-        // the handler chain — setting request.Version = HttpVersion20 against WireMock won't work
-        // because the server itself only speaks HTTP/1.1. ContentDisposingHandler reproduces the
-        // production condition reliably and guards against regressing the retry loop into sending
-        // the original request instead of a clone.
+        // ContentDisposingHandler simulates HTTP/2's disposal of request.Content after send;
+        // WireMock's loopback HTTP/1.1 path does not exhibit that on its own.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentRetry")
@@ -454,10 +450,7 @@ public class RetriesTests
     [Test]
     public async SystemTask SendRequestAsync_ShouldRetry_WhenHandlerDisposesRequestContent_AcrossMultipleRetries()
     {
-        // Multi-retry variant: three consecutive 5xx responses before the success, exercising the
-        // 2nd and 3rd clones of the same original content. The single-retry test above can pass
-        // even if a regression breaks the second or third clone in the sequence (e.g., a content
-        // type whose CopyToAsync is not idempotent across reads).
+        // Exercises 2nd and 3rd clones — the single-retry variant can pass if those break.
         _server
             .Given(WireMockRequest.Create().WithPath("/test").UsingPost())
             .InScenario("DisposeContentMultiRetry")

--- a/seed/csharp-sdk/x-fern-default/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/x-fern-default/src/SeedApi/Core/RawClient.cs
@@ -146,10 +146,6 @@ internal partial class RawClient(ClientOptions clientOptions)
 
         if (!isRetryableContent || maxRetries == 0)
         {
-            // Fast path — send the original request directly with no cloning when either:
-            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
-            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
-            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
             var response = await httpClient
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                 .ConfigureAwait(false);
@@ -160,11 +156,8 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        // Retryable content with at least one retry budgeted: always send a clone, never the original.
-        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
-        // it sends, so sending the original would leave its Content disposed and cause
-        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
-        // original Content alive across the entire retry loop.
+        // Always send a clone, never the original: HttpClient (e.g. under HTTP/2) disposes
+        // request.Content after sending, which would break the next attempt's clone.
         HttpResponseMessage? retryResponse = null;
         for (var attempt = 0; attempt <= maxRetries; attempt++)
         {

--- a/seed/csharp-sdk/x-fern-default/src/SeedApi/Core/RawClient.cs
+++ b/seed/csharp-sdk/x-fern-default/src/SeedApi/Core/RawClient.cs
@@ -57,7 +57,8 @@ internal partial class RawClient(ClientOptions clientOptions)
     }
 
     private static async global::System.Threading.Tasks.Task<HttpRequestMessage> CloneRequestAsync(
-        HttpRequestMessage request
+        HttpRequestMessage request,
+        CancellationToken cancellationToken = default
     )
     {
         var clonedRequest = new HttpRequestMessage(request.Method, request.RequestUri);
@@ -83,7 +84,11 @@ internal partial class RawClient(ClientOptions clientOptions)
                     foreach (var content in oldMultipartFormContent)
                     {
                         var ms = new MemoryStream();
+#if NET5_0_OR_GREATER
+                        await content.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+#else
                         await content.CopyToAsync(ms).ConfigureAwait(false);
+#endif
                         ms.Position = 0;
                         var newPart = new StreamContent(ms);
                         foreach (var header in content.Headers)
@@ -98,7 +103,13 @@ internal partial class RawClient(ClientOptions clientOptions)
                     break;
                 default:
                     var bodyStream = new MemoryStream();
+#if NET5_0_OR_GREATER
+                    await request
+                        .Content.CopyToAsync(bodyStream, cancellationToken)
+                        .ConfigureAwait(false);
+#else
                     await request.Content.CopyToAsync(bodyStream).ConfigureAwait(false);
+#endif
                     bodyStream.Position = 0;
                     var clonedContent = new StreamContent(bodyStream);
                     foreach (var header in request.Content.Headers)
@@ -130,14 +141,18 @@ internal partial class RawClient(ClientOptions clientOptions)
     )
     {
         var httpClient = options?.HttpClient ?? Options.HttpClient;
-        var maxRetries = options?.MaxRetries ?? Options.MaxRetries;
-        var response = await httpClient
-            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-            .ConfigureAwait(false);
+        var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
         var isRetryableContent = IsRetryableContent(request);
 
-        if (!isRetryableContent)
+        if (!isRetryableContent || maxRetries == 0)
         {
+            // Fast path — send the original request directly with no cloning when either:
+            //   - the content is not retryable (e.g. unbuffered streams cannot be re-sent), or
+            //   - the caller opted out of retries entirely with MaxRetries == 0 (no second send
+            //     can happen, so the clone-to-protect-against-disposal logic below is not needed).
+            var response = await httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
             return new global::SeedApi.Core.ApiResponse
             {
                 StatusCode = (int)response.StatusCode,
@@ -145,29 +160,40 @@ internal partial class RawClient(ClientOptions clientOptions)
             };
         }
 
-        for (var i = 0; i < maxRetries; i++)
+        // Retryable content with at least one retry budgeted: always send a clone, never the original.
+        // HttpClient (under HTTP/2 and some other configurations) disposes the Content of every request
+        // it sends, so sending the original would leave its Content disposed and cause
+        // ObjectDisposedException the next time we try to clone it. Cloning each attempt keeps the
+        // original Content alive across the entire retry loop.
+        HttpResponseMessage? retryResponse = null;
+        for (var attempt = 0; attempt <= maxRetries; attempt++)
         {
-            if (!ShouldRetry(response))
+            if (attempt > 0)
             {
-                break;
+                var delayMs = GetRetryDelayFromHeaders(retryResponse!, attempt - 1);
+                await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
-            var delayMs = GetRetryDelayFromHeaders(response, i);
-            await SystemTask.Delay(delayMs, cancellationToken).ConfigureAwait(false);
-            using var retryRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            response = await httpClient
+            using var attemptRequest = await CloneRequestAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            retryResponse = await httpClient
                 .SendAsync(
-                    retryRequest,
+                    attemptRequest,
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
+
+            if (!ShouldRetry(retryResponse))
+            {
+                break;
+            }
         }
 
         return new global::SeedApi.Core.ApiResponse
         {
-            StatusCode = (int)response.StatusCode,
-            Raw = response,
+            StatusCode = (int)retryResponse!.StatusCode,
+            Raw = retryResponse,
         };
     }
 


### PR DESCRIPTION
Closes FER-11195

## Summary

- Basis-Theory hit `ObjectDisposedException: Cannot access a disposed object. Object name: 'System.Net.Http.StringContent'` from `RawClient.CloneRequestAsync` on the first retry of a JSON request.
- Root cause: `SendWithRetriesAsync` sent the **original** `HttpRequestMessage` for the initial attempt and only cloned for subsequent retries. Under HTTP/2 (and some other configurations), `HttpClient` disposes the Content of every request it sends, so the original's Content was already disposed by the time the retry loop tried to clone it.
- Fix: restructure the retryable-content branch to always send a clone — never the original. Cloning each attempt keeps the original Content alive across the entire retry loop.
- Plus four review-driven additions: clamp negative `MaxRetries` to 0; short-circuit `MaxRetries == 0` and non-retryable content to a no-clone fast path; thread `CancellationToken` into `CloneRequestAsync`'s body buffering; new multi-retry regression test using a `DelegatingHandler` that disposes `request.Content` after send.

## Customer stack trace

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Net.Http.StringContent'.
   at System.Net.Http.HttpContent.CheckDisposed()
   at System.Net.Http.HttpContent.CopyToAsync(Stream stream, TransportContext context)
   at BasisTheory.Client.Core.RawClient.<CloneRequestAsync>d__12.MoveNext()
   at BasisTheory.Client.Core.RawClient.<SendWithRetriesAsync>d__13.MoveNext()
   at BasisTheory.Client.Core.RawClient.<SendRequestAsync>d__10.MoveNext()
   at BasisTheory.Client.ReactorsClient.<ReactAsyncCore>d__10.MoveNext()
```

## Before vs after

**Before** — original sent on attempt 0, cloned only for retries; first send disposed the original's Content:

```csharp
var response = await httpClient.SendAsync(request, ...);   // (A) ORIGINAL — HTTP/2 disposes its Content
// ...
for (var i = 0; i < maxRetries; i++) {
    if (!ShouldRetry(response)) break;
    using var retryRequest = await CloneRequestAsync(request);   // (B) original.Content already disposed → throws
    response = await httpClient.SendAsync(retryRequest, ...);
}
```

**After** — fast path for opt-out cases; always-clone loop for retryable content:

```csharp
var maxRetries = Math.Max(0, options?.MaxRetries ?? Options.MaxRetries);
var isRetryableContent = IsRetryableContent(request);

if (!isRetryableContent || maxRetries == 0) {
    // Fast path: send the original directly, no clone.
    var response = await httpClient.SendAsync(request, ...);
    return new ApiResponse { ... };
}

// Always send a clone — never the original.
HttpResponseMessage? response = null;
for (var attempt = 0; attempt <= maxRetries; attempt++) {
    if (attempt > 0) {
        var delayMs = GetRetryDelayFromHeaders(response!, attempt - 1);
        await SystemTask.Delay(delayMs, cancellationToken);
    }
    using var attemptRequest = await CloneRequestAsync(request, cancellationToken);
    response = await httpClient.SendAsync(attemptRequest, ...);
    if (!ShouldRetry(response)) break;
}
```

## Why our existing test missed it

`SendRequestAsync_ShouldPreserveJsonBody_OnRetry` (added in the prior fix #12914) exercises POST JSON → 500 → 200 against WireMock — exactly the failing scenario. But WireMock loopback HTTP/1.1 + `SocketsHttpHandler` doesn't dispose `request.Content` after `SendAsync` returns, so the test passes whether the bug is present or not. I verified this with a diagnostic `DelegatingHandler` that captured the disposal state.

The new regression test wraps `HttpClientHandler` in a `ContentDisposingHandler` that explicitly disposes `request.Content` after `base.SendAsync` returns — reproducing production HTTP/2 behavior reliably. Confirmed: without this PR's fix, the new test throws the exact customer stack; with the fix, all 16 RetriesTests pass.

## Test plan

- [x] Local: ported template into `seed/csharp-sdk/bytes-upload`, ran `dotnet test --filter RetriesTests` → 16/16 pass
- [x] Reverted the fix temporarily, re-ran the new regression test → fails with `ObjectDisposedException` at `CloneRequestAsync → CopyToAsync` (matches customer stack exactly)
- [x] Re-applied the fix, all 16 tests pass
- [ ] CI: `update-seed.yml` regenerates all 136 csharp-sdk fixtures, runs the full test suite
- [ ] Verify with Basis-Theory after release (their reproduction is non-local — they were unable to repro outside production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->