### PR TITLE
fix(cli-generator): emit http_client in root ApiClient struct literal

### DIFF
--- a/generators/cli/changes/unreleased/fix-root-http-client-glue.yml
+++ b/generators/cli/changes/unreleased/fix-root-http-client-glue.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix generated sdk_glue.rs to include `http_client` field in root
+    ApiClient struct literal for flat APIs (no sub-resources). Previously,
+    the SKIP_TYPES filter prevented it from appearing in the struct
+    initializer, causing "missing field http_client" compile errors.
+  type: fix

--- a/generators/cli/src/generateSdkGlue.ts
+++ b/generators/cli/src/generateSdkGlue.ts
@@ -38,6 +38,7 @@ interface ClientNode {
 export interface RootClientInfo {
     name: string;
     subClients: ClientNode[];
+    hasRootHttpClient: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -167,12 +168,15 @@ function qualifyType(sdkCrate: string, node: ClientNode): string {
  * Generate the `sdk_glue.rs` module content.
  */
 function renderSdkGlue(sdkCrateSnake: string, rootClient: RootClientInfo): string {
-    const subClientInits = rootClient.subClients
-        .map((node) => {
-            const init = renderClientInit(sdkCrateSnake, node, "        ");
-            return `        ${node.fieldName}: ${init},`;
-        })
-        .join("\n");
+    const fieldInits: string[] = [];
+    if (rootClient.hasRootHttpClient) {
+        fieldInits.push("        http_client: http_client.clone(),");
+    }
+    for (const node of rootClient.subClients) {
+        const init = renderClientInit(sdkCrateSnake, node, "        ");
+        fieldInits.push(`        ${node.fieldName}: ${init},`);
+    }
+    const subClientInits = fieldInits.join("\n");
 
     return `\
 //! Generated SDK client glue — bridges AppContext to the co-generated SDK.
@@ -312,9 +316,12 @@ export async function generateSdkGlue(args: {
         throw new Error("Could not find root client struct in SDK's api/resources/mod.rs");
     }
 
+    // Check if the root struct has a direct HttpClient field (flat APIs with no sub-resources).
+    const hasRootHttpClient = /pub\s+http_client\s*:\s*HttpClient/.test(modRsContent);
+
     // Recursively discover nested sub-clients from the SDK's resource tree.
     const subClients = await discoverClientTree(resourcesDir, rootStruct.fields, []);
-    const rootClient: RootClientInfo = { name: rootStruct.name, subClients };
+    const rootClient: RootClientInfo = { name: rootStruct.name, subClients, hasRootHttpClient };
 
     // Write the glue module.
     const binDir = path.join(outputDir, "cli", binaryName);

--- a/seed/cli/allof-inline/cli/allof-composition/sdk_glue.rs
+++ b/seed/cli/allof-inline/cli/allof-composition/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> allof_composition_sdk::api::ApiClient {
     );
     allof_composition_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/allof-inline/src/openapi/parser.rs
+++ b/seed/cli/allof-inline/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/allof/cli/allof-composition/sdk_glue.rs
+++ b/seed/cli/allof/cli/allof-composition/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> allof_composition_sdk::api::ApiClient {
     );
     allof_composition_sdk::api::ApiClient {
         config,
-        http_client: allof_composition_sdk::api::HttpClient { http_client: http_client.clone() },
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/allof/src/openapi/parser.rs
+++ b/seed/cli/allof/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/api-wide-base-path-with-default/src/openapi/parser.rs
+++ b/seed/cli/api-wide-base-path-with-default/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/openapi/parser.rs
+++ b/seed/cli/cli-multi-spec-namespaced/no-custom-config/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/cli-multi-spec/no-custom-config/cli/acme-cli/sdk_glue.rs
+++ b/seed/cli/cli-multi-spec/no-custom-config/cli/acme-cli/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> acme_cli_sdk::api::ApiClient {
     );
     acme_cli_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/cli-multi-spec/no-custom-config/src/openapi/parser.rs
+++ b/seed/cli/cli-multi-spec/no-custom-config/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/file-upload-openapi/src/openapi/parser.rs
+++ b/seed/cli/file-upload-openapi/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/imdb/src/openapi/parser.rs
+++ b/seed/cli/imdb/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/multi-url-environment-reference/src/openapi/parser.rs
+++ b/seed/cli/multi-url-environment-reference/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/no-content-response/src/openapi/parser.rs
+++ b/seed/cli/no-content-response/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/null-type/src/openapi/parser.rs
+++ b/seed/cli/null-type/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/nullable-allof-extends/cli/nullable-allof-extends-test/sdk_glue.rs
+++ b/seed/cli/nullable-allof-extends/cli/nullable-allof-extends-test/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> nullable_allof_extends_test_sdk::api::Api
     );
     nullable_allof_extends_test_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/nullable-allof-extends/src/openapi/parser.rs
+++ b/seed/cli/nullable-allof-extends/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/nullable-request-body/src/openapi/parser.rs
+++ b/seed/cli/nullable-request-body/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/oauth-client-credentials-openapi/src/openapi/parser.rs
+++ b/seed/cli/oauth-client-credentials-openapi/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/openapi-request-body-ref/src/openapi/parser.rs
+++ b/seed/cli/openapi-request-body-ref/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/query-param-name-conflict/cli/query-param-name-conflict-api/sdk_glue.rs
+++ b/seed/cli/query-param-name-conflict/cli/query-param-name-conflict-api/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> query_param_name_conflict_api_sdk::api::A
     );
     query_param_name_conflict_api_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/query-param-name-conflict/src/openapi/parser.rs
+++ b/seed/cli/query-param-name-conflict/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/query-parameters-openapi-as-objects/cli/query-parameters-api/sdk_glue.rs
+++ b/seed/cli/query-parameters-openapi-as-objects/cli/query-parameters-api/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> query_parameters_api_sdk::api::ApiClient 
     );
     query_parameters_api_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/query-parameters-openapi-as-objects/src/openapi/parser.rs
+++ b/seed/cli/query-parameters-openapi-as-objects/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/query-parameters-openapi/github-no-publish/cli/query-parameters-api/sdk_glue.rs
+++ b/seed/cli/query-parameters-openapi/github-no-publish/cli/query-parameters-api/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> query_parameters_api_sdk::api::ApiClient 
     );
     query_parameters_api_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/query-parameters-openapi/github-no-publish/src/openapi/parser.rs
+++ b/seed/cli/query-parameters-openapi/github-no-publish/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/query-parameters-openapi/github-npm/cli/query-parameters-api/sdk_glue.rs
+++ b/seed/cli/query-parameters-openapi/github-npm/cli/query-parameters-api/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> query_parameters_api_sdk::api::ApiClient 
     );
     query_parameters_api_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/query-parameters-openapi/github-npm/src/openapi/parser.rs
+++ b/seed/cli/query-parameters-openapi/github-npm/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/query-parameters-openapi/no-custom-config/cli/query-parameters-api/sdk_glue.rs
+++ b/seed/cli/query-parameters-openapi/no-custom-config/cli/query-parameters-api/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> query_parameters_api_sdk::api::ApiClient 
     );
     query_parameters_api_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/query-parameters-openapi/no-custom-config/src/openapi/parser.rs
+++ b/seed/cli/query-parameters-openapi/no-custom-config/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/schemaless-request-body-examples/cli/schemaless-request-body-examples-api/sdk_glue.rs
+++ b/seed/cli/schemaless-request-body-examples/cli/schemaless-request-body-examples-api/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> schemaless_request_body_examples_api_sdk:
     );
     schemaless_request_body_examples_api_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/schemaless-request-body-examples/src/openapi/parser.rs
+++ b/seed/cli/schemaless-request-body-examples/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/server-sent-events-openapi/cli/server-sent-events-openapi/sdk_glue.rs
+++ b/seed/cli/server-sent-events-openapi/cli/server-sent-events-openapi/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> server_sent_events_openapi_sdk::api::ApiC
     );
     server_sent_events_openapi_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/server-sent-events-openapi/src/openapi/parser.rs
+++ b/seed/cli/server-sent-events-openapi/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/server-url-templating/cli/server-url-templating-api/sdk_glue.rs
+++ b/seed/cli/server-url-templating/cli/server-url-templating-api/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> server_url_templating_api_sdk::api::ApiCl
     );
     server_url_templating_api_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/server-url-templating/src/openapi/parser.rs
+++ b/seed/cli/server-url-templating/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/url-form-encoded/cli/url-form-encoded-api/sdk_glue.rs
+++ b/seed/cli/url-form-encoded/cli/url-form-encoded-api/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> url_form_encoded_api_sdk::api::ApiClient 
     );
     url_form_encoded_api_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/url-form-encoded/src/openapi/parser.rs
+++ b/seed/cli/url-form-encoded/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/webhook-audience/src/openapi/parser.rs
+++ b/seed/cli/webhook-audience/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }

--- a/seed/cli/x-fern-default/cli/x-fern-default-test/sdk_glue.rs
+++ b/seed/cli/x-fern-default/cli/x-fern-default-test/sdk_glue.rs
@@ -53,7 +53,7 @@ pub fn sdk_client(ctx: &AppContext) -> x_fern_default_test_sdk::api::ApiClient {
     );
     x_fern_default_test_sdk::api::ApiClient {
         config,
-
+        http_client: http_client.clone(),
     }
 }
 

--- a/seed/cli/x-fern-default/src/openapi/parser.rs
+++ b/seed/cli/x-fern-default/src/openapi/parser.rs
@@ -719,7 +719,7 @@ struct OpenApiSchemaObject {
     #[serde(default)]
     nullable: bool,
     description: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     properties: HashMap<String, OpenApiSchemaObject>,
     items: Option<Box<OpenApiSchemaObject>>,
     #[serde(default)]
@@ -968,10 +968,76 @@ where
     deserializer.deserialize_any(AdditionalPropertiesVisitor)
 }
 
+/// Deserialize a `HashMap<String, OpenApiSchemaObject>` that tolerates
+/// malformed entries whose value is a YAML/JSON sequence (array) instead of
+/// a mapping (object).  Real-world specs — e.g. ElevenLabs 3.1 — sometimes
+/// emit `"property": [{"x-fern-type-name": "…"}]` which is not a valid
+/// JSON Schema property but must not prevent the rest of the spec from
+/// loading.  Entries with non-object values are logged as warnings and dropped.
+fn deserialize_tolerant_properties<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, OpenApiSchemaObject>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct TolerantPropertiesVisitor;
+
+    impl<'de> de::Visitor<'de> for TolerantPropertiesVisitor {
+        type Value = HashMap<String, OpenApiSchemaObject>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a map of schema objects (non-object values are skipped)")
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<Self::Value, M::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                // Try to deserialize the value. If the entry is a
+                // sequence or another unexpected type, `serde_yaml`
+                // will fail — catch the error and skip the entry
+                // rather than aborting the entire spec parse.
+                match map.next_value::<serde_yaml::Value>() {
+                    Ok(val) => {
+                        if val.is_mapping() {
+                            match OpenApiSchemaObject::deserialize(val) {
+                                Ok(schema) => { out.insert(key, schema); }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        key = %key,
+                                        error = %e,
+                                        "skipping property with malformed schema object",
+                                    );
+                                }
+                            }
+                        } else {
+                            tracing::warn!(
+                                key = %key,
+                                "skipping property whose value is not an object",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            key = %key,
+                            error = %e,
+                            "skipping unparseable property value",
+                        );
+                    }
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(TolerantPropertiesVisitor)
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct OpenApiComponents {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_tolerant_properties")]
     schemas: HashMap<String, OpenApiSchemaObject>,
     #[serde(default)]
     parameters: HashMap<String, OpenApiParameter>,
@@ -9919,6 +9985,58 @@ components:
         assert_eq!(
             lowered_31.properties["email"].prop_type.as_deref(),
             Some("string"),
+        );
+    }
+
+    /// Regression: a spec whose `properties` map contains an entry whose
+    /// value is a YAML/JSON **array** (e.g. `[{"x-fern-type-name": "…"}]`)
+    /// must not abort the entire parse. The tolerant deserializer should
+    /// silently drop the offending entry and preserve valid siblings.
+    #[test]
+    fn test_properties_with_array_value_are_skipped() {
+        let yaml = r##"
+openapi: "3.1.0"
+info:
+  title: test
+  version: "1.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Item"
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        state:
+          - x-fern-type-name: ItemState
+        count:
+          type: integer
+"##;
+        let desc = load_openapi_spec(yaml, "test-cli")
+            .expect("spec with array property value must not fail to parse");
+        let item_schema = desc.schemas.get("Item").expect("Item schema should exist");
+        // 'name' and 'count' are valid properties; 'state' (array) is dropped.
+        assert!(
+            item_schema.properties.contains_key("name"),
+            "valid property 'name' must be preserved",
+        );
+        assert!(
+            item_schema.properties.contains_key("count"),
+            "valid property 'count' must be preserved",
+        );
+        assert!(
+            !item_schema.properties.contains_key("state"),
+            "array property 'state' must be dropped",
         );
     }
 }


### PR DESCRIPTION
## Description

Fixes the `seed-test-results (cli)` failures affecting 12 fixtures on main since #16385.

## Changes Made

- **`generators/cli/src/generateSdkGlue.ts`**: Added `hasRootHttpClient` detection — when the root `ApiClient` struct has a direct `pub http_client: HttpClient` field (flat APIs with no sub-resources), the generated glue now emits `http_client: http_client.clone()` in the struct literal.

**Root cause**: #16385 introduced `SKIP_TYPES = ["ClientConfig", "HttpClient"]` to prevent recursing into infrastructure fields when discovering nested sub-clients. This correctly avoids treating `HttpClient` as a sub-client tree, but also prevented emitting `http_client` in the root struct initializer — causing "missing field `http_client`" compile errors for all flat API fixtures.

- Regenerated all 128 cli seed snapshots (includes `parser.rs` updates from the SDK template sync on main)

## Testing

- [x] All 140 CLI generator unit tests pass
- [x] All 128 cli seed test cases pass (`pnpm seed test --generator cli --skip-scripts`)
- [x] Verified the fix produces correct output: `http_client: http_client.clone()` now appears in struct literal for flat APIs
- [x] Fixtures with sub-resources (imdb, file-upload, etc.) are unaffected — they don't have `HttpClient` on the root struct

Link to Devin session: https://app.devin.ai/sessions/a2b0ee84cea44358aa5017c893c609c1
Requested by: @adidavid014