### PR TITLE
feat(docs): support translated API definitions in ledger publish path

### DIFF
--- a/packages/cli/cli/changes/unreleased/ledger-translated-api-definitions.yml
+++ b/packages/cli/cli/changes/unreleased/ledger-translated-api-definitions.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Ledger translations now include localized API reference content. When
+    translated OpenAPI specs exist under `translations/<locale>/apis/<apiName>/`,
+    the ledger publish path builds per-locale apiManifest blobs with translated
+    descriptions and patches sidebar titles to match the translated API content.
+  type: feat

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLedgerInput.test.ts
@@ -316,6 +316,58 @@ describe("buildLedgerInput", () => {
         expect(parsed).toEqual({ "api-def-1": minimalApiDefinition });
     });
 
+    it("produces different apiManifest blobs for different apiDefinitions maps (locale isolation)", () => {
+        const baseApiDefinition: ApiDefinition = {
+            types: {},
+            subpackages: {},
+            rootPackage: {
+                endpoints: [],
+                types: [],
+                subpackages: [],
+                websockets: [],
+                webhooks: []
+            },
+            auth: undefined,
+            snippetsConfiguration: {},
+            globalHeaders: [],
+            apiName: "plant-api"
+        };
+
+        const translatedApiDefinition: ApiDefinition = {
+            ...baseApiDefinition,
+            apiName: "plant-api-zh"
+        };
+
+        const baseMap = new Map<string, ApiDefinition>([["api-1", baseApiDefinition]]);
+        const translatedMap = new Map<string, ApiDefinition>([["api-1", translatedApiDefinition]]);
+        const docsDefinition = makeDocsDefinition();
+
+        const { localeEntry: baseEntry, blobs: baseBlobs } = buildLedgerInput({
+            docsDefinition,
+            apiDefinitions: baseMap
+        });
+        const { localeEntry: translatedEntry, blobs: translatedBlobs } = buildLedgerInput({
+            docsDefinition,
+            apiDefinitions: translatedMap,
+            locale: "zh"
+        });
+
+        // Both should have apiManifest blobs.
+        expect(baseEntry.apiManifest).not.toBeNull();
+        expect(translatedEntry.apiManifest).not.toBeNull();
+
+        // The hashes must differ because the API content differs.
+        expect(baseEntry.apiManifest?.hash).not.toBe(translatedEntry.apiManifest?.hash);
+
+        // Each blob should deserialize to its respective definition.
+        const baseParsed = JSON.parse(baseBlobs.get(baseEntry.apiManifest?.hash ?? "")?.toString("utf-8") ?? "");
+        const translatedParsed = JSON.parse(
+            translatedBlobs.get(translatedEntry.apiManifest?.hash ?? "")?.toString("utf-8") ?? ""
+        );
+        expect(baseParsed["api-1"].apiName).toBe("plant-api");
+        expect(translatedParsed["api-1"].apiName).toBe("plant-api-zh");
+    });
+
     it("forwards fileManifest unchanged (file blobs are loaded lazily, not included in blob map)", () => {
         // Image entry — exercises width/height fields.
         const imageBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]); // PNG header

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLocaleApiDefinitions.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/buildLocaleApiDefinitions.test.ts
@@ -1,0 +1,171 @@
+import { type TranslatedApiSpec } from "@fern-api/docs-resolver";
+import { type APIV1Write } from "@fern-api/fdr-sdk";
+import { type IntermediateRepresentation } from "@fern-api/ir-sdk";
+import { type TaskContext } from "@fern-api/task-context";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { buildLocaleApiDefinitions } from "../publishDocsLedger.js";
+
+// Mock the heavy @fern-api/register module so we don't need a real IR.
+vi.mock("@fern-api/register", () => ({
+    convertIrToFdrApi: vi.fn()
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { convertIrToFdrApi } = await import("@fern-api/register");
+const mockConvertIrToFdrApi = convertIrToFdrApi as Mock;
+
+function makeApiDefinition(overrides: Partial<APIV1Write.ApiDefinition> = {}): APIV1Write.ApiDefinition {
+    return {
+        types: {},
+        subpackages: {},
+        rootPackage: {
+            endpoints: [],
+            types: [],
+            subpackages: [],
+            websockets: [],
+            webhooks: []
+        },
+        auth: undefined,
+        snippetsConfiguration: {},
+        globalHeaders: [],
+        ...overrides
+    } as unknown as APIV1Write.ApiDefinition;
+}
+
+function makeTranslatedSpec(overrides: Partial<TranslatedApiSpec> = {}): TranslatedApiSpec {
+    return {
+        ir: {} as IntermediateRepresentation,
+        snippetsConfig: {},
+        apiName: "translated-api",
+        ...overrides
+    } as TranslatedApiSpec;
+}
+
+function makeContext(): TaskContext {
+    return {
+        logger: {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn()
+        }
+    } as unknown as TaskContext;
+}
+
+describe("buildLocaleApiDefinitions", () => {
+    beforeEach(() => {
+        mockConvertIrToFdrApi.mockReset();
+    });
+
+    it("replaces base definitions with translated ones for matching API IDs", () => {
+        const baseDef = makeApiDefinition({ apiName: "english" } as Partial<APIV1Write.ApiDefinition>);
+        const translatedDef = makeApiDefinition({ apiName: "chinese" } as Partial<APIV1Write.ApiDefinition>);
+        mockConvertIrToFdrApi.mockReturnValue(translatedDef);
+
+        const baseApiDefinitions = new Map([["api-1", baseDef]]);
+        const translatedSpecs = new Map([["api-1", makeTranslatedSpec()]]);
+        const context = makeContext();
+
+        const result = buildLocaleApiDefinitions({
+            baseApiDefinitions,
+            translatedSpecs,
+            context
+        });
+
+        expect(result.get("api-1")).toBe(translatedDef);
+        expect(result.get("api-1")).not.toBe(baseDef);
+    });
+
+    it("preserves base definitions for APIs without translations", () => {
+        const baseDef1 = makeApiDefinition();
+        const baseDef2 = makeApiDefinition();
+        const translatedDef = makeApiDefinition({ apiName: "translated" } as Partial<APIV1Write.ApiDefinition>);
+        mockConvertIrToFdrApi.mockReturnValue(translatedDef);
+
+        const baseApiDefinitions = new Map([
+            ["api-1", baseDef1],
+            ["api-2", baseDef2]
+        ]);
+        // Only api-1 has a translation.
+        const translatedSpecs = new Map([["api-1", makeTranslatedSpec()]]);
+        const context = makeContext();
+
+        const result = buildLocaleApiDefinitions({
+            baseApiDefinitions,
+            translatedSpecs,
+            context
+        });
+
+        expect(result.get("api-1")).toBe(translatedDef);
+        expect(result.get("api-2")).toBe(baseDef2);
+    });
+
+    it("does not mutate the original base map", () => {
+        const baseDef = makeApiDefinition();
+        const translatedDef = makeApiDefinition({ apiName: "translated" } as Partial<APIV1Write.ApiDefinition>);
+        mockConvertIrToFdrApi.mockReturnValue(translatedDef);
+
+        const baseApiDefinitions = new Map([["api-1", baseDef]]);
+        const translatedSpecs = new Map([["api-1", makeTranslatedSpec()]]);
+        const context = makeContext();
+
+        buildLocaleApiDefinitions({
+            baseApiDefinitions,
+            translatedSpecs,
+            context
+        });
+
+        // The original base map should still have the original definition.
+        expect(baseApiDefinitions.get("api-1")).toBe(baseDef);
+    });
+
+    it("falls back to base definition when conversion throws", () => {
+        const baseDef = makeApiDefinition();
+        mockConvertIrToFdrApi.mockImplementation(() => {
+            throw new Error("IR conversion failed");
+        });
+
+        const baseApiDefinitions = new Map([["api-1", baseDef]]);
+        const translatedSpecs = new Map([["api-1", makeTranslatedSpec()]]);
+        const context = makeContext();
+
+        const result = buildLocaleApiDefinitions({
+            baseApiDefinitions,
+            translatedSpecs,
+            context
+        });
+
+        // Should fall back to base, not throw.
+        expect(result.get("api-1")).toBe(baseDef);
+        expect(context.logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to convert translated API definition for API "api-1"')
+        );
+    });
+
+    it("passes correct arguments to convertIrToFdrApi", () => {
+        const translatedDef = makeApiDefinition();
+        mockConvertIrToFdrApi.mockReturnValue(translatedDef);
+
+        const spec = makeTranslatedSpec({
+            apiName: "plant-api",
+            snippetsConfig: { typescriptSdk: undefined } as unknown as APIV1Write.SnippetsConfig
+        });
+        const context = makeContext();
+
+        buildLocaleApiDefinitions({
+            baseApiDefinitions: new Map([["api-1", makeApiDefinition()]]),
+            translatedSpecs: new Map([["api-1", spec]]),
+            context
+        });
+
+        expect(mockConvertIrToFdrApi).toHaveBeenCalledWith({
+            ir: spec.ir,
+            snippetsConfig: spec.snippetsConfig,
+            playgroundConfig: spec.playgroundConfig,
+            graphqlOperations: spec.graphqlOperations,
+            graphqlTypes: spec.graphqlTypes,
+            context,
+            apiNameOverride: "plant-api"
+        });
+    });
+});

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -6,10 +6,10 @@ import {
 import {
     APIV1Read,
     APIV1Write,
-    type DocsV1Write,
     FdrAPI as CjsFdrSdk,
     convertAPIDefinitionToDb,
     convertDbAPIDefinitionToRead,
+    type DocsV1Write,
     SDKSnippetHolder
 } from "@fern-api/fdr-sdk";
 import {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -502,7 +502,8 @@ interface BuiltTranslation {
  */
 function toReadApiDefinition(
     definition: APIV1Write.ApiDefinition,
-    apiDefinitionId: string
+    apiDefinitionId: string,
+    context: TaskContext
 ): APIV1Read.ApiDefinition | undefined {
     try {
         const dbApiDefinition = convertAPIDefinitionToDb(
@@ -517,7 +518,10 @@ function toReadApiDefinition(
             })
         );
         return convertDbAPIDefinitionToRead(dbApiDefinition);
-    } catch {
+    } catch (error) {
+        context.logger.debug(
+            `[ledger] Failed to convert API definition "${apiDefinitionId}" to read form: ${String(error)}`
+        );
         return undefined;
     }
 }
@@ -536,6 +540,7 @@ function buildLocaleApiDefinitions({
     translatedSpecs: Map<string, TranslatedApiSpec>;
     context: TaskContext;
 }): Map<string, APIV1Write.ApiDefinition> {
+    // Shallow clone — replaced entries are new objects from convertIrToFdrApi.
     const localeApiDefs = new Map(baseApiDefinitions);
     for (const [baseApiId, spec] of translatedSpecs) {
         try {
@@ -604,6 +609,18 @@ async function buildAllTranslationInputs({
     // buildTranslatedApiDefinitions=true.
     const translatedApiSpecsByLocale = resolver.getTranslatedApiSpecs();
 
+    // Pre-compute base API read definitions once (expensive Write→Db→Read
+    // pipeline). Reused across all locales for nav title patching.
+    const baseReadApis: Record<string, APIV1Read.ApiDefinition> = {};
+    if (translatedApiSpecsByLocale.size > 0) {
+        for (const [apiId, def] of apiDefinitions) {
+            const readDef = toReadApiDefinition(def, apiId, context);
+            if (readDef != null) {
+                baseReadApis[apiId] = readDef;
+            }
+        }
+    }
+
     const localeEntries = Object.entries(translationPages);
     context.logger.info(`[ledger] Building ${localeEntries.length} translation locale(s)...`);
     const { buildTranslatedDocsDefinition } = await import("./buildTranslatedDocsDefinition.js");
@@ -634,19 +651,11 @@ async function buildAllTranslationInputs({
                 // Patch sidebar titles in the nav tree so endpoint/subpackage
                 // names reflect the translated API content.
                 if (translatedDefinition.config.root != null) {
-                    const baseApisForTitles: Record<string, APIV1Read.ApiDefinition> = {};
                     const translatedApisForTitles: Record<string, APIV1Read.ApiDefinition> = {};
                     for (const [baseApiId] of localeTranslatedSpecs) {
-                        const baseDef = apiDefinitions.get(baseApiId);
                         const translatedDef = localeApiDefinitions.get(baseApiId);
-                        if (baseDef != null) {
-                            const baseRead = toReadApiDefinition(baseDef, baseApiId);
-                            if (baseRead != null) {
-                                baseApisForTitles[baseApiId] = baseRead;
-                            }
-                        }
                         if (translatedDef != null) {
-                            const translatedRead = toReadApiDefinition(translatedDef, baseApiId);
+                            const translatedRead = toReadApiDefinition(translatedDef, baseApiId, context);
                             if (translatedRead != null) {
                                 translatedApisForTitles[baseApiId] = translatedRead;
                             }
@@ -655,7 +664,7 @@ async function buildAllTranslationInputs({
                     if (Object.keys(translatedApisForTitles).length > 0) {
                         translatedDefinition.config.root = applyTranslatedApiTitlesToNavTree(
                             translatedDefinition.config.root,
-                            baseApisForTitles,
+                            baseReadApis,
                             translatedApisForTitles
                         );
                     }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -531,7 +531,7 @@ function toReadApiDefinition(
  * with their translated equivalents (produced from translated OpenAPI specs
  * under `translations/<locale>/apis/<apiName>/`).
  */
-function buildLocaleApiDefinitions({
+export function buildLocaleApiDefinitions({
     baseApiDefinitions,
     translatedSpecs,
     context

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocsLedger.ts
@@ -1,5 +1,17 @@
-import { type DocsDefinitionResolver } from "@fern-api/docs-resolver";
-import type { APIV1Write, DocsV1Write } from "@fern-api/fdr-sdk";
+import {
+    applyTranslatedApiTitlesToNavTree,
+    type DocsDefinitionResolver,
+    type TranslatedApiSpec
+} from "@fern-api/docs-resolver";
+import {
+    APIV1Read,
+    APIV1Write,
+    type DocsV1Write,
+    FdrAPI as CjsFdrSdk,
+    convertAPIDefinitionToDb,
+    convertDbAPIDefinitionToRead,
+    SDKSnippetHolder
+} from "@fern-api/fdr-sdk";
 import {
     type DocsPublishGitInput,
     type DocsPublishInput,
@@ -7,6 +19,7 @@ import {
     type LocaleEntry
 } from "@fern-api/fdr-sdk/orpc-client";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { convertIrToFdrApi } from "@fern-api/register";
 import type { TaskContext } from "@fern-api/task-context";
 import { createHash } from "crypto";
 import { readFile } from "fs/promises";
@@ -484,7 +497,75 @@ interface BuiltTranslation {
 }
 
 /**
+ * Convert an APIV1Write.ApiDefinition to its APIV1Read form for nav title
+ * patching. Mirrors the `captureReadApiDefinition` helper in publishDocs.ts.
+ */
+function toReadApiDefinition(
+    definition: APIV1Write.ApiDefinition,
+    apiDefinitionId: string
+): APIV1Read.ApiDefinition | undefined {
+    try {
+        const dbApiDefinition = convertAPIDefinitionToDb(
+            definition,
+            CjsFdrSdk.ApiDefinitionId(apiDefinitionId),
+            new SDKSnippetHolder({
+                snippetsConfigWithSdkId: {},
+                snippetsBySdkId: {},
+                snippetTemplatesByEndpoint: {},
+                snippetTemplatesByEndpointId: {},
+                snippetsBySdkIdAndEndpointId: {}
+            })
+        );
+        return convertDbAPIDefinitionToRead(dbApiDefinition);
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Build a locale-specific apiDefinitions map by replacing base API definitions
+ * with their translated equivalents (produced from translated OpenAPI specs
+ * under `translations/<locale>/apis/<apiName>/`).
+ */
+function buildLocaleApiDefinitions({
+    baseApiDefinitions,
+    translatedSpecs,
+    context
+}: {
+    baseApiDefinitions: Map<string, APIV1Write.ApiDefinition>;
+    translatedSpecs: Map<string, TranslatedApiSpec>;
+    context: TaskContext;
+}): Map<string, APIV1Write.ApiDefinition> {
+    const localeApiDefs = new Map(baseApiDefinitions);
+    for (const [baseApiId, spec] of translatedSpecs) {
+        try {
+            const translatedApiDef = convertIrToFdrApi({
+                ir: spec.ir,
+                snippetsConfig: spec.snippetsConfig,
+                playgroundConfig: spec.playgroundConfig,
+                graphqlOperations: spec.graphqlOperations,
+                graphqlTypes: spec.graphqlTypes,
+                context,
+                apiNameOverride: spec.apiName
+            });
+            localeApiDefs.set(baseApiId, translatedApiDef);
+        } catch (error) {
+            context.logger.warn(
+                `[ledger] Failed to convert translated API definition for API "${baseApiId}": ${String(error)}. ` +
+                    `Falling back to base (untranslated) API.`
+            );
+        }
+    }
+    return localeApiDefs;
+}
+
+/**
  * Build ledger inputs for every translation locale the resolver discovered.
+ *
+ * For each locale, if translated API specs exist under
+ * `translations/<locale>/apis/<apiName>/`, the locale receives its own
+ * apiManifest blob with translated descriptions/summaries and a nav tree
+ * with localized sidebar titles. Otherwise the base apiManifest is reused.
  *
  * Locales are built with bounded concurrency. If ANY locale fails, the
  * returned promise rejects — callers should let the error propagate to
@@ -518,6 +599,11 @@ async function buildAllTranslationInputs({
         return [];
     }
 
+    // Get translated API specs (per-locale, per-base-apiDefinitionId).
+    // These are already populated by DocsDefinitionResolver.resolve() when
+    // buildTranslatedApiDefinitions=true.
+    const translatedApiSpecsByLocale = resolver.getTranslatedApiSpecs();
+
     const localeEntries = Object.entries(translationPages);
     context.logger.info(`[ledger] Building ${localeEntries.length} translation locale(s)...`);
     const { buildTranslatedDocsDefinition } = await import("./buildTranslatedDocsDefinition.js");
@@ -535,10 +621,51 @@ async function buildAllTranslationInputs({
                 context
             });
 
+            // Build locale-specific API definitions from translated OpenAPI specs.
+            const localeTranslatedSpecs = translatedApiSpecsByLocale.get(locale);
+            let localeApiDefinitions = apiDefinitions;
+            if (localeTranslatedSpecs != null && localeTranslatedSpecs.size > 0) {
+                localeApiDefinitions = buildLocaleApiDefinitions({
+                    baseApiDefinitions: apiDefinitions,
+                    translatedSpecs: localeTranslatedSpecs,
+                    context
+                });
+
+                // Patch sidebar titles in the nav tree so endpoint/subpackage
+                // names reflect the translated API content.
+                if (translatedDefinition.config.root != null) {
+                    const baseApisForTitles: Record<string, APIV1Read.ApiDefinition> = {};
+                    const translatedApisForTitles: Record<string, APIV1Read.ApiDefinition> = {};
+                    for (const [baseApiId] of localeTranslatedSpecs) {
+                        const baseDef = apiDefinitions.get(baseApiId);
+                        const translatedDef = localeApiDefinitions.get(baseApiId);
+                        if (baseDef != null) {
+                            const baseRead = toReadApiDefinition(baseDef, baseApiId);
+                            if (baseRead != null) {
+                                baseApisForTitles[baseApiId] = baseRead;
+                            }
+                        }
+                        if (translatedDef != null) {
+                            const translatedRead = toReadApiDefinition(translatedDef, baseApiId);
+                            if (translatedRead != null) {
+                                translatedApisForTitles[baseApiId] = translatedRead;
+                            }
+                        }
+                    }
+                    if (Object.keys(translatedApisForTitles).length > 0) {
+                        translatedDefinition.config.root = applyTranslatedApiTitlesToNavTree(
+                            translatedDefinition.config.root,
+                            baseApisForTitles,
+                            translatedApisForTitles
+                        );
+                    }
+                }
+            }
+
             const { localeEntry, blobs } = buildLedgerInput({
                 docsDefinition: translatedDefinition,
                 git,
-                apiDefinitions,
+                apiDefinitions: localeApiDefinitions,
                 fileManifest,
                 fileIdToPath,
                 locale


### PR DESCRIPTION
## Description

Refs [#16097 (feat/docs_ledger)](https://github.com/fern-api/fern/pull/16097) · [fern-testing-umbrella#80 (multilocale fixture)](https://github.com/fern-api/fern-testing-umbrella/pull/80)

In ledger-only mode, every translated locale received the same base (English) `apiManifest` blob because `buildAllTranslationInputs` passed the shared `apiDefinitionCollector` map to `buildLedgerInput` for all locales. This PR builds per-locale `apiDefinitions` maps from translated OpenAPI specs and patches sidebar titles to match.

## Changes Made

### `publishDocsLedger.ts`

- New exported helper `buildLocaleApiDefinitions`: clones base map, replaces entries with `convertIrToFdrApi(spec.ir, ...)` output, warns + falls back on error
- New private helper `toReadApiDefinition(def, id, context)`: Write→Db→Read pipeline for nav title patching (mirrors V2's `captureReadApiDefinition`, logs at debug on failure)
- Modified `buildAllTranslationInputs`:
  - Calls `resolver.getTranslatedApiSpecs()` for per-locale translated specs
  - Pre-computes `baseReadApis` outside the async pool (avoids redundant conversions across locales)
  - For each locale with translated specs: builds locale-specific map, applies `applyTranslatedApiTitlesToNavTree`
  - Passes locale-specific map to `buildLedgerInput`
- No `updateApiDefinitionIdInTree` needed — ledger locale entries carry their own `apiManifest` keyed by the same base IDs

### Changelog

- `ledger-translated-api-definitions.yml` — `feat` entry

### Not changed

- Existing docs/MDX page translation flow
- `buildLedgerInput` itself (already accepts `apiDefinitions`)
- FDR server (already handles per-locale `apiManifest` blobs)
- V2 publish path

## Testing

- [x] Unit tests added: `buildLocaleApiDefinitions.test.ts` (5 tests: override, preservation, immutability, fallback, arg forwarding) + 1 new test in `buildLedgerInput.test.ts` (locale isolation — different maps → different blob hashes)
- [x] All 187 tests pass across 18 test files
- [x] Compiles: `pnpm turbo run compile --filter @fern-api/remote-workspace-runner`
- [x] Lint/format: `pnpm biome check` clean
- [x] Manual testing with `multilocale-test` fixture (rebuilt local CLI, published V2 + ledger)

### V2 ↔ Ledger Parity Results (multilocale-test with zh API translations)

All 14 pages (7 en + 7 zh, including 4 translated API reference pages per locale):

| Check | Result |
|-------|--------|
| **Pixel diff** | 14/14 pages pass at 0.00% diff |
| **Links** | 14/14 pages identical |
| **SEO tags** | 14/14 pages identical |
| **Search records** | 72 total objectIDs — all fields identical except objectID (expected: v2 and ledger use different ID schemes) |
| **Assets** | llms.txt, robots.txt, sitemap.xml all identical |

Link to Devin session: https://app.devin.ai/sessions/bc286fe533854aef968e6eb9b860474b
Requested by: @emjoseph