### PR TITLE
fix(rust): import serde directly in multi-url environment.rs emission

### DIFF
--- a/generators/rust/sdk/changes/unreleased/fix-multi-url-environment-serde-import.yml
+++ b/generators/rust/sdk/changes/unreleased/fix-multi-url-environment-serde-import.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Import `serde::{Deserialize, Serialize}` directly in `environment.rs` for
+    multi-URL environments instead of relying on the crate prelude. The CLI
+    generator embeds the SDK and replaces `src/prelude.rs` with a bare
+    types-crate re-export, which dropped the serde derive macros and broke
+    compilation with `cannot find derive macro `Serialize` in this scope`.
+  type: fix

--- a/generators/rust/sdk/src/__test__/EnvironmentGenerator.test.ts
+++ b/generators/rust/sdk/src/__test__/EnvironmentGenerator.test.ts
@@ -323,6 +323,32 @@ describe("EnvironmentGenerator", () => {
             await expect(result?.fileContents).toMatchFileSnapshot("snapshots/multi-url-many-services.rs");
         });
 
+        it("should import serde derive macros directly so the file compiles without the prelude", () => {
+            // The CLI generator (generators/cli) embeds this SDK and overwrites
+            // src/prelude.rs with a bare types-crate re-export, so environment.rs
+            // cannot rely on the prelude for the Serialize/Deserialize derive macros.
+            const baseUrls = [createEnvironmentBaseUrl("api", "api"), createEnvironmentBaseUrl("auth", "auth")];
+
+            const environments = [
+                createMultipleBaseUrlsEnvironment("Production", {
+                    api: "https://api.example.com",
+                    auth: "https://auth.example.com"
+                })
+            ];
+
+            const environmentsConfig = {
+                environments: createMultipleBaseUrlsEnvironmentsUnion(environments, baseUrls),
+                defaultEnvironment: "ProductionId"
+            } as FernIr.EnvironmentsConfig;
+
+            const ir = createMockIR(environmentsConfig);
+            const context = createMockContext(ir);
+            const generator = new EnvironmentGenerator({ context });
+
+            const result = generator.generate();
+            expect(result?.fileContents).toContain("use serde::{Deserialize, Serialize};");
+        });
+
         it("should generate multiple URLs environment with mixed protocols", async () => {
             const baseUrls = [
                 createEnvironmentBaseUrl("api", "api"),

--- a/generators/rust/sdk/src/__test__/snapshots/multi-url-basic.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/multi-url-basic.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{*};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProductionUrls {

--- a/generators/rust/sdk/src/__test__/snapshots/multi-url-many-services.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/multi-url-many-services.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{*};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProductionUrls {

--- a/generators/rust/sdk/src/__test__/snapshots/multi-url-mixed-protocols.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/multi-url-mixed-protocols.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{*};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProductionUrls {

--- a/generators/rust/sdk/src/environment/EnvironmentGenerator.ts
+++ b/generators/rust/sdk/src/environment/EnvironmentGenerator.ts
@@ -103,9 +103,12 @@ export class EnvironmentGenerator {
 
     private generateMultiUrlEnvironment(config: FernIr.MultipleBaseUrlsEnvironments): RustFile {
         const useStatements = [
+            // Import serde directly rather than relying on the prelude re-export:
+            // the CLI generator embeds this SDK and replaces src/prelude.rs with a
+            // bare types-crate re-export that does not include the serde macros.
             new UseStatement({
-                path: "crate::prelude",
-                items: ["*"]
+                path: "serde",
+                items: ["Deserialize", "Serialize"]
             })
         ];
 


### PR DESCRIPTION
## Description

Fixes a compile failure in generated Rust code when an API uses **multiple base URLs per environment** (e.g. an https base URL plus a wss streaming URL):

```
error: cannot find derive macro `Serialize` in this scope
 --> sarvam-sdk/src/environment.rs:3:24
```

The multi-URL path in `EnvironmentGenerator` emitted only `use crate::prelude::*;` and relied on the prelude to provide the `Serialize`/`Deserialize` derive macros. That holds in a standalone rust-sdk crate (the stock prelude re-exports serde), but the **CLI generator embeds the SDK and replaces `src/prelude.rs`** with a bare types-crate re-export (`generators/cli/src/generateEmbeddedSdk.ts`), dropping the serde macros. This is what broke CI on regenerated CLIs (observed on fern-demo/sarvam-cli after the 0.17.3 / rust-sdk 0.40.5 error.rs fix unblocked compilation far enough to hit it).

The single-URL environment path already imports serde directly, as does `WebSocketChannelGenerator` — this brings the multi-URL path in line.

## Changes Made
- `generators/rust/sdk/src/environment/EnvironmentGenerator.ts`: `generateMultiUrlEnvironment` now emits `use serde::{Deserialize, Serialize};` instead of relying on the prelude glob
- Added a unit test asserting the multi-URL output imports serde directly (fails without the fix)
- Updated the three multi-URL snapshots (diff is exactly the one import line)
- Added changelog entry (`type: fix`)

## Testing
- [x] Unit tests added/updated — full `@fern-api/rust-sdk` suite passes (36 tests)
- [x] Manual testing completed — rebuilt `fern-rust-sdk` dist + a local `fern-cli-generator` image bundling it, generated a CLI from a minimal OpenAPI spec confirmed to produce `multipleBaseUrls` IR (https + wss servers); the embedded SDK crate including `environment.rs` now compiles (previously failed with the exact CI error)

## Notes
While testing, found a **separate pre-existing** CLI-generator bug (not addressed here): for APIs with root-level (ungrouped) endpoints, `sdk_glue.rs` builds the `ApiClient` struct literal without its `http_client` field (E0063). APIs whose endpoints are grouped into sub-clients (e.g. sarvam) are unaffected.

Release dance to get this to CLI users: rust-sdk patch release, then a cli-generator release to bundle the new rust-sdk dist (same as #16451 → 0.17.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)