### PR TITLE
chore(go): Remove SSE examples and allowedFailures entry

### DIFF
--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -216,13 +216,6 @@ fixtures:
         packageName: stream
         module:
           path: github.com/fern-api/stream-go
-  server-sent-event-examples:
-    - outputFolder: with-wire-tests
-      customConfig:
-        enableWireTests: true
-        packageName: sse
-        module:
-          path: github.com/fern-api/sse-examples-go
   server-sent-events:
     - outputFolder: with-wire-tests
       customConfig:
@@ -364,6 +357,3 @@ allowedFailures:
   - enum # enum-union header value is not converted to a string
   - trace # generated v2/ subpackage references undefined test types
   - request-parameters # int64 default 9223372036854775807 loses precision in the IR pipeline
-
-  # Dynamic snippet generation produces code that does not compile.
-  - server-sent-event-examples:with-wire-tests # TODO: update wiretests geranation then remove it


### PR DESCRIPTION
Delete the obsolete 'server-sent-event-examples' fixture (with-wire-tests customConfig) from seed/go-sdk/seed.yml and remove the corresponding allowedFailures comment/entry for 'server-sent-event-examples:with-wire-tests'. Cleans up outdated SSE example wiring-test configuration and stray blank lines.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/16475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->