### PR TITLE
fix(generator-cli): omit author so GitHub auto-signs API-created commits

### DIFF
--- a/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
+++ b/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
@@ -97,16 +97,16 @@ describe("pushSignedCommit", () => {
             "local-sha",
             expect.stringMatching(/^refs\/temp\/fern-/)
         );
-        // `author` always sent; `committer` omitted so GitHub fills it in and signs.
+        // `author` and `committer` both omitted so GitHub fills them in and signs.
         expect(octokit.git.createCommit).toHaveBeenCalledWith({
             owner: "acme",
             repo: "acme-sdk",
             message: "SDK Generation",
             tree: "tree-sha",
-            parents: ["parent-sha"],
-            author: { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" }
+            parents: ["parent-sha"]
         });
         const defaultCall = octokit.git.createCommit.mock.calls[0]?.[0] as Record<string, unknown>;
+        expect(defaultCall).not.toHaveProperty("author");
         expect(defaultCall).not.toHaveProperty("committer");
         expect(octokit.git.updateRef).toHaveBeenCalledWith({
             owner: "acme",
@@ -230,10 +230,10 @@ describe("pushSignedCommit", () => {
             repo: "acme-sdk",
             message: "SDK Generation",
             tree: "tree-sha-2",
-            parents: ["parent-sha-2"],
-            author: { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" }
+            parents: ["parent-sha-2"]
         });
         const retryCall = octokit.git.createCommit.mock.calls[1]?.[0] as Record<string, unknown>;
+        expect(retryCall).not.toHaveProperty("author");
         expect(retryCall).not.toHaveProperty("committer");
         // Temp ref re-push on the rebase retry must force, because the rebased commit
         // is not a descendant of the original tempRef tip.

--- a/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
+++ b/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
@@ -3,7 +3,6 @@ import type { ClonedRepository } from "@fern-api/github";
 import type { Octokit } from "@octokit/rest";
 
 import type { PipelineLogger } from "../PipelineLogger";
-import { FERN_BOT_EMAIL, FERN_BOT_NAME } from "./constants";
 
 const MAX_CONCURRENT_PUSH_RETRIES = 3;
 
@@ -35,8 +34,10 @@ export interface PushSignedCommitOptions {
     /**
      * Override the commit author and committer identity.
      *
-     * Omitted: `author` defaults to the Fern bot identity; `committer` is not sent, so
-     * GitHub fills it in from the authenticated installation and signs the commit.
+     * Omitted: neither `author` nor `committer` is sent, so GitHub fills both in from
+     * the authenticated installation (e.g. `fern-api[bot]` / the Fern bot noreply email)
+     * and signs the commit. Sending `author` alone is not enough: the Git Data API
+     * defaults `committer` to the provided `author`, which suppresses auto-signing.
      * Set: forces both `author` and `committer` to the provided identity — suppresses
      * auto-signing, but pins the committer for tooling that reads `git log --format=%cn`.
      */
@@ -81,20 +82,21 @@ export async function pushSignedCommit({
         tempRefPushed = true;
 
         for (let attempt = 0; attempt < MAX_CONCURRENT_PUSH_RETRIES; attempt++) {
-            // GitHub's web-flow signer keys off `committer`, not `author`. Omitting `committer`
-            // lets GitHub fill it in from the authenticated signing-capable principal (App
-            // installation, OAuth — never a PAT) and stamp the "Verified" signature. Always
-            // sending `author` keeps PR/`git log` attribution stable across every auth flavour.
-            const resolvedAuthor = author ?? { name: FERN_BOT_NAME, email: FERN_BOT_EMAIL };
-            const committerField = author != null ? { committer: author } : {};
+            // GitHub's web-flow signer keys off `committer`. The Git Data API defaults
+            // `committer` to `author` when `author` is provided, so sending `author` alone
+            // suppresses auto-signing. Omitting both lets GitHub fill them in from the
+            // authenticated signing-capable principal (App installation, OAuth — never a PAT)
+            // and stamp the "Verified" signature; the App's bot identity keeps the Fern bot
+            // noreply email, so attribution-based tooling (replay commit detection,
+            // findExistingUpdatablePR) still matches.
+            const identityFields = author != null ? { author, committer: author } : {};
             const { data: signedCommit } = await octokit.git.createCommit({
                 owner,
                 repo,
                 message,
                 tree: treeSha,
                 parents,
-                author: resolvedAuthor,
-                ...committerField
+                ...identityFields
             });
             const signedSha = signedCommit.sha;
 

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,18 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix commit signing on cloud-generated PRs. `pushSignedCommit` no longer sends
+        `author` by default: the Git Data API defaults `committer` to the provided
+        `author`, so sending `author` alone (the 0.9.32 behavior) still suppressed the
+        "Verified" signature. With both fields omitted, GitHub attributes the commit to
+        the authenticated App installation (`fern-api[bot]`, same noreply email) and
+        signs it. Callers that set `GithubStepConfig.author` still pin both identities.
+      type: fix
+  createdAt: "2026-06-11"
+  version: 0.9.40
+
+- changelogEntry:
+    - summary: |
         Re-release of 0.9.38 (whose publish failed due to a malformed versions.yml in git
         history). Carries the `@fern-api/replay` 0.18.0 bump: `.fernignore`-aware
         customization detection, trailing-slash pattern support, and the EPIPE crash fix.


### PR DESCRIPTION
## Description
Linear ticket: Refs

Cloud-generated PR commits are still unsigned despite the 0.9.32 "restore web-flow signing" fix. Root cause: the Git Data API defaults `committer` to the provided `author`, so sending `author` alone still suppresses GitHub's auto-signing — only a request with **both** fields omitted gets attributed to the authenticated App installation and signed.

Verified empirically against `fern-support/node-auth0` with an App installation token:

| createCommit request | committer | verification |
|---|---|---|
| `author` only (current 0.9.39 behavior) | copied from `author` (`fern-api`) | `unsigned` ([example from live regen](https://github.com/fern-support/node-auth0/pull/1)) |
| neither `author` nor `committer` | `GitHub <noreply@github.com>` | `valid` / Verified |

## Changes Made
- `pushSignedCommit`: when no `author` override is configured, omit both `author` and `committer` from `octokit.git.createCommit` (previously always sent `author`). GitHub then attributes the commit to the App bot (`fern-api[bot]`, same `115122769+fern-api[bot]@users.noreply.github.com` noreply email) and signs it — replay commit detection and `findExistingUpdatablePR` both match on that email, so attribution-based tooling is unaffected.
- When `GithubStepConfig.author` IS set, both `author` and `committer` are pinned to it (unchanged behavior).
- versions.yml: 0.9.40 changelog entry.
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated (`pushSignedCommit.test.ts` asserts both fields omitted by default, pinned when configured)
- [x] Manual testing completed (live API calls above reproducing unsigned/Verified behavior)


Link to Devin session: https://app.devin.ai/sessions/cb681df160884e2a8816e9b66f311bf2
Requested by: @tstanmay13