### PR TITLE
fix(swift): emit endpoint header arguments in wire tests and snippets

### DIFF
--- a/generators/swift/base/src/context/AbstractSwiftGeneratorContext.ts
+++ b/generators/swift/base/src/context/AbstractSwiftGeneratorContext.ts
@@ -6,12 +6,22 @@ import {
 } from "@fern-api/base-generator";
 import { assertDefined, assertNever, entries } from "@fern-api/core-utils";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { BaseSwiftCustomConfigSchema, Referencer, swift, UndiscriminatedUnion } from "@fern-api/swift-codegen";
+import {
+    BaseSwiftCustomConfigSchema,
+    NameRegistry,
+    Referencer,
+    swift,
+    UndiscriminatedUnion
+} from "@fern-api/swift-codegen";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { AsIsFileDefinition, SourceAsIsFiles, TestAsIsFiles } from "../AsIs.js";
 import { SwiftProject } from "../project/index.js";
 import { CycleDetector } from "./cycle-detector.js";
-import { registerLiteralEnums, registerLiteralEnumsForObjectProperties } from "./register-literal-enums.js";
+import {
+    registerLiteralEnums,
+    registerLiteralEnumsForObjectProperties,
+    registerLiteralEnumsForTypeReference
+} from "./register-literal-enums.js";
 import { registerUndiscriminatedUnionVariants } from "./register-undiscriminated-unions.js";
 
 export abstract class AbstractSwiftGeneratorContext<
@@ -156,12 +166,52 @@ export abstract class AbstractSwiftGeneratorContext<
             });
         });
         Object.entries(ir.subpackages).forEach(([subpackageId, subpackage]) => {
-            nameRegistry.registerSubClientSymbol({
+            const subClientSymbol = nameRegistry.registerSubClientSymbol({
                 subpackageId,
                 fernFilepathPartNamesPascalCase: subpackage.fernFilepath.allParts.map((name) =>
                     this.caseConverter.pascalUnsafe(name)
                 ),
                 subpackageNamePascalCase: this.caseConverter.pascalUnsafe(subpackage.name)
+            });
+            if (subpackage.service != null) {
+                this.registerEndpointParameterLiteralEnums({
+                    parentSymbol: subClientSymbol,
+                    service: ir.services[subpackage.service],
+                    registry: nameRegistry
+                });
+            }
+        });
+        if (ir.rootPackage.service != null) {
+            this.registerEndpointParameterLiteralEnums({
+                parentSymbol: nameRegistry.getRootClientSymbolOrThrow(),
+                service: ir.services[ir.rootPackage.service],
+                registry: nameRegistry
+            });
+        }
+    }
+
+    /**
+     * Inline literal query parameters become method parameters on the generated client, so their
+     * literal enums must be registered under the owning client symbol (matching the scope used to
+     * resolve the parameter's Swift type). Otherwise the parameter falls back to `JSONValue` while
+     * snippets and wire tests emit the literal enum case, producing a type mismatch.
+     */
+    private registerEndpointParameterLiteralEnums({
+        parentSymbol,
+        service,
+        registry
+    }: {
+        parentSymbol: swift.Symbol;
+        service: FernIr.HttpService | undefined;
+        registry: NameRegistry;
+    }): void {
+        service?.endpoints.forEach((endpoint) => {
+            endpoint.queryParameters.forEach((queryParam) => {
+                registerLiteralEnumsForTypeReference({
+                    parentSymbol,
+                    registry,
+                    typeReference: queryParam.valueType
+                });
             });
         });
     }
@@ -282,7 +332,7 @@ export abstract class AbstractSwiftGeneratorContext<
                 return typeReference.container._visit({
                     literal: (literal) =>
                         literal._visit({
-                            boolean: () => referencer.referenceAsIsType("JSONValue"),
+                            boolean: () => referencer.referenceSwiftType("Bool"),
                             string: (literalValue) => {
                                 const symbol = this.project.nameRegistry.getNestedLiteralEnumSymbol(
                                     fromSymbol,

--- a/generators/swift/codegen/src/ast/Class.ts
+++ b/generators/swift/codegen/src/ast/Class.ts
@@ -2,6 +2,7 @@ import { escapeReservedKeyword } from "../syntax/index.js";
 import { AccessLevel } from "./AccessLevel.js";
 import { AstNode, Writer } from "./core/index.js";
 import { DocComment } from "./DocComment.js";
+import { EnumWithRawValues } from "./EnumWithRawValues.js";
 import { Initializer } from "./Initializer.js";
 import { Method } from "./Method.js";
 import { Property } from "./Property.js";
@@ -16,6 +17,7 @@ export declare namespace Class {
         properties: Property[];
         initializers?: Initializer[];
         methods?: Method[];
+        nestedTypes?: EnumWithRawValues[];
         docs?: DocComment;
     }
 }
@@ -28,6 +30,7 @@ export class Class extends AstNode {
     public readonly properties: Property[];
     public readonly initializers: Initializer[];
     public readonly methods: Method[];
+    public readonly nestedTypes: EnumWithRawValues[];
     public readonly docs?: DocComment;
 
     public constructor({
@@ -38,6 +41,7 @@ export class Class extends AstNode {
         properties,
         initializers,
         methods,
+        nestedTypes,
         docs
     }: Class.Args) {
         super();
@@ -48,6 +52,7 @@ export class Class extends AstNode {
         this.properties = properties;
         this.initializers = initializers ?? [];
         this.methods = methods ?? [];
+        this.nestedTypes = nestedTypes ?? [];
         this.docs = docs;
     }
 
@@ -95,6 +100,16 @@ export class Class extends AstNode {
                     writer.newLine();
                 }
                 method.write(writer);
+                writer.newLine();
+            });
+        }
+        if (this.nestedTypes.length > 0) {
+            writer.newLine();
+            this.nestedTypes.forEach((nestedType, nestedTypeIdx) => {
+                if (nestedTypeIdx > 0) {
+                    writer.newLine();
+                }
+                nestedType.write(writer);
                 writer.newLine();
             });
         }

--- a/generators/swift/codegen/src/name-registry/name-registry.ts
+++ b/generators/swift/codegen/src/name-registry/name-registry.ts
@@ -448,8 +448,11 @@ export class NameRegistry {
         variants: UndiscriminatedUnionVariant[];
     }) {
         const parentSymbolId = typeof parentSymbol === "string" ? parentSymbol : parentSymbol.id;
+        // Preserve the declaration order of the union members. Decoding attempts are emitted in
+        // this order, and Fern decodes undiscriminated unions by trying members in declaration
+        // order; sorting (e.g. alphabetically) would, for example, try `double` before `int` and
+        // decode an integral JSON number as a `Double`.
         const distinctVariants = uniqWith(variants, (a, b) => a.caseName === b.caseName);
-        distinctVariants.sort((a, b) => a.caseName.localeCompare(b.caseName));
         this.undiscriminatedUnionVariantsByParentSymbolId.set(parentSymbolId, distinctVariants);
         return distinctVariants;
     }

--- a/generators/swift/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/swift/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -404,6 +404,19 @@ export class EndpointSnippetGenerator {
         this.context.errors.unscope();
         args.push(...pathParameterFields);
 
+        // The generated SDK declares endpoint headers as method parameters after the
+        // path parameters and before the query parameters, so emit them here to keep
+        // the rendered argument order aligned with the method signature.
+        this.context.errors.scope(Scope.Headers);
+        const headerParameterFields: swift.FunctionArgument[] = [];
+        if (request.headers != null) {
+            headerParameterFields.push(
+                ...this.getEndpointMethodHeaderParameters({ namedParameters: request.headers, snippet })
+            );
+        }
+        this.context.errors.unscope();
+        args.push(...headerParameterFields);
+
         this.context.errors.scope(Scope.QueryParameters);
         const queryParameterFields: swift.FunctionArgument[] = [];
         if (request.queryParameters != null) {
@@ -501,6 +514,39 @@ export class EndpointSnippetGenerator {
             .getExampleObjectProperties({
                 parameters: namedParameters,
                 snippetObject: snippet.queryParameters ?? {}
+            })
+            .map((parameter) => {
+                return swift.functionArgument({
+                    label: parameter.name.name.camelCase.unsafeName,
+                    value: this.context.dynamicTypeLiteralMapper.convert({
+                        fromSymbol: moduleSymbol,
+                        typeReference: parameter.typeReference,
+                        value: parameter.value
+                    })
+                });
+            });
+    }
+
+    private getEndpointMethodHeaderParameters({
+        namedParameters,
+        snippet
+    }: {
+        namedParameters: FernIr.dynamic.NamedParameter[];
+        snippet: FernIr.dynamic.EndpointSnippetRequest;
+    }): swift.FunctionArgument[] {
+        const moduleSymbol = this.context.nameRegistry.getRegisteredSourceModuleSymbolOrThrow();
+        const referencer = this.context.createReferencer(moduleSymbol);
+        return this.context
+            .getExampleObjectProperties({
+                parameters: namedParameters,
+                snippetObject: snippet.headers ?? {}
+            })
+            .filter((parameter) => {
+                // The generated SDK only surfaces String-typed headers as endpoint
+                // method parameters; non-String and literal headers are set
+                // automatically, so the snippet must omit them to match the signature.
+                const swiftType = this.context.getSwiftTypeReferenceFromScope(parameter.typeReference, moduleSymbol);
+                return referencer.resolvesToTheSwiftType(swiftType.nonOptional(), "String");
             })
             .map((parameter) => {
                 return swift.functionArgument({

--- a/generators/swift/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/swift/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -545,7 +545,11 @@ export class EndpointSnippetGenerator {
                 // The generated SDK only surfaces String-typed headers as endpoint
                 // method parameters; non-String and literal headers are set
                 // automatically, so the snippet must omit them to match the signature.
-                const swiftType = this.context.getSwiftTypeReferenceFromScope(parameter.typeReference, moduleSymbol);
+                // Resolve through type aliases first so that a header typed as an
+                // alias of String (which the SDK treats as a String parameter) is
+                // still emitted here.
+                const resolvedTypeReference = this.resolveAliasTypeReference(parameter.typeReference);
+                const swiftType = this.context.getSwiftTypeReferenceFromScope(resolvedTypeReference, moduleSymbol);
                 return referencer.resolvesToTheSwiftType(swiftType.nonOptional(), "String");
             })
             .map((parameter) => {
@@ -558,6 +562,16 @@ export class EndpointSnippetGenerator {
                     })
                 });
             });
+    }
+
+    private resolveAliasTypeReference(typeReference: FernIr.dynamic.TypeReference): FernIr.dynamic.TypeReference {
+        if (typeReference.type === "named") {
+            const namedType = this.context.ir.types[typeReference.value];
+            if (namedType != null && namedType.type === "alias") {
+                return this.resolveAliasTypeReference(namedType.typeReference);
+            }
+        }
+        return typeReference;
     }
 
     private getFilePropertyInfo({

--- a/generators/swift/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/swift/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -8,6 +8,7 @@ private func main() async throws {
     let client = AcmeClient(token: "<YOUR_API_KEY>")
 
     _ = try await client.service.getMetadata(
+        xAPIVersion: "0.0.1",
         shallow: false,
         tag: [
             "development",

--- a/generators/swift/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/swift/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -9,7 +9,11 @@ import { BaseSwiftCustomConfigSchema, NameRegistry, Referencer, swift } from "@f
 import { pascalCase } from "../util/pascal-case.js";
 import { DynamicTypeLiteralMapper } from "./DynamicTypeLiteralMapper.js";
 import { FilePropertyMapper } from "./FilePropertyMapper.js";
-import { registerLiteralEnums, registerLiteralEnumsForObjectProperties } from "./register-literal-enums.js";
+import {
+    registerLiteralEnums,
+    registerLiteralEnumsForObjectProperties,
+    registerLiteralEnumsForTypeReference
+} from "./register-literal-enums.js";
 import { registerUndiscriminatedUnionVariants } from "./register-undiscriminated-unions.js";
 
 export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGeneratorContext {
@@ -131,6 +135,17 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
                         requestNamePascalCase: endpoint.request.declaration.name.pascalCase.unsafeName
                     });
                 }
+                // Inline literal query parameters are resolved against the source module symbol
+                // (see EndpointSnippetGenerator.getEndpointMethodQueryParameters), so their literal
+                // enums must be registered under that same scope. This mirrors the SDK generator's
+                // AbstractSwiftGeneratorContext, which registers them under the owning client symbol.
+                endpoint.request.queryParameters?.forEach((queryParameter) => {
+                    registerLiteralEnumsForTypeReference({
+                        parentSymbol: registeredSourceModuleSymbol,
+                        registry: nameRegistry,
+                        typeReference: queryParameter.typeReference
+                    });
+                });
             }
         });
 
@@ -164,12 +179,12 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
             list: (ref) => swift.TypeReference.array(this.getSwiftTypeReferenceFromScope(ref.value, fromSymbol)),
             literal: (ref) => {
                 return visitDiscriminatedUnion(ref.value, "type")._visit({
-                    boolean: () => referencer.referenceAsIsType("JSONValue"),
+                    boolean: () => referencer.referenceSwiftType("Bool"),
                     string: (literalType) => {
-                        const symbol = this.nameRegistry.getNestedLiteralEnumSymbolOrThrow(
-                            fromSymbol,
-                            literalType.value
-                        );
+                        const symbol = this.nameRegistry.getNestedLiteralEnumSymbol(fromSymbol, literalType.value);
+                        if (symbol == null) {
+                            return referencer.referenceAsIsType("JSONValue");
+                        }
                         return referencer.referenceType(symbol);
                     },
                     _other: () => referencer.referenceAsIsType("JSONValue")

--- a/generators/swift/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/swift/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -259,10 +259,19 @@ export class DynamicTypeLiteralMapper {
                     if (record == null) {
                         return swift.Expression.nop();
                     }
+                    // A single-property variant wraps its value under the variant's property
+                    // wire key (the union's CodingKeys raw value), which defaults to "value" but
+                    // can be customized via `key:` and is not exposed on the dynamic IR. The
+                    // discriminant has already been stripped from the record, so exclude any
+                    // inherited base properties to isolate the wrapped value's key.
+                    const basePropertyKeys = new Set(
+                        (unionVariant.properties ?? []).map((property) => property.name.wireValue)
+                    );
+                    const propertyKey = Object.keys(record).find((key) => !basePropertyKeys.has(key)) ?? "value";
                     const converted = this.convert({
                         fromSymbol,
                         typeReference: unionVariant.typeReference,
-                        value: record[unionVariant.discriminantValue.wireValue]
+                        value: record[propertyKey]
                     });
                     return swift.Expression.methodCall({
                         target: swift.Expression.reference(unionSymbol.name),

--- a/generators/swift/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/swift/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -323,13 +323,30 @@ export class DynamicTypeLiteralMapper {
         value: unknown;
     }): swift.Expression {
         const symbol = this.context.nameRegistry.getSchemaTypeSymbolOrThrow(typeId);
+        const exampleProperties = this.context.getExampleObjectProperties({
+            parameters: object_.properties,
+            snippetObject: value
+        });
+        const examplePropertiesByWireValue = new Map(
+            exampleProperties.map((typeInstance) => [typeInstance.name.wireValue, typeInstance])
+        );
+        // Literal properties are constants that the generated initializer always requires, so emit
+        // them in declaration order even when the example omits them.
+        const orderedProperties = object_.properties
+            .map((property) => {
+                const exampleProperty = examplePropertiesByWireValue.get(property.name.wireValue);
+                if (exampleProperty != null) {
+                    return exampleProperty;
+                }
+                if (property.typeReference.type === "literal") {
+                    return { name: property.name, typeReference: property.typeReference, value: undefined };
+                }
+                return null;
+            })
+            .filter((typeInstance) => typeInstance != null);
         return swift.Expression.structInitialization({
             unsafeName: symbol.name,
-            arguments_: this.context
-                .getExampleObjectProperties({
-                    parameters: object_.properties,
-                    snippetObject: value
-                })
+            arguments_: orderedProperties
                 .map((typeInstance) => {
                     const expression = this.convert({
                         fromSymbol,

--- a/generators/swift/sdk/changes/unreleased/fix-literal-query-parameters.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-literal-query-parameters.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fixed inline literal query parameters so they are typed correctly in the
+    generated client method instead of falling back to the placeholder
+    `JSONValue`. A boolean literal now maps to `Bool` and a string literal maps
+    to a dedicated literal enum nested on the owning client. Previously the
+    parameter was typed as `JSONValue` while the generated snippets and wire
+    tests emitted the literal enum case, causing a type mismatch that failed to
+    compile.
+  type: fix

--- a/generators/swift/sdk/changes/unreleased/fix-plain-text-response-type.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-plain-text-response-type.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fixed endpoints that return a `text/plain` response so the generated method
+    returns `String` instead of the placeholder `JSONValue`. The HTTP client
+    already decodes a `String` response type from the raw UTF-8 body, so the
+    generated wire tests now compile and pass (previously `response == "string"`
+    failed because the response was typed as `JSONValue`).
+  type: fix

--- a/generators/swift/sdk/changes/unreleased/fix-single-property-union-snippets.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-single-property-union-snippets.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fixed generated snippets and wire tests for single-property discriminated
+    union variants. The wrapped value is serialized under the variant's property
+    wire key (the union's CodingKeys raw value), but the snippet/wire-test
+    generator was reading it from the discriminant's wire name, so variants whose
+    discriminant differed from that key (e.g. a `date` or `datetime` case) emitted
+    an empty enum case like `UnionWithTime.date()` that failed to compile. The
+    value is now read from the correct property key, including variants that
+    customize it via `key:`.
+  type: fix

--- a/generators/swift/sdk/changes/unreleased/fix-undiscriminated-union-member-order.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-undiscriminated-union-member-order.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Preserve the declaration order of undiscriminated union members in generated
+    code. Members were previously sorted alphabetically, which reordered the
+    decoding attempts emitted in the `Decodable` initializer. For a union
+    containing both `int` and `double`, this tried `Double` before `Int` and
+    decoded integral JSON numbers (e.g. `1`) as a `Double` (`1.0`), so wire tests
+    failed to round-trip. Members are now decoded in declaration order, matching
+    Fern's undiscriminated union semantics.
+  type: fix

--- a/generators/swift/sdk/changes/unreleased/fix-wire-test-and-snippet-endpoint-headers.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-wire-test-and-snippet-endpoint-headers.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fixed generated wire tests and snippets so that they pass endpoint header
+    arguments to the endpoint method. The endpoint method call previously emitted
+    only path, query, and body arguments, omitting required header parameters
+    (e.g. `X-API-Version`), which produced calls missing required arguments that
+    failed to compile. Headers are now rendered between the path and query
+    arguments to match the generated method signature, filtered to the
+    String-typed headers the SDK surfaces as parameters.
+  type: fix

--- a/generators/swift/sdk/changes/unreleased/fix-wire-test-and-snippet-endpoint-headers.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-wire-test-and-snippet-endpoint-headers.yml
@@ -7,5 +7,7 @@
     (e.g. `X-API-Version`), which produced calls missing required arguments that
     failed to compile. Headers are now rendered between the path and query
     arguments to match the generated method signature, filtered to the
-    String-typed headers the SDK surfaces as parameters.
+    String-typed headers the SDK surfaces as parameters. The String-type filter
+    resolves through type aliases, so a header typed as an alias of String is
+    emitted just like the SDK declares it.
   type: fix

--- a/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
@@ -187,7 +187,7 @@ export class EndpointMethodGenerator {
             json: (resp) =>
                 this.sdkGeneratorContext.getSwiftTypeReferenceFromScope(resp.responseBodyType, this.parentClassSymbol),
             fileDownload: () => this.referencer.referenceFoundationType("Data"),
-            text: () => this.referencer.referenceAsIsType("JSONValue"), // TODO(kafkas): Handle text responses
+            text: () => this.referencer.referenceSwiftType("String"),
             bytes: () => this.referencer.referenceAsIsType("JSONValue"), // TODO(kafkas): Handle bytes responses
             streaming: () => this.referencer.referenceAsIsType("JSONValue"), // TODO(kafkas): Handle streaming responses
             streamParameter: () => this.referencer.referenceAsIsType("JSONValue"), // TODO(kafkas): Handle stream parameter responses

--- a/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
@@ -1,6 +1,7 @@
 import { getWireValue } from "@fern-api/base-generator";
 import { assertNever, visitDiscriminatedUnion } from "@fern-api/core-utils";
 import { Referencer, swift } from "@fern-api/swift-codegen";
+import { LiteralEnumGenerator } from "@fern-api/swift-model";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../../SdkGeneratorContext.js";
 import { ClientGeneratorContext } from "./ClientGeneratorContext.js";
@@ -114,11 +115,20 @@ export class RootClientGenerator {
             ],
             initializers: this.generateInitializers(),
             methods: this.generateMethods(),
+            nestedTypes: this.generateNestedLiteralEnums(),
             docs: swift.docComment({
                 summary:
                     "Use this class to access the different functions within the SDK. You can instantiate any number of clients with different configuration that will propagate to these functions."
             })
         });
+    }
+
+    private generateNestedLiteralEnums(): swift.EnumWithRawValues[] {
+        return this.sdkGeneratorContext.project.nameRegistry
+            .getAllNestedLiteralEnumSymbolsOrThrow(this.symbol)
+            .map(({ symbol, literalValue }) =>
+                new LiteralEnumGenerator({ name: symbol.name, literalValue }).generate()
+            );
     }
 
     private generateInitializers(): swift.Initializer[] {

--- a/generators/swift/sdk/src/generators/client/SubClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/SubClientGenerator.ts
@@ -1,4 +1,5 @@
 import { Referencer, swift } from "@fern-api/swift-codegen";
+import { LiteralEnumGenerator } from "@fern-api/swift-model";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../../SdkGeneratorContext.js";
 import { ClientGeneratorContext } from "./ClientGeneratorContext.js";
@@ -48,8 +49,17 @@ export class SubClientGenerator {
                 this.clientGeneratorContext.httpClient.property
             ],
             initializers: [this.generateInitializer()],
-            methods: this.generateMethods()
+            methods: this.generateMethods(),
+            nestedTypes: this.generateNestedLiteralEnums()
         });
+    }
+
+    private generateNestedLiteralEnums(): swift.EnumWithRawValues[] {
+        return this.sdkGeneratorContext.project.nameRegistry
+            .getAllNestedLiteralEnumSymbolsOrThrow(this.symbol)
+            .map(({ symbol, literalValue }) =>
+                new LiteralEnumGenerator({ name: symbol.name, literalValue }).generate()
+            );
     }
 
     private generateInitializer(): swift.Initializer {

--- a/generators/swift/sdk/src/generators/test/WireTestFunctionGenerator.ts
+++ b/generators/swift/sdk/src/generators/test/WireTestFunctionGenerator.ts
@@ -205,16 +205,7 @@ export class WireTestFunctionGenerator {
                         return literalContainer.literal._visit({
                             string: (val) =>
                                 swift.Expression.enumCaseShorthand(LiteralEnum.generateEnumCaseLabel(val.original)),
-                            boolean: (val) =>
-                                swift.Expression.methodCall({
-                                    target: swift.Expression.reference("JSONValue"),
-                                    methodName: "bool",
-                                    arguments_: [
-                                        swift.functionArgument({
-                                            value: swift.Expression.boolLiteral(val)
-                                        })
-                                    ]
-                                }),
+                            boolean: (val) => swift.Expression.boolLiteral(val),
                             integer: () => swift.Expression.nop(),
                             uint: () => swift.Expression.nop(),
                             uint64: () => swift.Expression.nop(),
@@ -559,7 +550,7 @@ export class WireTestFunctionGenerator {
                                     .createReferencer(fromScope)
                                     .referenceType(literalEnumSymbol);
                             },
-                            boolean: () => this.referencer.referenceAsIsType("JSONValue"),
+                            boolean: () => this.referencer.referenceSwiftType("Bool"),
                             integer: () => this.referencer.referenceAsIsType("JSONValue"),
                             uint: () => this.referencer.referenceAsIsType("JSONValue"),
                             uint64: () => this.referencer.referenceAsIsType("JSONValue"),

--- a/seed/swift-sdk/circular-references/Sources/Schemas/JsonLike.swift
+++ b/seed/swift-sdk/circular-references/Sources/Schemas/JsonLike.swift
@@ -1,24 +1,24 @@
 import Foundation
 
 public indirect enum JsonLike: Codable, Hashable, Sendable {
-    case bool(Bool)
-    case int(Int)
     case jsonLikeArray([JsonLike])
-    case string(String)
     case stringToJsonLikeDictionary([String: JsonLike])
+    case string(String)
+    case int(Int)
+    case bool(Bool)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Bool.self) {
-            self = .bool(value)
-        } else if let value = try? container.decode(Int.self) {
-            self = .int(value)
-        } else if let value = try? container.decode([JsonLike].self) {
+        if let value = try? container.decode([JsonLike].self) {
             self = .jsonLikeArray(value)
-        } else if let value = try? container.decode(String.self) {
-            self = .string(value)
         } else if let value = try? container.decode([String: JsonLike].self) {
             self = .stringToJsonLikeDictionary(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -30,15 +30,15 @@ public indirect enum JsonLike: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .bool(let value):
-            try container.encode(value)
-        case .int(let value):
-            try container.encode(value)
         case .jsonLikeArray(let value):
+            try container.encode(value)
+        case .stringToJsonLikeDictionary(let value):
             try container.encode(value)
         case .string(let value):
             try container.encode(value)
-        case .stringToJsonLikeDictionary(let value):
+        case .int(let value):
+            try container.encode(value)
+        case .bool(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/circular-references/Sources/Schemas/JsonLikeWithNullAndUndefined.swift
+++ b/seed/swift-sdk/circular-references/Sources/Schemas/JsonLikeWithNullAndUndefined.swift
@@ -1,24 +1,24 @@
 import Foundation
 
 public indirect enum JsonLikeWithNullAndUndefined: Codable, Hashable, Sendable {
-    case optionalNullableBool(Nullable<Bool>?)
-    case optionalNullableInt(Nullable<Int>?)
     case optionalNullableJsonLikeWithNullAndUndefinedArray([Nullable<JsonLikeWithNullAndUndefined>?])
-    case optionalNullableString(Nullable<String>?)
     case stringToOptionalNullableJsonLikeWithNullAndUndefinedDictionary([String: Nullable<JsonLikeWithNullAndUndefined>?])
+    case optionalNullableString(Nullable<String>?)
+    case optionalNullableInt(Nullable<Int>?)
+    case optionalNullableBool(Nullable<Bool>?)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Nullable<Bool>?.self) {
-            self = .optionalNullableBool(value)
-        } else if let value = try? container.decode(Nullable<Int>?.self) {
-            self = .optionalNullableInt(value)
-        } else if let value = try? container.decode([Nullable<JsonLikeWithNullAndUndefined>?].self) {
+        if let value = try? container.decode([Nullable<JsonLikeWithNullAndUndefined>?].self) {
             self = .optionalNullableJsonLikeWithNullAndUndefinedArray(value)
-        } else if let value = try? container.decode(Nullable<String>?.self) {
-            self = .optionalNullableString(value)
         } else if let value = try? container.decode([String: Nullable<JsonLikeWithNullAndUndefined>?].self) {
             self = .stringToOptionalNullableJsonLikeWithNullAndUndefinedDictionary(value)
+        } else if let value = try? container.decode(Nullable<String>?.self) {
+            self = .optionalNullableString(value)
+        } else if let value = try? container.decode(Nullable<Int>?.self) {
+            self = .optionalNullableInt(value)
+        } else if let value = try? container.decode(Nullable<Bool>?.self) {
+            self = .optionalNullableBool(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -30,15 +30,15 @@ public indirect enum JsonLikeWithNullAndUndefined: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .optionalNullableBool(let value):
-            try container.encode(value)
-        case .optionalNullableInt(let value):
-            try container.encode(value)
         case .optionalNullableJsonLikeWithNullAndUndefinedArray(let value):
+            try container.encode(value)
+        case .stringToOptionalNullableJsonLikeWithNullAndUndefinedDictionary(let value):
             try container.encode(value)
         case .optionalNullableString(let value):
             try container.encode(value)
-        case .stringToOptionalNullableJsonLikeWithNullAndUndefinedDictionary(let value):
+        case .optionalNullableInt(let value):
+            try container.encode(value)
+        case .optionalNullableBool(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example17.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example17.swift
@@ -8,6 +8,9 @@ enum Example17 {
             token: "<token>"
         )
 
-        _ = try await client.service.getMetadata(shallow: false)
+        _ = try await client.service.getMetadata(
+            xApiVersion: "0.0.1",
+            shallow: false
+        )
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example18.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example18.swift
@@ -8,6 +8,9 @@ enum Example18 {
             token: "<token>"
         )
 
-        _ = try await client.service.getMetadata(shallow: true)
+        _ = try await client.service.getMetadata(
+            xApiVersion: "X-API-Version",
+            shallow: true
+        )
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example19.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example19.swift
@@ -42,7 +42,7 @@ enum Example19 {
                 name: "name"
             ),
             metadata: MetadataType.html(
-
+                "metadata"
             ),
             commonMetadata: Metadata(
                 id: "id",
@@ -61,7 +61,7 @@ enum Example19 {
                 )
             ),
             data: Data.string(
-
+                "data"
             ),
             migration: Migration(
                 name: "name",
@@ -75,7 +75,7 @@ enum Example19 {
                 )
             ),
             test: Test.and(
-
+                true
             ),
             node: Node(
                 name: "name",

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example5.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example5.swift
@@ -8,6 +8,9 @@ enum Example5 {
             token: "<token>"
         )
 
-        _ = try await client.file.service.getFile(filename: "file.txt")
+        _ = try await client.file.service.getFile(
+            filename: "file.txt",
+            xFileApiVersion: "0.0.2"
+        )
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example6.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example6.swift
@@ -8,6 +8,9 @@ enum Example6 {
             token: "<token>"
         )
 
-        _ = try await client.file.service.getFile(filename: "filename")
+        _ = try await client.file.service.getFile(
+            filename: "filename",
+            xFileApiVersion: "X-File-API-Version"
+        )
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example7.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Snippets/Example7.swift
@@ -8,6 +8,9 @@ enum Example7 {
             token: "<token>"
         )
 
-        _ = try await client.file.service.getFile(filename: "filename")
+        _ = try await client.file.service.getFile(
+            filename: "filename",
+            xFileApiVersion: "X-File-API-Version"
+        )
     }
 }

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/File/Service/FileServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/File/Service/FileServiceClientWireTests.swift
@@ -26,6 +26,7 @@ import Examples
         )
         let response = try await client.file.service.getFile(
             filename: "filename",
+            xFileApiVersion: "X-File-API-Version",
             requestOptions: RequestOptions(additionalHeaders: stub.headers)
         )
         try #require(response == expectedResponse)

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
@@ -357,7 +357,7 @@ import Examples
                     name: "name"
                 ),
                 metadata: MetadataType.html(
-
+                    "metadata"
                 ),
                 commonMetadata: Metadata(
                     id: "id",
@@ -376,7 +376,7 @@ import Examples
                     )
                 ),
                 data: Data.string(
-
+                    "data"
                 ),
                 migration: Migration(
                     name: "name",
@@ -390,7 +390,7 @@ import Examples
                     )
                 ),
                 test: Test.and(
-
+                    true
                 ),
                 node: Node(
                     name: "name",

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
@@ -230,6 +230,7 @@ import Examples
         )
         let expectedResponse = MetadataType.html("<head>...</head>")
         let response = try await client.service.getMetadata(
+            xApiVersion: "0.0.1",
             shallow: false,
             requestOptions: RequestOptions(additionalHeaders: stub.headers)
         )
@@ -261,6 +262,7 @@ import Examples
         )
         let expectedResponse = MetadataType.html("string")
         let response = try await client.service.getMetadata(
+            xApiVersion: "X-API-Version",
             shallow: true,
             requestOptions: RequestOptions(additionalHeaders: stub.headers)
         )

--- a/seed/swift-sdk/examples/no-custom-config/reference.md
+++ b/seed/swift-sdk/examples/no-custom-config/reference.md
@@ -654,7 +654,7 @@ private func main() async throws {
             name: "name"
         ),
         metadata: MetadataType.html(
-
+            "metadata"
         ),
         commonMetadata: Metadata(
             id: "id",
@@ -673,7 +673,7 @@ private func main() async throws {
             )
         ),
         data: Data.string(
-
+            "data"
         ),
         migration: Migration(
             name: "name",
@@ -687,7 +687,7 @@ private func main() async throws {
             )
         ),
         test: Test.and(
-
+            true
         ),
         node: Node(
             name: "name",

--- a/seed/swift-sdk/examples/no-custom-config/reference.md
+++ b/seed/swift-sdk/examples/no-custom-config/reference.md
@@ -205,7 +205,10 @@ import Examples
 private func main() async throws {
     let client = ExamplesClient(token: "<token>")
 
-    _ = try await client.file.service.getFile(filename: "file.txt")
+    _ = try await client.file.service.getFile(
+        filename: "file.txt",
+        xFileApiVersion: "0.0.2"
+    )
 }
 
 try await main()
@@ -541,7 +544,10 @@ import Examples
 private func main() async throws {
     let client = ExamplesClient(token: "<token>")
 
-    _ = try await client.service.getMetadata(shallow: false)
+    _ = try await client.service.getMetadata(
+        xApiVersion: "0.0.1",
+        shallow: false
+    )
 }
 
 try await main()

--- a/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example17.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example17.swift
@@ -8,6 +8,9 @@ enum Example17 {
             token: "<token>"
         )
 
-        _ = try await client.service.getMetadata(shallow: false)
+        _ = try await client.service.getMetadata(
+            xApiVersion: "0.0.1",
+            shallow: false
+        )
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example18.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example18.swift
@@ -8,6 +8,9 @@ enum Example18 {
             token: "<token>"
         )
 
-        _ = try await client.service.getMetadata(shallow: true)
+        _ = try await client.service.getMetadata(
+            xApiVersion: "X-API-Version",
+            shallow: true
+        )
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example19.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example19.swift
@@ -42,7 +42,7 @@ enum Example19 {
                 name: "name"
             ),
             metadata: MetadataType.html(
-
+                "metadata"
             ),
             commonMetadata: Metadata(
                 id: "id",
@@ -61,7 +61,7 @@ enum Example19 {
                 )
             ),
             data: Data.string(
-
+                "data"
             ),
             migration: Migration(
                 name: "name",
@@ -75,7 +75,7 @@ enum Example19 {
                 )
             ),
             test: Test.and(
-
+                true
             ),
             node: Node(
                 name: "name",

--- a/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example5.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example5.swift
@@ -8,6 +8,9 @@ enum Example5 {
             token: "<token>"
         )
 
-        _ = try await client.file.service.getFile(filename: "file.txt")
+        _ = try await client.file.service.getFile(
+            filename: "file.txt",
+            xFileApiVersion: "0.0.2"
+        )
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example6.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example6.swift
@@ -8,6 +8,9 @@ enum Example6 {
             token: "<token>"
         )
 
-        _ = try await client.file.service.getFile(filename: "filename")
+        _ = try await client.file.service.getFile(
+            filename: "filename",
+            xFileApiVersion: "X-File-API-Version"
+        )
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example7.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Snippets/Example7.swift
@@ -8,6 +8,9 @@ enum Example7 {
             token: "<token>"
         )
 
-        _ = try await client.file.service.getFile(filename: "filename")
+        _ = try await client.file.service.getFile(
+            filename: "filename",
+            xFileApiVersion: "X-File-API-Version"
+        )
     }
 }

--- a/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/File/Service/FileServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/File/Service/FileServiceClientWireTests.swift
@@ -26,6 +26,7 @@ import Examples
         )
         let response = try await client.file.service.getFile(
             filename: "filename",
+            xFileApiVersion: "X-File-API-Version",
             requestOptions: RequestOptions(additionalHeaders: stub.headers)
         )
         try #require(response == expectedResponse)

--- a/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
@@ -357,7 +357,7 @@ import Examples
                     name: "name"
                 ),
                 metadata: MetadataType.html(
-
+                    "metadata"
                 ),
                 commonMetadata: Metadata(
                     id: "id",
@@ -376,7 +376,7 @@ import Examples
                     )
                 ),
                 data: Data.string(
-
+                    "data"
                 ),
                 migration: Migration(
                     name: "name",
@@ -390,7 +390,7 @@ import Examples
                     )
                 ),
                 test: Test.and(
-
+                    true
                 ),
                 node: Node(
                     name: "name",

--- a/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
@@ -230,6 +230,7 @@ import Examples
         )
         let expectedResponse = MetadataType.html("<head>...</head>")
         let response = try await client.service.getMetadata(
+            xApiVersion: "0.0.1",
             shallow: false,
             requestOptions: RequestOptions(additionalHeaders: stub.headers)
         )
@@ -261,6 +262,7 @@ import Examples
         )
         let expectedResponse = MetadataType.html("string")
         let response = try await client.service.getMetadata(
+            xApiVersion: "X-API-Version",
             shallow: true,
             requestOptions: RequestOptions(additionalHeaders: stub.headers)
         )

--- a/seed/swift-sdk/examples/readme-config/reference.md
+++ b/seed/swift-sdk/examples/readme-config/reference.md
@@ -654,7 +654,7 @@ private func main() async throws {
             name: "name"
         ),
         metadata: MetadataType.html(
-
+            "metadata"
         ),
         commonMetadata: Metadata(
             id: "id",
@@ -673,7 +673,7 @@ private func main() async throws {
             )
         ),
         data: Data.string(
-
+            "data"
         ),
         migration: Migration(
             name: "name",
@@ -687,7 +687,7 @@ private func main() async throws {
             )
         ),
         test: Test.and(
-
+            true
         ),
         node: Node(
             name: "name",

--- a/seed/swift-sdk/examples/readme-config/reference.md
+++ b/seed/swift-sdk/examples/readme-config/reference.md
@@ -205,7 +205,10 @@ import Examples
 private func main() async throws {
     let client = ExamplesClient(token: "<token>")
 
-    _ = try await client.file.service.getFile(filename: "file.txt")
+    _ = try await client.file.service.getFile(
+        filename: "file.txt",
+        xFileApiVersion: "0.0.2"
+    )
 }
 
 try await main()
@@ -541,7 +544,10 @@ import Examples
 private func main() async throws {
     let client = ExamplesClient(token: "<token>")
 
-    _ = try await client.service.getMetadata(shallow: false)
+    _ = try await client.service.getMetadata(
+        xApiVersion: "0.0.1",
+        shallow: false
+    )
 }
 
 try await main()

--- a/seed/swift-sdk/exhaustive/Sources/Schemas/MixedType.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Schemas/MixedType.swift
@@ -1,17 +1,17 @@
 import Foundation
 
 public enum MixedType: Codable, Hashable, Sendable {
-    case bool(Bool)
     case double(Double)
+    case bool(Bool)
     case string(String)
     case stringArray([String])
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Bool.self) {
-            self = .bool(value)
-        } else if let value = try? container.decode(Double.self) {
+        if let value = try? container.decode(Double.self) {
             self = .double(value)
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
         } else if let value = try? container.decode(String.self) {
             self = .string(value)
         } else if let value = try? container.decode([String].self) {
@@ -27,9 +27,9 @@ public enum MixedType: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .bool(let value):
-            try container.encode(value)
         case .double(let value):
+            try container.encode(value)
+        case .bool(let value):
             try container.encode(value)
         case .string(let value):
             try container.encode(value)

--- a/seed/swift-sdk/exhaustive/Tests/Snippets/Example62.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Snippets/Example62.swift
@@ -8,9 +8,12 @@ enum Example62 {
             token: "<token>"
         )
 
-        _ = try await client.inlinedRequests.postWithArrayBodyAndHeaders(request: [
-            "string",
-            "string"
-        ])
+        _ = try await client.inlinedRequests.postWithArrayBodyAndHeaders(
+            xCustomHeader: "X-Custom-Header",
+            request: [
+                "string",
+                "string"
+            ]
+        )
     }
 }

--- a/seed/swift-sdk/exhaustive/Tests/Snippets/Example66.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Snippets/Example66.swift
@@ -8,6 +8,10 @@ enum Example66 {
             token: "<token>"
         )
 
-        _ = try await client.noReqBody.postWithNoRequestBody()
+        _ = try await client.reqWithHeaders.getWithCustomHeader(
+            xTestServiceHeader: "X-TEST-SERVICE-HEADER",
+            xTestEndpointHeader: "X-TEST-ENDPOINT-HEADER",
+            request: "string"
+        )
     }
 }

--- a/seed/swift-sdk/exhaustive/Tests/Snippets/Example66.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Snippets/Example66.swift
@@ -8,10 +8,6 @@ enum Example66 {
             token: "<token>"
         )
 
-        _ = try await client.reqWithHeaders.getWithCustomHeader(
-            xTestServiceHeader: "X-TEST-SERVICE-HEADER",
-            xTestEndpointHeader: "X-TEST-ENDPOINT-HEADER",
-            request: "string"
-        )
+        _ = try await client.noReqBody.postWithNoRequestBody()
     }
 }

--- a/seed/swift-sdk/exhaustive/Tests/Snippets/Example67.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Snippets/Example67.swift
@@ -8,6 +8,10 @@ enum Example67 {
             token: "<token>"
         )
 
-        _ = try await client.reqWithHeaders.getWithCustomHeader(request: "string")
+        _ = try await client.reqWithHeaders.getWithCustomHeader(
+            xTestServiceHeader: "X-TEST-SERVICE-HEADER",
+            xTestEndpointHeader: "X-TEST-ENDPOINT-HEADER",
+            request: "string"
+        )
     }
 }

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/InlinedRequests/InlinedRequestsClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/InlinedRequests/InlinedRequestsClientWireTests.swift
@@ -102,6 +102,7 @@ import Exhaustive
         )
         let expectedResponse = "string"
         let response = try await client.inlinedRequests.postWithArrayBodyAndHeaders(
+            xCustomHeader: "X-Custom-Header",
             request: [
                 "string",
                 "string"

--- a/seed/swift-sdk/exhaustive/reference.md
+++ b/seed/swift-sdk/exhaustive/reference.md
@@ -4036,7 +4036,11 @@ import Exhaustive
 private func main() async throws {
     let client = ExhaustiveClient(token: "<token>")
 
-    _ = try await client.reqWithHeaders.getWithCustomHeader(request: "string")
+    _ = try await client.reqWithHeaders.getWithCustomHeader(
+        xTestServiceHeader: "X-TEST-SERVICE-HEADER",
+        xTestEndpointHeader: "X-TEST-ENDPOINT-HEADER",
+        request: "string"
+    )
 }
 
 try await main()

--- a/seed/swift-sdk/exhaustive/reference.md
+++ b/seed/swift-sdk/exhaustive/reference.md
@@ -3794,10 +3794,13 @@ import Exhaustive
 private func main() async throws {
     let client = ExhaustiveClient(token: "<token>")
 
-    _ = try await client.inlinedRequests.postWithArrayBodyAndHeaders(request: [
-        "string",
-        "string"
-    ])
+    _ = try await client.inlinedRequests.postWithArrayBodyAndHeaders(
+        xCustomHeader: "X-Custom-Header",
+        request: [
+            "string",
+            "string"
+        ]
+    )
 }
 
 try await main()

--- a/seed/swift-sdk/inferred-auth-explicit/README.md
+++ b/seed/swift-sdk/inferred-auth-explicit/README.md
@@ -54,13 +54,16 @@ import InferredAuthExplicit
 private func main() async throws {
     let client = InferredAuthExplicitClient()
 
-    _ = try await client.auth.getTokenWithClientCredentials(request: .init(
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        audience: .httpsApiExampleCom,
-        grantType: .clientCredentials,
-        scope: "scope"
-    ))
+    _ = try await client.auth.getTokenWithClientCredentials(
+        xApiKey: "X-Api-Key",
+        request: .init(
+            clientId: "client_id",
+            clientSecret: "client_secret",
+            audience: .httpsApiExampleCom,
+            grantType: .clientCredentials,
+            scope: "scope"
+        )
+    )
 }
 
 try await main()

--- a/seed/swift-sdk/inferred-auth-explicit/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Tests/Core/ClientErrorTests.swift
@@ -20,6 +20,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -59,6 +60,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -98,6 +100,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -139,6 +142,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -178,6 +182,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -219,6 +224,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -258,6 +264,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",

--- a/seed/swift-sdk/inferred-auth-explicit/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Tests/Core/ClientRetryTests.swift
@@ -21,6 +21,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -54,6 +55,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -87,6 +89,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -119,6 +122,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -150,6 +154,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -182,6 +187,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -214,6 +220,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -251,6 +258,7 @@ import Testing
         let startTime = Date()
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -298,6 +306,7 @@ import Testing
         let startTime = Date()
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -341,6 +350,7 @@ import Testing
         let startTime = Date()
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -395,6 +405,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -423,6 +434,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -455,6 +467,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",

--- a/seed/swift-sdk/inferred-auth-explicit/Tests/Snippets/Example0.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Tests/Snippets/Example0.swift
@@ -5,12 +5,15 @@ enum Example0 {
     static func snippet() async throws {
         let client = InferredAuthExplicitClient(baseURL: "https://api.fern.com")
 
-        _ = try await client.auth.getTokenWithClientCredentials(request: .init(
-            clientId: "client_id",
-            clientSecret: "client_secret",
-            audience: .httpsApiExampleCom,
-            grantType: .clientCredentials,
-            scope: "scope"
-        ))
+        _ = try await client.auth.getTokenWithClientCredentials(
+            xApiKey: "X-Api-Key",
+            request: .init(
+                clientId: "client_id",
+                clientSecret: "client_secret",
+                audience: .httpsApiExampleCom,
+                grantType: .clientCredentials,
+                scope: "scope"
+            )
+        )
     }
 }

--- a/seed/swift-sdk/inferred-auth-explicit/Tests/Snippets/Example1.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Tests/Snippets/Example1.swift
@@ -5,13 +5,16 @@ enum Example1 {
     static func snippet() async throws {
         let client = InferredAuthExplicitClient(baseURL: "https://api.fern.com")
 
-        _ = try await client.auth.refreshToken(request: .init(
-            clientId: "client_id",
-            clientSecret: "client_secret",
-            refreshToken: "refresh_token",
-            audience: .httpsApiExampleCom,
-            grantType: .refreshToken,
-            scope: "scope"
-        ))
+        _ = try await client.auth.refreshToken(
+            xApiKey: "X-Api-Key",
+            request: .init(
+                clientId: "client_id",
+                clientSecret: "client_secret",
+                refreshToken: "refresh_token",
+                audience: .httpsApiExampleCom,
+                grantType: .refreshToken,
+                scope: "scope"
+            )
+        )
     }
 }

--- a/seed/swift-sdk/inferred-auth-explicit/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -26,6 +26,7 @@ import InferredAuthExplicit
             refreshToken: Optional("refresh_token")
         )
         let response = try await client.auth.getTokenWithClientCredentials(
+            xApiKey: "X-Api-Key",
             request: .init(
                 clientId: "client_id",
                 clientSecret: "client_secret",
@@ -61,6 +62,7 @@ import InferredAuthExplicit
             refreshToken: Optional("refresh_token")
         )
         let response = try await client.auth.refreshToken(
+            xApiKey: "X-Api-Key",
             request: .init(
                 clientId: "client_id",
                 clientSecret: "client_secret",

--- a/seed/swift-sdk/inferred-auth-explicit/reference.md
+++ b/seed/swift-sdk/inferred-auth-explicit/reference.md
@@ -19,13 +19,16 @@ import InferredAuthExplicit
 private func main() async throws {
     let client = InferredAuthExplicitClient()
 
-    _ = try await client.auth.getTokenWithClientCredentials(request: .init(
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        audience: .httpsApiExampleCom,
-        grantType: .clientCredentials,
-        scope: "scope"
-    ))
+    _ = try await client.auth.getTokenWithClientCredentials(
+        xApiKey: "X-Api-Key",
+        request: .init(
+            clientId: "client_id",
+            clientSecret: "client_secret",
+            audience: .httpsApiExampleCom,
+            grantType: .clientCredentials,
+            scope: "scope"
+        )
+    )
 }
 
 try await main()
@@ -90,14 +93,17 @@ import InferredAuthExplicit
 private func main() async throws {
     let client = InferredAuthExplicitClient()
 
-    _ = try await client.auth.refreshToken(request: .init(
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        refreshToken: "refresh_token",
-        audience: .httpsApiExampleCom,
-        grantType: .refreshToken,
-        scope: "scope"
-    ))
+    _ = try await client.auth.refreshToken(
+        xApiKey: "X-Api-Key",
+        request: .init(
+            clientId: "client_id",
+            clientSecret: "client_secret",
+            refreshToken: "refresh_token",
+            audience: .httpsApiExampleCom,
+            grantType: .refreshToken,
+            scope: "scope"
+        )
+    )
 }
 
 try await main()

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/README.md
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/README.md
@@ -53,7 +53,7 @@ import InferredAuthImplicitApiKey
 private func main() async throws {
     let client = InferredAuthImplicitApiKeyClient()
 
-    _ = try await client.auth.getToken()
+    _ = try await client.auth.getToken(apiKey: "api_key")
 }
 
 try await main()

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Core/ClientErrorTests.swift
@@ -19,7 +19,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
             Issue.record("Expected error to be thrown")
         } catch let error as InferredAuthImplicitApiKeyError {
@@ -49,7 +52,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
             Issue.record("Expected error to be thrown")
         } catch let error as InferredAuthImplicitApiKeyError {
@@ -79,7 +85,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
             Issue.record("Expected error to be thrown")
         } catch let error as InferredAuthImplicitApiKeyError {
@@ -111,7 +120,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
             Issue.record("Expected error to be thrown")
         } catch let error as InferredAuthImplicitApiKeyError {
@@ -141,7 +153,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
             Issue.record("Expected error to be thrown")
         } catch let error as InferredAuthImplicitApiKeyError {
@@ -173,7 +188,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
             Issue.record("Expected error to be thrown")
         } catch let error as InferredAuthImplicitApiKeyError {
@@ -203,7 +221,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
             Issue.record("Expected error to be thrown")
         } catch let error as InferredAuthImplicitApiKeyError {

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Core/ClientRetryTests.swift
@@ -20,7 +20,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
         } catch {
         }
@@ -44,7 +47,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
         } catch {
         }
@@ -68,7 +74,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
         } catch {
         }
@@ -91,7 +100,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
         } catch {
         }
@@ -113,7 +125,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
             Issue.record("Expected error to be thrown")
         } catch {
@@ -136,7 +151,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
             Issue.record("Expected error to be thrown")
         } catch {
@@ -159,7 +177,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
             Issue.record("Expected error to be thrown")
         } catch {
@@ -187,7 +208,10 @@ import Testing
 
         let startTime = Date()
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
         } catch {
         }
@@ -225,7 +249,10 @@ import Testing
 
         let startTime = Date()
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
         } catch {
         }
@@ -259,7 +286,10 @@ import Testing
 
         let startTime = Date()
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
         } catch {
         }
@@ -304,7 +334,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(maxRetries: 5, additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(maxRetries: 5, additionalHeaders: stub.headers)
+            )
 
         } catch {
         }
@@ -323,7 +356,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(maxRetries: 0, additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(maxRetries: 0, additionalHeaders: stub.headers)
+            )
 
             Issue.record("Expected error to be thrown")
         } catch {
@@ -346,7 +382,10 @@ import Testing
         )
 
         do {
-            _ = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+            _ = try await client.auth.getToken(
+                apiKey: "api_key",
+                requestOptions: RequestOptions(additionalHeaders: stub.headers)
+            )
 
         } catch {
         }

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Snippets/Example0.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Snippets/Example0.swift
@@ -5,6 +5,6 @@ enum Example0 {
     static func snippet() async throws {
         let client = InferredAuthImplicitApiKeyClient(baseURL: "https://api.fern.com")
 
-        _ = try await client.auth.getToken()
+        _ = try await client.auth.getToken(apiKey: "api_key")
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -27,7 +27,10 @@ import InferredAuthImplicitApiKey
             expiresIn: 1,
             scope: Optional("scope")
         )
-        let response = try await client.auth.getToken(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+        let response = try await client.auth.getToken(
+            apiKey: "api_key",
+            requestOptions: RequestOptions(additionalHeaders: stub.headers)
+        )
         try #require(response == expectedResponse)
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/reference.md
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/reference.md
@@ -19,7 +19,7 @@ import InferredAuthImplicitApiKey
 private func main() async throws {
     let client = InferredAuthImplicitApiKeyClient()
 
-    _ = try await client.auth.getToken()
+    _ = try await client.auth.getToken(apiKey: "api_key")
 }
 
 try await main()

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/README.md
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/README.md
@@ -54,13 +54,16 @@ import InferredAuthImplicitNoExpiry
 private func main() async throws {
     let client = InferredAuthImplicitNoExpiryClient()
 
-    _ = try await client.auth.getTokenWithClientCredentials(request: .init(
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        audience: .httpsApiExampleCom,
-        grantType: .clientCredentials,
-        scope: "scope"
-    ))
+    _ = try await client.auth.getTokenWithClientCredentials(
+        xApiKey: "X-Api-Key",
+        request: .init(
+            clientId: "client_id",
+            clientSecret: "client_secret",
+            audience: .httpsApiExampleCom,
+            grantType: .clientCredentials,
+            scope: "scope"
+        )
+    )
 }
 
 try await main()

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Core/ClientErrorTests.swift
@@ -20,6 +20,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -59,6 +60,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -98,6 +100,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -139,6 +142,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -178,6 +182,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -219,6 +224,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -258,6 +264,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Core/ClientRetryTests.swift
@@ -21,6 +21,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -54,6 +55,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -87,6 +89,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -119,6 +122,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -150,6 +154,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -182,6 +187,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -214,6 +220,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -251,6 +258,7 @@ import Testing
         let startTime = Date()
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -298,6 +306,7 @@ import Testing
         let startTime = Date()
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -341,6 +350,7 @@ import Testing
         let startTime = Date()
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -395,6 +405,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -423,6 +434,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -455,6 +467,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Snippets/Example0.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Snippets/Example0.swift
@@ -5,12 +5,15 @@ enum Example0 {
     static func snippet() async throws {
         let client = InferredAuthImplicitNoExpiryClient(baseURL: "https://api.fern.com")
 
-        _ = try await client.auth.getTokenWithClientCredentials(request: .init(
-            clientId: "client_id",
-            clientSecret: "client_secret",
-            audience: .httpsApiExampleCom,
-            grantType: .clientCredentials,
-            scope: "scope"
-        ))
+        _ = try await client.auth.getTokenWithClientCredentials(
+            xApiKey: "X-Api-Key",
+            request: .init(
+                clientId: "client_id",
+                clientSecret: "client_secret",
+                audience: .httpsApiExampleCom,
+                grantType: .clientCredentials,
+                scope: "scope"
+            )
+        )
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Snippets/Example1.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Snippets/Example1.swift
@@ -5,13 +5,16 @@ enum Example1 {
     static func snippet() async throws {
         let client = InferredAuthImplicitNoExpiryClient(baseURL: "https://api.fern.com")
 
-        _ = try await client.auth.refreshToken(request: .init(
-            clientId: "client_id",
-            clientSecret: "client_secret",
-            refreshToken: "refresh_token",
-            audience: .httpsApiExampleCom,
-            grantType: .refreshToken,
-            scope: "scope"
-        ))
+        _ = try await client.auth.refreshToken(
+            xApiKey: "X-Api-Key",
+            request: .init(
+                clientId: "client_id",
+                clientSecret: "client_secret",
+                refreshToken: "refresh_token",
+                audience: .httpsApiExampleCom,
+                grantType: .refreshToken,
+                scope: "scope"
+            )
+        )
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -24,6 +24,7 @@ import InferredAuthImplicitNoExpiry
             refreshToken: Optional("refresh_token")
         )
         let response = try await client.auth.getTokenWithClientCredentials(
+            xApiKey: "X-Api-Key",
             request: .init(
                 clientId: "client_id",
                 clientSecret: "client_secret",
@@ -57,6 +58,7 @@ import InferredAuthImplicitNoExpiry
             refreshToken: Optional("refresh_token")
         )
         let response = try await client.auth.refreshToken(
+            xApiKey: "X-Api-Key",
             request: .init(
                 clientId: "client_id",
                 clientSecret: "client_secret",

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/reference.md
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/reference.md
@@ -19,13 +19,16 @@ import InferredAuthImplicitNoExpiry
 private func main() async throws {
     let client = InferredAuthImplicitNoExpiryClient()
 
-    _ = try await client.auth.getTokenWithClientCredentials(request: .init(
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        audience: .httpsApiExampleCom,
-        grantType: .clientCredentials,
-        scope: "scope"
-    ))
+    _ = try await client.auth.getTokenWithClientCredentials(
+        xApiKey: "X-Api-Key",
+        request: .init(
+            clientId: "client_id",
+            clientSecret: "client_secret",
+            audience: .httpsApiExampleCom,
+            grantType: .clientCredentials,
+            scope: "scope"
+        )
+    )
 }
 
 try await main()
@@ -90,14 +93,17 @@ import InferredAuthImplicitNoExpiry
 private func main() async throws {
     let client = InferredAuthImplicitNoExpiryClient()
 
-    _ = try await client.auth.refreshToken(request: .init(
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        refreshToken: "refresh_token",
-        audience: .httpsApiExampleCom,
-        grantType: .refreshToken,
-        scope: "scope"
-    ))
+    _ = try await client.auth.refreshToken(
+        xApiKey: "X-Api-Key",
+        request: .init(
+            clientId: "client_id",
+            clientSecret: "client_secret",
+            refreshToken: "refresh_token",
+            audience: .httpsApiExampleCom,
+            grantType: .refreshToken,
+            scope: "scope"
+        )
+    )
 }
 
 try await main()

--- a/seed/swift-sdk/inferred-auth-implicit/README.md
+++ b/seed/swift-sdk/inferred-auth-implicit/README.md
@@ -54,13 +54,16 @@ import InferredAuthImplicit
 private func main() async throws {
     let client = InferredAuthImplicitClient()
 
-    _ = try await client.auth.getTokenWithClientCredentials(request: .init(
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        audience: .httpsApiExampleCom,
-        grantType: .clientCredentials,
-        scope: "scope"
-    ))
+    _ = try await client.auth.getTokenWithClientCredentials(
+        xApiKey: "X-Api-Key",
+        request: .init(
+            clientId: "client_id",
+            clientSecret: "client_secret",
+            audience: .httpsApiExampleCom,
+            grantType: .clientCredentials,
+            scope: "scope"
+        )
+    )
 }
 
 try await main()

--- a/seed/swift-sdk/inferred-auth-implicit/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Tests/Core/ClientErrorTests.swift
@@ -20,6 +20,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -59,6 +60,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -98,6 +100,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -139,6 +142,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -178,6 +182,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -219,6 +224,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -258,6 +264,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",

--- a/seed/swift-sdk/inferred-auth-implicit/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Tests/Core/ClientRetryTests.swift
@@ -21,6 +21,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -54,6 +55,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -87,6 +89,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -119,6 +122,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -150,6 +154,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -182,6 +187,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -214,6 +220,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -251,6 +258,7 @@ import Testing
         let startTime = Date()
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -298,6 +306,7 @@ import Testing
         let startTime = Date()
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -341,6 +350,7 @@ import Testing
         let startTime = Date()
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -395,6 +405,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -423,6 +434,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -455,6 +467,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",

--- a/seed/swift-sdk/inferred-auth-implicit/Tests/Snippets/Example0.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Tests/Snippets/Example0.swift
@@ -5,12 +5,15 @@ enum Example0 {
     static func snippet() async throws {
         let client = InferredAuthImplicitClient(baseURL: "https://api.fern.com")
 
-        _ = try await client.auth.getTokenWithClientCredentials(request: .init(
-            clientId: "client_id",
-            clientSecret: "client_secret",
-            audience: .httpsApiExampleCom,
-            grantType: .clientCredentials,
-            scope: "scope"
-        ))
+        _ = try await client.auth.getTokenWithClientCredentials(
+            xApiKey: "X-Api-Key",
+            request: .init(
+                clientId: "client_id",
+                clientSecret: "client_secret",
+                audience: .httpsApiExampleCom,
+                grantType: .clientCredentials,
+                scope: "scope"
+            )
+        )
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit/Tests/Snippets/Example1.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Tests/Snippets/Example1.swift
@@ -5,13 +5,16 @@ enum Example1 {
     static func snippet() async throws {
         let client = InferredAuthImplicitClient(baseURL: "https://api.fern.com")
 
-        _ = try await client.auth.refreshToken(request: .init(
-            clientId: "client_id",
-            clientSecret: "client_secret",
-            refreshToken: "refresh_token",
-            audience: .httpsApiExampleCom,
-            grantType: .refreshToken,
-            scope: "scope"
-        ))
+        _ = try await client.auth.refreshToken(
+            xApiKey: "X-Api-Key",
+            request: .init(
+                clientId: "client_id",
+                clientSecret: "client_secret",
+                refreshToken: "refresh_token",
+                audience: .httpsApiExampleCom,
+                grantType: .refreshToken,
+                scope: "scope"
+            )
+        )
     }
 }

--- a/seed/swift-sdk/inferred-auth-implicit/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -26,6 +26,7 @@ import InferredAuthImplicit
             refreshToken: Optional("refresh_token")
         )
         let response = try await client.auth.getTokenWithClientCredentials(
+            xApiKey: "X-Api-Key",
             request: .init(
                 clientId: "client_id",
                 clientSecret: "client_secret",
@@ -61,6 +62,7 @@ import InferredAuthImplicit
             refreshToken: Optional("refresh_token")
         )
         let response = try await client.auth.refreshToken(
+            xApiKey: "X-Api-Key",
             request: .init(
                 clientId: "client_id",
                 clientSecret: "client_secret",

--- a/seed/swift-sdk/inferred-auth-implicit/reference.md
+++ b/seed/swift-sdk/inferred-auth-implicit/reference.md
@@ -19,13 +19,16 @@ import InferredAuthImplicit
 private func main() async throws {
     let client = InferredAuthImplicitClient()
 
-    _ = try await client.auth.getTokenWithClientCredentials(request: .init(
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        audience: .httpsApiExampleCom,
-        grantType: .clientCredentials,
-        scope: "scope"
-    ))
+    _ = try await client.auth.getTokenWithClientCredentials(
+        xApiKey: "X-Api-Key",
+        request: .init(
+            clientId: "client_id",
+            clientSecret: "client_secret",
+            audience: .httpsApiExampleCom,
+            grantType: .clientCredentials,
+            scope: "scope"
+        )
+    )
 }
 
 try await main()
@@ -90,14 +93,17 @@ import InferredAuthImplicit
 private func main() async throws {
     let client = InferredAuthImplicitClient()
 
-    _ = try await client.auth.refreshToken(request: .init(
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        refreshToken: "refresh_token",
-        audience: .httpsApiExampleCom,
-        grantType: .refreshToken,
-        scope: "scope"
-    ))
+    _ = try await client.auth.refreshToken(
+        xApiKey: "X-Api-Key",
+        request: .init(
+            clientId: "client_id",
+            clientSecret: "client_secret",
+            refreshToken: "refresh_token",
+            audience: .httpsApiExampleCom,
+            grantType: .refreshToken,
+            scope: "scope"
+        )
+    )
 }
 
 try await main()

--- a/seed/swift-sdk/literal/Sources/Requests/Requests+SendLiteralsInlinedRequest.swift
+++ b/seed/swift-sdk/literal/Sources/Requests/Requests+SendLiteralsInlinedRequest.swift
@@ -6,7 +6,7 @@ extension Requests {
         public let context: YoureSuperWise?
         public let query: String
         public let temperature: Double?
-        public let stream: JSONValue
+        public let stream: Bool
         public let aliasedContext: SomeAliasedLiteral
         public let maybeContext: SomeAliasedLiteral?
         public let objectWithLiteral: ATopLevelLiteral
@@ -18,7 +18,7 @@ extension Requests {
             context: YoureSuperWise? = nil,
             query: String,
             temperature: Double? = nil,
-            stream: JSONValue,
+            stream: Bool,
             aliasedContext: SomeAliasedLiteral,
             maybeContext: SomeAliasedLiteral? = nil,
             objectWithLiteral: ATopLevelLiteral,
@@ -41,7 +41,7 @@ extension Requests {
             self.context = try container.decodeIfPresent(YoureSuperWise.self, forKey: .context)
             self.query = try container.decode(String.self, forKey: .query)
             self.temperature = try container.decodeIfPresent(Double.self, forKey: .temperature)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.aliasedContext = try container.decode(SomeAliasedLiteral.self, forKey: .aliasedContext)
             self.maybeContext = try container.decodeIfPresent(SomeAliasedLiteral.self, forKey: .maybeContext)
             self.objectWithLiteral = try container.decode(ATopLevelLiteral.self, forKey: .objectWithLiteral)

--- a/seed/swift-sdk/literal/Sources/Resources/Query/QueryClient.swift
+++ b/seed/swift-sdk/literal/Sources/Resources/Query/QueryClient.swift
@@ -7,23 +7,27 @@ public final class QueryClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func send(prompt: JSONValue, optionalPrompt: JSONValue? = nil, aliasPrompt: AliasToPrompt, aliasOptionalPrompt: AliasToPrompt? = nil, query: String, stream: JSONValue, optionalStream: JSONValue? = nil, aliasStream: AliasToStream, aliasOptionalStream: AliasToStream? = nil, requestOptions: RequestOptions? = nil) async throws -> SendResponse {
+    public func send(prompt: YouAreAHelpfulAssistant, optionalPrompt: YouAreAHelpfulAssistant? = nil, aliasPrompt: AliasToPrompt, aliasOptionalPrompt: AliasToPrompt? = nil, query: String, stream: Bool, optionalStream: Bool? = nil, aliasStream: AliasToStream, aliasOptionalStream: AliasToStream? = nil, requestOptions: RequestOptions? = nil) async throws -> SendResponse {
         return try await httpClient.performRequest(
             method: .post,
             path: "/query",
             queryParams: [
-                "prompt": .unknown(prompt), 
-                "optional_prompt": optionalPrompt.map { .unknown($0) }, 
-                "alias_prompt": .unknown(aliasPrompt), 
+                "prompt": .string(prompt.rawValue), 
+                "optional_prompt": optionalPrompt.map { .string($0.rawValue) }, 
+                "alias_prompt": .string(aliasPrompt.rawValue), 
                 "alias_optional_prompt": aliasOptionalPrompt.map { .unknown($0) }, 
                 "query": .string(query), 
-                "stream": .unknown(stream), 
-                "optional_stream": optionalStream.map { .unknown($0) }, 
-                "alias_stream": .unknown(aliasStream), 
+                "stream": .bool(stream), 
+                "optional_stream": optionalStream.map { .bool($0) }, 
+                "alias_stream": .bool(aliasStream), 
                 "alias_optional_stream": aliasOptionalStream.map { .unknown($0) }
             ],
             requestOptions: requestOptions,
             responseType: SendResponse.self
         )
+    }
+
+    public enum YouAreAHelpfulAssistant: String, Codable, Hashable, CaseIterable, Sendable {
+        case youAreAHelpfulAssistant = "You are a helpful assistant"
     }
 }

--- a/seed/swift-sdk/literal/Sources/Schemas/AliasToStream.swift
+++ b/seed/swift-sdk/literal/Sources/Schemas/AliasToStream.swift
@@ -1,3 +1,3 @@
 import Foundation
 
-public typealias AliasToStream = JSONValue
+public typealias AliasToStream = Bool

--- a/seed/swift-sdk/literal/Sources/Schemas/DiscriminatedLiteral.swift
+++ b/seed/swift-sdk/literal/Sources/Schemas/DiscriminatedLiteral.swift
@@ -4,7 +4,7 @@ public enum DiscriminatedLiteral: Codable, Hashable, Sendable {
     case customName(String)
     case defaultName(Bob)
     case george(Bool)
-    case literalGeorge(JSONValue)
+    case literalGeorge(Bool)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -17,7 +17,7 @@ public enum DiscriminatedLiteral: Codable, Hashable, Sendable {
         case "george":
             self = .george(try container.decode(Bool.self, forKey: .value))
         case "literalGeorge":
-            self = .literalGeorge(try container.decode(JSONValue.self, forKey: .value))
+            self = .literalGeorge(try container.decode(Bool.self, forKey: .value))
         default:
             throw DecodingError.dataCorrupted(
                 DecodingError.Context(

--- a/seed/swift-sdk/literal/Sources/Schemas/SendRequest.swift
+++ b/seed/swift-sdk/literal/Sources/Schemas/SendRequest.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct SendRequest: Codable, Hashable, Sendable {
     public let prompt: YouAreAHelpfulAssistant
     public let query: String
-    public let stream: JSONValue
+    public let stream: Bool
     public let ending: Ending
     public let context: SomeLiteral
     public let maybeContext: SomeLiteral?
@@ -14,7 +14,7 @@ public struct SendRequest: Codable, Hashable, Sendable {
     public init(
         prompt: YouAreAHelpfulAssistant,
         query: String,
-        stream: JSONValue,
+        stream: Bool,
         ending: Ending,
         context: SomeLiteral,
         maybeContext: SomeLiteral? = nil,
@@ -35,7 +35,7 @@ public struct SendRequest: Codable, Hashable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.prompt = try container.decode(YouAreAHelpfulAssistant.self, forKey: .prompt)
         self.query = try container.decode(String.self, forKey: .query)
-        self.stream = try container.decode(JSONValue.self, forKey: .stream)
+        self.stream = try container.decode(Bool.self, forKey: .stream)
         self.ending = try container.decode(Ending.self, forKey: .ending)
         self.context = try container.decode(SomeLiteral.self, forKey: .context)
         self.maybeContext = try container.decodeIfPresent(SomeLiteral.self, forKey: .maybeContext)

--- a/seed/swift-sdk/literal/Sources/Schemas/SendResponse.swift
+++ b/seed/swift-sdk/literal/Sources/Schemas/SendResponse.swift
@@ -3,14 +3,14 @@ import Foundation
 public struct SendResponse: Codable, Hashable, Sendable {
     public let message: String
     public let status: Int
-    public let success: JSONValue
+    public let success: Bool
     /// Additional properties that are not explicitly defined in the schema
     public let additionalProperties: [String: JSONValue]
 
     public init(
         message: String,
         status: Int,
-        success: JSONValue,
+        success: Bool,
         additionalProperties: [String: JSONValue] = .init()
     ) {
         self.message = message
@@ -23,7 +23,7 @@ public struct SendResponse: Codable, Hashable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.message = try container.decode(String.self, forKey: .message)
         self.status = try container.decode(Int.self, forKey: .status)
-        self.success = try container.decode(JSONValue.self, forKey: .success)
+        self.success = try container.decode(Bool.self, forKey: .success)
         self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
     }
 

--- a/seed/swift-sdk/literal/Sources/Schemas/UndiscriminatedLiteral.swift
+++ b/seed/swift-sdk/literal/Sources/Schemas/UndiscriminatedLiteral.swift
@@ -1,21 +1,21 @@
 import Foundation
 
 public enum UndiscriminatedLiteral: Codable, Hashable, Sendable {
-    case bool(Bool)
-    case ending(Ending)
     case string(String)
+    case ending(Ending)
     case value(Value)
+    case bool(Bool)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Bool.self) {
-            self = .bool(value)
+        if let value = try? container.decode(String.self) {
+            self = .string(value)
         } else if let value = try? container.decode(Ending.self) {
             self = .ending(value)
-        } else if let value = try? container.decode(String.self) {
-            self = .string(value)
         } else if let value = try? container.decode(Value.self) {
             self = .value(value)
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -27,13 +27,13 @@ public enum UndiscriminatedLiteral: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .bool(let value):
+        case .string(let value):
             try container.encode(value)
         case .ending(let value):
             try container.encode(value)
-        case .string(let value):
-            try container.encode(value)
         case .value(let value):
+            try container.encode(value)
+        case .bool(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/literal/Sources/Schemas/UndiscriminatedLiteral.swift
+++ b/seed/swift-sdk/literal/Sources/Schemas/UndiscriminatedLiteral.swift
@@ -3,7 +3,6 @@ import Foundation
 public enum UndiscriminatedLiteral: Codable, Hashable, Sendable {
     case bool(Bool)
     case ending(Ending)
-    case jsonValue(JSONValue)
     case string(String)
     case value(Value)
 
@@ -13,8 +12,6 @@ public enum UndiscriminatedLiteral: Codable, Hashable, Sendable {
             self = .bool(value)
         } else if let value = try? container.decode(Ending.self) {
             self = .ending(value)
-        } else if let value = try? container.decode(JSONValue.self) {
-            self = .jsonValue(value)
         } else if let value = try? container.decode(String.self) {
             self = .string(value)
         } else if let value = try? container.decode(Value.self) {
@@ -33,8 +30,6 @@ public enum UndiscriminatedLiteral: Codable, Hashable, Sendable {
         case .bool(let value):
             try container.encode(value)
         case .ending(let value):
-            try container.encode(value)
-        case .jsonValue(let value):
             try container.encode(value)
         case .string(let value):
             try container.encode(value)

--- a/seed/swift-sdk/literal/Tests/Snippets/Example8.swift
+++ b/seed/swift-sdk/literal/Tests/Snippets/Example8.swift
@@ -9,6 +9,7 @@ enum Example8 {
             prompt: .youAreAHelpfulAssistant,
             query: "What is the weather today",
             stream: false,
+            ending: .ending,
             context: .youreSuperWise,
             containerObject: ContainerObject(
                 nestedObjects: [

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Headers/HeadersClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Headers/HeadersClientWireTests.swift
@@ -23,7 +23,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "The weather is sunny",
             status: 200,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.headers.send(
             request: .init(query: "What is the weather today"),
@@ -52,7 +52,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "message",
             status: 1,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.headers.send(
             request: .init(query: "query"),

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Inlined/InlinedClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Inlined/InlinedClientWireTests.swift
@@ -23,7 +23,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "The weather is sunny",
             status: 200,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.inlined.send(
             request: .init(
@@ -65,7 +65,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "message",
             status: 1,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.inlined.send(
             request: .init(

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Path/PathClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Path/PathClientWireTests.swift
@@ -23,7 +23,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "The weather is sunny",
             status: 200,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.path.send(
             id: "123",
@@ -52,7 +52,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "message",
             status: 1,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.path.send(
             id: "123",

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Query/QueryClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Query/QueryClientWireTests.swift
@@ -23,7 +23,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "The weather is sunny",
             status: 200,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.query.send(
             prompt: .youAreAHelpfulAssistant,
@@ -60,7 +60,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "message",
             status: 1,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.query.send(
             prompt: .youAreAHelpfulAssistant,

--- a/seed/swift-sdk/literal/Tests/Wire/Resources/Reference/ReferenceClientWireTests.swift
+++ b/seed/swift-sdk/literal/Tests/Wire/Resources/Reference/ReferenceClientWireTests.swift
@@ -23,13 +23,14 @@ import Literal
         let expectedResponse = SendResponse(
             message: "The weather is sunny",
             status: 200,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.reference.send(
             request: SendRequest(
                 prompt: .youAreAHelpfulAssistant,
                 query: "What is the weather today",
                 stream: false,
+                ending: .ending,
                 context: .youreSuperWise,
                 containerObject: ContainerObject(
                     nestedObjects: [
@@ -66,7 +67,7 @@ import Literal
         let expectedResponse = SendResponse(
             message: "message",
             status: 1,
-            success: JSONValue.bool(true)
+            success: true
         )
         let response = try await client.reference.send(
             request: SendRequest(

--- a/seed/swift-sdk/literal/reference.md
+++ b/seed/swift-sdk/literal/reference.md
@@ -187,7 +187,7 @@ try await main()
 </details>
 
 ## Query
-<details><summary><code>client.query.<a href="/Sources/Resources/Query/QueryClient.swift">send</a>(prompt: JSONValue, optionalPrompt: JSONValue?, aliasPrompt: AliasToPrompt, aliasOptionalPrompt: AliasToPrompt?, query: String, stream: JSONValue, optionalStream: JSONValue?, aliasStream: AliasToStream, aliasOptionalStream: AliasToStream?, requestOptions: RequestOptions?) -> SendResponse</code></summary>
+<details><summary><code>client.query.<a href="/Sources/Resources/Query/QueryClient.swift">send</a>(prompt: JSONValue, optionalPrompt: JSONValue?, aliasPrompt: AliasToPrompt, aliasOptionalPrompt: AliasToPrompt?, query: String, stream: Bool, optionalStream: Bool?, aliasStream: AliasToStream, aliasOptionalStream: AliasToStream?, requestOptions: RequestOptions?) -> SendResponse</code></summary>
 <dl>
 <dd>
 
@@ -274,7 +274,7 @@ try await main()
 <dl>
 <dd>
 
-**stream:** `JSONValue` 
+**stream:** `Bool` 
     
 </dd>
 </dl>
@@ -282,7 +282,7 @@ try await main()
 <dl>
 <dd>
 
-**optionalStream:** `JSONValue?` 
+**optionalStream:** `Bool?` 
     
 </dd>
 </dl>
@@ -342,6 +342,7 @@ private func main() async throws {
         prompt: .youAreAHelpfulAssistant,
         query: "What is the weather today",
         stream: false,
+        ending: .ending,
         context: .youreSuperWise,
         containerObject: ContainerObject(
             nestedObjects: [

--- a/seed/swift-sdk/literals-unions/Sources/Schemas/UnionOverLiteral.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Schemas/UnionOverLiteral.swift
@@ -2,15 +2,15 @@ import Foundation
 
 /// An undiscriminated union over a literal.
 public enum UnionOverLiteral: Codable, Hashable, Sendable {
-    case literalString(LiteralString)
     case string(String)
+    case literalString(LiteralString)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(LiteralString.self) {
-            self = .literalString(value)
-        } else if let value = try? container.decode(String.self) {
+        if let value = try? container.decode(String.self) {
             self = .string(value)
+        } else if let value = try? container.decode(LiteralString.self) {
+            self = .literalString(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -22,9 +22,9 @@ public enum UnionOverLiteral: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .literalString(let value):
-            try container.encode(value)
         case .string(let value):
+            try container.encode(value)
+        case .literalString(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Schemas/WeirdNumber.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Schemas/WeirdNumber.swift
@@ -1,21 +1,21 @@
 import Foundation
 
 public enum WeirdNumber: Codable, Hashable, Sendable {
-    case double(Double)
     case int(Int)
     case nullableFloat(Nullable<Float>)
     case optionalNullableString(Nullable<String>?)
+    case double(Double)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Double.self) {
-            self = .double(value)
-        } else if let value = try? container.decode(Int.self) {
+        if let value = try? container.decode(Int.self) {
             self = .int(value)
         } else if let value = try? container.decode(Nullable<Float>.self) {
             self = .nullableFloat(value)
         } else if let value = try? container.decode(Nullable<String>?.self) {
             self = .optionalNullableString(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -27,13 +27,13 @@ public enum WeirdNumber: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .double(let value):
-            try container.encode(value)
         case .int(let value):
             try container.encode(value)
         case .nullableFloat(let value):
             try container.encode(value)
         case .optionalNullableString(let value):
+            try container.encode(value)
+        case .double(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Schemas/WeirdNumber.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Schemas/WeirdNumber.swift
@@ -1,21 +1,21 @@
 import Foundation
 
 public enum WeirdNumber: Codable, Hashable, Sendable {
-    case double(Double)
     case int(Int)
     case nullableFloat(Nullable<Float>)
     case optionalNullableString(Nullable<String>?)
+    case double(Double)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Double.self) {
-            self = .double(value)
-        } else if let value = try? container.decode(Int.self) {
+        if let value = try? container.decode(Int.self) {
             self = .int(value)
         } else if let value = try? container.decode(Nullable<Float>.self) {
             self = .nullableFloat(value)
         } else if let value = try? container.decode(Nullable<String>?.self) {
             self = .optionalNullableString(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -27,13 +27,13 @@ public enum WeirdNumber: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .double(let value):
-            try container.encode(value)
         case .int(let value):
             try container.encode(value)
         case .nullableFloat(let value):
             try container.encode(value)
         case .optionalNullableString(let value):
+            try container.encode(value)
+        case .double(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/openapi-request-body-ref/Tests/Snippets/Example3.swift
+++ b/seed/swift-sdk/openapi-request-body-ref/Tests/Snippets/Example3.swift
@@ -5,9 +5,12 @@ enum Example3 {
     static func snippet() async throws {
         let client = ApiClient(baseURL: "https://api.fern.com")
 
-        _ = try await client.vendor.createVendor(request: .init(
-            name: "name",
-            address: "address"
-        ))
+        _ = try await client.vendor.createVendor(
+            idempotencyKey: "idempotencyKey",
+            request: .init(
+                name: "name",
+                address: "address"
+            )
+        )
     }
 }

--- a/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/Vendor/VendorClientWireTests.swift
+++ b/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/Vendor/VendorClientWireTests.swift
@@ -152,6 +152,7 @@ import Api
             ))
         )
         let response = try await client.vendor.createVendor(
+            idempotencyKey: "idempotencyKey",
             request: .init(
                 name: "name",
                 address: "address"

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Schemas/SearchRequestQuery.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Schemas/SearchRequestQuery.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 public enum SearchRequestQuery: Codable, Hashable, Sendable {
-    case multipleFilterSearchRequest(MultipleFilterSearchRequest)
     case singleFilterSearchRequest(SingleFilterSearchRequest)
+    case multipleFilterSearchRequest(MultipleFilterSearchRequest)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(MultipleFilterSearchRequest.self) {
-            self = .multipleFilterSearchRequest(value)
-        } else if let value = try? container.decode(SingleFilterSearchRequest.self) {
+        if let value = try? container.decode(SingleFilterSearchRequest.self) {
             self = .singleFilterSearchRequest(value)
+        } else if let value = try? container.decode(MultipleFilterSearchRequest.self) {
+            self = .multipleFilterSearchRequest(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -21,9 +21,9 @@ public enum SearchRequestQuery: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .multipleFilterSearchRequest(let value):
-            try container.encode(value)
         case .singleFilterSearchRequest(let value):
+            try container.encode(value)
+        case .multipleFilterSearchRequest(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Schemas/SearchRequestQuery.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Schemas/SearchRequestQuery.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 public enum SearchRequestQuery: Codable, Hashable, Sendable {
-    case multipleFilterSearchRequest(MultipleFilterSearchRequest)
     case singleFilterSearchRequest(SingleFilterSearchRequest)
+    case multipleFilterSearchRequest(MultipleFilterSearchRequest)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(MultipleFilterSearchRequest.self) {
-            self = .multipleFilterSearchRequest(value)
-        } else if let value = try? container.decode(SingleFilterSearchRequest.self) {
+        if let value = try? container.decode(SingleFilterSearchRequest.self) {
             self = .singleFilterSearchRequest(value)
+        } else if let value = try? container.decode(MultipleFilterSearchRequest.self) {
+            self = .multipleFilterSearchRequest(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -21,9 +21,9 @@ public enum SearchRequestQuery: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .multipleFilterSearchRequest(let value):
-            try container.encode(value)
         case .singleFilterSearchRequest(let value):
+            try container.encode(value)
+        case .multipleFilterSearchRequest(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Schemas/SearchRequestQuery.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Schemas/SearchRequestQuery.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 public enum SearchRequestQuery: Codable, Hashable, Sendable {
-    case multipleFilterSearchRequest(MultipleFilterSearchRequest)
     case singleFilterSearchRequest(SingleFilterSearchRequest)
+    case multipleFilterSearchRequest(MultipleFilterSearchRequest)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(MultipleFilterSearchRequest.self) {
-            self = .multipleFilterSearchRequest(value)
-        } else if let value = try? container.decode(SingleFilterSearchRequest.self) {
+        if let value = try? container.decode(SingleFilterSearchRequest.self) {
             self = .singleFilterSearchRequest(value)
+        } else if let value = try? container.decode(MultipleFilterSearchRequest.self) {
+            self = .multipleFilterSearchRequest(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -21,9 +21,9 @@ public enum SearchRequestQuery: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .multipleFilterSearchRequest(let value):
-            try container.encode(value)
         case .singleFilterSearchRequest(let value):
+            try container.encode(value)
+        case .multipleFilterSearchRequest(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/plain-text/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Resources/Service/ServiceClient.swift
@@ -16,21 +16,21 @@ public final class ServiceClient: Sendable {
         )
     }
 
-    public func getCsv(requestOptions: RequestOptions? = nil) async throws -> JSONValue {
+    public func getCsv(requestOptions: RequestOptions? = nil) async throws -> String {
         return try await httpClient.performRequest(
             method: .get,
             path: "/csv",
             requestOptions: requestOptions,
-            responseType: JSONValue.self
+            responseType: String.self
         )
     }
 
-    public func getXml(requestOptions: RequestOptions? = nil) async throws -> JSONValue {
+    public func getXml(requestOptions: RequestOptions? = nil) async throws -> String {
         return try await httpClient.performRequest(
             method: .get,
             path: "/xml",
             requestOptions: requestOptions,
-            responseType: JSONValue.self
+            responseType: String.self
         )
     }
 }

--- a/seed/swift-sdk/plain-text/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Resources/Service/ServiceClient.swift
@@ -7,12 +7,12 @@ public final class ServiceClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getText(requestOptions: RequestOptions? = nil) async throws -> JSONValue {
+    public func getText(requestOptions: RequestOptions? = nil) async throws -> String {
         return try await httpClient.performRequest(
             method: .post,
             path: "/text",
             requestOptions: requestOptions,
-            responseType: JSONValue.self
+            responseType: String.self
         )
     }
 

--- a/seed/swift-sdk/plain-text/reference.md
+++ b/seed/swift-sdk/plain-text/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Service
-<details><summary><code>client.service.<a href="/Sources/Resources/Service/ServiceClient.swift">getText</a>(requestOptions: RequestOptions?) -> JSONValue</code></summary>
+<details><summary><code>client.service.<a href="/Sources/Resources/Service/ServiceClient.swift">getText</a>(requestOptions: RequestOptions?) -> String</code></summary>
 <dl>
 <dd>
 

--- a/seed/swift-sdk/plain-text/reference.md
+++ b/seed/swift-sdk/plain-text/reference.md
@@ -49,7 +49,7 @@ try await main()
 </dl>
 </details>
 
-<details><summary><code>client.service.<a href="/Sources/Resources/Service/ServiceClient.swift">getCsv</a>(requestOptions: RequestOptions?) -> JSONValue</code></summary>
+<details><summary><code>client.service.<a href="/Sources/Resources/Service/ServiceClient.swift">getCsv</a>(requestOptions: RequestOptions?) -> String</code></summary>
 <dl>
 <dd>
 
@@ -98,7 +98,7 @@ try await main()
 </dl>
 </details>
 
-<details><summary><code>client.service.<a href="/Sources/Resources/Service/ServiceClient.swift">getXml</a>(requestOptions: RequestOptions?) -> JSONValue</code></summary>
+<details><summary><code>client.service.<a href="/Sources/Resources/Service/ServiceClient.swift">getXml</a>(requestOptions: RequestOptions?) -> String</code></summary>
 <dl>
 <dd>
 

--- a/seed/swift-sdk/property-access/Sources/Schemas/UserOrAdmin.swift
+++ b/seed/swift-sdk/property-access/Sources/Schemas/UserOrAdmin.swift
@@ -2,15 +2,15 @@ import Foundation
 
 /// Example of an undiscriminated union
 public enum UserOrAdmin: Codable, Hashable, Sendable {
-    case admin(Admin)
     case user(User)
+    case admin(Admin)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Admin.self) {
-            self = .admin(value)
-        } else if let value = try? container.decode(User.self) {
+        if let value = try? container.decode(User.self) {
             self = .user(value)
+        } else if let value = try? container.decode(Admin.self) {
+            self = .admin(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -22,9 +22,9 @@ public enum UserOrAdmin: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .admin(let value):
-            try container.encode(value)
         case .user(let value):
+            try container.encode(value)
+        case .admin(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Schemas/SearchRequestNeighbor.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Schemas/SearchRequestNeighbor.swift
@@ -1,21 +1,21 @@
 import Foundation
 
 public enum SearchRequestNeighbor: Codable, Hashable, Sendable {
-    case int(Int)
+    case user(User)
     case nestedUser(NestedUser)
     case string(String)
-    case user(User)
+    case int(Int)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Int.self) {
-            self = .int(value)
+        if let value = try? container.decode(User.self) {
+            self = .user(value)
         } else if let value = try? container.decode(NestedUser.self) {
             self = .nestedUser(value)
         } else if let value = try? container.decode(String.self) {
             self = .string(value)
-        } else if let value = try? container.decode(User.self) {
-            self = .user(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -27,13 +27,13 @@ public enum SearchRequestNeighbor: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .int(let value):
+        case .user(let value):
             try container.encode(value)
         case .nestedUser(let value):
             try container.encode(value)
         case .string(let value):
             try container.encode(value)
-        case .user(let value):
+        case .int(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Schemas/SearchRequestNeighborRequired.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Schemas/SearchRequestNeighborRequired.swift
@@ -1,21 +1,21 @@
 import Foundation
 
 public enum SearchRequestNeighborRequired: Codable, Hashable, Sendable {
-    case int(Int)
+    case user(User)
     case nestedUser(NestedUser)
     case string(String)
-    case user(User)
+    case int(Int)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Int.self) {
-            self = .int(value)
+        if let value = try? container.decode(User.self) {
+            self = .user(value)
         } else if let value = try? container.decode(NestedUser.self) {
             self = .nestedUser(value)
         } else if let value = try? container.decode(String.self) {
             self = .string(value)
-        } else if let value = try? container.decode(User.self) {
-            self = .user(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -27,13 +27,13 @@ public enum SearchRequestNeighborRequired: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .int(let value):
+        case .user(let value):
             try container.encode(value)
         case .nestedUser(let value):
             try container.encode(value)
         case .string(let value):
             try container.encode(value)
-        case .user(let value):
+        case .int(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Schemas/SearchRequestNeighbor.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Schemas/SearchRequestNeighbor.swift
@@ -1,21 +1,21 @@
 import Foundation
 
 public enum SearchRequestNeighbor: Codable, Hashable, Sendable {
-    case int(Int)
+    case user(User)
     case nestedUser(NestedUser)
     case string(String)
-    case user(User)
+    case int(Int)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Int.self) {
-            self = .int(value)
+        if let value = try? container.decode(User.self) {
+            self = .user(value)
         } else if let value = try? container.decode(NestedUser.self) {
             self = .nestedUser(value)
         } else if let value = try? container.decode(String.self) {
             self = .string(value)
-        } else if let value = try? container.decode(User.self) {
-            self = .user(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -27,13 +27,13 @@ public enum SearchRequestNeighbor: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .int(let value):
+        case .user(let value):
             try container.encode(value)
         case .nestedUser(let value):
             try container.encode(value)
         case .string(let value):
             try container.encode(value)
-        case .user(let value):
+        case .int(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Schemas/SearchRequestNeighborRequired.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Schemas/SearchRequestNeighborRequired.swift
@@ -1,21 +1,21 @@
 import Foundation
 
 public enum SearchRequestNeighborRequired: Codable, Hashable, Sendable {
-    case int(Int)
+    case user(User)
     case nestedUser(NestedUser)
     case string(String)
-    case user(User)
+    case int(Int)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Int.self) {
-            self = .int(value)
+        if let value = try? container.decode(User.self) {
+            self = .user(value)
         } else if let value = try? container.decode(NestedUser.self) {
             self = .nestedUser(value)
         } else if let value = try? container.decode(String.self) {
             self = .string(value)
-        } else if let value = try? container.decode(User.self) {
-            self = .user(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -27,13 +27,13 @@ public enum SearchRequestNeighborRequired: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .int(let value):
+        case .user(let value):
             try container.encode(value)
         case .nestedUser(let value):
             try container.encode(value)
         case .string(let value):
             try container.encode(value)
-        case .user(let value):
+        case .int(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/required-nullable/no-custom-config/Tests/Snippets/Example2.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Tests/Snippets/Example2.swift
@@ -7,6 +7,7 @@ enum Example2 {
 
         _ = try await client.updateFoo(
             id: "id",
+            xIdempotencyKey: "X-Idempotency-Key",
             request: .init(
                 nullableText: .value("nullable_text"),
                 nullableNumber: .value(1.1),

--- a/seed/swift-sdk/required-nullable/no-custom-config/reference.md
+++ b/seed/swift-sdk/required-nullable/no-custom-config/reference.md
@@ -104,6 +104,7 @@ private func main() async throws {
 
     _ = try await client.updateFoo(
         id: "id",
+        xIdempotencyKey: "X-Idempotency-Key",
         request: .init(
             nullableText: .value("nullable_text"),
             nullableNumber: .value(1.1),

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Tests/Snippets/Example2.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Tests/Snippets/Example2.swift
@@ -7,6 +7,7 @@ enum Example2 {
 
         _ = try await client.updateFoo(
             id: "id",
+            xIdempotencyKey: "X-Idempotency-Key",
             request: .init(
                 nullableText: .value("nullable_text"),
                 nullableNumber: .value(1.1),

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/reference.md
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/reference.md
@@ -104,6 +104,7 @@ private func main() async throws {
 
     _ = try await client.updateFoo(
         id: "id",
+        xIdempotencyKey: "X-Idempotency-Key",
         request: .init(
             nullableText: .value("nullable_text"),
             nullableNumber: .value(1.1),

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -133,7 +133,6 @@ allowedFailures:
   - examples:no-custom-config
   - examples:readme-config
   - exhaustive
-  - literal
   - multi-url-environment
   - multi-url-environment-no-default
   - multi-url-environment-reference

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -136,8 +136,6 @@ allowedFailures:
   - multi-url-environment
   - multi-url-environment-no-default
   - multi-url-environment-reference
-  - nullable:no-custom-config
-  - nullable:nullable-as-optional
   - oauth-client-credentials-with-variables
   - query-parameters
   - request-parameters
@@ -145,8 +143,6 @@ allowedFailures:
   - streaming-parameter
   - trace
   - undiscriminated-unions
-  # Java-specific fixture for LocalDate support
-  - unions-with-local-date
   # Server URL templating not yet supported in Swift SDK
   - server-sent-events-openapi
   - server-url-templating

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -133,10 +133,6 @@ allowedFailures:
   - examples:no-custom-config
   - examples:readme-config
   - exhaustive
-  - inferred-auth-explicit
-  - inferred-auth-implicit
-  - inferred-auth-implicit-no-expiry
-  - inferred-auth-implicit-api-key
   - literal
   - multi-url-environment
   - multi-url-environment-no-default
@@ -147,8 +143,6 @@ allowedFailures:
   - plain-text
   - query-parameters
   - request-parameters
-  - required-nullable:no-custom-config
-  - required-nullable:nullable-as-optional
   - streaming
   - streaming-parameter
   - trace
@@ -159,4 +153,3 @@ allowedFailures:
   - server-sent-events-openapi
   - server-url-templating
   - variables
-  - websocket-inferred-auth

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -140,7 +140,6 @@ allowedFailures:
   - nullable:no-custom-config
   - nullable:nullable-as-optional
   - oauth-client-credentials-with-variables
-  - plain-text
   - query-parameters
   - request-parameters
   - streaming

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingConditionRequest.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingConditionRequest.swift
@@ -5,13 +5,13 @@ extension Requests {
         /// The prompt or query to complete.
         public let query: String
         /// Whether to stream the response.
-        public let stream: JSONValue
+        public let stream: Bool
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
             query: String,
-            stream: JSONValue,
+            stream: Bool,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.query = query
@@ -22,7 +22,7 @@ extension Requests {
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.query = try container.decode(String.self, forKey: .query)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingConditionStreamRequest.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingConditionStreamRequest.swift
@@ -5,13 +5,13 @@ extension Requests {
         /// The prompt or query to complete.
         public let query: String
         /// Whether to stream the response.
-        public let stream: JSONValue
+        public let stream: Bool
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
             query: String,
-            stream: JSONValue,
+            stream: Bool,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.query = query
@@ -22,7 +22,7 @@ extension Requests {
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.query = try container.decode(String.self, forKey: .query)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingNullableConditionRequest.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingNullableConditionRequest.swift
@@ -5,13 +5,13 @@ extension Requests {
         /// The prompt or query to complete.
         public let query: String
         /// Whether to stream the response. This field is nullable (OAS 3.1 type array), which previously caused the const literal to be overwritten by the nullable type during spread in the importer.
-        public let stream: JSONValue
+        public let stream: Bool
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
             query: String,
-            stream: JSONValue,
+            stream: Bool,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.query = query
@@ -22,7 +22,7 @@ extension Requests {
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.query = try container.decode(String.self, forKey: .query)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingNullableConditionStreamRequest.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingNullableConditionStreamRequest.swift
@@ -5,13 +5,13 @@ extension Requests {
         /// The prompt or query to complete.
         public let query: String
         /// Whether to stream the response. This field is nullable (OAS 3.1 type array), which previously caused the const literal to be overwritten by the nullable type during spread in the importer.
-        public let stream: JSONValue
+        public let stream: Bool
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
             query: String,
-            stream: JSONValue,
+            stream: Bool,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.query = query
@@ -22,7 +22,7 @@ extension Requests {
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.query = try container.decode(String.self, forKey: .query)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingSharedSchemaRequest.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingSharedSchemaRequest.swift
@@ -7,14 +7,14 @@ extension Requests {
         /// The model to use.
         public let model: String
         /// Whether to stream the response.
-        public let stream: JSONValue
+        public let stream: Bool
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
             prompt: String,
             model: String,
-            stream: JSONValue,
+            stream: Bool,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.prompt = prompt
@@ -27,7 +27,7 @@ extension Requests {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.prompt = try container.decode(String.self, forKey: .prompt)
             self.model = try container.decode(String.self, forKey: .model)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingSharedSchemaStreamRequest.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Requests/Requests+StreamXFernStreamingSharedSchemaStreamRequest.swift
@@ -7,14 +7,14 @@ extension Requests {
         /// The model to use.
         public let model: String
         /// Whether to stream the response.
-        public let stream: JSONValue
+        public let stream: Bool
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
             prompt: String,
             model: String,
-            stream: JSONValue,
+            stream: Bool,
             additionalProperties: [String: JSONValue] = .init()
         ) {
             self.prompt = prompt
@@ -27,7 +27,7 @@ extension Requests {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.prompt = try container.decode(String.self, forKey: .prompt)
             self.model = try container.decode(String.self, forKey: .model)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }
 

--- a/seed/swift-sdk/streaming/Sources/Requests/Requests+GenerateStreamRequest.swift
+++ b/seed/swift-sdk/streaming/Sources/Requests/Requests+GenerateStreamRequest.swift
@@ -2,13 +2,13 @@ import Foundation
 
 extension Requests {
     public struct GenerateStreamRequest: Codable, Hashable, Sendable {
-        public let stream: JSONValue
+        public let stream: Bool
         public let numEvents: Int
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
-            stream: JSONValue,
+            stream: Bool,
             numEvents: Int,
             additionalProperties: [String: JSONValue] = .init()
         ) {
@@ -19,7 +19,7 @@ extension Requests {
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.numEvents = try container.decode(Int.self, forKey: .numEvents)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }

--- a/seed/swift-sdk/streaming/Sources/Requests/Requests+Generateequest.swift
+++ b/seed/swift-sdk/streaming/Sources/Requests/Requests+Generateequest.swift
@@ -2,13 +2,13 @@ import Foundation
 
 extension Requests {
     public struct Generateequest: Codable, Hashable, Sendable {
-        public let stream: JSONValue
+        public let stream: Bool
         public let numEvents: Int
         /// Additional properties that are not explicitly defined in the schema
         public let additionalProperties: [String: JSONValue]
 
         public init(
-            stream: JSONValue,
+            stream: Bool,
             numEvents: Int,
             additionalProperties: [String: JSONValue] = .init()
         ) {
@@ -19,7 +19,7 @@ extension Requests {
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.stream = try container.decode(JSONValue.self, forKey: .stream)
+            self.stream = try container.decode(Bool.self, forKey: .stream)
             self.numEvents = try container.decode(Int.self, forKey: .numEvents)
             self.additionalProperties = try decoder.decodeAdditionalProperties(using: CodingKeys.self)
         }

--- a/seed/swift-sdk/trace/Tests/Snippets/Example11.swift
+++ b/seed/swift-sdk/trace/Tests/Snippets/Example11.swift
@@ -8,6 +8,6 @@ enum Example11 {
             token: "<token>"
         )
 
-        _ = try await client.migration.getAttemptedMigrations()
+        _ = try await client.migration.getAttemptedMigrations(adminKeyHeader: "admin-key-header")
     }
 }

--- a/seed/swift-sdk/trace/Tests/Snippets/Example2.swift
+++ b/seed/swift-sdk/trace/Tests/Snippets/Example2.swift
@@ -13,7 +13,7 @@ enum Example2 {
             request: TestSubmissionUpdate(
                 updateTime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
                 updateInfo: TestSubmissionUpdateInfo.running(
-
+                    .queueingSubmission
                 )
             )
         )

--- a/seed/swift-sdk/trace/Tests/Snippets/Example20.swift
+++ b/seed/swift-sdk/trace/Tests/Snippets/Example20.swift
@@ -13,10 +13,10 @@ enum Example20 {
             problemDescription: ProblemDescription(
                 boards: [
                     ProblemDescriptionBoard.html(
-
+                        "boards"
                     ),
                     ProblemDescriptionBoard.html(
-
+                        "boards"
                     )
                 ]
             ),
@@ -55,15 +55,15 @@ enum Example20 {
                         id: "id",
                         params: [
                             VariableValue.integerValue(
-
+                                1
                             ),
                             VariableValue.integerValue(
-
+                                1
                             )
                         ]
                     ),
                     expectedResult: VariableValue.integerValue(
-
+                        1
                     )
                 ),
                 TestCaseWithExpectedResult(
@@ -71,15 +71,15 @@ enum Example20 {
                         id: "id",
                         params: [
                             VariableValue.integerValue(
-
+                                1
                             ),
                             VariableValue.integerValue(
-
+                                1
                             )
                         ]
                     ),
                     expectedResult: VariableValue.integerValue(
-
+                        1
                     )
                 )
             ],

--- a/seed/swift-sdk/trace/Tests/Snippets/Example21.swift
+++ b/seed/swift-sdk/trace/Tests/Snippets/Example21.swift
@@ -15,10 +15,10 @@ enum Example21 {
                 problemDescription: ProblemDescription(
                     boards: [
                         ProblemDescriptionBoard.html(
-
+                            "boards"
                         ),
                         ProblemDescriptionBoard.html(
-
+                            "boards"
                         )
                     ]
                 ),
@@ -57,15 +57,15 @@ enum Example21 {
                             id: "id",
                             params: [
                                 VariableValue.integerValue(
-
+                                    1
                                 ),
                                 VariableValue.integerValue(
-
+                                    1
                                 )
                             ]
                         ),
                         expectedResult: VariableValue.integerValue(
-
+                            1
                         )
                     ),
                     TestCaseWithExpectedResult(
@@ -73,15 +73,15 @@ enum Example21 {
                             id: "id",
                             params: [
                                 VariableValue.integerValue(
-
+                                    1
                                 ),
                                 VariableValue.integerValue(
-
+                                    1
                                 )
                             ]
                         ),
                         expectedResult: VariableValue.integerValue(
-
+                            1
                         )
                     )
                 ],

--- a/seed/swift-sdk/trace/Tests/Snippets/Example4.swift
+++ b/seed/swift-sdk/trace/Tests/Snippets/Example4.swift
@@ -13,7 +13,7 @@ enum Example4 {
             request: WorkspaceSubmissionUpdate(
                 updateTime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
                 updateInfo: WorkspaceSubmissionUpdateInfo.running(
-
+                    .queueingSubmission
                 )
             )
         )

--- a/seed/swift-sdk/trace/Tests/Snippets/Example5.swift
+++ b/seed/swift-sdk/trace/Tests/Snippets/Example5.swift
@@ -15,11 +15,11 @@ enum Example5 {
                 result: TestCaseResultWithStdout(
                     result: TestCaseResult(
                         expectedResult: VariableValue.integerValue(
-
+                            1
                         ),
                         actualResult: ActualResult.value(
                             VariableValue.integerValue(
-
+                                1
                             )
                         ),
                         passed: true
@@ -31,7 +31,7 @@ enum Example5 {
                         submissionId: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")!,
                         lineNumber: 1,
                         returnValue: DebugVariableValue.integerValue(
-
+                            1
                         ),
                         expressionLocation: ExpressionLocation(
                             start: 1,
@@ -46,14 +46,14 @@ enum Example5 {
                                     Scope(
                                         variables: [
                                             "variables": DebugVariableValue.integerValue(
-
+                                                1
                                             )
                                         ]
                                     ),
                                     Scope(
                                         variables: [
                                             "variables": DebugVariableValue.integerValue(
-
+                                                1
                                             )
                                         ]
                                     )
@@ -66,7 +66,7 @@ enum Example5 {
                         submissionId: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")!,
                         lineNumber: 1,
                         returnValue: DebugVariableValue.integerValue(
-
+                            1
                         ),
                         expressionLocation: ExpressionLocation(
                             start: 1,
@@ -81,14 +81,14 @@ enum Example5 {
                                     Scope(
                                         variables: [
                                             "variables": DebugVariableValue.integerValue(
-
+                                                1
                                             )
                                         ]
                                     ),
                                     Scope(
                                         variables: [
                                             "variables": DebugVariableValue.integerValue(
-
+                                                1
                                             )
                                         ]
                                     )

--- a/seed/swift-sdk/trace/Tests/Snippets/Example6.swift
+++ b/seed/swift-sdk/trace/Tests/Snippets/Example6.swift
@@ -20,7 +20,7 @@ enum Example6 {
                         directory: "directory"
                     ),
                     returnValue: DebugVariableValue.integerValue(
-
+                        1
                     ),
                     expressionLocation: ExpressionLocation(
                         start: 1,
@@ -35,14 +35,14 @@ enum Example6 {
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 ),
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 )
@@ -59,7 +59,7 @@ enum Example6 {
                         directory: "directory"
                     ),
                     returnValue: DebugVariableValue.integerValue(
-
+                        1
                     ),
                     expressionLocation: ExpressionLocation(
                         start: 1,
@@ -74,14 +74,14 @@ enum Example6 {
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 ),
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 )

--- a/seed/swift-sdk/trace/Tests/Snippets/Example7.swift
+++ b/seed/swift-sdk/trace/Tests/Snippets/Example7.swift
@@ -31,7 +31,7 @@ enum Example7 {
                         submissionId: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")!,
                         lineNumber: 1,
                         returnValue: DebugVariableValue.integerValue(
-
+                            1
                         ),
                         expressionLocation: ExpressionLocation(
                             start: 1,
@@ -46,14 +46,14 @@ enum Example7 {
                                     Scope(
                                         variables: [
                                             "variables": DebugVariableValue.integerValue(
-
+                                                1
                                             )
                                         ]
                                     ),
                                     Scope(
                                         variables: [
                                             "variables": DebugVariableValue.integerValue(
-
+                                                1
                                             )
                                         ]
                                     )
@@ -66,7 +66,7 @@ enum Example7 {
                         submissionId: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")!,
                         lineNumber: 1,
                         returnValue: DebugVariableValue.integerValue(
-
+                            1
                         ),
                         expressionLocation: ExpressionLocation(
                             start: 1,
@@ -81,14 +81,14 @@ enum Example7 {
                                     Scope(
                                         variables: [
                                             "variables": DebugVariableValue.integerValue(
-
+                                                1
                                             )
                                         ]
                                     ),
                                     Scope(
                                         variables: [
                                             "variables": DebugVariableValue.integerValue(
-
+                                                1
                                             )
                                         ]
                                     )

--- a/seed/swift-sdk/trace/Tests/Snippets/Example8.swift
+++ b/seed/swift-sdk/trace/Tests/Snippets/Example8.swift
@@ -19,7 +19,7 @@ enum Example8 {
                         directory: "directory"
                     ),
                     returnValue: DebugVariableValue.integerValue(
-
+                        1
                     ),
                     expressionLocation: ExpressionLocation(
                         start: 1,
@@ -34,14 +34,14 @@ enum Example8 {
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 ),
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 )
@@ -58,7 +58,7 @@ enum Example8 {
                         directory: "directory"
                     ),
                     returnValue: DebugVariableValue.integerValue(
-
+                        1
                     ),
                     expressionLocation: ExpressionLocation(
                         start: 1,
@@ -73,14 +73,14 @@ enum Example8 {
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 ),
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 )

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Migration/MigrationClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Migration/MigrationClientWireTests.swift
@@ -36,7 +36,10 @@ import Trace
                 status: .running
             )
         ]
-        let response = try await client.migration.getAttemptedMigrations(requestOptions: RequestOptions(additionalHeaders: stub.headers))
+        let response = try await client.migration.getAttemptedMigrations(
+            adminKeyHeader: "admin-key-header",
+            requestOptions: RequestOptions(additionalHeaders: stub.headers)
+        )
         try #require(response == expectedResponse)
     }
 }

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Problem/ProblemClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Problem/ProblemClientWireTests.swift
@@ -27,10 +27,10 @@ import Trace
                 problemDescription: ProblemDescription(
                     boards: [
                         ProblemDescriptionBoard.html(
-
+                            "boards"
                         ),
                         ProblemDescriptionBoard.html(
-
+                            "boards"
                         )
                     ]
                 ),
@@ -69,15 +69,15 @@ import Trace
                             id: "id",
                             params: [
                                 VariableValue.integerValue(
-
+                                    1
                                 ),
                                 VariableValue.integerValue(
-
+                                    1
                                 )
                             ]
                         ),
                         expectedResult: VariableValue.integerValue(
-
+                            1
                         )
                     ),
                     TestCaseWithExpectedResult(
@@ -85,15 +85,15 @@ import Trace
                             id: "id",
                             params: [
                                 VariableValue.integerValue(
-
+                                    1
                                 ),
                                 VariableValue.integerValue(
-
+                                    1
                                 )
                             ]
                         ),
                         expectedResult: VariableValue.integerValue(
-
+                            1
                         )
                     )
                 ],
@@ -130,10 +130,10 @@ import Trace
                 problemDescription: ProblemDescription(
                     boards: [
                         ProblemDescriptionBoard.html(
-
+                            "boards"
                         ),
                         ProblemDescriptionBoard.html(
-
+                            "boards"
                         )
                     ]
                 ),
@@ -172,15 +172,15 @@ import Trace
                             id: "id",
                             params: [
                                 VariableValue.integerValue(
-
+                                    1
                                 ),
                                 VariableValue.integerValue(
-
+                                    1
                                 )
                             ]
                         ),
                         expectedResult: VariableValue.integerValue(
-
+                            1
                         )
                     ),
                     TestCaseWithExpectedResult(
@@ -188,15 +188,15 @@ import Trace
                             id: "id",
                             params: [
                                 VariableValue.integerValue(
-
+                                    1
                                 ),
                                 VariableValue.integerValue(
-
+                                    1
                                 )
                             ]
                         ),
                         expectedResult: VariableValue.integerValue(
-
+                            1
                         )
                     )
                 ],

--- a/seed/swift-sdk/trace/reference.md
+++ b/seed/swift-sdk/trace/reference.md
@@ -142,7 +142,7 @@ private func main() async throws {
         request: TestSubmissionUpdate(
             updateTime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
             updateInfo: TestSubmissionUpdateInfo.running(
-
+                .queueingSubmission
             )
         )
     )
@@ -283,7 +283,7 @@ private func main() async throws {
         request: WorkspaceSubmissionUpdate(
             updateTime: try! Date("2024-01-15T09:30:00Z", strategy: .iso8601),
             updateInfo: WorkspaceSubmissionUpdateInfo.running(
-
+                .queueingSubmission
             )
         )
     )
@@ -358,11 +358,11 @@ private func main() async throws {
             result: TestCaseResultWithStdout(
                 result: TestCaseResult(
                     expectedResult: VariableValue.integerValue(
-
+                        1
                     ),
                     actualResult: ActualResult.value(
                         VariableValue.integerValue(
-
+                            1
                         )
                     ),
                     passed: true
@@ -374,7 +374,7 @@ private func main() async throws {
                     submissionId: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")!,
                     lineNumber: 1,
                     returnValue: DebugVariableValue.integerValue(
-
+                        1
                     ),
                     expressionLocation: ExpressionLocation(
                         start: 1,
@@ -389,14 +389,14 @@ private func main() async throws {
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 ),
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 )
@@ -409,7 +409,7 @@ private func main() async throws {
                     submissionId: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")!,
                     lineNumber: 1,
                     returnValue: DebugVariableValue.integerValue(
-
+                        1
                     ),
                     expressionLocation: ExpressionLocation(
                         start: 1,
@@ -424,14 +424,14 @@ private func main() async throws {
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 ),
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 )
@@ -527,7 +527,7 @@ private func main() async throws {
                     directory: "directory"
                 ),
                 returnValue: DebugVariableValue.integerValue(
-
+                    1
                 ),
                 expressionLocation: ExpressionLocation(
                     start: 1,
@@ -542,14 +542,14 @@ private func main() async throws {
                             Scope(
                                 variables: [
                                     "variables": DebugVariableValue.integerValue(
-
+                                        1
                                     )
                                 ]
                             ),
                             Scope(
                                 variables: [
                                     "variables": DebugVariableValue.integerValue(
-
+                                        1
                                     )
                                 ]
                             )
@@ -566,7 +566,7 @@ private func main() async throws {
                     directory: "directory"
                 ),
                 returnValue: DebugVariableValue.integerValue(
-
+                    1
                 ),
                 expressionLocation: ExpressionLocation(
                     start: 1,
@@ -581,14 +581,14 @@ private func main() async throws {
                             Scope(
                                 variables: [
                                     "variables": DebugVariableValue.integerValue(
-
+                                        1
                                     )
                                 ]
                             ),
                             Scope(
                                 variables: [
                                     "variables": DebugVariableValue.integerValue(
-
+                                        1
                                     )
                                 ]
                             )
@@ -694,7 +694,7 @@ private func main() async throws {
                     submissionId: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")!,
                     lineNumber: 1,
                     returnValue: DebugVariableValue.integerValue(
-
+                        1
                     ),
                     expressionLocation: ExpressionLocation(
                         start: 1,
@@ -709,14 +709,14 @@ private func main() async throws {
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 ),
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 )
@@ -729,7 +729,7 @@ private func main() async throws {
                     submissionId: UUID(uuidString: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32")!,
                     lineNumber: 1,
                     returnValue: DebugVariableValue.integerValue(
-
+                        1
                     ),
                     expressionLocation: ExpressionLocation(
                         start: 1,
@@ -744,14 +744,14 @@ private func main() async throws {
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 ),
                                 Scope(
                                     variables: [
                                         "variables": DebugVariableValue.integerValue(
-
+                                            1
                                         )
                                     ]
                                 )
@@ -838,7 +838,7 @@ private func main() async throws {
                     directory: "directory"
                 ),
                 returnValue: DebugVariableValue.integerValue(
-
+                    1
                 ),
                 expressionLocation: ExpressionLocation(
                     start: 1,
@@ -853,14 +853,14 @@ private func main() async throws {
                             Scope(
                                 variables: [
                                     "variables": DebugVariableValue.integerValue(
-
+                                        1
                                     )
                                 ]
                             ),
                             Scope(
                                 variables: [
                                     "variables": DebugVariableValue.integerValue(
-
+                                        1
                                     )
                                 ]
                             )
@@ -877,7 +877,7 @@ private func main() async throws {
                     directory: "directory"
                 ),
                 returnValue: DebugVariableValue.integerValue(
-
+                    1
                 ),
                 expressionLocation: ExpressionLocation(
                     start: 1,
@@ -892,14 +892,14 @@ private func main() async throws {
                             Scope(
                                 variables: [
                                     "variables": DebugVariableValue.integerValue(
-
+                                        1
                                     )
                                 ]
                             ),
                             Scope(
                                 variables: [
                                     "variables": DebugVariableValue.integerValue(
-
+                                        1
                                     )
                                 ]
                             )
@@ -1649,10 +1649,10 @@ private func main() async throws {
         problemDescription: ProblemDescription(
             boards: [
                 ProblemDescriptionBoard.html(
-
+                    "boards"
                 ),
                 ProblemDescriptionBoard.html(
-
+                    "boards"
                 )
             ]
         ),
@@ -1691,15 +1691,15 @@ private func main() async throws {
                     id: "id",
                     params: [
                         VariableValue.integerValue(
-
+                            1
                         ),
                         VariableValue.integerValue(
-
+                            1
                         )
                     ]
                 ),
                 expectedResult: VariableValue.integerValue(
-
+                    1
                 )
             ),
             TestCaseWithExpectedResult(
@@ -1707,15 +1707,15 @@ private func main() async throws {
                     id: "id",
                     params: [
                         VariableValue.integerValue(
-
+                            1
                         ),
                         VariableValue.integerValue(
-
+                            1
                         )
                     ]
                 ),
                 expectedResult: VariableValue.integerValue(
-
+                    1
                 )
             )
         ],
@@ -1798,10 +1798,10 @@ private func main() async throws {
             problemDescription: ProblemDescription(
                 boards: [
                     ProblemDescriptionBoard.html(
-
+                        "boards"
                     ),
                     ProblemDescriptionBoard.html(
-
+                        "boards"
                     )
                 ]
             ),
@@ -1840,15 +1840,15 @@ private func main() async throws {
                         id: "id",
                         params: [
                             VariableValue.integerValue(
-
+                                1
                             ),
                             VariableValue.integerValue(
-
+                                1
                             )
                         ]
                     ),
                     expectedResult: VariableValue.integerValue(
-
+                        1
                     )
                 ),
                 TestCaseWithExpectedResult(
@@ -1856,15 +1856,15 @@ private func main() async throws {
                         id: "id",
                         params: [
                             VariableValue.integerValue(
-
+                                1
                             ),
                             VariableValue.integerValue(
-
+                                1
                             )
                         ]
                     ),
                     expectedResult: VariableValue.integerValue(
-
+                        1
                     )
                 )
             ],

--- a/seed/swift-sdk/trace/reference.md
+++ b/seed/swift-sdk/trace/reference.md
@@ -1085,7 +1085,7 @@ import Trace
 private func main() async throws {
     let client = TraceClient(token: "<token>")
 
-    _ = try await client.migration.getAttemptedMigrations()
+    _ = try await client.migration.getAttemptedMigrations(adminKeyHeader: "admin-key-header")
 }
 
 try await main()

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/Key.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/Key.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 public enum Key: Codable, Hashable, Sendable {
-    case `default`(Default)
     case keyType(KeyType)
+    case `default`(Default)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Default.self) {
-            self = .default(value)
-        } else if let value = try? container.decode(KeyType.self) {
+        if let value = try? container.decode(KeyType.self) {
             self = .keyType(value)
+        } else if let value = try? container.decode(Default.self) {
+            self = .default(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -21,9 +21,9 @@ public enum Key: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .default(let value):
-            try container.encode(value)
         case .keyType(let value):
+            try container.encode(value)
+        case .default(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/MetadataUnion.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/MetadataUnion.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 public enum MetadataUnion: Codable, Hashable, Sendable {
-    case namedMetadata(NamedMetadata)
     case optionalMetadata(OptionalMetadata)
+    case namedMetadata(NamedMetadata)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(NamedMetadata.self) {
-            self = .namedMetadata(value)
-        } else if let value = try? container.decode(OptionalMetadata.self) {
+        if let value = try? container.decode(OptionalMetadata.self) {
             self = .optionalMetadata(value)
+        } else if let value = try? container.decode(NamedMetadata.self) {
+            self = .namedMetadata(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -21,9 +21,9 @@ public enum MetadataUnion: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .namedMetadata(let value):
-            try container.encode(value)
         case .optionalMetadata(let value):
+            try container.encode(value)
+        case .namedMetadata(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/MyUnion.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/MyUnion.swift
@@ -2,16 +2,20 @@ import Foundation
 
 /// Several different types are accepted.
 public enum MyUnion: Codable, Hashable, Sendable {
+    case string(String)
+    case stringArray([String])
     case int(Int)
     case intArray([Int])
     case intArrayArray([[Int]])
     case jsonValue(JSONValue)
-    case string(String)
-    case stringArray([String])
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Int.self) {
+        if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([String].self) {
+            self = .stringArray(value)
+        } else if let value = try? container.decode(Int.self) {
             self = .int(value)
         } else if let value = try? container.decode([Int].self) {
             self = .intArray(value)
@@ -19,10 +23,6 @@ public enum MyUnion: Codable, Hashable, Sendable {
             self = .intArrayArray(value)
         } else if let value = try? container.decode(JSONValue.self) {
             self = .jsonValue(value)
-        } else if let value = try? container.decode(String.self) {
-            self = .string(value)
-        } else if let value = try? container.decode([String].self) {
-            self = .stringArray(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -34,6 +34,10 @@ public enum MyUnion: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .stringArray(let value):
+            try container.encode(value)
         case .int(let value):
             try container.encode(value)
         case .intArray(let value):
@@ -41,10 +45,6 @@ public enum MyUnion: Codable, Hashable, Sendable {
         case .intArrayArray(let value):
             try container.encode(value)
         case .jsonValue(let value):
-            try container.encode(value)
-        case .string(let value):
-            try container.encode(value)
-        case .stringArray(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/NestedUnionL1.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/NestedUnionL1.swift
@@ -4,8 +4,8 @@ import Foundation
 public enum NestedUnionL1: Codable, Hashable, Sendable {
     case int(Int)
     case jsonValue(JSONValue)
-    case nestedUnionL2(NestedUnionL2)
     case stringArray([String])
+    case nestedUnionL2(NestedUnionL2)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
@@ -13,10 +13,10 @@ public enum NestedUnionL1: Codable, Hashable, Sendable {
             self = .int(value)
         } else if let value = try? container.decode(JSONValue.self) {
             self = .jsonValue(value)
-        } else if let value = try? container.decode(NestedUnionL2.self) {
-            self = .nestedUnionL2(value)
         } else if let value = try? container.decode([String].self) {
             self = .stringArray(value)
+        } else if let value = try? container.decode(NestedUnionL2.self) {
+            self = .nestedUnionL2(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -32,9 +32,9 @@ public enum NestedUnionL1: Codable, Hashable, Sendable {
             try container.encode(value)
         case .jsonValue(let value):
             try container.encode(value)
-        case .nestedUnionL2(let value):
-            try container.encode(value)
         case .stringArray(let value):
+            try container.encode(value)
+        case .nestedUnionL2(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/NestedUnionRoot.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/NestedUnionRoot.swift
@@ -2,18 +2,18 @@ import Foundation
 
 /// Nested union root.
 public enum NestedUnionRoot: Codable, Hashable, Sendable {
-    case nestedUnionL1(NestedUnionL1)
     case string(String)
     case stringArray([String])
+    case nestedUnionL1(NestedUnionL1)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(NestedUnionL1.self) {
-            self = .nestedUnionL1(value)
-        } else if let value = try? container.decode(String.self) {
+        if let value = try? container.decode(String.self) {
             self = .string(value)
         } else if let value = try? container.decode([String].self) {
             self = .stringArray(value)
+        } else if let value = try? container.decode(NestedUnionL1.self) {
+            self = .nestedUnionL1(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -25,11 +25,11 @@ public enum NestedUnionRoot: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .nestedUnionL1(let value):
-            try container.encode(value)
         case .string(let value):
             try container.encode(value)
         case .stringArray(let value):
+            try container.encode(value)
+        case .nestedUnionL1(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/PaymentMethodUnion.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/PaymentMethodUnion.swift
@@ -3,15 +3,15 @@ import Foundation
 /// Tests that nested properties with camelCase wire names are properly
 /// converted from snake_case Ruby keys when passed as Hash values.
 public enum PaymentMethodUnion: Codable, Hashable, Sendable {
-    case convertToken(ConvertToken)
     case tokenizeCard(TokenizeCard)
+    case convertToken(ConvertToken)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(ConvertToken.self) {
-            self = .convertToken(value)
-        } else if let value = try? container.decode(TokenizeCard.self) {
+        if let value = try? container.decode(TokenizeCard.self) {
             self = .tokenizeCard(value)
+        } else if let value = try? container.decode(ConvertToken.self) {
+            self = .convertToken(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -23,9 +23,9 @@ public enum PaymentMethodUnion: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .convertToken(let value):
-            try container.encode(value)
         case .tokenizeCard(let value):
+            try container.encode(value)
+        case .convertToken(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/UnionWithDuplicateTypes.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/UnionWithDuplicateTypes.swift
@@ -2,21 +2,21 @@ import Foundation
 
 /// Duplicate types.
 public enum UnionWithDuplicateTypes: Codable, Hashable, Sendable {
-    case int(Int)
-    case jsonValue(JSONValue)
     case string(String)
     case stringArray([String])
+    case int(Int)
+    case jsonValue(JSONValue)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Int.self) {
-            self = .int(value)
-        } else if let value = try? container.decode(JSONValue.self) {
-            self = .jsonValue(value)
-        } else if let value = try? container.decode(String.self) {
+        if let value = try? container.decode(String.self) {
             self = .string(value)
         } else if let value = try? container.decode([String].self) {
             self = .stringArray(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(JSONValue.self) {
+            self = .jsonValue(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -28,13 +28,13 @@ public enum UnionWithDuplicateTypes: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .int(let value):
-            try container.encode(value)
-        case .jsonValue(let value):
-            try container.encode(value)
         case .string(let value):
             try container.encode(value)
         case .stringArray(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .jsonValue(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/UnionWithIdenticalPrimitives.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/UnionWithIdenticalPrimitives.swift
@@ -2,16 +2,16 @@ import Foundation
 
 /// Mix of primitives where some resolve to the same Java type.
 public enum UnionWithIdenticalPrimitives: Codable, Hashable, Sendable {
-    case double(Double)
     case int(Int)
+    case double(Double)
     case string(String)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Double.self) {
-            self = .double(value)
-        } else if let value = try? container.decode(Int.self) {
+        if let value = try? container.decode(Int.self) {
             self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
         } else if let value = try? container.decode(String.self) {
             self = .string(value)
         } else {
@@ -25,9 +25,9 @@ public enum UnionWithIdenticalPrimitives: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .double(let value):
-            try container.encode(value)
         case .int(let value):
+            try container.encode(value)
+        case .double(let value):
             try container.encode(value)
         case .string(let value):
             try container.encode(value)

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/UnionWithReservedNames.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/UnionWithReservedNames.swift
@@ -2,18 +2,18 @@ import Foundation
 
 /// Tests that union members named 'Type' or 'Value' don't collide with internal properties
 public enum UnionWithReservedNames: Codable, Hashable, Sendable {
-    case string(String)
     case type(`Type`)
     case value(Value)
+    case string(String)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(String.self) {
-            self = .string(value)
-        } else if let value = try? container.decode(`Type`.self) {
+        if let value = try? container.decode(`Type`.self) {
             self = .type(value)
         } else if let value = try? container.decode(Value.self) {
             self = .value(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -25,11 +25,11 @@ public enum UnionWithReservedNames: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .string(let value):
-            try container.encode(value)
         case .type(let value):
             try container.encode(value)
         case .value(let value):
+            try container.encode(value)
+        case .string(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/UnionWithTypeAliases.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Schemas/UnionWithTypeAliases.swift
@@ -7,18 +7,18 @@ import Foundation
 ///   public static implicit operator UnionWithTypeAliases(string value) => ...
 /// causing CS0557 compiler error.
 public enum UnionWithTypeAliases: Codable, Hashable, Sendable {
-    case name(Name)
     case string(String)
     case userId(UserId)
+    case name(Name)
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Name.self) {
-            self = .name(value)
-        } else if let value = try? container.decode(String.self) {
+        if let value = try? container.decode(String.self) {
             self = .string(value)
         } else if let value = try? container.decode(UserId.self) {
             self = .userId(value)
+        } else if let value = try? container.decode(Name.self) {
+            self = .name(value)
         } else {
             throw DecodingError.dataCorruptedError(
                 in: container,
@@ -30,11 +30,11 @@ public enum UnionWithTypeAliases: Codable, Hashable, Sendable {
     public func encode(to encoder: Encoder) throws -> Void {
         var container = encoder.singleValueContainer()
         switch self {
-        case .name(let value):
-            try container.encode(value)
         case .string(let value):
             try container.encode(value)
         case .userId(let value):
+            try container.encode(value)
+        case .name(let value):
             try container.encode(value)
         }
     }

--- a/seed/swift-sdk/unions-with-local-date/Tests/Snippets/Example6.swift
+++ b/seed/swift-sdk/unions-with-local-date/Tests/Snippets/Example6.swift
@@ -6,7 +6,7 @@ enum Example6 {
         let client = UnionsClient(baseURL: "https://api.fern.com")
 
         _ = try await client.types.update(request: UnionWithTime.date(
-
+            CalendarDate("1994-01-01")!
         ))
     }
 }

--- a/seed/swift-sdk/unions-with-local-date/Tests/Snippets/Example7.swift
+++ b/seed/swift-sdk/unions-with-local-date/Tests/Snippets/Example7.swift
@@ -6,7 +6,7 @@ enum Example7 {
         let client = UnionsClient(baseURL: "https://api.fern.com")
 
         _ = try await client.types.update(request: UnionWithTime.datetime(
-
+            try! Date("1994-01-01T01:01:01Z", strategy: .iso8601)
         ))
     }
 }

--- a/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Types/TypesClientWireTests.swift
+++ b/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Types/TypesClientWireTests.swift
@@ -91,7 +91,7 @@ import Unions
         let expectedResponse = true
         let response = try await client.types.update(
             request: UnionWithTime.date(
-
+                CalendarDate("1994-01-01")!
             ),
             requestOptions: RequestOptions(additionalHeaders: stub.headers)
         )
@@ -114,7 +114,7 @@ import Unions
         let expectedResponse = true
         let response = try await client.types.update(
             request: UnionWithTime.datetime(
-
+                try! Date("1994-01-01T01:01:01Z", strategy: .iso8601)
             ),
             requestOptions: RequestOptions(additionalHeaders: stub.headers)
         )

--- a/seed/swift-sdk/unions-with-local-date/reference.md
+++ b/seed/swift-sdk/unions-with-local-date/reference.md
@@ -264,7 +264,7 @@ private func main() async throws {
     let client = UnionsClient()
 
     _ = try await client.types.update(request: UnionWithTime.date(
-
+        CalendarDate("1994-01-01")!
     ))
 }
 

--- a/seed/swift-sdk/websocket-inferred-auth/README.md
+++ b/seed/swift-sdk/websocket-inferred-auth/README.md
@@ -54,13 +54,16 @@ import WebsocketAuth
 private func main() async throws {
     let client = WebsocketAuthClient()
 
-    _ = try await client.auth.getTokenWithClientCredentials(request: .init(
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        audience: .httpsApiExampleCom,
-        grantType: .clientCredentials,
-        scope: "scope"
-    ))
+    _ = try await client.auth.getTokenWithClientCredentials(
+        xApiKey: "X-Api-Key",
+        request: .init(
+            clientId: "client_id",
+            clientSecret: "client_secret",
+            audience: .httpsApiExampleCom,
+            grantType: .clientCredentials,
+            scope: "scope"
+        )
+    )
 }
 
 try await main()

--- a/seed/swift-sdk/websocket-inferred-auth/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Tests/Core/ClientErrorTests.swift
@@ -20,6 +20,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -59,6 +60,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -98,6 +100,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -139,6 +142,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -178,6 +182,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -219,6 +224,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -258,6 +264,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",

--- a/seed/swift-sdk/websocket-inferred-auth/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Tests/Core/ClientRetryTests.swift
@@ -21,6 +21,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -54,6 +55,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -87,6 +89,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -119,6 +122,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -150,6 +154,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -182,6 +187,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -214,6 +220,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -251,6 +258,7 @@ import Testing
         let startTime = Date()
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -298,6 +306,7 @@ import Testing
         let startTime = Date()
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -341,6 +350,7 @@ import Testing
         let startTime = Date()
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -395,6 +405,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -423,6 +434,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",
@@ -455,6 +467,7 @@ import Testing
 
         do {
             _ = try await client.auth.getTokenWithClientCredentials(
+                xApiKey: "X-Api-Key",
                 request: .init(
                     clientId: "client_id",
                     clientSecret: "client_secret",

--- a/seed/swift-sdk/websocket-inferred-auth/Tests/Snippets/Example0.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Tests/Snippets/Example0.swift
@@ -5,12 +5,15 @@ enum Example0 {
     static func snippet() async throws {
         let client = WebsocketAuthClient(baseURL: "https://api.fern.com")
 
-        _ = try await client.auth.getTokenWithClientCredentials(request: .init(
-            clientId: "client_id",
-            clientSecret: "client_secret",
-            audience: .httpsApiExampleCom,
-            grantType: .clientCredentials,
-            scope: "scope"
-        ))
+        _ = try await client.auth.getTokenWithClientCredentials(
+            xApiKey: "X-Api-Key",
+            request: .init(
+                clientId: "client_id",
+                clientSecret: "client_secret",
+                audience: .httpsApiExampleCom,
+                grantType: .clientCredentials,
+                scope: "scope"
+            )
+        )
     }
 }

--- a/seed/swift-sdk/websocket-inferred-auth/Tests/Snippets/Example1.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Tests/Snippets/Example1.swift
@@ -5,13 +5,16 @@ enum Example1 {
     static func snippet() async throws {
         let client = WebsocketAuthClient(baseURL: "https://api.fern.com")
 
-        _ = try await client.auth.refreshToken(request: .init(
-            clientId: "client_id",
-            clientSecret: "client_secret",
-            refreshToken: "refresh_token",
-            audience: .httpsApiExampleCom,
-            grantType: .refreshToken,
-            scope: "scope"
-        ))
+        _ = try await client.auth.refreshToken(
+            xApiKey: "X-Api-Key",
+            request: .init(
+                clientId: "client_id",
+                clientSecret: "client_secret",
+                refreshToken: "refresh_token",
+                audience: .httpsApiExampleCom,
+                grantType: .refreshToken,
+                scope: "scope"
+            )
+        )
     }
 }

--- a/seed/swift-sdk/websocket-inferred-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -24,6 +24,7 @@ import WebsocketAuth
             refreshToken: Optional("refresh_token")
         )
         let response = try await client.auth.getTokenWithClientCredentials(
+            xApiKey: "X-Api-Key",
             request: .init(
                 clientId: "client_id",
                 clientSecret: "client_secret",
@@ -57,6 +58,7 @@ import WebsocketAuth
             refreshToken: Optional("refresh_token")
         )
         let response = try await client.auth.refreshToken(
+            xApiKey: "X-Api-Key",
             request: .init(
                 clientId: "client_id",
                 clientSecret: "client_secret",

--- a/seed/swift-sdk/websocket-inferred-auth/reference.md
+++ b/seed/swift-sdk/websocket-inferred-auth/reference.md
@@ -19,13 +19,16 @@ import WebsocketAuth
 private func main() async throws {
     let client = WebsocketAuthClient()
 
-    _ = try await client.auth.getTokenWithClientCredentials(request: .init(
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        audience: .httpsApiExampleCom,
-        grantType: .clientCredentials,
-        scope: "scope"
-    ))
+    _ = try await client.auth.getTokenWithClientCredentials(
+        xApiKey: "X-Api-Key",
+        request: .init(
+            clientId: "client_id",
+            clientSecret: "client_secret",
+            audience: .httpsApiExampleCom,
+            grantType: .clientCredentials,
+            scope: "scope"
+        )
+    )
 }
 
 try await main()
@@ -90,14 +93,17 @@ import WebsocketAuth
 private func main() async throws {
     let client = WebsocketAuthClient()
 
-    _ = try await client.auth.refreshToken(request: .init(
-        clientId: "client_id",
-        clientSecret: "client_secret",
-        refreshToken: "refresh_token",
-        audience: .httpsApiExampleCom,
-        grantType: .refreshToken,
-        scope: "scope"
-    ))
+    _ = try await client.auth.refreshToken(
+        xApiKey: "X-Api-Key",
+        request: .init(
+            clientId: "client_id",
+            clientSecret: "client_secret",
+            refreshToken: "refresh_token",
+            audience: .httpsApiExampleCom,
+            grantType: .refreshToken,
+            scope: "scope"
+        )
+    )
 }
 
 try await main()


### PR DESCRIPTION
## Description

The generated Swift endpoint-method call (used by both dynamic snippets and the
wire-test `client.x.endpoint(...)` invocation) emitted only path, query, and body
arguments — it omitted endpoint **header** parameters entirely. For any endpoint
with a required header (e.g. `X-API-Version`, `X-Api-Key`, `X-Idempotency-Key`),
the generated call was missing a required argument and failed to compile:

```
error: missing argument for parameter 'xApiVersion' in call
```

The generated SDK method declares headers as parameters **between the path and
query parameters**, filtered to the String-typed headers it surfaces (non-String
and literal headers are set automatically). This PR makes the snippet/wire-test
generator emit header arguments in that same position and with the same filter,
so the rendered calls match the method signature.

Stacked on #16490.

## Changes Made
- `EndpointSnippetGenerator.getEndpointMethodArgsForInlinedRequest`: emit header
  arguments after path params and before query params.
- Added `getEndpointMethodHeaderParameters`, mirroring the path/query helpers —
  pulls values via `getExampleObjectProperties`, then keeps only headers that
  resolve to the Swift `String` type (matching what the SDK exposes as params).
- Removed 7 fixtures from `seed/swift-sdk/seed.yml` `allowedFailures`, all now
  passing `swift test -c release`: `inferred-auth-explicit`,
  `inferred-auth-implicit`, `inferred-auth-implicit-api-key`,
  `inferred-auth-implicit-no-expiry`, `required-nullable:no-custom-config`,
  `required-nullable:nullable-as-optional`, `websocket-inferred-auth`.
- Regenerated affected fixtures and updated the dynamic-snippets snapshot.
- Added changelog entry.

## Testing
- [x] Unit tests added/updated — `@fern-api/swift-dynamic-snippets` 33/33 pass
  (updated 1 snapshot to include the new header arg; `required-headers` cases
  validate the behavior).
- [x] Manual testing completed — the 7 removed fixtures pass `swift test -c release`
  in the `swift:6.1.2` Docker image; `openapi-request-body-ref` (the only
  previously-passing fixture that gained header args) still passes — no regression.


Link to Devin session: https://app.devin.ai/sessions/24c6efc2110b4c8ead19d72f7fe013b2
Requested by: @iamnamananand996