### PR TITLE
fix(php): construct typed token request for reference-body OAuth/inferred-auth

### DIFF
--- a/generators/php/sdk/changes/unreleased/fix-oauth-reference-token-request.yml
+++ b/generators/php/sdk/changes/unreleased/fix-oauth-reference-token-request.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix the generated OAuth and inferred-auth token providers to construct the typed token request
+    object when the token endpoint uses a referenced (non-inlined) request body. Previously the
+    provider passed an associative array to the token endpoint method, which expects the typed
+    request, causing PHPStan failures.
+  type: fix

--- a/generators/php/sdk/src/inferred-auth/InferredAuthProviderGenerator.ts
+++ b/generators/php/sdk/src/inferred-auth/InferredAuthProviderGenerator.ts
@@ -320,8 +320,14 @@ export class InferredAuthProviderGenerator extends FileGenerator<PhpFile, SdkCus
 
         // Add request body properties
         this.tokenEndpoint.requestBody?._visit({
-            reference: () => {
-                // For referenced request bodies, we don't have individual properties
+            reference: (reference) => {
+                for (const property of this.getPropertiesForTypeReference(reference.requestBodyType)) {
+                    properties.push({
+                        camelName: this.case.camelUnsafe(property.name),
+                        isOptional: this.context.isOptional(property.valueType),
+                        literal: this.context.maybeLiteral(property.valueType)
+                    });
+                }
             },
             inlinedRequestBody: (request) => {
                 for (const property of request.properties) {
@@ -392,7 +398,36 @@ export class InferredAuthProviderGenerator extends FileGenerator<PhpFile, SdkCus
                 namespace: this.context.getLocationForWrappedRequest(this.tokenEndpointReference.serviceId).namespace
             });
         }
+        const requestBody = this.tokenEndpoint.requestBody;
+        if (requestBody != null && requestBody.type === "reference") {
+            const internalType = this.context.phpTypeMapper
+                .convert({ reference: requestBody.requestBodyType })
+                .underlyingType().internalType;
+            if (internalType.type === "reference") {
+                return internalType.value;
+            }
+        }
         return undefined;
+    }
+
+    private getPropertiesForTypeReference(typeReference: FernIr.TypeReference): FernIr.ObjectProperty[] {
+        if (typeReference.type !== "named") {
+            return [];
+        }
+        return this.getPropertiesForTypeId(typeReference.typeId);
+    }
+
+    private getPropertiesForTypeId(typeId: FernIr.TypeId): FernIr.ObjectProperty[] {
+        const typeDeclaration = this.context.getTypeDeclarationOrThrow(typeId);
+        if (typeDeclaration.shape.type !== "object") {
+            return [];
+        }
+        const properties: FernIr.ObjectProperty[] = [];
+        for (const extended of typeDeclaration.shape.extends) {
+            properties.push(...this.getPropertiesForTypeId(extended.typeId));
+        }
+        properties.push(...typeDeclaration.shape.properties);
+        return properties;
     }
 
     private getExpiresAtMethod(): php.Method {

--- a/generators/php/sdk/src/oauth/OauthTokenProviderGenerator.ts
+++ b/generators/php/sdk/src/oauth/OauthTokenProviderGenerator.ts
@@ -294,6 +294,15 @@ export class OauthTokenProviderGenerator extends FileGenerator<PhpFile, SdkCusto
                 namespace: this.context.getLocationForWrappedRequest(this.tokenEndpointReference.serviceId).namespace
             });
         }
+        const requestBody = this.tokenEndpoint.requestBody;
+        if (requestBody != null && requestBody.type === "reference") {
+            const internalType = this.context.phpTypeMapper
+                .convert({ reference: requestBody.requestBodyType })
+                .underlyingType().internalType;
+            if (internalType.type === "reference") {
+                return internalType.value;
+            }
+        }
         return undefined;
     }
 

--- a/seed/php-sdk/inferred-auth-implicit-reference/src/Core/InferredAuthProvider.php
+++ b/seed/php-sdk/inferred-auth-implicit-reference/src/Core/InferredAuthProvider.php
@@ -4,6 +4,7 @@ namespace Seed\Core;
 
 use Seed\Auth\AuthClient;
 use DateTime;
+use Seed\Auth\Types\GetTokenRequest;
 use Seed\Exceptions\SeedException;
 
 /**
@@ -84,11 +85,18 @@ class InferredAuthProvider
      */
     private function refresh(): string
     {
-        /** @var array{} $values */
+        /** @var array{clientId: string, clientSecret: string, audience: 'https://api.example.com', grantType: 'client_credentials', scope?: string|null} $values */
         $values = [
+            'clientId' => $this->options['clientId'] ?? '',
+            'clientSecret' => $this->options['clientSecret'] ?? '',
+            'audience' => 'https://api.example.com',
+            'grantType' => 'client_credentials',
+            'scope' => $this->options['scope'] ?? null,
         ];
 
-        $tokenResponse = $this->authClient->getTokenWithClientCredentials($values);
+        $request = new GetTokenRequest($values);
+
+        $tokenResponse = $this->authClient->getTokenWithClientCredentials($request);
 
         if ($tokenResponse === null) {
             throw new SeedException(message: "Expected a token response, but received an empty response.");

--- a/seed/php-sdk/oauth-client-credentials-reference/src/Core/OAuthTokenProvider.php
+++ b/seed/php-sdk/oauth-client-credentials-reference/src/Core/OAuthTokenProvider.php
@@ -4,6 +4,7 @@ namespace Seed\Core;
 
 use Seed\Auth\AuthClient;
 use DateTime;
+use Seed\Auth\Types\GetTokenRequest;
 use Seed\Exceptions\SeedException;
 
 /**
@@ -79,10 +80,12 @@ class OAuthTokenProvider
      */
     private function refresh(): string
     {
-        $tokenResponse = $this->authClient->getToken([
+        $request = new GetTokenRequest([
             'clientId' => $this->clientId,
             'clientSecret' => $this->clientSecret,
         ]);
+
+        $tokenResponse = $this->authClient->getToken($request);
 
         if ($tokenResponse === null) {
             throw new SeedException(message: "Expected a token response, but received an empty response.");

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -192,9 +192,7 @@ allowedFailures:
 
   # PHPDoc unresolvable enum-as-map-key type + dynamic snippet errors (unrelated to union serialization).
   - trace
-  # OAuth/InferredAuth custom properties need non-literal property passthrough.
+  # OAuth custom properties need non-literal property passthrough to the token request.
   - oauth-client-credentials-custom
-  - oauth-client-credentials-reference
-  - inferred-auth-implicit-reference
 
 


### PR DESCRIPTION
## Description

First (easy) batch of fixes toward running the PHP SDK seed suite with no `allowedFailures`.

When an OAuth or inferred-auth **token endpoint uses a referenced (non-inlined) request body**, the generated token provider built an associative array and passed it to the token endpoint method — but that method expects the typed request object (e.g. `GetTokenRequest`). PHPStan then failed with `expects GetTokenRequest, array given` (and, for inferred-auth, `$options is never read`).

Root cause: both `OauthTokenProviderGenerator` and `InferredAuthProviderGenerator` only resolved a request class reference for the `wrapper` request shape, returning `undefined` for reference bodies and falling back to the array call.

Fix: resolve the request class reference for reference bodies too and construct the typed request.

```ts
// getTokenEndpointRequestClassReference()
const requestBody = this.tokenEndpoint.requestBody;
if (requestBody != null && requestBody.type === "reference") {
    const internalType = this.context.phpTypeMapper
        .convert({ reference: requestBody.requestBodyType })
        .underlyingType().internalType;
    if (internalType.type === "reference") {
        return internalType.value;
    }
}
```

For inferred-auth the reference body's properties were also never enumerated (so `$values` was empty and `$options` was unused). The reference visitor now resolves the referenced object's properties (recursing through `extends`) so `$values` is populated from `$this->options` + literals before constructing the typed request.

Resulting generated code:

```php
// before
$tokenResponse = $this->authClient->getToken([
    'clientId' => $this->clientId,
    'clientSecret' => $this->clientSecret,
]);
// after
$request = new GetTokenRequest([
    'clientId' => $this->clientId,
    'clientSecret' => $this->clientSecret,
]);
$tokenResponse = $this->authClient->getToken($request);
```

## Changes Made
- `OauthTokenProviderGenerator.getTokenEndpointRequestClassReference`: resolve class reference for reference request bodies.
- `InferredAuthProviderGenerator`: same class-reference resolution, plus enumerate referenced request-body properties (with `extends` recursion) so the typed request is built from `$options`.
- Removed `oauth-client-credentials-reference` and `inferred-auth-implicit-reference` from `seed/php-sdk/seed.yml` `allowedFailures`; regenerated their seed output.
- Added PHP SDK changelog entry.
- [ ] Updated README.md generator (if applicable) — n/a

Scope note: this PR intentionally covers only the two reference-body fixtures. The remaining `allowedFailures` (`oauth-client-credentials-custom`, `variables`, `oauth-client-credentials-with-variables`, `api-wide-base-path-with-default`, `trace`, `exhaustive:wire-tests`) are deferred for review — `oauth-client-credentials-custom` in particular requires threading non-literal custom properties as new client constructor params, which is a public-API change worth discussing separately.

## Testing
- [x] Manual testing completed: `seed test --generator php-sdk --fixture oauth-client-credentials-reference --fixture inferred-auth-implicit-reference` — both pass build + PHPStan + tests (`2/2 test cases passed`); seed now reports them as succeeding unexpectedly relative to `allowedFailures`.
- [x] `pnpm run check` (biome) and `tsc` compile pass.
- [ ] Unit tests added/updated — covered by seed fixture regeneration.


Link to Devin session: https://app.devin.ai/sessions/061e09e6d9bf4b7dbb24899b3bb9b9a2
Requested by: @iamnamananand996