### PR TITLE
fix(swift): return String for text/plain response endpoints

### DIFF
--- a/generators/swift/sdk/changes/unreleased/fix-plain-text-response-type.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-plain-text-response-type.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fixed endpoints that return a `text/plain` response so the generated method
+    returns `String` instead of the placeholder `JSONValue`. The HTTP client
+    already decodes a `String` response type from the raw UTF-8 body, so the
+    generated wire tests now compile and pass (previously `response == "string"`
+    failed because the response was typed as `JSONValue`).
+  type: fix

--- a/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/EndpointMethodGenerator.ts
@@ -187,7 +187,7 @@ export class EndpointMethodGenerator {
             json: (resp) =>
                 this.sdkGeneratorContext.getSwiftTypeReferenceFromScope(resp.responseBodyType, this.parentClassSymbol),
             fileDownload: () => this.referencer.referenceFoundationType("Data"),
-            text: () => this.referencer.referenceAsIsType("JSONValue"), // TODO(kafkas): Handle text responses
+            text: () => this.referencer.referenceSwiftType("String"),
             bytes: () => this.referencer.referenceAsIsType("JSONValue"), // TODO(kafkas): Handle bytes responses
             streaming: () => this.referencer.referenceAsIsType("JSONValue"), // TODO(kafkas): Handle streaming responses
             streamParameter: () => this.referencer.referenceAsIsType("JSONValue"), // TODO(kafkas): Handle stream parameter responses

--- a/seed/swift-sdk/plain-text/Sources/Resources/Service/ServiceClient.swift
+++ b/seed/swift-sdk/plain-text/Sources/Resources/Service/ServiceClient.swift
@@ -7,12 +7,12 @@ public final class ServiceClient: Sendable {
         self.httpClient = HTTPClient(config: config)
     }
 
-    public func getText(requestOptions: RequestOptions? = nil) async throws -> JSONValue {
+    public func getText(requestOptions: RequestOptions? = nil) async throws -> String {
         return try await httpClient.performRequest(
             method: .post,
             path: "/text",
             requestOptions: requestOptions,
-            responseType: JSONValue.self
+            responseType: String.self
         )
     }
 }

--- a/seed/swift-sdk/plain-text/reference.md
+++ b/seed/swift-sdk/plain-text/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Service
-<details><summary><code>client.service.<a href="/Sources/Resources/Service/ServiceClient.swift">getText</a>(requestOptions: RequestOptions?) -> JSONValue</code></summary>
+<details><summary><code>client.service.<a href="/Sources/Resources/Service/ServiceClient.swift">getText</a>(requestOptions: RequestOptions?) -> String</code></summary>
 <dl>
 <dd>
 

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -140,7 +140,6 @@ allowedFailures:
   - nullable:no-custom-config
   - nullable:nullable-as-optional
   - oauth-client-credentials-with-variables
-  - plain-text
   - query-parameters
   - request-parameters
   - streaming


### PR DESCRIPTION
## Description

Endpoints returning a `text/plain` response were generated with the placeholder
return type `JSONValue` (an explicit `TODO(kafkas): Handle text responses`). This
made the generated wire tests fail to compile:

```
error: referencing operator function '==' on 'StringProtocol' requires that
'JSONValue' conform to 'StringProtocol'
   try #require(response == expectedResponse)   // response: JSONValue, expected: String
```

The generated `HTTPClient.performRequest` already special-cases `String.self` and
decodes the raw response body as UTF-8:

```swift
if responseType == Swift.String.self {
    if let string = Swift.String(data: data, encoding: .utf8) as? T { return string }
    ...
}
```

So the fix is simply to map the IR `text` response body to Swift `String` instead
of `JSONValue`. The other placeholder branches (`bytes`, `streaming`,
`streamParameter`) are intentionally left as-is — those are separate, larger
features.

Stacked on #16492.

## Changes Made
- `EndpointMethodGenerator.getMethodReturnTypeForEndpoint`: `text` response body
  now maps to `String` (was `JSONValue`).
- Removed `plain-text` from `seed/swift-sdk/seed.yml` `allowedFailures`.
- Regenerated the `plain-text` fixture (`getText() -> String`, `responseType: String.self`).
- Added changelog entry.

## Testing
- [x] Manual testing completed — `plain-text` passes `swift test -c release` in
  the `swift:6.1.2` Docker image (21/21 tests pass, including the wire test that
  compares the decoded `String` response).
- [x] Verified isolation — `plain-text` is the only seed fixture with a `text/plain`
  response, so no other fixture is affected (`bytes`/`streaming`/`sse` use
  different response body types and are untouched).


Link to Devin session: https://app.devin.ai/sessions/24c6efc2110b4c8ead19d72f7fe013b2
Requested by: @iamnamananand996