### PR TITLE
fix(php): forward required custom OAuth token request properties

### DIFF
--- a/generators/php/sdk/changes/unreleased/fix-oauth-custom-token-request-properties.yml
+++ b/generators/php/sdk/changes/unreleased/fix-oauth-custom-token-request-properties.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix the generated OAuth token provider to forward required non-literal token request
+    properties (custom scopes and other required body properties such as an entity id) to the
+    token endpoint. Previously these properties were silently dropped, so the generated
+    typed token request was missing required keys and failed PHPStan. They are now collected
+    as client constructor parameters and threaded through to the token request.
+  type: fix

--- a/generators/php/sdk/src/oauth/OauthTokenProviderGenerator.ts
+++ b/generators/php/sdk/src/oauth/OauthTokenProviderGenerator.ts
@@ -6,6 +6,7 @@ import { FernIr } from "@fern-fern/ir-sdk";
 
 import { SdkCustomConfigSchema } from "../SdkCustomConfig.js";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
+import { getOAuthTokenRequestProperties, OAuthTokenRequestProperty } from "./oauthTokenRequestProperties.js";
 
 export declare namespace OauthTokenProviderGenerator {
     interface Args {
@@ -23,6 +24,7 @@ export class OauthTokenProviderGenerator extends FileGenerator<PhpFile, SdkCusto
     private tokenEndpointHttpService: FernIr.HttpService;
     private tokenEndpointReference: FernIr.EndpointReference;
     private tokenEndpoint: FernIr.HttpEndpoint;
+    private extraRequestProperties: OAuthTokenRequestProperty[];
 
     constructor({ context, scheme }: OauthTokenProviderGenerator.Args) {
         super(context);
@@ -43,6 +45,10 @@ export class OauthTokenProviderGenerator extends FileGenerator<PhpFile, SdkCusto
             throw GeneratorError.referenceError(`Endpoint with id ${this.tokenEndpointReference.endpointId} not found`);
         }
         this.tokenEndpoint = endpoint;
+        this.extraRequestProperties = getOAuthTokenRequestProperties(
+            this.context,
+            this.scheme.configuration.tokenEndpoint.requestProperties
+        );
     }
 
     public doGenerate(): PhpFile {
@@ -100,6 +106,16 @@ export class OauthTokenProviderGenerator extends FileGenerator<PhpFile, SdkCusto
             })
         );
 
+        for (const property of this.extraRequestProperties) {
+            class_.addField(
+                php.field({
+                    name: `$${property.parameterName}`,
+                    access: "private",
+                    type: this.context.phpTypeMapper.convert({ reference: property.valueType })
+                })
+            );
+        }
+
         class_.addField(
             php.field({
                 name: "$authClient",
@@ -140,6 +156,13 @@ export class OauthTokenProviderGenerator extends FileGenerator<PhpFile, SdkCusto
                 type: php.Type.string(),
                 docs: "The client secret for OAuth authentication."
             }),
+            ...this.extraRequestProperties.map((property) =>
+                php.parameter({
+                    name: property.parameterName,
+                    type: this.context.phpTypeMapper.convert({ reference: property.valueType }),
+                    docs: "A property required by the OAuth token endpoint."
+                })
+            ),
             php.parameter({
                 name: "authClient",
                 type: php.Type.reference(this.getAuthClientClassReference()),
@@ -152,6 +175,9 @@ export class OauthTokenProviderGenerator extends FileGenerator<PhpFile, SdkCusto
             body: php.codeblock((writer) => {
                 writer.writeLine("$this->clientId = $clientId;");
                 writer.writeLine("$this->clientSecret = $clientSecret;");
+                for (const property of this.extraRequestProperties) {
+                    writer.writeLine(`$this->${property.parameterName} = $${property.parameterName};`);
+                }
                 writer.writeLine("$this->authClient = $authClient;");
                 writer.writeLine("$this->accessToken = null;");
 
@@ -235,6 +261,10 @@ export class OauthTokenProviderGenerator extends FileGenerator<PhpFile, SdkCusto
                     if (scopesLiteral != null) {
                         writer.writeLine(`'${scopesPropName}' => ${this.context.getLiteralAsString(scopesLiteral)},`);
                     }
+                }
+
+                for (const property of this.extraRequestProperties) {
+                    writer.writeLine(`'${property.parameterName}' => $this->${property.parameterName},`);
                 }
 
                 writer.dedent();

--- a/generators/php/sdk/src/oauth/oauthTokenRequestProperties.ts
+++ b/generators/php/sdk/src/oauth/oauthTokenRequestProperties.ts
@@ -1,0 +1,53 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+
+import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
+
+/**
+ * A non-literal request property (beyond client id / client secret) that the
+ * generated SDK must collect from the user and forward to the OAuth token
+ * endpoint. Examples include custom scopes or arbitrary required body
+ * properties such as an entity id.
+ */
+export interface OAuthTokenRequestProperty {
+    /** The camelCase parameter/field name used in generated PHP. */
+    parameterName: string;
+    /** The value type of the property. */
+    valueType: FernIr.TypeReference;
+    /** Whether the property is optional on the token request. */
+    isOptional: boolean;
+}
+
+/**
+ * Returns the required non-literal request properties (scopes and custom
+ * properties) that must be threaded through the generated OAuth token provider.
+ * Literal and optional properties are excluded: literals are emitted inline and
+ * optional properties default to null on the request object.
+ */
+export function getOAuthTokenRequestProperties(
+    context: SdkGeneratorContext,
+    requestProperties: FernIr.OAuthAccessTokenRequestProperties
+): OAuthTokenRequestProperty[] {
+    const properties: OAuthTokenRequestProperty[] = [];
+
+    const candidates: FernIr.RequestProperty[] = [
+        ...(requestProperties.scopes != null ? [requestProperties.scopes] : []),
+        ...(requestProperties.customProperties ?? [])
+    ];
+
+    for (const candidate of candidates) {
+        const valueType = candidate.property.valueType;
+        if (context.maybeLiteral(valueType) != null) {
+            continue;
+        }
+        if (context.isOptional(valueType)) {
+            continue;
+        }
+        properties.push({
+            parameterName: context.case.camelUnsafe(candidate.property.name),
+            valueType,
+            isOptional: false
+        });
+    }
+
+    return properties;
+}

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -5,6 +5,7 @@ import { FileGenerator, PhpFile } from "@fern-api/php-base";
 import { php } from "@fern-api/php-codegen";
 import { FernIr } from "@fern-fern/ir-sdk";
 
+import { getOAuthTokenRequestProperties } from "../oauth/oauthTokenRequestProperties.js";
 import { SdkCustomConfigSchema } from "../SdkCustomConfig.js";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
@@ -715,6 +716,21 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                             environmentVariable: oauthConfig.clientSecretEnvVar
                         }
                     ];
+                    for (const property of getOAuthTokenRequestProperties(
+                        this.context,
+                        oauthConfig.tokenEndpoint.requestProperties
+                    )) {
+                        params.push({
+                            name: property.parameterName,
+                            docs: "A property required by the OAuth token endpoint.",
+                            isOptional,
+                            typeReference: this.getAuthParameterTypeReference({
+                                typeReference: property.valueType,
+                                envVar: undefined,
+                                isOptional
+                            })
+                        });
+                    }
                     return params;
                 }
                 // Fallback to the default bearer token scheme for other OAuth types
@@ -889,7 +905,13 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
         const clientIdFallback = oauth.configuration.clientIdEnvVar != null ? "$clientId" : "$clientId ?? ''";
         const clientSecretFallback =
             oauth.configuration.clientSecretEnvVar != null ? "$clientSecret" : "$clientSecret ?? ''";
-        writer.writeLine(`(${clientIdFallback}, ${clientSecretFallback}, $authClient);`);
+        const isAuthMandatory = this.context.ir.sdkConfig.isAuthMandatory;
+        const extraArgs = getOAuthTokenRequestProperties(
+            this.context,
+            oauth.configuration.tokenEndpoint.requestProperties
+        ).map((property) => (isAuthMandatory ? `$${property.parameterName}` : `$${property.parameterName} ?? ''`));
+        const args = [clientIdFallback, clientSecretFallback, ...extraArgs, "$authClient"].join(", ");
+        writer.writeLine(`(${args});`);
         writer.writeLine();
     }
 

--- a/seed/php-sdk/oauth-client-credentials-custom/src/Core/OAuthTokenProvider.php
+++ b/seed/php-sdk/oauth-client-credentials-custom/src/Core/OAuthTokenProvider.php
@@ -29,6 +29,16 @@ class OAuthTokenProvider
     private string $clientSecret;
 
     /**
+     * @var string $scp
+     */
+    private string $scp;
+
+    /**
+     * @var string $entityId
+     */
+    private string $entityId;
+
+    /**
      * @var AuthClient $authClient
      */
     private AuthClient $authClient;
@@ -46,15 +56,21 @@ class OAuthTokenProvider
     /**
      * @param string $clientId The client ID for OAuth authentication.
      * @param string $clientSecret The client secret for OAuth authentication.
+     * @param string $scp A property required by the OAuth token endpoint.
+     * @param string $entityId A property required by the OAuth token endpoint.
      * @param AuthClient $authClient The client used to retrieve the OAuth token.
      */
     public function __construct(
         string $clientId,
         string $clientSecret,
+        string $scp,
+        string $entityId,
         AuthClient $authClient,
     ) {
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
+        $this->scp = $scp;
+        $this->entityId = $entityId;
         $this->authClient = $authClient;
         $this->accessToken = null;
         $this->expiresAt = null;
@@ -85,6 +101,8 @@ class OAuthTokenProvider
             'csr' => $this->clientSecret,
             'audience' => 'https://api.example.com',
             'grantType' => 'client_credentials',
+            'scp' => $this->scp,
+            'entityId' => $this->entityId,
         ]);
 
         $tokenResponse = $this->authClient->getTokenWithClientCredentials($request);

--- a/seed/php-sdk/oauth-client-credentials-custom/src/SeedClient.php
+++ b/seed/php-sdk/oauth-client-credentials-custom/src/SeedClient.php
@@ -56,6 +56,8 @@ class SeedClient
     /**
      * @param ?string $clientId The client ID for OAuth authentication.
      * @param ?string $clientSecret The client secret for OAuth authentication.
+     * @param ?string $scp A property required by the OAuth token endpoint.
+     * @param ?string $entityId A property required by the OAuth token endpoint.
      * @param ?array{
      *   baseUrl?: string,
      *   client?: ClientInterface,
@@ -67,6 +69,8 @@ class SeedClient
     public function __construct(
         ?string $clientId = null,
         ?string $clientSecret = null,
+        ?string $scp = null,
+        ?string $entityId = null,
         ?array $options = null,
     ) {
         $defaultHeaders = [
@@ -80,7 +84,7 @@ class SeedClient
 
         $authRawClient = new RawClient(['headers' => []]);
         $authClient = new AuthClient($authRawClient);
-        $this->oauthTokenProvider = new OAuthTokenProvider($clientId ?? '', $clientSecret ?? '', $authClient);
+        $this->oauthTokenProvider = new OAuthTokenProvider($clientId ?? '', $clientSecret ?? '', $scp ?? '', $entityId ?? '', $authClient);
 
         $this->options['headers'] = array_merge(
             $defaultHeaders,

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -192,7 +192,5 @@ allowedFailures:
 
   # PHPDoc unresolvable enum-as-map-key type + dynamic snippet errors (unrelated to union serialization).
   - trace
-  # OAuth custom properties need non-literal property passthrough to the token request.
-  - oauth-client-credentials-custom
 
 


### PR DESCRIPTION
## Description
Removes `oauth-client-credentials-custom` from the PHP SDK seed `allowedFailures` by fixing the underlying generator bug. Follow-up to #16478 (now merged).

### Root cause
For an OAuth client-credentials token endpoint whose request body has **required, non-literal** properties beyond client id / client secret (e.g. a custom `scp` scopes property and an `entity_id`), the generated `OAuthTokenProvider::refresh()` only emitted client id, client secret, and literal properties. The typed `GetTokenRequest` it constructed was therefore missing required keys, so PHPStan failed:

```
Array ... might not have keys 'scp' and 'entityId'.
```

Other languages (e.g. Java) thread these properties through as token-provider constructor parameters sourced from the root client; PHP did not.

### Fix
Introduce a shared helper `getOAuthTokenRequestProperties(context, requestProperties)` returning the required non-literal token request properties (scopes + custom properties, skipping literals and optionals). Both generators consume it:

- `OauthTokenProviderGenerator` adds a private field + constructor parameter per property and emits it into the token request array:
  ```php
  $request = new GetTokenRequest([
      'cid' => $this->clientId,
      'csr' => $this->clientSecret,
      'audience' => 'https://api.example.com',
      'grantType' => 'client_credentials',
      'scp' => $this->scp,
      'entityId' => $this->entityId,
  ]);
  ```
- `RootClientGenerator` adds matching root-client constructor parameters and forwards them to the provider (mirroring the existing inferred-auth path), using `$x ?? ''` fallbacks when auth is not mandatory:
  ```php
  $this->oauthTokenProvider = new OAuthTokenProvider($clientId ?? '', $clientSecret ?? '', $scp ?? '', $entityId ?? '', $authClient);
  ```

Literal properties (`audience`, `grant_type`) and optional properties (`scope`) are unchanged, so all other OAuth fixtures regenerate byte-identically.

## Changes Made
- Add `generators/php/sdk/src/oauth/oauthTokenRequestProperties.ts` shared helper
- `OauthTokenProviderGenerator.ts`: thread required non-literal token request properties through fields/constructor/refresh
- `RootClientGenerator.ts`: expose those properties as root client constructor params and pass them to the provider
- Regenerate `oauth-client-credentials-custom` seed output
- Remove `oauth-client-credentials-custom` from `seed/php-sdk/seed.yml` `allowedFailures`
- Add changelog entry

## Testing
- [x] `oauth-client-credentials-custom` seed fixture now passes (build + PHPStan + tests)
- [x] All other OAuth fixtures (`oauth-client-credentials`, `-default`, `-environment-variables`, `-nested-root`, `-mandatory-auth`, `-reference`) regenerate with no behavioral diff (only metadata noise)
- [x] `@fern-api/php-sdk` unit tests pass
- [ ] CI

Link to Devin session: https://app.devin.ai/sessions/061e09e6d9bf4b7dbb24899b3bb9b9a2
Requested by: @iamnamananand996