### PR TITLE
chore(cli-generator): trigger release to bundle rust-sdk 0.40.6

### DIFF
--- a/generators/cli/changes/unreleased/bump-embedded-rust-sdk.yml
+++ b/generators/cli/changes/unreleased/bump-embedded-rust-sdk.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Rebuild to pick up rust-sdk 0.40.6 which fixes serde imports in
+    `environment.rs` for multi-URL environments when embedded in the CLI.
+  type: chore


### PR DESCRIPTION
## Description

Trigger a new CLI generator release so it bundles the latest Rust SDK (0.40.6), which fixes `serde::{Deserialize, Serialize}` imports in `environment.rs` for multi-URL environments embedded in the CLI.

## Changes Made

- Added unreleased changelog entry for CLI generator (`generators/cli/changes/unreleased/bump-embedded-rust-sdk.yml`)

## Testing

- No code changes — changelog-only PR to trigger a release build

Link to Devin session: https://app.devin.ai/sessions/2a5114ece63a444b88709c8515904a90
Requested by: @cade-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->