### PR TITLE
fix(swift): JSON-encode wire-test response bodies for non-string types

### DIFF
--- a/generators/swift/sdk/changes/unreleased/fix-wire-test-response-body-encoding.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-wire-test-response-body-encoding.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fixed wire-test stub response bodies so they are valid JSON for every
+    response type. The generated SDK reads `String`-typed response bodies as raw
+    UTF-8 but decodes every other type via `JSONDecoder`. Wire tests now mirror
+    that: `String`-decoded responses (string/bigInteger/base64 primitives) emit
+    the raw payload, while all other types (objects, enums, dates, UUIDs, numbers,
+    unions, etc.) are JSON-encoded. Previously bare scalars such as a UUID or enum
+    value were emitted unquoted, producing invalid JSON that failed to decode.
+  type: fix

--- a/generators/swift/sdk/src/generators/test/WireTestFunctionGenerator.ts
+++ b/generators/swift/sdk/src/generators/test/WireTestFunctionGenerator.ts
@@ -654,12 +654,54 @@ export class WireTestFunctionGenerator {
 }
 
 function renderWireTestResponseBody(exampleTypeRef: FernIr.ExampleTypeReference): string {
-    if (typeof exampleTypeRef.jsonExample === "string") {
-        return exampleTypeRef.jsonExample;
-    }
     const value = buildJsonFromExampleTypeReference(exampleTypeRef);
-    if (typeof value === "string") {
-        return value;
+    // The generated SDK reads `String`-typed response bodies as the raw UTF-8
+    // payload (see HTTPClient: `responseType == String.self`), whereas every
+    // other type is parsed as JSON. Mirror that here: emit the raw string for
+    // String-decoded responses, and JSON-encode everything else so a bare
+    // scalar (e.g. a UUID or number) is still valid JSON the decoder accepts.
+    if (responseDecodesAsRawString(exampleTypeRef)) {
+        return typeof value === "string" ? value : String(value ?? "");
     }
     return JSON.stringify(value, null, 2);
+}
+
+/**
+ * Whether the SDK decodes the given response type as a raw Swift `String`
+ * (rather than parsing it as JSON). Mirrors the Swift type mapping in which
+ * `string`, `bigInteger`, and `base64` primitives resolve to `String`.
+ */
+function responseDecodesAsRawString(exampleTypeRef: FernIr.ExampleTypeReference): boolean {
+    return exampleTypeRef.shape._visit<boolean>({
+        primitive: (primitive) =>
+            primitive._visit<boolean>({
+                string: () => true,
+                bigInteger: () => true,
+                base64: () => true,
+                integer: () => false,
+                long: () => false,
+                uint: () => false,
+                uint64: () => false,
+                float: () => false,
+                double: () => false,
+                boolean: () => false,
+                date: () => false,
+                datetime: () => false,
+                datetimeRfc2822: () => false,
+                uuid: () => false,
+                _other: () => false
+            }),
+        named: (named) =>
+            named.shape._visit<boolean>({
+                alias: (alias) => responseDecodesAsRawString(alias.value),
+                enum: () => false,
+                object: () => false,
+                union: () => false,
+                undiscriminatedUnion: () => false,
+                _other: () => false
+            }),
+        container: () => false,
+        unknown: () => false,
+        _other: () => false
+    });
 }

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Enum/EnumClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Enum/EnumClientWireTests.swift
@@ -8,7 +8,7 @@ import Exhaustive
         stub.setResponse(
             body: Data(
                 #"""
-                SUNNY
+                "SUNNY"
                 """#.utf8
             )
         )

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Primitive/PrimitiveClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Primitive/PrimitiveClientWireTests.swift
@@ -118,7 +118,7 @@ import Exhaustive
         stub.setResponse(
             body: Data(
                 #"""
-                2024-01-15T09:30:00Z
+                "2024-01-15T09:30:00Z"
                 """#.utf8
             )
         )
@@ -140,7 +140,7 @@ import Exhaustive
         stub.setResponse(
             body: Data(
                 #"""
-                2023-01-15
+                "2023-01-15"
                 """#.utf8
             )
         )
@@ -162,7 +162,7 @@ import Exhaustive
         stub.setResponse(
             body: Data(
                 #"""
-                d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32
+                "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 """#.utf8
             )
         )

--- a/seed/swift-sdk/idempotency-headers/Tests/Wire/Resources/Payment/PaymentClientWireTests.swift
+++ b/seed/swift-sdk/idempotency-headers/Tests/Wire/Resources/Payment/PaymentClientWireTests.swift
@@ -8,7 +8,7 @@ import IdempotencyHeaders
         stub.setResponse(
             body: Data(
                 #"""
-                d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32
+                "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 """#.utf8
             )
         )

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -135,7 +135,6 @@ allowedFailures:
   - exhaustive
   - extra-properties
   - file-upload-openapi
-  - idempotency-headers
   - inferred-auth-explicit
   - inferred-auth-implicit
   - inferred-auth-implicit-no-expiry

--- a/seed/swift-sdk/undiscriminated-unions/Tests/Wire/Resources/Union/UnionClientWireTests.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Tests/Wire/Resources/Union/UnionClientWireTests.swift
@@ -8,7 +8,7 @@ import UndiscriminatedUnions
         stub.setResponse(
             body: Data(
                 #"""
-                string
+                "string"
                 """#.utf8
             )
         )
@@ -201,7 +201,7 @@ import UndiscriminatedUnions
         stub.setResponse(
             body: Data(
                 #"""
-                string
+                "string"
                 """#.utf8
             )
         )


### PR DESCRIPTION
## Description

Stacked on #16484. Fixes the dominant runtime wire-test bug in the Swift SDK generator: stub response bodies were emitted as raw, unencoded strings, producing invalid JSON that the generated SDK could not decode.

The generated SDK's `HTTPClient` reads `String`-typed response bodies as raw UTF-8, but decodes **every other type** via `JSONDecoder`:

```swift
if responseType == String.self {
    return String(data: data, encoding: .utf8)   // raw UTF-8
} else {
    return try JSONDecoder().decode(T.self, from: data)  // JSON
}
```

`renderWireTestResponseBody()` did not mirror this — it emitted bare scalars (e.g. a UUID as `d5e9c84f-...`, an enum as `SUNNY`) which are not valid JSON, so decoding failed at runtime.

The fix mirrors the SDK's mapping via `responseDecodesAsRawString()`:
- `string` / `bigInteger` / `base64` primitives (which resolve to Swift `String`) → emit the **raw** payload.
- Everything else (objects, enums, dates, UUIDs, numbers, booleans, unions, …) → **JSON-encode**.

Example diffs in regenerated fixtures:
```
getAndReturnString → string                                   (raw, unchanged)
getAndReturnInt    → 1                                         (valid JSON)
getAndReturnUuid   → "d5e9c84f-..."   (was: d5e9c84f-...)      (now valid JSON)
getAndReturnDate   → "2023-01-15"     (was: 2023-01-15)
enum response      → "SUNNY"          (was: SUNNY)
```

## Changes Made
- `renderWireTestResponseBody()` now JSON-encodes non-`String` response bodies and keeps raw UTF-8 only for `String`-decoded types, via a new `responseDecodesAsRawString()` shape walk.
- Removed `idempotency-headers` from `seed/swift-sdk/seed.yml` `allowedFailures` (now fully compiles and passes 21/21 wire tests).
- Regenerated affected snapshots (`exhaustive`, `undiscriminated-unions`, `idempotency-headers`).
- Added changelog entry.

## Testing
- [x] `idempotency-headers` passes full `swift test -c release` (21/21) in Docker (`swift:6.1.2`).
- [x] Verified no double-encoding regression in `undiscriminated-unions` String responses (stay raw).
- [x] `exhaustive` primitive wire tests now emit valid JSON for every scalar type.
- [x] TypeScript compile + biome clean.

Link to Devin session: https://app.devin.ai/sessions/24c6efc2110b4c8ead19d72f7fe013b2
Requested by: @iamnamananand996